### PR TITLE
fix: proper title tracking

### DIFF
--- a/src/components/onboarding/screens/choose-account.tsx
+++ b/src/components/onboarding/screens/choose-account.tsx
@@ -14,7 +14,6 @@ import { selectIdentities, selectCurrentWallet } from '@store/wallet/selectors';
 import { ConfigApp } from '@blockstack/keychain/dist/wallet';
 import { Wallet } from '@blockstack/keychain';
 import { gaiaUrl } from '@common/constants';
-import useDocumentTitle from '@rehooks/document-title';
 import {
   doTrack,
   CHOOSE_ACCOUNT_REUSE_WARNING,
@@ -30,7 +29,6 @@ interface ChooseAccountProps {
 }
 
 export const ChooseAccount: React.FC<ChooseAccountProps> = ({ next }) => {
-  useDocumentTitle('Choose account');
   const { appName, identities, wallet } = useSelector((state: AppState) => ({
     appName: selectAppName(state),
     identities: selectIdentities(state),

--- a/src/components/onboarding/screens/create.tsx
+++ b/src/components/onboarding/screens/create.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Spinner, Flex, Text } from '@blockstack/ui';
 import { Screen, ScreenBody, PoweredBy, ScreenFooter } from '@blockstack/connect';
-import useDocumentTitle from '@rehooks/document-title';
 import { ScreenHeader } from '@components/connected-screen-header';
 
 import { doCreateSecretKey } from '@store/onboarding/actions';
@@ -51,9 +50,7 @@ interface CreateProps {
   next: () => void;
 }
 export const Create: React.FC<CreateProps> = props => {
-  const title = 'Generating your Secret Key...';
   const [cardIndex, setCardIndex] = useState(0);
-  useDocumentTitle(title);
   const { wallet } = useSelector((state: AppState) => ({
     wallet: selectCurrentWallet(state),
   }));

--- a/src/components/onboarding/screens/decrypt-recovery-code.tsx
+++ b/src/components/onboarding/screens/decrypt-recovery-code.tsx
@@ -10,7 +10,6 @@ import { Box, Input, Text, Button } from '@blockstack/ui';
 import { Screen, ScreenBody, ScreenActions, Title, PoweredBy, ScreenFooter } from '@blockstack/connect';
 import { ScreenHeader } from '@components/connected-screen-header';
 import { decrypt } from '@blockstack/keychain';
-import useDocumentTitle from '@rehooks/document-title';
 import { ErrorLabel } from '@components/error-label';
 
 interface RecoveryProps {
@@ -19,7 +18,6 @@ interface RecoveryProps {
 
 export const DecryptRecoveryCode: React.FC<RecoveryProps> = ({ next }) => {
   const title = 'Enter your password';
-  useDocumentTitle(title);
   const [passwordError, setPasswordError] = useState('');
   const [password, setCode] = useState('');
   const [loading, setLoading] = useState(false);

--- a/src/components/onboarding/screens/registery-error.tsx
+++ b/src/components/onboarding/screens/registery-error.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { Screen, ScreenHeader, ScreenBody, PoweredBy, ScreenFooter, Title } from '@blockstack/connect';
-import useDocumentTitle from '@rehooks/document-title';
 import { Flex, Box, Button } from '@blockstack/ui';
 
 export const UsernameRegistryError: React.FC = () => {
-  useDocumentTitle('Failed to register username');
-
   return (
     <Screen textAlign="center">
       <ScreenHeader title="Secret Key" />

--- a/src/components/onboarding/screens/save-key.tsx
+++ b/src/components/onboarding/screens/save-key.tsx
@@ -10,7 +10,6 @@ import { AppState } from '@store';
 
 import { selectAppName } from '@store/onboarding/selectors';
 import { faqs } from '@components/onboarding/data';
-import useDocumentTitle from '@rehooks/document-title';
 
 interface SaveKeyProps {
   next: () => void;
@@ -18,7 +17,6 @@ interface SaveKeyProps {
 
 export const SaveKey: React.FC<SaveKeyProps> = ({ next }) => {
   const title = 'Save your Secret Key';
-  useDocumentTitle(title);
   const appName = useSelector((state: AppState) => selectAppName(state));
   const [loading, setLoading] = useState(false);
   return (

--- a/src/components/onboarding/screens/secret-key.tsx
+++ b/src/components/onboarding/screens/secret-key.tsx
@@ -9,7 +9,6 @@ import { Card } from '@components/card';
 import { SeedTextarea } from '@components/seed-textarea';
 import { AppState } from '@store';
 import { selectSecretKey } from '@store/onboarding/selectors';
-import useDocumentTitle from '@rehooks/document-title';
 
 interface SecretKeyProps {
   next: () => void;
@@ -17,7 +16,6 @@ interface SecretKeyProps {
 
 export const SecretKey: React.FC<SecretKeyProps> = props => {
   const title = 'Your Secret Key';
-  useDocumentTitle(title);
   const { secretKey } = useSelector((state: AppState) => ({
     secretKey: selectSecretKey(state),
   }));

--- a/src/components/onboarding/screens/username.tsx
+++ b/src/components/onboarding/screens/username.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import { Box, Flex, Input, Text, Button } from '@blockstack/ui';
 import { Screen, ScreenBody, ScreenActions, Title, PoweredBy, ScreenFooter } from '@blockstack/connect';
 import { ScreenHeader } from '@components/connected-screen-header';
-import useDocumentTitle from '@rehooks/document-title';
 
 import { useAppDetails } from '@common/hooks/useAppDetails';
 import { useDispatch, useSelector } from 'react-redux';
@@ -40,7 +39,6 @@ interface UsernameProps {
 
 export const Username: React.FC<UsernameProps> = ({ next }) => {
   const title = 'Choose a username';
-  useDocumentTitle(title);
   const dispatch = useDispatch();
   const { name } = useAppDetails();
 

--- a/src/store/onboarding/actions.ts
+++ b/src/store/onboarding/actions.ts
@@ -7,6 +7,7 @@ import {
   SAVE_AUTH_REQUEST,
   SET_MAGIC_RECOVERY_CODE,
   SET_USERNAME,
+  titleNameMap,
 } from './types';
 import { decodeToken } from 'jsontokens';
 import { doGenerateWallet, didGenerateWallet, WalletActions } from '../wallet';
@@ -27,6 +28,7 @@ import { gaiaUrl } from '@common/constants';
 import { pageTrackingNameMap } from './types';
 
 export const doChangeScreen = (screen: ScreenName): OnboardingActions => {
+  document.title = titleNameMap[screen];
   window.analytics.page(pageTrackingNameMap[screen]);
   return {
     type: CHANGE_PAGE,
@@ -112,6 +114,7 @@ export function doSaveAuthRequest(authRequest: string): ThunkAction<void, AppSta
     if ((screen === ScreenName.GENERATION || screen === ScreenName.SIGN_IN) && hasIdentities) {
       dispatch(doChangeScreen(ScreenName.CHOOSE_ACCOUNT));
     } else {
+      document.title = titleNameMap[screen];
       window.analytics.page(pageTrackingNameMap[screen]);
     }
   };

--- a/src/store/onboarding/types.ts
+++ b/src/store/onboarding/types.ts
@@ -33,6 +33,19 @@ export const pageTrackingNameMap = {
   [ScreenName.REGISTRY_ERROR]: 'Username Registry Error',
 };
 
+export const titleNameMap = {
+  [ScreenName.CHOOSE_ACCOUNT]: 'Choose account',
+  [ScreenName.USERNAME]: 'Choose a username',
+  [ScreenName.GENERATION]: 'Generating your Secret Key',
+  [ScreenName.SECRET_KEY]: 'Your Secret Key',
+  [ScreenName.SAVE_KEY]: 'Save your Secret Key',
+  [ScreenName.CONNECT_APP]: 'Connect App',
+  [ScreenName.SIGN_IN]: 'Sign in',
+  [ScreenName.RECOVERY_CODE]: 'Enter your password',
+  [ScreenName.ADD_ACCOUNT]: ' Select Username',
+  [ScreenName.REGISTRY_ERROR]: 'Failed to register username',
+};
+
 // TODO: clarify usage of password for local key encryption
 export const DEFAULT_PASSWORD = 'password';
 


### PR DESCRIPTION
This updates our `document.title` logic, so that whenever we call `doChangeScreen`, we update the title before calling `analytics.page`. Previously, we were using hooks, so the title was changed after the page event.

I've kept all of the same title names.