### PR TITLE
feat: Add a keyboard shortcut to open popup

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,46 +1,53 @@
 {
-	"name": "Blockstack",
-	"author": "ymdevs",
-	"version": "1.0.0",
-	"description": "The Blockstack app is all you need to access the new internet. Access privacy-friendly apps and keep data in your control.",
-	"icons": {
-		"128": "assets/logo-128@1x.png",
-		"256": "assets/logo-128@2x.png",
-		"512": "assets/logo-128@3x.png"
-	},
-	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-	"permissions": [
-		"activeTab",
-		"alarms",
-		"bookmarks",
-		"cookies",
-		"storage",
-		"tabs",
-		"webRequest",
-		"webRequestBlocking",
-		"*://*/*"
-	],
-	"manifest_version": 2,
-	"background": {
-		"scripts": [
-			"background.js"
-		],
-		"persistent": true
-	},
-	"web_accessible_resources": ["inpage.js"],
-	"browser_action": {
-		"default_title": "Blockstack",
-		"default_icon": "assets/logo-16@3x.png",
-		"default_popup": "popup.html"
-	},
-	"options_ui": {
-		"page": "index.html",
-		"open_in_tab": true
-	},
-	"content_scripts": [
-		{
-			"js": ["message-bus.js"],
-			"matches": ["*://*/*"]
-		}
-	]
+  "name": "Blockstack",
+  "author": "ymdevs",
+  "version": "1.0.0",
+  "description": "The Blockstack app is all you need to access the new internet. Access privacy-friendly apps and keep data in your control.",
+  "icons": {
+    "128": "assets/logo-128@1x.png",
+    "256": "assets/logo-128@2x.png",
+    "512": "assets/logo-128@3x.png"
+  },
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "permissions": [
+    "activeTab",
+    "alarms",
+    "bookmarks",
+    "cookies",
+    "storage",
+    "tabs",
+    "webRequest",
+    "webRequestBlocking",
+    "*://*/*"
+  ],
+  "manifest_version": 2,
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  },
+  "web_accessible_resources": ["inpage.js"],
+  "browser_action": {
+    "default_title": "Blockstack",
+    "default_icon": "assets/logo-16@3x.png",
+    "default_popup": "popup.html"
+  },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+B",
+        "mac": "MacCtrl+Shift+B"
+      },
+      "description": "Opens Blockstack app interface"
+    }
+  },
+  "options_ui": {
+    "page": "index.html",
+    "open_in_tab": true
+  },
+  "content_scripts": [
+    {
+      "js": ["message-bus.js"],
+      "matches": ["*://*/*"]
+    }
+  ]
 }


### PR DESCRIPTION
Looking into ChromeExtensions and saw we can do this:

Press `Ctrl + Shift + B` to open the popup.