### PR TITLE
build: lib versions, update typings on connect

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/connect",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "bundlesize": [
     {
       "path": "./dist/**/*.js",
@@ -81,6 +81,6 @@
     "typecheck": "tsc --noEmit"
   },
   "sideEffects": false,
-  "typings": "dist/index.d.ts",
+  "typings": "dist/connect/src/index.d.ts",
   "unpkg": "dist/bundle.js"
 }

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/keychain",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A package for managing Blockstack keychains",
   "main": "./dist/index.js",
   "umd:main": "./dist/keychain.umd.production.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/ui",
   "description": "Blockstack UI components built using React and styled-components with styled-system.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.org/)",
   "bundlesize": [
     {


### PR DESCRIPTION
Somehow our versions here got out of sync with published npm versions, this should fix it.