### PR TITLE
feat: add fn to generate 24-word phrases

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,6 +26,7 @@
     "@blockstack/connect": "^2.7.3",
     "@blockstack/keychain": "^0.4.0",
     "@blockstack/prettier-config": "^0.0.5",
+    "@blockstack/stacks-transactions": "^0.4.6",
     "@blockstack/stats": "^0.7.0",
     "@blockstack/ui": "^1.6.1",
     "@rehooks/document-title": "^1.0.1",

--- a/packages/app/src/store/wallet/actions.ts
+++ b/packages/app/src/store/wallet/actions.ts
@@ -1,6 +1,7 @@
 import { ThunkAction } from 'redux-thunk';
 import { Wallet } from '@blockstack/keychain';
 import { WalletActions, RESTORE_WALLET, IS_RESTORING_WALLET, GENERATE_WALLET, SIGN_OUT } from './types';
+import { ChainID } from '@blockstack/stacks-transactions';
 
 export function didRestoreWallet(wallet: Wallet): WalletActions {
   return {
@@ -31,7 +32,7 @@ export function doSignOut(): WalletActions {
 export function doStoreSeed(secretKey: string, password: string): ThunkAction<Promise<Wallet>, {}, {}, WalletActions> {
   return async dispatch => {
     dispatch(isRestoringWallet());
-    const wallet = await Wallet.restore(password, secretKey);
+    const wallet = await Wallet.restore(password, secretKey, ChainID.Testnet);
     dispatch(didRestoreWallet(wallet));
     return wallet;
   };
@@ -40,7 +41,7 @@ export function doStoreSeed(secretKey: string, password: string): ThunkAction<Pr
 export function doGenerateWallet(password: string): ThunkAction<Promise<Wallet>, {}, {}, WalletActions> {
   return async dispatch => {
     dispatch(isRestoringWallet());
-    const wallet = await Wallet.generate(password);
+    const wallet = await Wallet.generate(password, ChainID.Testnet);
     dispatch(didGenerateWallet(wallet));
     return wallet;
   };

--- a/packages/app/tests/integration/authentication.test.ts
+++ b/packages/app/tests/integration/authentication.test.ts
@@ -6,6 +6,7 @@ import { DemoPage } from './page-objects/demo.page';
 import { randomString, Browser } from './utils';
 import { AuthPage } from './page-objects/auth.page';
 import { Wallet } from '@blockstack/keychain';
+import { ChainID } from '@blockstack/stacks-transactions';
 
 const SECRET_KEY = 'invite helmet save lion indicate chuckle world pride afford hard broom draft';
 const WRONG_SECRET_KEY = 'invite helmet save lion indicate chuckle world pride afford hard broom yup';
@@ -234,7 +235,7 @@ describe.each(environments)('auth scenarios - %o %o', (browserType, deviceType) 
     const authPage = auth.page;
 
     const seed = generateMnemonic();
-    const wallet = await Wallet.restore('password', seed);
+    const wallet = await Wallet.restore('password', seed, ChainID.Testnet);
     await auth.loginWithPreviousSecretKey(seed);
     await authPage.click(auth.$firstAccount);
 

--- a/packages/keychain/jest.config.js
+++ b/packages/keychain/jest.config.js
@@ -4,7 +4,6 @@ module.exports = {
   coverageDirectory: './coverage/',
   collectCoverage: true,
   globals: {
-    fetchMock: true,
     'ts-jest': {
       diagnostics: {
         ignoreCodes: ['TS151001'],

--- a/packages/keychain/jest.config.js
+++ b/packages/keychain/jest.config.js
@@ -4,16 +4,13 @@ module.exports = {
   coverageDirectory: './coverage/',
   collectCoverage: true,
   globals: {
+    fetchMock: true,
     'ts-jest': {
       diagnostics: {
-        ignoreCodes: ['TS151001']
-      }
-    }
+        ignoreCodes: ['TS151001'],
+      },
+    },
   },
-  setupFiles: [
-    './tests/global-setup.ts'
-  ],
-  setupFilesAfterEnv: [
-    './tests/setup.ts'
-  ]
+  setupFiles: ['./tests/global-setup.ts'],
+  setupFilesAfterEnv: ['./tests/setup.ts'],
 };

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -35,7 +35,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@blockstack/prettier-config": "^0.0.6",
     "@types/jest": "^25.2.1",
-    "@types/node": "^13.11.1",
+    "@types/node": "^13.13.10",
     "@types/triplesec": "^3.0.0",
     "codecov": "^3.5.0",
     "cross-env": "^6.0.3",
@@ -46,14 +46,16 @@
     "jest-fetch-mock": "^2.1.2",
     "npm-run-all": "^4.1.5",
     "shx": "^0.3.2",
-    "ts-jest": "^24.0.2",
+    "ts-jest": "^24.3.0",
     "tsdx": "^0.11.0",
     "typescript": "^3.7.3"
   },
   "dependencies": {
+    "@blockstack/stacks-transactions": "^0.4.6",
     "bip39": "^3.0.2",
     "bitcoinjs-lib": "^5.1.6",
     "blockstack": "21.0.0-alpha.2",
+    "c32check": "^1.0.1",
     "jsontokens": "^3.0.0",
     "prettier": "^2.0.5",
     "triplesec": "^3.0.27"

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -32,6 +32,7 @@
   "typings": "dist/index.d.ts",
   "prettier": "@blockstack/prettier-config",
   "devDependencies": {
+    "@babel/compat-data": "^7.10.1",
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@blockstack/prettier-config": "^0.0.6",
     "@types/jest": "^25.2.1",

--- a/packages/keychain/src/address-derivation/index.ts
+++ b/packages/keychain/src/address-derivation/index.ts
@@ -1,0 +1,28 @@
+import { ChainID, getAddressFromPrivateKey } from '@blockstack/stacks-transactions';
+import { BIP32Interface, ECPair } from 'bitcoinjs-lib';
+import { ecPairToHexString } from 'blockstack';
+
+export const derivationPaths = {
+  [ChainID.Mainnet]: `m/44'/5757'/0'/0/0`,
+  [ChainID.Testnet]: `m/44'/1'/0'/0/0`,
+};
+
+export function getDerivationPath(chain: ChainID) {
+  return derivationPaths[chain];
+}
+
+export function deriveStxAddressChain(chain: ChainID) {
+  return (rootNode: BIP32Interface) => {
+    const childKey = rootNode.derivePath(getDerivationPath(chain));
+    if (!childKey.privateKey) {
+      throw new Error('Unable to derive private key from `rootNode`, bip32 master keychain');
+    }
+    const ecPair = ECPair.fromPrivateKey(childKey.privateKey);
+    const privateKey = ecPairToHexString(ecPair);
+    return {
+      childKey,
+      address: getAddressFromPrivateKey(privateKey),
+      privateKey,
+    };
+  };
+}

--- a/packages/keychain/src/index.ts
+++ b/packages/keychain/src/index.ts
@@ -1,5 +1,7 @@
 import Wallet from './wallet';
 export * from './utils';
+export * from './mnemonic';
+export * from './address-derivation';
 export { default as Wallet } from './wallet';
 export { decrypt } from './encryption/decrypt';
 export { encrypt } from './encryption/encrypt';

--- a/packages/keychain/src/mnemonic/index.ts
+++ b/packages/keychain/src/mnemonic/index.ts
@@ -6,7 +6,17 @@ import { encrypt } from '../encryption/encrypt';
 
 export type AllowedKeyEntropyBits = 128 | 256;
 
-export async function generateMnemonicRootKeychain(
+export async function generateMnemonicRootKeychain(entropy: AllowedKeyEntropyBits) {
+  const plaintextMnemonic = generateBip39Mnemonic(entropy, randomBytes);
+  const seedBuffer = await mnemonicToSeed(plaintextMnemonic);
+  const rootNode = bip32.fromSeed(seedBuffer);
+  return {
+    rootNode,
+    plaintextMnemonic,
+  };
+}
+
+export async function generateEncryptedMnemonicRootKeychain(
   password: string,
   entropy: AllowedKeyEntropyBits
 ) {

--- a/packages/keychain/src/mnemonic/index.ts
+++ b/packages/keychain/src/mnemonic/index.ts
@@ -1,0 +1,34 @@
+import { generateMnemonic as generateBip39Mnemonic, mnemonicToSeed } from 'bip39';
+import { randomBytes } from 'blockstack/lib/encryption/cryptoRandom';
+import { bip32 } from 'bitcoinjs-lib';
+
+import { encrypt } from '../encryption/encrypt';
+
+export type AllowedKeyEntropyBits = 128 | 256;
+
+export async function generateMnemonicRootKeychain(
+  password: string,
+  entropy: AllowedKeyEntropyBits
+) {
+  const plaintextMnemonic = generateBip39Mnemonic(entropy, randomBytes);
+  const seedBuffer = await mnemonicToSeed(plaintextMnemonic);
+  const rootNode = bip32.fromSeed(seedBuffer);
+  const ciphertextBuffer = await encrypt(plaintextMnemonic, password);
+  const encryptedMnemonicPhrase = ciphertextBuffer.toString('hex');
+  return {
+    rootNode,
+    encryptedMnemonicPhrase,
+  };
+}
+
+export async function deriveRootKeychainFromMnemonic(plaintextMnemonic: string, password: string) {
+  const encryptedMnemonic = await encrypt(plaintextMnemonic, password);
+  const encryptedMnemonicHex = encryptedMnemonic.toString('hex');
+  const seedBuffer = await mnemonicToSeed(plaintextMnemonic);
+  const rootNode = bip32.fromSeed(seedBuffer);
+  return {
+    rootNode,
+    encryptedMnemonic,
+    encryptedMnemonicHex,
+  };
+}

--- a/packages/keychain/src/utils/index.ts
+++ b/packages/keychain/src/utils/index.ts
@@ -8,19 +8,20 @@ import { Subdomains, registrars } from '../profiles';
 
 const IDENTITY_KEYCHAIN = 888;
 const BLOCKSTACK_ON_BITCOIN = 0;
-export function getIdentityPrivateKeychain(masterKeychain: BIP32Interface) {
-  return masterKeychain.deriveHardened(IDENTITY_KEYCHAIN).deriveHardened(BLOCKSTACK_ON_BITCOIN);
+
+export function getIdentityPrivateKeychain(rootNode: BIP32Interface) {
+  return rootNode.deriveHardened(IDENTITY_KEYCHAIN).deriveHardened(BLOCKSTACK_ON_BITCOIN);
 }
 
 const EXTERNAL_ADDRESS = 'EXTERNAL_ADDRESS';
 const CHANGE_ADDRESS = 'CHANGE_ADDRESS';
 
-export function getBitcoinPrivateKeychain(masterKeychain: BIP32Interface) {
+export function getBitcoinPrivateKeychain(rootNode: BIP32Interface) {
   const BIP_44_PURPOSE = 44;
   const BITCOIN_COIN_TYPE = 0;
   const ACCOUNT_INDEX = 0;
 
-  return masterKeychain
+  return rootNode
     .deriveHardened(BIP_44_PURPOSE)
     .deriveHardened(BITCOIN_COIN_TYPE)
     .deriveHardened(ACCOUNT_INDEX);
@@ -91,11 +92,11 @@ export async function deriveIdentityKeyPair(
 }
 
 export async function getBlockchainIdentities(
-  masterKeychain: BIP32Interface,
+  rootNode: BIP32Interface,
   identitiesToGenerate: number
 ) {
-  const identityPrivateKeychainNode = getIdentityPrivateKeychain(masterKeychain);
-  const bitcoinPrivateKeychainNode = getBitcoinPrivateKeychain(masterKeychain);
+  const identityPrivateKeychainNode = getIdentityPrivateKeychain(rootNode);
+  const bitcoinPrivateKeychainNode = getBitcoinPrivateKeychain(rootNode);
 
   const identityPublicKeychainNode = identityPrivateKeychainNode.neutered();
   const identityPublicKeychain = identityPublicKeychainNode.toBase58();
@@ -112,7 +113,7 @@ export async function getBlockchainIdentities(
   // We pre-generate a number of identity addresses so that we
   // don't have to prompt the user for the password on each new profile
   for (let addressIndex = 0; addressIndex < identitiesToGenerate; addressIndex++) {
-    const identity = await makeIdentity(masterKeychain, addressIndex);
+    const identity = await makeIdentity(rootNode, addressIndex);
     identities.push(identity);
     identityKeypairs.push(identity.keyPair);
     identityAddresses.push(identity.address);
@@ -128,8 +129,8 @@ export async function getBlockchainIdentities(
   };
 }
 
-export const makeIdentity = async (masterKeychain: BIP32Interface, index: number) => {
-  const identityPrivateKeychainNode = getIdentityPrivateKeychain(masterKeychain);
+export const makeIdentity = async (rootNode: BIP32Interface, index: number) => {
+  const identityPrivateKeychainNode = getIdentityPrivateKeychain(rootNode);
   const identityOwnerAddressNode = await getIdentityOwnerAddressNode(
     identityPrivateKeychainNode,
     index

--- a/packages/keychain/src/wallet/index.ts
+++ b/packages/keychain/src/wallet/index.ts
@@ -21,7 +21,7 @@ import { GaiaHubConfig, uploadToGaiaHub } from 'blockstack/lib/storage/hub';
 import { makeReadOnlyGaiaConfig, DEFAULT_GAIA_HUB } from '../utils/gaia';
 import {
   AllowedKeyEntropyBits,
-  generateMnemonicRootKeychain,
+  generateEncryptedMnemonicRootKeychain,
   deriveRootKeychainFromMnemonic,
 } from '../mnemonic';
 import { deriveStxAddressChain } from '../address-derivation';
@@ -104,7 +104,7 @@ export class Wallet {
 
   static generateFactory(bitsEntropy: AllowedKeyEntropyBits) {
     return async (password: string, chain: ChainID) => {
-      const { rootNode, encryptedMnemonicPhrase } = await generateMnemonicRootKeychain(
+      const { rootNode, encryptedMnemonicPhrase } = await generateEncryptedMnemonicRootKeychain(
         password,
         bitsEntropy
       );
@@ -116,12 +116,12 @@ export class Wallet {
     };
   }
 
-  static async generate(password: string) {
-    return await this.generateFactory(128)(password, ChainID.Testnet);
+  static async generate(password: string, chain: ChainID) {
+    return await this.generateFactory(128)(password, chain);
   }
 
-  static async generateStrong(password: string) {
-    return await this.generateFactory(256)(password, ChainID.Testnet);
+  static async generateStrong(password: string, chain: ChainID) {
+    return await this.generateFactory(256)(password, chain);
   }
 
   static async restore(password: string, seedPhrase: string, chain: ChainID) {
@@ -142,7 +142,7 @@ export class Wallet {
   static async createAccount({
     encryptedBackupPhrase,
     rootNode,
-    chain = ChainID.Testnet,
+    chain,
     identitiesToGenerate = 1,
   }: {
     encryptedBackupPhrase: string;

--- a/packages/keychain/tests/address-derivation/address-derivation.test.ts
+++ b/packages/keychain/tests/address-derivation/address-derivation.test.ts
@@ -1,0 +1,28 @@
+import { ChainID } from '@blockstack/stacks-transactions';
+
+import { deriveStxAddressChain } from '../../src/address-derivation';
+import { deriveRootKeychainFromMnemonic } from '../../src/mnemonic';
+
+const phrase =
+  'humble ramp winner eagle stumble follow gravity roast receive quote buddy start demise issue egg jewel return hurdle ball blind pulse physical uncle room';
+const password = '41wU*1pM$zlA';
+
+describe('deriveStxAddressChain()', () => {
+  test('it returns mainnet derived keys', async () => {
+    const deriveStxMainnetAddressChain = deriveStxAddressChain(ChainID.Mainnet);
+    const { rootNode } = await deriveRootKeychainFromMnemonic(phrase, password);
+    const result = deriveStxMainnetAddressChain(rootNode);
+    expect(result.privateKey).toEqual(
+      '2d088f14028baf5d0b4a8df8ec9faeb8f6f011f8f26d70c8d8abc04a204e3beb01'
+    );
+  });
+
+  test('it returns testnet derived keys', async () => {
+    const deriveStxTestnetAddressChain = deriveStxAddressChain(ChainID.Testnet);
+    const { rootNode } = await deriveRootKeychainFromMnemonic(phrase, password);
+    const result = deriveStxTestnetAddressChain(rootNode);
+    expect(result.privateKey).toEqual(
+      '4cf240ef1e9b467c64b196b6ff3d24d9709f287f667939056fbcfc54e4a1642901'
+    );
+  });
+});

--- a/packages/keychain/tests/global-setup.ts
+++ b/packages/keychain/tests/global-setup.ts
@@ -1,5 +1,5 @@
 import { GlobalWithFetchMock } from 'jest-fetch-mock';
 
-const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
+const customGlobal: GlobalWithFetchMock = (global as any) as GlobalWithFetchMock;
 customGlobal.fetch = require('jest-fetch-mock');
 customGlobal.fetchMock = customGlobal.fetch;

--- a/packages/keychain/tests/helpers.ts
+++ b/packages/keychain/tests/helpers.ts
@@ -18,7 +18,7 @@ export const getIdentity = async (seed: string = defaultSeed) => {
 };
 
 export const getNewIdentity = async () => {
-  const wallet = await Wallet.generate('password');
+  const wallet = await Wallet.generate('password', ChainID.Testnet);
   return wallet.identities[0];
 };
 

--- a/packages/keychain/tests/helpers.ts
+++ b/packages/keychain/tests/helpers.ts
@@ -1,4 +1,5 @@
 import Wallet from '../src/wallet';
+import { ChainID } from '@blockstack/stacks-transactions';
 
 const defaultSeed =
   'sound idle panel often situate develop unit text design antenna ' +
@@ -6,7 +7,7 @@ const defaultSeed =
   'update opinion media';
 
 export const getWallet = async (seed: string = defaultSeed) => {
-  const wallet = await Wallet.restore('password', seed);
+  const wallet = await Wallet.restore('password', seed, ChainID.Mainnet);
   return wallet;
 };
 

--- a/packages/keychain/tests/mnemonic/mnemonic.test.ts
+++ b/packages/keychain/tests/mnemonic/mnemonic.test.ts
@@ -1,11 +1,14 @@
-import { generateMnemonicRootKeychain, deriveRootKeychainFromMnemonic } from '../../src/mnemonic';
+import {
+  generateEncryptedMnemonicRootKeychain,
+  deriveRootKeychainFromMnemonic,
+} from '../../src/mnemonic';
 import { decrypt } from '../../src/encryption/decrypt';
 
-describe('generateMnemonicKeychain()', () => {
+describe('generateEncryptedMnemonicRootKeychain()', () => {
   test('both 12 and 24 word phrases are returned', async () => {
     const password = '427706da374f435f959283de93652375';
-    const twelveWorder = await generateMnemonicRootKeychain(password, 128);
-    const twentyFourWorder = await generateMnemonicRootKeychain(password, 256);
+    const twelveWorder = await generateEncryptedMnemonicRootKeychain(password, 128);
+    const twentyFourWorder = await generateEncryptedMnemonicRootKeychain(password, 256);
 
     const twelveWordDecrypted = await decrypt(twelveWorder.encryptedMnemonicPhrase, password);
     const twentyFourWordDecrypted = await decrypt(

--- a/packages/keychain/tests/mnemonic/mnemonic.test.ts
+++ b/packages/keychain/tests/mnemonic/mnemonic.test.ts
@@ -1,0 +1,32 @@
+import { generateMnemonicRootKeychain, deriveRootKeychainFromMnemonic } from '../../src/mnemonic';
+import { decrypt } from '../../src/encryption/decrypt';
+
+describe('generateMnemonicKeychain()', () => {
+  test('both 12 and 24 word phrases are returned', async () => {
+    const password = '427706da374f435f959283de93652375';
+    const twelveWorder = await generateMnemonicRootKeychain(password, 128);
+    const twentyFourWorder = await generateMnemonicRootKeychain(password, 256);
+
+    const twelveWordDecrypted = await decrypt(twelveWorder.encryptedMnemonicPhrase, password);
+    const twentyFourWordDecrypted = await decrypt(
+      twentyFourWorder.encryptedMnemonicPhrase,
+      password
+    );
+
+    expect(twelveWordDecrypted.split(' ').length).toEqual(12);
+    expect(twentyFourWordDecrypted.split(' ').length).toEqual(24);
+  });
+});
+
+describe('restoreKeychainFromMnemonic()', () => {
+  test('it restores keychain from a seed', async () => {
+    const password = '6bd8106ff1704446ba11e31ff3b0ce8b';
+    const phrase =
+      'eternal army wreck noodle click shock include orchard jungle only middle forget idle pulse give empower iron curtain silent blush blossom chef animal sphere';
+
+    const { rootNode } = await deriveRootKeychainFromMnemonic(phrase, password);
+    expect(rootNode.privateKey?.toString('hex')).toEqual(
+      'a1ce135a6a63ba49c9d118bbc5b9f501d6a36feb45f810576781955b9a57d3b2'
+    );
+  });
+});

--- a/packages/keychain/tests/setup.ts
+++ b/packages/keychain/tests/setup.ts
@@ -4,7 +4,7 @@ import { config as bskConfig } from 'blockstack';
 
 bskConfig.logLevel = 'none';
 
-const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
+const customGlobal: GlobalWithFetchMock = (global as any) as GlobalWithFetchMock;
 customGlobal.fetch = require('jest-fetch-mock');
 customGlobal.fetchMock = customGlobal.fetch;
 

--- a/packages/keychain/tests/utils.test.ts
+++ b/packages/keychain/tests/utils.test.ts
@@ -1,3 +1,4 @@
+import './setup';
 import {
   IdentityNameValidityError,
   validateSubdomainFormat,
@@ -37,12 +38,12 @@ describe(validateSubdomainFormat.name, () => {
   });
 
   it('returns error state when using sneaky homoglyphs', () => {
-    const legitIndentity = 'kyranjamie';
+    const legitIdentity = 'kyranjamie';
     const homoglyph = 'kyrаnjamie';
     // eslint-disable-next-line
     // @ts-ignore
-    expect(legitIndentity === homoglyph).toEqual(false);
-    const shouldPassResult = validateSubdomainFormat(legitIndentity);
+    expect(legitIdentity === homoglyph).toEqual(false);
+    const shouldPassResult = validateSubdomainFormat(legitIdentity);
     expect(shouldPassResult).toBeNull();
 
     const shouldFailResult = validateSubdomainFormat(homoglyph);

--- a/packages/keychain/tests/utils.test.ts
+++ b/packages/keychain/tests/utils.test.ts
@@ -10,6 +10,7 @@ import { Subdomains, registrars, Wallet, decrypt } from '../src';
 import { mnemonicToSeed } from 'bip39';
 import { bip32 } from 'bitcoinjs-lib';
 import { profileResponse } from './helpers';
+import { ChainID } from '@blockstack/stacks-transactions';
 
 describe(validateSubdomainFormat.name, () => {
   it('returns error state when string less than 8 characters', () => {
@@ -90,7 +91,7 @@ describe(validateSubdomain.name, () => {
 });
 
 test('recursively makes identities', async () => {
-  const wallet = await Wallet.generate('password');
+  const wallet = await Wallet.generate('password', ChainID.Testnet);
   const plainTextBuffer = await decrypt(
     Buffer.from(wallet.encryptedBackupPhrase, 'hex'),
     'password'

--- a/packages/keychain/tests/wallet.test.ts
+++ b/packages/keychain/tests/wallet.test.ts
@@ -50,7 +50,7 @@ describe('Restoring a wallet', () => {
 
   test('generates and restores the same wallet', async () => {
     const password = 'password';
-    const generated = await Wallet.generate(password);
+    const generated = await Wallet.generate(password, ChainID.Testnet);
 
     const encryptedBackupPhrase = generated.encryptedBackupPhrase;
 
@@ -65,7 +65,7 @@ describe('Restoring a wallet', () => {
 
   test('generates 24-word seed phrase', async () => {
     const pass = 'password';
-    const wallet = await Wallet.generateStrong(pass);
+    const wallet = await Wallet.generateStrong(pass, ChainID.Testnet);
     const encryptedBackupPhrase = wallet.encryptedBackupPhrase;
     const plainTextBuffer = await decrypt(Buffer.from(encryptedBackupPhrase, 'hex'), pass);
     const backupPhrase = plainTextBuffer.toString();
@@ -73,7 +73,7 @@ describe('Restoring a wallet', () => {
   });
 
   test('generates a config private key', async () => {
-    const wallet = await Wallet.generate('password');
+    const wallet = await Wallet.generate('password', ChainID.Testnet);
     expect(wallet.configPrivateKey).not.toBeFalsy();
     const node = ECPair.fromPrivateKey(Buffer.from(wallet.configPrivateKey, 'hex'));
     expect(node.privateKey).not.toBeFalsy();
@@ -90,7 +90,7 @@ test('returns null if no config in gaia', async () => {
       })
     )
     .once('', { status: 404 });
-  const wallet = await Wallet.generate('password');
+  const wallet = await Wallet.generate('password', ChainID.Testnet);
   const hubConfig = await wallet.createGaiaConfig('https://gaia.blockstack.org');
   const config = await wallet.fetchConfig(hubConfig);
   expect(config).toBeFalsy();
@@ -117,7 +117,7 @@ test('returns config if present', async () => {
     ],
   };
 
-  const wallet = await Wallet.generate('password');
+  const wallet = await Wallet.generate('password', ChainID.Testnet);
   const publicKey = getPublicKeyFromPrivate(wallet.configPrivateKey);
   const encrypted = await encryptContent(JSON.stringify(stubConfig), { publicKey });
 
@@ -155,7 +155,7 @@ test('creates a config', async () => {
     )
     .once('', { status: 404 })
     .once(JSON.stringify({ publicUrl: 'asdf' }));
-  const wallet = await Wallet.generate('password');
+  const wallet = await Wallet.generate('password', ChainID.Testnet);
   const hubConfig = await wallet.createGaiaConfig('https://gaia.blockstack.org');
   const config = await wallet.getOrCreateConfig(hubConfig);
   expect(Object.keys(config.identities[0].apps).length).toEqual(0);
@@ -177,7 +177,7 @@ test('updates wallet config', async () => {
     .once(JSON.stringify({ publicUrl: 'asdf' }))
     .once(JSON.stringify({ publicUrl: 'asdf' }));
 
-  const wallet = await Wallet.generate('password');
+  const wallet = await Wallet.generate('password', ChainID.Testnet);
   const gaiaConfig = await wallet.createGaiaConfig('https://gaia.blockstack.org');
   await wallet.getOrCreateConfig(gaiaConfig);
   const app: ConfigApp = {
@@ -214,7 +214,7 @@ test('updates config for reusing id warning', async () => {
     .once(JSON.stringify({ publicUrl: 'asdf' }))
     .once(JSON.stringify({ publicUrl: 'asdf' }));
 
-  const wallet = await Wallet.generate('password');
+  const wallet = await Wallet.generate('password', ChainID.Testnet);
   const gaiaConfig = await wallet.createGaiaConfig('https://gaia.blockstack.org');
   await wallet.getOrCreateConfig(gaiaConfig);
   expect(wallet.walletConfig?.hideWarningForReusingIdentity).toBeFalsy();
@@ -230,7 +230,7 @@ test('updates config for reusing id warning', async () => {
 });
 
 test('restoreIdentities', async () => {
-  const wallet = await Wallet.generate('password');
+  const wallet = await Wallet.generate('password', ChainID.Testnet);
 
   const stubConfig: WalletConfig = {
     identities: [

--- a/packages/keychain/tests/wallet.test.ts
+++ b/packages/keychain/tests/wallet.test.ts
@@ -5,6 +5,7 @@ import { ECPair, bip32 } from 'bitcoinjs-lib';
 import { decryptContent, encryptContent, getPublicKeyFromPrivate } from 'blockstack';
 import { DEFAULT_GAIA_HUB } from '../src/utils/gaia';
 import { mnemonicToSeed } from 'bip39';
+import { ChainID } from '@blockstack/stacks-transactions';
 
 describe('Restoring a wallet', () => {
   test('restores an existing wallet and keychain', async () => {
@@ -35,7 +36,7 @@ describe('Restoring a wallet', () => {
       },
     ];
 
-    const wallet = await Wallet.restore(password, backupPhrase);
+    const wallet = await Wallet.restore(password, backupPhrase, ChainID.Mainnet);
     expect(wallet.bitcoinPublicKeychain).toEqual(bitcoinPublicKeychain);
     expect(wallet.identityPublicKeychain).toEqual(identityPublicKeychain);
     expect(wallet.firstBitcoinAddress).toEqual(firstBitcoinAddress);
@@ -57,9 +58,18 @@ describe('Restoring a wallet', () => {
 
     const backupPhrase = plainTextBuffer.toString();
 
-    const restored = await Wallet.restore(password, backupPhrase);
+    const restored = await Wallet.restore(password, backupPhrase, ChainID.Mainnet);
 
     expect(restored.identityPublicKeychain).toEqual(generated.identityPublicKeychain);
+  });
+
+  test('generates 24-word seed phrase', async () => {
+    const pass = 'password';
+    const wallet = await Wallet.generateStrong(pass);
+    const encryptedBackupPhrase = wallet.encryptedBackupPhrase;
+    const plainTextBuffer = await decrypt(Buffer.from(encryptedBackupPhrase, 'hex'), pass);
+    const backupPhrase = plainTextBuffer.toString();
+    expect(backupPhrase.split(' ').length).toEqual(24);
   });
 
   test('generates a config private key', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,6 +1616,27 @@
   resolved "https://registry.yarnpkg.com/@blockstack/prettier-config/-/prettier-config-0.0.5.tgz#871bd2a38b5bc9aabb1cefeeba6199cc64098957"
   integrity sha512-A+wfdVwD1Sxd/D3PPJI67Evo7q2fp15hCOFLB5jmzcS1MdN8BQdFm6j51Sti8xLN4qHmuYkicbFBUluGx2h63g==
 
+"@blockstack/stacks-transactions@^0.4.6":
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/@blockstack/stacks-transactions/-/stacks-transactions-0.4.6.tgz#b774250fbaadbadf42313a82fbd628b1728cd6ed"
+  integrity sha512-3Hb+v0ZmG5bVZHasfM9KzlwK+2e5r6oKsKk0eRgavLb5bBMQy/cw0YYoUWmt+ipNqDP5ssZgoOA1KKRhoSWvXg==
+  dependencies:
+    "@types/bn.js" "^4.11.6"
+    "@types/elliptic" "^6.4.12"
+    "@types/lodash" "^4.14.149"
+    "@types/randombytes" "^2.0.0"
+    "@types/ripemd160" "^2.0.0"
+    "@types/sha.js" "^2.4.0"
+    bn.js "^4.11.8"
+    c32check "^1.0.1"
+    cross-fetch "^3.0.4"
+    elliptic "^6.5.2"
+    lodash "^4.17.15"
+    randombytes "^2.1.0"
+    ripemd160 "^2.0.2"
+    sha.js "^2.4.11"
+    smart-buffer "^4.1.0"
+
 "@blockstack/stats@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@blockstack/stats/-/stats-0.7.0.tgz#be39d3e76c2a16c1cd1283aa702d1e20b5e04645"
@@ -3596,7 +3617,7 @@
   dependencies:
     "@types/color-convert" "*"
 
-"@types/elliptic@^6.4.10", "@types/elliptic@^6.4.9":
+"@types/elliptic@^6.4.10", "@types/elliptic@^6.4.12", "@types/elliptic@^6.4.9":
   version "6.4.12"
   resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.12.tgz#e8add831f9cc9a88d9d84b3733ff669b68eaa124"
   integrity sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==
@@ -3744,6 +3765,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.149":
+  version "4.14.155"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
+  integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
+
 "@types/mime-types@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
@@ -3778,6 +3804,11 @@
   version "12.12.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.29.tgz#46275f028b4e463b9ac5fefc1d08bc66cc193f25"
   integrity sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==
+
+"@types/node@^13.13.10":
+  version "13.13.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.11.tgz#f8d2acb51f793bd5f4b07d9926bb5ce1dfb7a23e"
+  integrity sha512-FX7mIFKfnGCfq10DGWNhfCNxhACEeqH5uulT6wRRA1KEt7zgLe0HdrAd9/QQkObDqp2Z0KEV3OAmNgs0lTx5tQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -3891,10 +3922,24 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/ripemd160@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/ripemd160/-/ripemd160-2.0.0.tgz#d33e49cf66edf4668828030d4aa80116bbf8ae81"
+  integrity sha512-LD6AO/+8cAa1ghXax9NG9iPDLPUEGB2WWPjd//04KYfXxTwHvlDEfL0NRjrM5z9XWBi6WbKw75Are0rDyn3PSA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/segment-analytics@^0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/segment-analytics/-/segment-analytics-0.0.32.tgz#63e27737a81f6bd0fbecd86207afb92d12d85cca"
   integrity sha512-p0SHnfHfZwemTeaISvu8WUXtw81A4AOU4GEr7B9S9jLx2iu/z/4aLT0flRJtHVusVAlMeJSdobn0uD/oR1sFEw==
+
+"@types/sha.js@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/sha.js/-/sha.js-2.4.0.tgz#bce682ef860b40f419d024fa08600c3b8d24bb01"
+  integrity sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/shelljs@^0.8.5":
   version "0.8.6"
@@ -5420,12 +5465,24 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-x@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-1.1.0.tgz#42d3d717474f9ea02207f6d1aa1f426913eeb7ac"
+  integrity sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w=
+
 base-x@^3.0.2:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
   integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
   dependencies:
     safe-buffer "^5.0.1"
+
+base58check@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base58check/-/base58check-2.0.0.tgz#8046652d14bc87f063bd16be94a39134d3b61173"
+  integrity sha1-gEZlLRS8h/BjvRa+lKORNNO2EXM=
+  dependencies:
+    bs58 "^3.0.0"
 
 base64-js@^1.0.2:
   version "1.3.1"
@@ -5866,6 +5923,13 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
+bs58@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-3.1.0.tgz#d4c26388bf4804cac714141b1945aa47e5eb248e"
+  integrity sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=
+  dependencies:
+    base-x "^1.1.0"
+
 bs58@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
@@ -6008,6 +6072,14 @@ bytes@3.1.0, bytes@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
+c32check@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/c32check/-/c32check-1.0.1.tgz#857dcd60de12f515d582dc70e85b9fb9666cbf32"
+  integrity sha512-0e1+39uLNLyRm9sNoPUCg38LOELUqiBDZXD9kpUUAFNBq21gY3VaNImp1rfznQOsqK27ArvQ2JaZmfokZznqHg==
+  dependencies:
+    base58check "^2.0.0"
+    ripemd160 "^2.0.1"
 
 cacache@^12.0.0, cacache@^12.0.2, cacache@^12.0.3:
   version "12.0.3"
@@ -7870,7 +7942,7 @@ electron-to-chromium@^1.3.322, electron-to-chromium@^1.3.341, electron-to-chromi
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.372.tgz#fb61b6dfe06f3278a384d084ebef75d463ec7580"
   integrity sha512-77a4jYC52OdisHM+Tne7dgWEvQT1FoNu/jYl279pP88ZtG4ZRIPyhQwAKxj6C2rzsyC1OwsOds9JlZtNncSz6g==
 
-elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.1:
+elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.1, elliptic@^6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
   integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
@@ -18383,7 +18455,7 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-jest@^24.0.2:
+ts-jest@^24.0.2, ts-jest@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.3.0.tgz#b97814e3eab359ea840a1ac112deae68aa440869"
   integrity sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==


### PR DESCRIPTION
This PR refactors the `Wallet` class in that it moves mnemonic generation/restore logic into separate functions, that `Wallet` now composes. These functions will be used in the Stacks Wallet.

Support has been added for 256bit 24-word mnemonic phrases.

Looking for feedback on the when & where is best, when generating a `Wallet`, to define which chain it belongs to. Currently I've added some hard coded chain (testnet) values. I'm leaning towards saying we should be explicit here, and not use a default value. (This will introduce breaking changes, though).

`Wallet` now has a new property, `stxAddressKeychain` which uses the correct derivation path. I don't fully understand the identity stuff, but I'm under the impression it's okay to have separate derived keys for address & identities? 

Using function currying for the `deriveStxAddressChain()` fn, so it can be used as follows:

```ts
const deriveMainnetChain = deriveStxAddressChain(ChainID.Mainnet);
const deriveTestnetChain = deriveStxAddressChain(ChainID.Testnet);
```

Reckon this creates a nice abstraction and can avoid having to repeat the network you're targetting, and also reduce error.