### PR TITLE
Restore previously used identities when signing in

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Blockstack PBC",
   "dependencies": {
     "@blockstack/connect": "^1.0.6",
-    "@blockstack/keychain": "^0.2.5",
+    "@blockstack/keychain": "^0.3.0-beta.2",
     "@blockstack/prettier-config": "^0.0.5",
     "@blockstack/ui": "^1.0.0-alpha.34",
     "@rehooks/document-title": "^1.0.1",

--- a/src/components/onboarding/index.tsx
+++ b/src/components/onboarding/index.tsx
@@ -71,7 +71,7 @@ const RenderScreen = ({ ...rest }) => {
     case ScreenName.SIGN_IN:
       return (
         <SignIn
-          next={() => doChangeScreen(ScreenName.CHOOSE_ACCOUNT)}
+          next={() => dispatch(doChangeScreen(ScreenName.CHOOSE_ACCOUNT))}
           back={() => {
             dispatch(doChangeScreen(ScreenName.SECRET_KEY));
           }}

--- a/src/components/onboarding/screens/sign-in.tsx
+++ b/src/components/onboarding/screens/sign-in.tsx
@@ -92,7 +92,7 @@ export const SignIn: React.FC<SignInProps> = props => {
             color="blue"
             onClick={() => {
               doTrack(SIGN_IN_CREATE);
-              dispatch(doChangeScreen(ScreenName.USERNAME));
+              dispatch(doChangeScreen(ScreenName.GENERATION));
             }}
           >
             Create a Secret Key

--- a/src/store/wallet/actions.ts
+++ b/src/store/wallet/actions.ts
@@ -1,7 +1,6 @@
 import { ThunkAction } from 'redux-thunk';
 import { Wallet } from '@blockstack/keychain';
 import { WalletActions, RESTORE_WALLET, IS_RESTORING_WALLET, GENERATE_WALLET, SIGN_OUT } from './types';
-import { gaiaUrl } from '@common/constants';
 
 export function didRestoreWallet(wallet: Wallet): WalletActions {
   return {

--- a/src/store/wallet/actions.ts
+++ b/src/store/wallet/actions.ts
@@ -33,11 +33,6 @@ export function doStoreSeed(seed: string, password: string): ThunkAction<Promise
   return async dispatch => {
     dispatch(isRestoringWallet());
     const wallet = await Wallet.restore(password, seed);
-    const gaiaConfig = await wallet.createGaiaConfig(gaiaUrl);
-    const config = await wallet.fetchConfig(gaiaConfig);
-    if (config?.identities[0]?.username) {
-      wallet.identities[0].defaultUsername = config.identities[0].username;
-    }
     dispatch(didRestoreWallet(wallet));
     return wallet;
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -923,10 +923,10 @@
     use-events "^1.4.1"
     use-onclickoutside "^0.3.1"
 
-"@blockstack/keychain@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@blockstack/keychain/-/keychain-0.2.5.tgz#07b97603e4e620fb52686d03d79a9ef3c2c09fcd"
-  integrity sha512-Vh3DTGQhr7CrwTRA/M2VhdiHagQ5+kONnUcv+mCoQGu0UgpjechBHyiypMv2C5iwJj2uDTuo08w4+UQn5E2VGA==
+"@blockstack/keychain@^0.3.0-beta.2":
+  version "0.3.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@blockstack/keychain/-/keychain-0.3.0-beta.2.tgz#dfdc9fb3e46a2f755ab44bf4595959ea6b431c3d"
+  integrity sha512-hNJw9UMjXcX8cq1MY21NkrLOF6h60kY2XyGqpwzvDuroC+HVtG9dsu3KM5ydIEddZOCB8tVw9lMyDsSNkyNsFA==
   dependencies:
     bip39 "^3.0.2"
     bitcoinjs-lib "^5.1.6"


### PR DESCRIPTION
One common bug reported in the current Browser is that, when you sign in with your seed phrase, you only see the first identity. If you have other usernames you've registered, then you have to go to "profiles -> more -> add", and it's very non-intuitive even when following directions.

This improves that with two new mechanisms:

- If this seed phrase was used with our new authenticator, then it'll have a `walletConfig` file that we can use to restore the previous identities. This is O(1)
- If the seed phrase is coming from the Browser, and was never used in the new authenticator (aka doesn't have a `walletConfig`), then we recursively make new identities and check if it has an existing username that has been registered. This is O(n), but should only happen once.

All of the real logic is in https://github.com/blockstack/keychain/pull/21

Also: Test apps are updated to test this PR

QA Steps:

- Existing seed from new authenticator
  - Make a new wallet, create at least one extra ID for it
  - Restore with seed phrase, make sure all IDs are back
- Seed from Browser (never used in authenticator)
  - Make sure it has ~2/3 IDs in it
  - Restore with seed phrase, make sure all IDs are back