### PR TITLE
fix: send to sign-in if sendToSignIn, even if path = sign-up

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -32,6 +32,7 @@
     "@types/react-router-dom": "^5.1.3",
     "blockstack": "^19.3.0",
     "formik": "^2.1.4",
+    "history": "^5.0.0-beta.4",
     "mdi-react": "^6.7.0",
     "preact": "^10.3.2",
     "react": "^16.12.0",

--- a/packages/app/src/components/routes.tsx
+++ b/packages/app/src/components/routes.tsx
@@ -23,7 +23,7 @@ export const Routes: React.FC = () => {
   const dispatch = useDispatch();
   const { doChangeScreen } = useAnalytics();
   const { identities } = useWallet();
-  const { isOnboardingInProgress } = useOnboardingState();
+  const { isOnboardingInProgress, decodedAuthRequest } = useOnboardingState();
   const authRequest = authenticationInit();
 
   useEffect(() => {
@@ -37,20 +37,21 @@ export const Routes: React.FC = () => {
 
   const isSignedIn = !isOnboardingInProgress && identities.length;
 
+  const getSignUpElement = () => {
+    if (isSignedIn) {
+      return <Navigate to={{ pathname: '/', hash: `connect/choose-account?${location.hash.split('?')[1]}` }} />;
+    }
+    if (decodedAuthRequest?.sendToSignIn) {
+      return <Navigate to={{ pathname: '/', hash: `sign-in?${location.hash.split('?')[1]}` }} />;
+    }
+    return <Create next={() => doChangeScreen(ScreenPaths.SECRET_KEY)} />;
+  };
+
   return (
     <RoutesDom>
       <Route path="/" element={<Home />} />
       {/*Sign Up*/}
-      <Route
-        path="/sign-up"
-        element={
-          isSignedIn ? (
-            <Navigate to={{ pathname: '/', hash: `connect/choose-account?${location.hash.split('?')[1]}` }} />
-          ) : (
-            <Create next={() => doChangeScreen(ScreenPaths.SECRET_KEY)} />
-          )
-        }
-      />
+      <Route path="/sign-up" element={getSignUpElement()} />
       <Route path="/sign-up/secret-key" element={<SecretKey next={() => doChangeScreen(ScreenPaths.SAVE_KEY)} />} />
       <Route
         path="/sign-up/save-secret-key"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8657,6 +8657,13 @@ history@5.0.0-beta.4:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
+history@^5.0.0-beta.4:
+  version "5.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0-beta.5.tgz#6ec8661fcec09901ceccc540385ee3ad3d917157"
+  integrity sha512-ahtCDSKtbIUI83WDz2B6dd7sbtEd5bcISD5rFI+Mjd4Y61Niz69ciS4opFxertJVOwgDYPgFmeIXsUNsfdM61w==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
This bug only happens on apps with an older version of Connect, like Banter.

QA:

- Open banter.pub
- 'Get Started'
- 'I already have a secret key'
- See that it starts generating a key for you, instead of asking for one

To test the fix:

- When the popup comes up, copy the URL part starting with `?authRequest=...`
- Paste that into the end of this URL: `https://deploy-preview-293--authenticator-demo.netlify.com/actions.html`
- See that it properly asks you to enter a key