### PR TITLE
feat: improve accessibility of connect modal, links

### DIFF
--- a/packages/app/src/components/link.tsx
+++ b/packages/app/src/components/link.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import { Text, Box, BoxProps } from '@blockstack/ui';
+import { BoxProps } from '@blockstack/ui';
+import { Link as ConnectLink } from '@blockstack/connect';
 
 interface LinkProps extends BoxProps {
   _hover?: BoxProps;
+  onClick: () => void;
 }
 
-export const Link: React.FC<LinkProps> = ({ _hover = {}, children, fontSize = '14px', ...rest }) => (
-  <Box {...rest}>
-    <Text
-      _hover={{ textDecoration: 'underline', cursor: 'pointer', ..._hover }}
-      fontSize={fontSize}
-      fontWeight="medium"
-    >
-      {children}
-    </Text>
-  </Box>
+export const Link: React.FC<LinkProps> = ({ children, fontSize = '14px', ...rest }) => (
+  <ConnectLink fontSize={fontSize} {...rest}>
+    {children}
+  </ConnectLink>
 );

--- a/packages/connect/src/react/components/link.tsx
+++ b/packages/connect/src/react/components/link.tsx
@@ -3,16 +3,26 @@ import { Text, Box, BoxProps } from '@blockstack/ui';
 
 interface LinkProps extends BoxProps {
   _hover?: BoxProps;
+  onClick: () => void;
 }
+
+export const buildEnterKeyEvent = (onClick: () => void) => {
+  return (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' && onClick) {
+      onClick();
+    }
+  };
+};
 
 export const Link: React.FC<LinkProps> = ({
   _hover = {},
   children,
   fontSize = '12px',
   textStyle = 'caption.medium',
+  onClick,
   ...rest
 }) => (
-  <Box {...rest}>
+  <Box {...rest} onKeyPress={buildEnterKeyEvent(onClick)} onClick={onClick} tabIndex={0}>
     <Text
       _hover={{ textDecoration: 'underline', cursor: 'pointer', ..._hover }}
       fontSize={fontSize}

--- a/packages/connect/src/react/components/powered-by.tsx
+++ b/packages/connect/src/react/components/powered-by.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import { Flex, PseudoBox, Box } from '@blockstack/ui';
 import { BlockstackMini } from './vector';
+import { buildEnterKeyEvent } from './link';
+
+const onClick = () => {
+  typeof window !== 'undefined' && window.open('https://blockstack.org', '_blank');
+};
 
 export const PoweredBy: React.FC = () => (
   <Flex fontSize={['12px', '14px']} justifyContent="center" color="ink.600" textAlign="center" width="100%" my="loose">
     <PseudoBox
       textAlign="center"
-      onClick={() => typeof window !== 'undefined' && window.open('https://blockstack.org', '_blank')}
+      onClick={onClick}
+      onKeyPress={buildEnterKeyEvent(onClick)}
       textStyle="caption"
       display="flex"
       alignSelf="flex-end"
+      tabIndex={0}
       _hover={{
         cursor: 'pointer',
       }}

--- a/packages/connect/src/react/index.ts
+++ b/packages/connect/src/react/index.ts
@@ -3,3 +3,4 @@ export { useConnect } from './hooks/use-connect';
 export * from './components/screen';
 export * from './components/powered-by';
 export { Title } from './components/typography';
+export { Link } from './components/link';


### PR DESCRIPTION
Small improvements to connect that improve accessiblity.

- Makes `<Link>` tab-able, and calls `onClick` when "Enter" key is pressed while focused
- Uses same logic for above in `PoweredBy`
  - It seems like there are lots of places where we recreate `<Link>`-type functionality. Those all need these new features, too. This is a good area for investigation and refactoring

I think it's safe to say that this is still not totally accessible, but the tab-ability is greatly improved.