### PR TITLE
feat: Layout closer to designs, created <ExplainerCard />

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "prettier": "@blockstack/prettier-config",
   "license": "MIT",
   "dependencies": {
-    "@blockstack/connect": "^0.2.0",
+    "@blockstack/connect": "^0.2.1",
     "@blockstack/keychain": "^0.1.2",
     "@blockstack/prettier-config": "^0.0.5",
     "@blockstack/ui": "^1.0.0-alpha.24",

--- a/src/components/onboarding/screens/create.tsx
+++ b/src/components/onboarding/screens/create.tsx
@@ -1,10 +1,39 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Box, Spinner, Flex, Text } from '@blockstack/ui';
 import { Screen, ScreenBody } from '@blockstack/connect';
 import { ScreenHeader } from '@components/connected-screen-header';
+import { Title } from '../../typography';
 
 import { doCreateSecretKey } from '@store/onboarding/actions';
+
+interface ExplainerCardProps {
+  title: string;
+  imageUrl: string;
+}
+
+const ExplainerCard = ({ title, imageUrl }: ExplainerCardProps) => (
+  <Flex height="300px" flexDirection="column" justifyContent="space-between">
+    <Box>
+      <Text>{imageUrl ? 'With Stacks:' : ' '}</Text>
+    </Box>
+    <Flex justifyContent="center" alignItems="center" height="180px" mb={imageUrl ? 8 : 0} flexDirection="column">
+      {imageUrl && (
+        <Box flex="1" justifyContent="center">
+          <Flex mx="auto" width="240px" height="152px" justifyContent="center">
+            <img src={imageUrl} />
+          </Flex>
+        </Box>
+      )}
+      <Box pb={imageUrl ? 6 : 0}>
+        <Title>{title}</Title>
+      </Box>
+    </Flex>
+    <Flex width="100%" flexDirection="column" alignItems="center">
+      <Spinner thickness="3px" size="lg" color="blue" />
+    </Flex>
+  </Flex>
+);
 
 interface MockData {
   title: string;
@@ -26,7 +55,7 @@ interface CreateProps {
 }
 
 export const Create: React.FC<CreateProps> = props => {
-  const [state, setState] = React.useState({
+  const [state, setState] = useState({
     title: 'Creating your Data Vault',
     imageUrl: '',
   });
@@ -51,7 +80,7 @@ export const Create: React.FC<CreateProps> = props => {
     },
   ];
 
-  React.useEffect(() => {
+  useEffect(() => {
     // This timeout is important because if the app is navigated to as a sign in, the
     // create page will be rendered momentarily, and we need to cancel these
     // functions if we're on a different screen
@@ -62,26 +91,15 @@ export const Create: React.FC<CreateProps> = props => {
     return () => clearTimeout(timeout);
   }, []);
 
+  const offCenterOffset = '.44';
+
   return (
     <Screen textAlign="center">
       <ScreenHeader />
-      {state.imageUrl === '' ? (
-        undefined
-      ) : (
-        <Box>
-          <Text>Your Data Vault includes:</Text>
-          <Flex mt={6} mx="auto" width="240px" height="152px" justifyContent="center">
-            <img src={state.imageUrl} />
-          </Flex>
-        </Box>
-      )}
       <ScreenBody
-        title={state.title}
-        body={[
-          <Box pt={10} width="100%">
-            <Spinner thickness="3px" size="lg" color="blue" />
-          </Box>,
-        ]}
+        flex={offCenterOffset}
+        justifyContent="center"
+        body={[<ExplainerCard title={state.title} imageUrl={state.imageUrl} />]}
       />
     </Screen>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,10 +846,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blockstack/connect@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@blockstack/connect/-/connect-0.2.0.tgz#6421b7d4d5ea8befcc21d7e8a7b5fda3617a2c0c"
-  integrity sha512-i2hr4N6I9SUaxIxt27tiJbBIRgs6DwuotE7uvcb8RnODg3oZ107VsJWrkYWr1oxcQCwTefGsKmqsfGYn3XopNA==
+"@blockstack/connect@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@blockstack/connect/-/connect-0.2.1.tgz#4ddf2a3bfa58f35ba52ce73596a1b9f8f627e7cc"
+  integrity sha512-RmRo3Adsx79J8l5rTpKxAPVTRTBJiAmZia/Bn11K/oU0UnfwLFrPoP2R9d4GnmRfZ5ezDMDJ4ZAtGep2YzM/4A==
   dependencies:
     "@blockstack/ui" "^1.0.0-alpha.24"
     mdi-react "^6.6.0"


### PR DESCRIPTION
This PR follows on [yesterday's PR](https://github.com/blockstack/connect/pull/18), aligning the explanation of DataVault to the designs.

I've created a new component, as the flexbox props needed to get this as per the designs are many. It requires some absolute unit values, as well as the `flex: .44` to off-centre align the content. Also note the loading spinner is fixed position in all screens.

Closes https://github.com/blockstack/connect/issues/13 

For a successful build, [this PR in `connect` needs to first be merged and published](https://github.com/blockstack/connect/pull/21).

**Demo**
![demo-of-explainer-card](https://user-images.githubusercontent.com/1618764/73260132-9313c600-41c9-11ea-953b-35cdb9d1c716.gif)

**n.b.** Not sure why it's modal isn't opening centred 