### PR TITLE
fix: size units for svg component

### DIFF
--- a/packages/ui/src/svg/index.tsx
+++ b/packages/ui/src/svg/index.tsx
@@ -9,8 +9,8 @@ interface SVGProps {
 type SVG = SVGProps & BoxProps;
 
 export const Svg = ({
-  width = 24,
-  height = 24,
+  width = '24px',
+  height = 'auto',
   viewBox = '0 0 24 24',
   fill = 'none',
   ...rest


### PR DESCRIPTION
### What this does
This fixes a small bug in our svg component where the size was using a larger size than what we had intended as the default, and sets height to auto to allow icons to auto scale.