### PR TITLE
fix: Input/Textarea fields autocapitalizing on iOS, Closes #180

### DIFF
--- a/src/components/onboarding/screens/secret-key.tsx
+++ b/src/components/onboarding/screens/secret-key.tsx
@@ -47,6 +47,7 @@ export const SecretKey: React.FC<SecretKeyProps> = props => {
               <SeedTextarea
                 readOnly
                 spellCheck="false"
+                autoCapitalize="false"
                 value={secretKey}
                 className="hidden-secret-key"
                 data-test="textarea-seed-phrase"

--- a/src/components/onboarding/screens/sign-in.tsx
+++ b/src/components/onboarding/screens/sign-in.tsx
@@ -68,6 +68,7 @@ export const SignIn: React.FC<SignInProps> = props => {
               placeholder="12-word Secret Key"
               as="textarea"
               value={seed}
+              autoCapitalize="false"
               spellCheck={false}
               style={{ resize: 'none' }}
               onChange={(evt: React.FormEvent<HTMLInputElement>) => {

--- a/src/components/onboarding/screens/username.tsx
+++ b/src/components/onboarding/screens/username.tsx
@@ -124,6 +124,7 @@ export const Username: React.FC<UsernameProps> = ({ next }) => {
               </Flex>
               <Input
                 data-test="input-username"
+                autoCapitalize="false"
                 paddingRight="100px"
                 autoFocus
                 placeholder="username"


### PR DESCRIPTION
Adds attribute to disable this functionality