### PR TITLE
feat: slight speedup on final auth transition

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -58,7 +58,7 @@ export const finalizeAuthResponse = ({ decodedAuthRequest, authRequest, authResp
       window.open(redirect);
     }
     window.close();
-  }, 500);
+  }, 150);
   window.addEventListener('message', event => {
     if (authRequest && event.data.authRequest === authRequest) {
       const source = getEventSourceWindow(event);

--- a/src/components/onboarding/screens/secret-key.tsx
+++ b/src/components/onboarding/screens/secret-key.tsx
@@ -8,7 +8,7 @@ import { Toast } from '@components/toast';
 import { Card } from '@components/card';
 import { SeedTextarea } from '@components/seed-textarea';
 import { AppState } from '@store';
-import { selectSecretKey } from '@store/onboarding/selectors';
+import { selectSecretKey, selectAppName } from '@store/onboarding/selectors';
 
 interface SecretKeyProps {
   next: () => void;
@@ -16,8 +16,9 @@ interface SecretKeyProps {
 
 export const SecretKey: React.FC<SecretKeyProps> = props => {
   const title = 'Your Secret Key';
-  const { secretKey } = useSelector((state: AppState) => ({
+  const { secretKey, appName } = useSelector((state: AppState) => ({
     secretKey: selectSecretKey(state),
+    appName: selectAppName(state),
   }));
   const [copied, setCopiedState] = React.useState(false);
 
@@ -38,7 +39,7 @@ export const SecretKey: React.FC<SecretKeyProps> = props => {
           body={[
             <Title>{title}</Title>,
             <Text mt={2} display="block">
-              Here’s your Secret Key: 12 words that prove it’s you when you want to use Messenger on a new device. Once
+              Here’s your Secret Key: 12 words that prove it’s you when you want to use {appName} on a new device. Once
               lost it’s lost forever, so save it somewhere you won’t forget.
             </Text>,
             <Card title="Your Secret Key" mt={6}>

--- a/src/store/onboarding/actions.ts
+++ b/src/store/onboarding/actions.ts
@@ -151,13 +151,12 @@ export function doFinishSignIn(
         name: appName as string,
       },
     });
-    dispatch(didGenerateWallet(wallet));
-    console.log('Updated wallet config', wallet.walletConfig);
     const authResponse = await currentIdentity.makeAuthResponse({
       gaiaUrl,
       appDomain: appURL.origin,
       transitPublicKey: decodedAuthRequest.public_keys[0],
     });
     finalizeAuthResponse({ decodedAuthRequest, authRequest, authResponse });
+    dispatch(didGenerateWallet(wallet));
   };
 }


### PR DESCRIPTION
This does two things:

- Shortens the timeout before redirect to 150ms, from 500ms. [Suggested by Kyran](https://github.com/blockstack/app/pull/216#issuecomment-590264033)
- Moves a redux action to after auth message passing, which was causing a re-render of the 'choose account' loading state