### PR TITLE
Link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This monorepo contains a few key packages that the User Experience team at Blockstack maintains:
 
-- [app]('./packages/app'): An application for authenticating into Blockstack apps. Available as a web app and a browser extension.
-- [connect]('./packages/connect'): A developer tool for building excellent user experiences in Blockstack apps
-- [ui]('./packages/ui'): Blockstack's internal design system and React component library
-- [keychain]('./packages/keychain'): A library for Blockstack identity management
+- [app](./packages/app): An application for authenticating into Blockstack apps. Available as a web app and a browser extension.
+- [connect](./packages/connect): A developer tool for building excellent user experiences in Blockstack apps
+- [ui](./packages/ui): Blockstack's internal design system and React component library
+- [keychain](./packages/keychain): A library for Blockstack identity management
 
 ## Development environment setup
 


### PR DESCRIPTION
fix: removed quotes on markdown links, causing 404 errors