### PR TITLE
feat: add alternate button, closes #397

### DIFF
--- a/packages/test-app/components/app.tsx
+++ b/packages/test-app/components/app.tsx
@@ -94,8 +94,7 @@ export const App: React.FC = () => {
   };
 
   React.useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    handleRedirectAuth();
+    void handleRedirectAuth();
   }, []);
 
   const authOptions: AuthOptions = {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/ui",
   "description": "Blockstack UI components built using React and styled-components with styled-system.",
-  "version": "1.6.2",
+  "version": "2.6.2",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.org/)",
   "bundlesize": [
     {

--- a/packages/ui/src/button/index.tsx
+++ b/packages/ui/src/button/index.tsx
@@ -60,7 +60,7 @@ export const Button = forwardRef<Ref<HTMLDivElement>, ButtonProps>(
         fontWeight="medium"
         position="relative"
         data-active={isActive ? 'true' : undefined}
-        as={'button' || Comp}
+        as={Comp || 'button'}
         {...rest}
         {...styles}
         {...bind}
@@ -89,9 +89,9 @@ export const Button = forwardRef<Ref<HTMLDivElement>, ButtonProps>(
               )
             : children}
         </Box>
-        {mode === 'secondary' ? null : (
+        {mode === 'primary' ? (
           <HoverChange isDisabled={isDisabled || false} isHovered={hovered} />
-        )}
+        ) : null}
       </PseudoBox>
     );
   }

--- a/packages/ui/src/button/styles.tsx
+++ b/packages/ui/src/button/styles.tsx
@@ -19,13 +19,13 @@ const baseProps = {
 
 const sizes = {
   lg: {
-    height: 12,
+    minHeight: 12,
     minWidth: 9 * 14,
     fontSize: '14px !important',
     px: 5,
   },
   md: {
-    height: 10,
+    minHeight: 10,
     minWidth: 10,
     fontSize: '14px !important',
     px: 4,
@@ -109,6 +109,27 @@ const solidVariantProps = ({
         pointerEvents: 'none',
         cursor: 'not-allowed',
         color: 'blue.300',
+      },
+    },
+    alternate: {
+      bg: 'blue.100',
+      color: 'blue',
+      border: '1px solid',
+      borderColor: 'blue.300',
+      boxShadow: null,
+      _hover: {
+        cursor: 'pointer',
+        bg: 'blue.200',
+      },
+      _focus: {
+        borderColor: 'blue.300',
+        boxShadow: shadows.focus,
+      },
+      _disabled: {
+        bg: 'blue.200',
+        cursor: 'not-allowed',
+        color: 'white',
+        border: 'none',
       },
     },
   };

--- a/packages/ui/src/button/styles.tsx
+++ b/packages/ui/src/button/styles.tsx
@@ -92,26 +92,6 @@ const solidVariantProps = ({
       },
     },
     secondary: {
-      bg: 'white',
-      color: 'blue',
-      boxShadow: shadows['button.secondary'],
-      _hover: {
-        cursor: 'pointer',
-        bg: 'white',
-        boxShadow: shadows['button.secondary'],
-      },
-      _focus: {
-        borderColor: 'blue.300',
-        boxShadow: shadows.focus,
-      },
-      _disabled: {
-        bg: 'white',
-        pointerEvents: 'none',
-        cursor: 'not-allowed',
-        color: 'blue.300',
-      },
-    },
-    alternate: {
       bg: 'blue.100',
       color: 'blue',
       border: '1px solid',
@@ -130,6 +110,26 @@ const solidVariantProps = ({
         cursor: 'not-allowed',
         color: 'white',
         border: 'none',
+      },
+    },
+    tertiary: {
+      bg: 'white',
+      color: 'blue',
+      boxShadow: shadows['button.secondary'],
+      _hover: {
+        cursor: 'pointer',
+        bg: 'white',
+        boxShadow: shadows['button.secondary'],
+      },
+      _focus: {
+        borderColor: 'blue.300',
+        boxShadow: shadows.focus,
+      },
+      _disabled: {
+        bg: 'white',
+        pointerEvents: 'none',
+        cursor: 'not-allowed',
+        color: 'blue.300',
       },
     },
   };

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -17,12 +17,11 @@ export type ButtonVariants = 'outline' | 'unstyled' | 'link' | 'solid';
 /**
  * The mode of the button style to use.
  */
-export type ButtonModes = 'primary' | 'secondary';
+export type ButtonModes = 'primary' | 'secondary' | 'alternate';
 
-export interface CustomStyles {
-  primary: PseudoBoxProps;
-  secondary: PseudoBoxProps;
-}
+export type CustomStyles = {
+  [key in ButtonModes]: PseudoBoxProps;
+};
 
 interface ButtonPropsBase {
   size?: ButtonSizes;

--- a/packages/ui/src/button/types.ts
+++ b/packages/ui/src/button/types.ts
@@ -17,7 +17,7 @@ export type ButtonVariants = 'outline' | 'unstyled' | 'link' | 'solid';
 /**
  * The mode of the button style to use.
  */
-export type ButtonModes = 'primary' | 'secondary' | 'alternate';
+export type ButtonModes = 'primary' | 'secondary' | 'tertiary';
 
 export type CustomStyles = {
   [key in ButtonModes]: PseudoBoxProps;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1618764/84879164-22dbe300-b08b-11ea-91eb-db3d7f6d7588.png)

As the buttons are `inline-flex` elements, I've noticed this makes them susceptible to shrinking below their `height` when wrapped in other Flex elements. This is fixed using `min-height` rather than height.