### PR TITLE
fix: long usernames text-align: left, fixes #174

### DIFF
--- a/src/components/accounts/index.tsx
+++ b/src/components/accounts/index.tsx
@@ -67,7 +67,9 @@ const AccountItem = ({ label, iconComponent, isFirst, hasAction, ...rest }: Acco
     >
       {iconComponent && iconComponent({ hover })}
       <Box overflow="hidden">
-        <Text textStyle="body.small.medium">{label}</Text>
+        <Text display="inline-block" textAlign="left" textStyle="body.small.medium">
+          {label}
+        </Text>
       </Box>
     </Flex>
   );


### PR DESCRIPTION
![Screen Shot 2020-02-20 at 2 54 52 PM](https://user-images.githubusercontent.com/11803153/74977767-f7a0fa00-53f0-11ea-86cb-b6d49f09d550.png)
