### PR TITLE
feat: adds cancelled method for when popup closed

### DIFF
--- a/packages/app/src/common/hooks/use-message-pong.ts
+++ b/packages/app/src/common/hooks/use-message-pong.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { selectAuthRequest } from '@store/onboarding/selectors';
+import { getEventSourceWindow } from '@common/utils';
+
+export const useMessagePong = () => {
+  const authRequest = useSelector(selectAuthRequest);
+  const sendMessage = (event: MessageEvent) => {
+    console.log('internal event', event);
+    if (event.data.method === 'ping') {
+      const source = getEventSourceWindow(event);
+      source?.postMessage(
+        {
+          method: 'pong',
+          authRequest: event.data.authRequest,
+          source: 'blockstack-app',
+        },
+        event.origin
+      );
+    }
+  };
+
+  const deregister = () => {
+    window.removeEventListener('message', sendMessage);
+  };
+
+  useEffect(() => {
+    window.addEventListener('message', sendMessage);
+    return deregister;
+  }, [authRequest]);
+};

--- a/packages/app/src/components/app.tsx
+++ b/packages/app/src/components/app.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider, theme, CSSReset } from '@blockstack/ui';
 import { createGlobalStyle } from 'styled-components';
 import { Routes } from '@components/routes';
 import { HashRouter as Router } from 'react-router-dom';
+import { useMessagePong } from '@common/hooks/use-message-pong';
 
 const GlobalStyles = createGlobalStyle`
 #actions-root{
@@ -13,6 +14,7 @@ flex-direction: column;
 }`;
 
 export const App: React.FC = () => {
+  useMessagePong();
   return (
     <ThemeProvider theme={theme}>
       <React.Fragment>

--- a/packages/test-app/components/app.tsx
+++ b/packages/test-app/components/app.tsx
@@ -107,6 +107,9 @@ export const App: React.FC = () => {
       setAuthResponse(authResponse);
       console.log(userData);
     },
+    onCancel: () => {
+      console.log('popup closed!');
+    },
     authOrigin,
     appDetails: {
       name: 'Testing App',


### PR DESCRIPTION
For this, I tried a few things before ending up with the current solution. Lots of odd behavior with this cross-origin stuff.

### `popup.onunload`

First I tried to add an event handler for `onunload`, using the `popup` variable on the originating app. `popup` is a `Window` referencing the opened window. Oddly, using `popup.onunload = () => {}` as well as `popup.addEventListener('unload')` didn't work - the callback would be fired immediately. I'm not sure what's up with that, but I couldn't get it to work "correctly".

### `window.onunload` => `window.opener.postMessage`

Next, I tried to have the popup send a `postMessage` back to the app when the popup is closed, using the `window.onunload` functionality. This time, the callback was fired correctly (when the window is about to be closed), however, I was unable to send a message back to the app, due to cross-origin limitations. This was surprising to me, because I thought you we allowed to do cross origin passing if you use `window.opener`. But I guess not! Same thing happened when using the `beforeunload` callback.

### Ping-Pong messaging

I ended up using our existing message-passing code, and simply send a `ping`/`pong` message back and forth. If the app/client doesn't get a pong back within ~100 ms, it fires the `cancelled` callback. So far, this seems to work pretty well.