### PR TITLE
refactor: break deriveRootNode into two functions

### DIFF
--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/keychain",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A package for managing Blockstack keychains",
   "main": "./dist/index.js",
   "umd:main": "./dist/keychain.umd.production.js",

--- a/packages/keychain/src/mnemonic/index.ts
+++ b/packages/keychain/src/mnemonic/index.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'blockstack/lib/encryption/cryptoRandom';
 import { bip32 } from 'bitcoinjs-lib';
 
 import { encrypt } from '../encryption/encrypt';
+import { encryptMnemonic } from 'blockstack';
 
 export type AllowedKeyEntropyBits = 128 | 256;
 
@@ -31,14 +32,14 @@ export async function generateEncryptedMnemonicRootKeychain(
   };
 }
 
-export async function deriveRootKeychainFromMnemonic(plaintextMnemonic: string, password: string) {
-  const encryptedMnemonic = await encrypt(plaintextMnemonic, password);
-  const encryptedMnemonicHex = encryptedMnemonic.toString('hex');
+export async function deriveRootKeychainFromMnemonic(plaintextMnemonic: string) {
   const seedBuffer = await mnemonicToSeed(plaintextMnemonic);
   const rootNode = bip32.fromSeed(seedBuffer);
-  return {
-    rootNode,
-    encryptedMnemonic,
-    encryptedMnemonicHex,
-  };
+  return rootNode;
+}
+
+export async function encryptMnemonicFormatted(plaintextMnemonic: string, password: string) {
+  const encryptedMnemonic = await encryptMnemonic(plaintextMnemonic, password);
+  const encryptedMnemonicHex = encryptedMnemonic.toString('hex');
+  return { encryptedMnemonic, encryptedMnemonicHex };
 }

--- a/packages/keychain/src/wallet/index.ts
+++ b/packages/keychain/src/wallet/index.ts
@@ -23,6 +23,7 @@ import {
   AllowedKeyEntropyBits,
   generateEncryptedMnemonicRootKeychain,
   deriveRootKeychainFromMnemonic,
+  encryptMnemonicFormatted,
 } from '../mnemonic';
 import { deriveStxAddressChain } from '../address-derivation';
 
@@ -125,10 +126,8 @@ export class Wallet {
   }
 
   static async restore(password: string, seedPhrase: string, chain: ChainID) {
-    const { rootNode, encryptedMnemonicHex } = await deriveRootKeychainFromMnemonic(
-      seedPhrase,
-      password
-    );
+    const rootNode = await deriveRootKeychainFromMnemonic(seedPhrase);
+    const { encryptedMnemonicHex } = await encryptMnemonicFormatted(seedPhrase, password);
 
     const wallet = await Wallet.createAccount({
       encryptedBackupPhrase: encryptedMnemonicHex,

--- a/packages/keychain/tests/address-derivation/address-derivation.test.ts
+++ b/packages/keychain/tests/address-derivation/address-derivation.test.ts
@@ -5,12 +5,11 @@ import { deriveRootKeychainFromMnemonic } from '../../src/mnemonic';
 
 const phrase =
   'humble ramp winner eagle stumble follow gravity roast receive quote buddy start demise issue egg jewel return hurdle ball blind pulse physical uncle room';
-const password = '41wU*1pM$zlA';
 
 describe('deriveStxAddressChain()', () => {
   test('it returns mainnet derived keys', async () => {
     const deriveStxMainnetAddressChain = deriveStxAddressChain(ChainID.Mainnet);
-    const { rootNode } = await deriveRootKeychainFromMnemonic(phrase, password);
+    const rootNode = await deriveRootKeychainFromMnemonic(phrase);
     const result = deriveStxMainnetAddressChain(rootNode);
     expect(result.privateKey).toEqual(
       '2d088f14028baf5d0b4a8df8ec9faeb8f6f011f8f26d70c8d8abc04a204e3beb01'
@@ -19,7 +18,7 @@ describe('deriveStxAddressChain()', () => {
 
   test('it returns testnet derived keys', async () => {
     const deriveStxTestnetAddressChain = deriveStxAddressChain(ChainID.Testnet);
-    const { rootNode } = await deriveRootKeychainFromMnemonic(phrase, password);
+    const rootNode = await deriveRootKeychainFromMnemonic(phrase);
     const result = deriveStxTestnetAddressChain(rootNode);
     expect(result.privateKey).toEqual(
       '4cf240ef1e9b467c64b196b6ff3d24d9709f287f667939056fbcfc54e4a1642901'

--- a/packages/keychain/tests/mnemonic/mnemonic.test.ts
+++ b/packages/keychain/tests/mnemonic/mnemonic.test.ts
@@ -27,7 +27,7 @@ describe('restoreKeychainFromMnemonic()', () => {
     const phrase =
       'eternal army wreck noodle click shock include orchard jungle only middle forget idle pulse give empower iron curtain silent blush blossom chef animal sphere';
 
-    const { rootNode } = await deriveRootKeychainFromMnemonic(phrase, password);
+    const rootNode = await deriveRootKeychainFromMnemonic(phrase);
     expect(rootNode.privateKey?.toString('hex')).toEqual(
       'a1ce135a6a63ba49c9d118bbc5b9f501d6a36feb45f810576781955b9a57d3b2'
     );


### PR DESCRIPTION
Working with this fn in the stacks wallet, I've realised it's responsible for two things distinct behaviours. Better split into separate functions of a single task.

@hstove should be good right? No dependents for which this'd be a breaking change?