### PR TITLE
ui-docs: improve next.js build, add fathom

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "packages/**"
   ],
   "devDependencies": {
-    "@blockstack/eslint-config": "^1.0.4",
+    "@blockstack/eslint-config": "^1.0.5",
     "@blockstack/prettier-config": "^0.0.6",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
@@ -51,5 +51,9 @@
   "dependencies": {
     "@babel/preset-env": "^7.10.3",
     "tsdx": "^0.13.2"
+  },
+  "resolutions": {
+    "@blockstack/eslint-config": "^1.0.5",
+    "@blockstack/prettier-config": "^0.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:eslint": "eslint packages/**/*.{ts,tsx}",
     "lint:fix": "eslint --ext .ts,.tsx . -f unix --fix && prettier --write **/*.{ts,tsx} *.js",
     "lint:prettier": "prettier --check **/*.{ts,tsx} *.js",
+    "lint:prettier:fix": "prettier --write **/*.{ts,tsx} *.js",
     "version": "lerna bootstrap"
   },
   "prettier": "@blockstack/prettier-config",

--- a/packages/app/src/components/accounts/index.tsx
+++ b/packages/app/src/components/accounts/index.tsx
@@ -89,7 +89,13 @@ export const Accounts = ({ identities, showAddAccount, next }: AccountsProps) =>
           cursor={selectedAddress ? 'not-allowed' : 'pointer'}
           hasAction
           iconComponent={() => (
-            <Flex justify="center" width="36px" mr={3} color="ink.300" transition="0.08s all ease-in-out">
+            <Flex
+              justify="center"
+              width="36px"
+              mr={3}
+              color="ink.300"
+              transition="0.08s all ease-in-out"
+            >
               <PlusInCircle />
             </Flex>
           )}

--- a/packages/app/src/components/card/index.tsx
+++ b/packages/app/src/components/card/index.tsx
@@ -7,7 +7,14 @@ interface CardProps extends BoxProps {
 
 const Card: React.FC<CardProps> = ({ title, children, ...rest }) => {
   return (
-    <Box borderRadius="6px" border="1px solid" borderColor="#E5E5EC" boxShadow="mid" textAlign="center" {...rest}>
+    <Box
+      borderRadius="6px"
+      border="1px solid"
+      borderColor="#E5E5EC"
+      boxShadow="mid"
+      textAlign="center"
+      {...rest}
+    >
       <Box borderBottom="1px solid" borderColor="#E5E5EC" p={3}>
         <Text textStyle="caption" color="ink.600">
           {title}

--- a/packages/app/src/components/drawer/index.tsx
+++ b/packages/app/src/components/drawer/index.tsx
@@ -75,11 +75,12 @@ export const Drawer: React.FC<DrawerProps> = ({ showing, close, apps, confirm })
           <ScreenBody
             body={[
               <Title>
-                You{"'"}re using this account with {apps.length} other app{apps.length > 1 ? 's' : ''}.
+                You{"'"}re using this account with {apps.length} other app
+                {apps.length > 1 ? 's' : ''}.
               </Title>,
               <Text display="block" mt={3}>
-                The apps used by an account is public information. If you want your use of this app to be private,
-                consider choosing a different account or creating a new account.
+                The apps used by an account is public information. If you want your use of this app
+                to be private, consider choosing a different account or creating a new account.
               </Text>,
               <>
                 <Flex mt={4} align="center">

--- a/packages/app/src/components/logo-with-name.tsx
+++ b/packages/app/src/components/logo-with-name.tsx
@@ -7,7 +7,10 @@ interface LogoWithNameProps {
   hideIcon?: boolean;
 }
 
-export const LogoWithName: React.FC<LogoWithNameProps> = ({ title = 'Secret Key', hideIcon = false }) => (
+export const LogoWithName: React.FC<LogoWithNameProps> = ({
+  title = 'Secret Key',
+  hideIcon = false,
+}) => (
   <Flex align="center">
     {hideIcon ? null : <Logo mr={2} />}
     <Text fontWeight="bold" fontSize={'12px'}>

--- a/packages/app/src/components/pw-manager-input.tsx
+++ b/packages/app/src/components/pw-manager-input.tsx
@@ -7,7 +7,8 @@ interface PasswordManagerHiddenInput {
 
 const visuallyHiddenProps = { opacity: 0, position: 'absolute' } as const;
 
-const passwordManagerUsername = (appName?: string) => 'Blockstack Secret Key' + (!!appName && ` ${appName} `);
+const passwordManagerUsername = (appName?: string) =>
+  'Blockstack Secret Key' + (!!appName && ` ${appName} `);
 
 export const PasswordManagerHiddenInput = ({ secretKey, appName }: PasswordManagerHiddenInput) => {
   if (!secretKey) return null;
@@ -24,7 +25,13 @@ export const PasswordManagerHiddenInput = ({ secretKey, appName }: PasswordManag
       </label>
       <label style={visuallyHiddenProps} htmlFor="password">
         Secret Key
-        <input id="secret-key" type="password" name="password" autoComplete="new-password" defaultValue={secretKey} />
+        <input
+          id="secret-key"
+          type="password"
+          name="password"
+          autoComplete="new-password"
+          defaultValue={secretKey}
+        />
       </label>
     </>
   );

--- a/packages/app/src/components/routes.tsx
+++ b/packages/app/src/components/routes.tsx
@@ -68,7 +68,10 @@ export const Routes: React.FC = () => {
       <Route path="/" element={<Home />} />
       {/*Sign Up*/}
       <Route path="/sign-up" element={getSignUpElement()} />
-      <Route path="/sign-up/secret-key" element={<SecretKey next={() => doChangeScreen(ScreenPaths.SAVE_KEY)} />} />
+      <Route
+        path="/sign-up/secret-key"
+        element={<SecretKey next={() => doChangeScreen(ScreenPaths.SAVE_KEY)} />}
+      />
       <Route
         path="/sign-up/save-secret-key"
         element={
@@ -110,7 +113,10 @@ export const Routes: React.FC = () => {
         }
       />
       {/*Error/Misc*/}
-      <Route path="/settings/secret-key" element={<SecretKey next={() => doChangeScreen(ScreenPaths.HOME)} />} />
+      <Route
+        path="/settings/secret-key"
+        element={<SecretKey next={() => doChangeScreen(ScreenPaths.HOME)} />}
+      />
     </RoutesDom>
   );
 };

--- a/packages/app/src/components/sign-out.tsx
+++ b/packages/app/src/components/sign-out.tsx
@@ -21,7 +21,8 @@ export const SignOut = ({ buttonMode = 'primary', signOut, ...rest }: SignOutPro
         Sign out
       </Button>
       <Text as="small" color="ink.600" textAlign="center" mt={4}>
-        This will sign you out on this device. To sign back in, you will have to enter your Secret Key.
+        This will sign you out on this device. To sign back in, you will have to enter your Secret
+        Key.
       </Text>
     </Flex>
   );

--- a/packages/app/src/components/toast/index.tsx
+++ b/packages/app/src/components/toast/index.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { Flex, Box, Text } from '@blockstack/ui';
 import { SuccessCheckmark } from '../success-checkmark';
 
-export const Toast = ({ show = false, icon: Icon = SuccessCheckmark, text = 'Copied to clipboard' }) => (
+export const Toast = ({
+  show = false,
+  icon: Icon = SuccessCheckmark,
+  text = 'Copied to clipboard',
+}) => (
   <Flex
     p={6}
     width="100%"

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -26,6 +26,5 @@ if (EXT_ENV === 'web') {
   buildApp(store);
 } else {
   const store = ExtStore();
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   store.ready().then(() => buildApp(store));
 }

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -33,7 +33,10 @@ const SignedOut = () => (
 const SecretKeyButton = () => {
   const { doChangeScreen } = useAnalytics();
   return (
-    <PseudoBox _hover={{ cursor: 'pointer' }} onClick={() => doChangeScreen(ScreenPaths.SETTINGS_KEY)}>
+    <PseudoBox
+      _hover={{ cursor: 'pointer' }}
+      onClick={() => doChangeScreen(ScreenPaths.SETTINGS_KEY)}
+    >
       <Text color="blue" fontWeight={500} textStyle="body.small.medium" fontSize="12px">
         View Secret Key
       </Text>

--- a/packages/app/src/pages/registery-error.tsx
+++ b/packages/app/src/pages/registery-error.tsx
@@ -10,7 +10,10 @@ interface RegisterErrorProps {
   onTryAgain: () => void;
 }
 
-export const UsernameRegistryError: React.FC<RegisterErrorProps> = ({ errorReason, onTryAgain }) => {
+export const UsernameRegistryError: React.FC<RegisterErrorProps> = ({
+  errorReason,
+  onTryAgain,
+}) => {
   const getMessage = () => {
     if (errorReason === 'rateLimited') {
       return 'You’ve tried to register too many usernames on this network. Please try again on a different network.';

--- a/packages/app/src/pages/secret-key.tsx
+++ b/packages/app/src/pages/secret-key.tsx
@@ -1,6 +1,13 @@
 import React, { useState, useEffect } from 'react';
 
-import { Screen, ScreenBody, ScreenActions, Title, PoweredBy, ScreenFooter } from '@blockstack/connect';
+import {
+  Screen,
+  ScreenBody,
+  ScreenActions,
+  Title,
+  PoweredBy,
+  ScreenFooter,
+} from '@blockstack/connect';
 import { ScreenHeader } from '@components/connected-screen-header';
 import { Button, Text } from '@blockstack/ui';
 
@@ -47,8 +54,8 @@ export const SecretKey: React.FC<SecretKeyProps> = props => {
           body={[
             <Title>{title}</Title>,
             <Text mt={2} display="block">
-              Here’s your Secret Key: 12 words that prove it’s you when you want to use {name} on a new device. Once
-              lost it’s lost forever, so save it somewhere you won’t forget.
+              Here’s your Secret Key: 12 words that prove it’s you when you want to use {name} on a
+              new device. Once lost it’s lost forever, so save it somewhere you won’t forget.
             </Text>,
             <Card title="Your Secret Key" mt={6}>
               <SeedTextarea
@@ -63,7 +70,14 @@ export const SecretKey: React.FC<SecretKeyProps> = props => {
           ]}
         />
         <ScreenActions>
-          <Button type="submit" data-test="button-copy-secret-key" size="lg" width="100%" mt={6} isDisabled={copied}>
+          <Button
+            type="submit"
+            data-test="button-copy-secret-key"
+            size="lg"
+            width="100%"
+            mt={6}
+            isDisabled={copied}
+          >
             Copy Secret Key
           </Button>
         </ScreenActions>

--- a/packages/app/src/pages/sign-in/decrypt-recovery-code.tsx
+++ b/packages/app/src/pages/sign-in/decrypt-recovery-code.tsx
@@ -7,7 +7,14 @@ import { doStoreSeed } from '@store/wallet/actions';
 import { DEFAULT_PASSWORD } from '@store/onboarding/types';
 
 import { Box, Input, Text, Button } from '@blockstack/ui';
-import { Screen, ScreenBody, ScreenActions, Title, PoweredBy, ScreenFooter } from '@blockstack/connect';
+import {
+  Screen,
+  ScreenBody,
+  ScreenActions,
+  Title,
+  PoweredBy,
+  ScreenFooter,
+} from '@blockstack/connect';
 import { ScreenHeader } from '@components/connected-screen-header';
 import { decrypt } from '@blockstack/keychain';
 import { ErrorLabel } from '@components/error-label';
@@ -48,7 +55,8 @@ export const DecryptRecoveryCode: React.FC<RecoveryProps> = ({ next }) => {
         body={[
           <Title>{title}</Title>,
           <Box mt={2}>
-            You entered a Magic Recovery Code. Enter the password you set when you first created your Blockstack ID.
+            You entered a Magic Recovery Code. Enter the password you set when you first created
+            your Blockstack ID.
             <Box textAlign="left">
               {/*Validate: track SIGN_IN_INCORRECT*/}
               <Input

--- a/packages/app/src/pages/sign-in/initial.tsx
+++ b/packages/app/src/pages/sign-in/initial.tsx
@@ -1,5 +1,12 @@
 import React, { useState, createRef } from 'react';
-import { Screen, ScreenBody, ScreenActions, Title, PoweredBy, ScreenFooter } from '@blockstack/connect';
+import {
+  Screen,
+  ScreenBody,
+  ScreenActions,
+  Title,
+  PoweredBy,
+  ScreenFooter,
+} from '@blockstack/connect';
 import { ScreenHeader } from '@components/connected-screen-header';
 import { Box, Text, Input, Flex, Button } from '@blockstack/ui';
 import { AppIcon } from '@components/app-icon';

--- a/packages/app/src/pages/sign-up/create.tsx
+++ b/packages/app/src/pages/sign-up/create.tsx
@@ -28,7 +28,11 @@ const ExplainerCard = ({ title, imageUrl }: ExplainerCardProps) => (
   </Flex>
 );
 
-const createTimeoutLoop = (setCardIndex: (cardIndex: number) => void, length: number, onEnd: () => void) => {
+const createTimeoutLoop = (
+  setCardIndex: (cardIndex: number) => void,
+  length: number,
+  onEnd: () => void
+) => {
   for (let index = 1; index < length; index++) {
     setTimeout(() => {
       setCardIndex(index);

--- a/packages/app/src/pages/sign-up/save-key.tsx
+++ b/packages/app/src/pages/sign-up/save-key.tsx
@@ -29,7 +29,8 @@ export const SaveKey: React.FC<SaveKeyProps> = ({ next }) => {
         body={[
           <Title>{title}</Title>,
           <Text display="block" mt={2}>
-            Paste your Secret Key wherever you keep critical, private, information such as passwords.
+            Paste your Secret Key wherever you keep critical, private, information such as
+            passwords.
           </Text>,
           <Text display="block" mt={5}>
             {' '}

--- a/packages/app/src/pages/username.tsx
+++ b/packages/app/src/pages/username.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 
 import { Box, Button, Input, Text } from '@blockstack/ui';
-import { PoweredBy, Screen, ScreenActions, ScreenBody, ScreenFooter, Title } from '@blockstack/connect';
+import {
+  PoweredBy,
+  Screen,
+  ScreenActions,
+  ScreenBody,
+  ScreenFooter,
+  Title,
+} from '@blockstack/connect';
 import { ScreenHeader } from '@components/connected-screen-header';
 
 import { useAppDetails } from '@common/hooks/useAppDetails';
@@ -11,7 +18,12 @@ import { useWallet } from '@common/hooks/use-wallet';
 import { UsernameRegistryError, ErrorReason } from './registery-error';
 
 import { DEFAULT_PASSWORD, ScreenPaths } from '@store/onboarding/types';
-import { Identity, IdentityNameValidityError, registerSubdomain, validateSubdomain } from '@blockstack/keychain';
+import {
+  Identity,
+  IdentityNameValidityError,
+  registerSubdomain,
+  validateSubdomain,
+} from '@blockstack/keychain';
 import { didGenerateWallet } from '@store/wallet';
 import { ErrorLabel } from '@components/error-label';
 import { gaiaUrl, Subdomain } from '@common/constants';
@@ -24,8 +36,10 @@ import {
 import { useAnalytics } from '@common/hooks/use-analytics';
 import { useLocation } from 'react-router-dom';
 
-const identityNameLengthError = 'Your username should be at least 8 characters, with a maximum of 37 characters.';
-const identityNameIllegalCharError = 'You can only use lowercase letters (a–z), numbers (0–9), and underscores (_).';
+const identityNameLengthError =
+  'Your username should be at least 8 characters, with a maximum of 37 characters.';
+const identityNameIllegalCharError =
+  'You can only use lowercase letters (a–z), numbers (0–9), and underscores (_).';
 const identityNameUnavailableError = 'This username is not available';
 const errorTextMap = {
   [IdentityNameValidityError.MINIMUM_LENGTH]: identityNameLengthError,
@@ -133,7 +147,8 @@ export const Username: React.FC<{}> = () => {
           <Box>
             <Title>Choose a username</Title>
             <Text mt={2} display="block">
-              This is how people will find you in {name} and other apps you use with your Secret Key.
+              This is how people will find you in {name} and other apps you use with your Secret
+              Key.
             </Text>
             <Box textAlign="left" position="relative" mt={4}>
               <Input

--- a/packages/connect/src/react/components/screens/sign-in.tsx
+++ b/packages/connect/src/react/components/screens/sign-in.tsx
@@ -25,8 +25,7 @@ const ContinueWithAuth: React.FC = props => {
       bg={hovered ? 'rgba(0,0,0,0.02)' : 'white'}
       transform={hovered ? 'translateY(-2px)' : 'none'}
       onClick={() => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        authenticate({ ...authOptions, sendToSignIn: true });
+        void authenticate({ ...authOptions, sendToSignIn: true });
       }}
       {...bind}
       {...props}

--- a/packages/ui-docs/next.config.js
+++ b/packages/ui-docs/next.config.js
@@ -32,6 +32,9 @@ module.exports = withBundleAnalyzer(
       polyfillsOptimization: true,
       jsconfigPaths: true,
     },
+    env: {
+      FATHOM_ID: 'XHIKWSQD',
+    },
     pageExtensions: ['ts', 'tsx', 'md', 'mdx'],
     webpack: (config, options) => {
       if (!options.isServer) {

--- a/packages/ui-docs/package.json
+++ b/packages/ui-docs/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^14.0.14",
     "@types/nprogress": "^0.2.0",
     "@types/reach__tooltip": "^0.2.0",
+    "fathom-client": "^3.0.0",
     "mdi-react": "^7.3.0",
     "next": "^9.4.4",
     "next-google-fonts": "^1.1.0",

--- a/packages/ui-docs/package.json
+++ b/packages/ui-docs/package.json
@@ -2,7 +2,7 @@
   "name": "@blockstack/ui-docs",
   "version": "0.1.10",
   "dependencies": {
-    "@blockstack/ui": "2.7.2-beta.2",
+    "@blockstack/ui": "2.7.3",
     "@mdx-js/loader": "1.6.6",
     "@mdx-js/mdx": "^1.6.6",
     "@mdx-js/react": "^1.6.6",
@@ -15,7 +15,7 @@
     "@types/nprogress": "^0.2.0",
     "@types/reach__tooltip": "^0.2.0",
     "mdi-react": "^7.3.0",
-    "next": "^9.4.5-canary.22",
+    "next": "^9.4.4",
     "next-google-fonts": "^1.1.0",
     "next-mdx-enhanced": "^3.0.0",
     "nookies": "^2.3.2",

--- a/packages/ui-docs/src/common/hooks/use-app-state.tsx
+++ b/packages/ui-docs/src/common/hooks/use-app-state.tsx
@@ -5,33 +5,31 @@ import { State } from '@components/app-state/types';
 interface UseAppStateReturn extends State {
   doChangeActiveSlug: (activeSlug: string) => void;
   doChangeSlugInView: (slugInView: string) => void;
+  doSetVersion: (version: string) => void;
 }
 
 export const useAppState = (): UseAppStateReturn => {
   const { setState, ...rest } = React.useContext(AppStateContext);
 
-  const doChangeActiveSlug = React.useCallback(
-    (activeSlug: string) =>
+  function setter<T>(key: string) {
+    return (value: T) =>
       setState((state: State) => ({
         ...state,
-        activeSlug,
-      })),
-    []
-  );
+        [key]: value,
+      }));
+  }
 
-  const doChangeSlugInView = React.useCallback(
-    (slugInView: string) =>
-      setState((state: State) => ({
-        ...state,
-        slugInView,
-      })),
-    []
-  );
+  const doSetVersion = setter<string>('version');
+
+  const doChangeActiveSlug = setter<string>('activeSlug');
+
+  const doChangeSlugInView = setter<string>('slugInView');
 
   return {
     ...rest,
     doChangeActiveSlug,
     doChangeSlugInView,
     setState,
+    doSetVersion,
   };
 };

--- a/packages/ui-docs/src/common/hooks/use-fathom.ts
+++ b/packages/ui-docs/src/common/hooks/use-fathom.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import * as Fathom from 'fathom-client';
+
+export const useFathom = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    // Initialize Fathom when the app loads
+    Fathom.load(process.env.FATHOM_ID, {
+      includedDomains: ['blockstack.design'],
+    });
+
+    function onRouteChangeComplete() {
+      Fathom.trackPageview();
+    }
+    // Record a page view when route changes
+    router.events.on('routeChangeComplete', onRouteChangeComplete);
+
+    // Un assign event listener
+    return () => {
+      router.events.off('routeChangeComplete', onRouteChangeComplete);
+    };
+  }, []);
+};

--- a/packages/ui-docs/src/common/lib.ts
+++ b/packages/ui-docs/src/common/lib.ts
@@ -1,0 +1,13 @@
+export const fetchLatestPackageVersion = async (): Promise<{ version?: string }> => {
+  try {
+    const res = await fetch('https://registry.npmjs.org/@blockstack/ui');
+    const data = await res.json();
+    const version = data['dist-tags'].latest;
+    return { version };
+  } catch (e) {
+    console.log(e);
+    return {
+      version: '',
+    };
+  }
+};

--- a/packages/ui-docs/src/components/app-state/index.tsx
+++ b/packages/ui-docs/src/components/app-state/index.tsx
@@ -4,20 +4,12 @@ import { AppStateContext, initialState } from '@components/app-state/context';
 const AppStateProvider = ({ version, ...props }: any) => {
   const [state, setState] = React.useState(initialState);
 
-  const handleSetVersion = (version: string) => {
-    setState(s => ({
-      ...s,
-      version,
-    }));
-  };
-
   return (
     <AppStateContext.Provider
       value={{
         ...state,
         setState,
         version,
-        handleSetVersion,
       }}
       {...props}
     />

--- a/packages/ui-docs/src/components/code-editor.tsx
+++ b/packages/ui-docs/src/components/code-editor.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import Editor from 'react-simple-code-editor';
 import { createGlobalStyle } from 'styled-components';
 import { Box, BoxProps, Highlighter } from '@blockstack/ui';
-import { Language } from '@blockstack/ui/src/highlighter/types';
+// TODO: change when new version is published
+import { Language } from '@blockstack/ui/dist/ui/src/highlighter/types';
 
 const TextAreaOverrides = createGlobalStyle`
 .code-editor{

--- a/packages/ui-docs/src/components/code-editor.tsx
+++ b/packages/ui-docs/src/components/code-editor.tsx
@@ -81,7 +81,7 @@ export const CodeEditor = React.memo((props: CodeEditorProps) => {
           textareaId={id}
           // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
           // @ts-ignore
-          language={language as any}
+          language={language}
           onValueChange={updateContent}
           highlight={c => <Highlighter code={c} language={language as any} />}
           style={

--- a/packages/ui-docs/src/components/code-editor.tsx
+++ b/packages/ui-docs/src/components/code-editor.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Editor from 'react-simple-code-editor';
 import { createGlobalStyle } from 'styled-components';
 import { Box, BoxProps, Highlighter } from '@blockstack/ui';
+import { Language } from '@blockstack/ui/src/highlighter/types';
 
 const TextAreaOverrides = createGlobalStyle`
 .code-editor{
@@ -36,7 +37,7 @@ const TextAreaOverrides = createGlobalStyle`
 interface CodeEditorProps extends Partial<Omit<BoxProps, 'onChange'>> {
   value: string;
   disabled?: boolean;
-  language?: string;
+  language?: Language;
   onChange?: (code: string) => void;
   name?: string;
   id?: string;
@@ -83,7 +84,7 @@ export const CodeEditor = React.memo((props: CodeEditorProps) => {
           // @ts-ignore
           language={language}
           onValueChange={updateContent}
-          highlight={c => <Highlighter code={c} language={language as any} />}
+          highlight={c => <Highlighter code={c} language={language} />}
           style={
             {
               ...style,

--- a/packages/ui-docs/src/components/docs-layout.tsx
+++ b/packages/ui-docs/src/components/docs-layout.tsx
@@ -5,7 +5,7 @@ import { Header } from './header';
 import { Main } from './main';
 import { Footer } from './footer';
 import { useRouter } from 'next/router';
-import { WaffleHeader } from './waffle-header';
+import { GettingStartedHeader } from './getting-started-header';
 import { ContentWrapper } from './content-wrapper';
 import NotFoundPage from '@pages/404';
 import { createGlobalStyle } from 'styled-components';
@@ -52,7 +52,7 @@ const DocsLayout: React.FC<{ headings?: string[] }> = ({ children, headings }) =
         >
           <Main mx="unset" width={'100%'}>
             {router.pathname === '/getting-started' || router.pathname === '/' ? (
-              <WaffleHeader />
+              <GettingStartedHeader />
             ) : null}
             <Flex
               flexDirection={['column', 'column', 'row', 'row']}

--- a/packages/ui-docs/src/components/getting-started-header.tsx
+++ b/packages/ui-docs/src/components/getting-started-header.tsx
@@ -4,7 +4,7 @@ import { Text } from '@components/typography';
 import { ContentWrapper } from './content-wrapper';
 import { useAppState } from '@common/hooks/use-app-state';
 
-export const WaffleHeader = () => {
+export const GettingStartedHeader = () => {
   const { version } = useAppState();
   return (
     <Flex
@@ -22,9 +22,11 @@ export const WaffleHeader = () => {
         <Text pt={1} display="block" as="h2" fontSize={[3, 3, 4]} color="white">
           The Blockstack design system, built with React and styled-system.
         </Text>
-        <Text opacity={0.5} display="block" pt={2} fontFamily="mono" color="white">
-          v{version}
-        </Text>
+        {version !== '' ? (
+          <Text opacity={0.5} display="block" pt={2} fontFamily="mono" color="white">
+            v{version}
+          </Text>
+        ) : null}
       </ContentWrapper>
     </Flex>
   );

--- a/packages/ui-docs/src/components/header.tsx
+++ b/packages/ui-docs/src/components/header.tsx
@@ -31,6 +31,7 @@ const GithubButton = () => (
     as="a"
     href="https://github.com/blockstack/ux/tree/master/packages/ui#blockstack-ui"
     target="_blank"
+    rel="nofollow noopener noreferrer"
     title="Find us on GitHub"
     position="relative"
     overflow="hidden"
@@ -90,6 +91,7 @@ const Header = ({ ...rest }: any) => {
             mr={space('base')}
             href="https://www.dropbox.com/sh/5uyhon1dxax4t6t/AABnh34kFRzD2TSck1wE9fmqa?dl=0"
             target="_blank"
+            rel="nofollow noopener noreferrer"
             fontSize="12px"
           >
             Branding Assets

--- a/packages/ui-docs/src/components/text-display.tsx
+++ b/packages/ui-docs/src/components/text-display.tsx
@@ -14,10 +14,7 @@ const types = [
 ];
 
 const transformTextStyle = (value: string) =>
-  value
-    .replace(' ', '.')
-    .replace(' ', '.')
-    .toLowerCase();
+  value.replace(' ', '.').replace(' ', '.').toLowerCase();
 
 const Cell = ({ ...rest }: any) => (
   <Box width={1 / 5}>

--- a/packages/ui-docs/src/components/text-display.tsx
+++ b/packages/ui-docs/src/components/text-display.tsx
@@ -14,7 +14,10 @@ const types = [
 ];
 
 const transformTextStyle = (value: string) =>
-  value.replace(' ', '.').replace(' ', '.').toLowerCase();
+  value
+    .replace(' ', '.')
+    .replace(' ', '.')
+    .toLowerCase();
 
 const Cell = ({ ...rest }: any) => (
   <Box width={1 / 5}>

--- a/packages/ui-docs/src/pages/404.tsx
+++ b/packages/ui-docs/src/pages/404.tsx
@@ -67,6 +67,7 @@ const NotFoundPage = () => {
                 as="a"
                 color={color('accent')}
                 href="https://github.com/blockstack/ux"
+                rel="nofollow noopener noreferrer"
                 target="_blank"
               >
                 Want to contribute?

--- a/packages/ui-docs/src/pages/_app.tsx
+++ b/packages/ui-docs/src/pages/_app.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import App, { AppContext } from 'next/app';
 import { CSSReset, ThemeProvider, theme, ColorModeProvider } from '@blockstack/ui';
 import { MDXProvider } from '@mdx-js/react';
 import { MDXComponents } from '@components/mdx';
 import { AppStateProvider } from '@components/app-state';
-import { parseCookies } from 'nookies';
 import { MdxOverrides } from '@components/docs-layout';
 import { ProgressBar } from '@components/progress-bar';
 import engine from 'store/src/store-engine';
@@ -45,35 +43,6 @@ const MyApp = ({ Component, pageProps, colorMode, ...rest }: any) => {
       <Component {...pageProps} />
     </AppWrapper>
   );
-};
-
-MyApp.getInitialProps = async (appContext: AppContext) => {
-  const appProps = await App.getInitialProps(appContext);
-  const cookies = parseCookies(appContext.ctx);
-  let colorMode = undefined;
-
-  if (cookies) {
-    colorMode = cookies[COLOR_MODE_COOKIE] ? JSON.parse(cookies[COLOR_MODE_COOKIE]) : undefined;
-  }
-  if (appContext.ctx.res) {
-    try {
-      const res = await fetch('https://registry.npmjs.org/@blockstack/ui');
-      const data = await res.json();
-      const version = data['dist-tags'].latest;
-      return {
-        ...appProps,
-        pageProps: {
-          ...appProps.pageProps,
-          version,
-        },
-        colorMode,
-      };
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
-  return { ...appProps, colorMode };
 };
 
 export default MyApp;

--- a/packages/ui-docs/src/pages/_app.tsx
+++ b/packages/ui-docs/src/pages/_app.tsx
@@ -8,6 +8,8 @@ import { ProgressBar } from '@components/progress-bar';
 import engine from 'store/src/store-engine';
 import cookieStorage from 'store/storages/cookieStorage';
 import GoogleFonts from 'next-google-fonts';
+import { useFathom } from '@common/hooks/use-fathom';
+import { trackGoal } from 'fathom-client';
 
 const COLOR_MODE_COOKIE = 'color_mode';
 
@@ -38,11 +40,45 @@ const MyApp = ({ Component, pageProps, colorMode, ...rest }: any) => {
   if (!version && pageProps?.version) {
     setVersion(pageProps?.version);
   }
+  useFathom();
   return (
     <AppWrapper colorMode={colorMode} version={version}>
       <Component {...pageProps} />
     </AppWrapper>
   );
 };
+
+// https://nextjs.org/docs/advanced-features/measuring-performance#sending-results-to-analytics
+export function reportWebVitals(metric) {
+  switch (metric.name) {
+    case 'FCP':
+      // handle FCP results
+      // AMRPJB41
+      trackGoal('AMRPJB41', Math.round(metric.value));
+      break;
+    case 'LCP':
+      // handle LCP results
+      // 0YIWHNVQ
+      trackGoal('0YIWHNVQ', Math.round(metric.value));
+      break;
+    case 'CLS':
+      // handle CLS results
+      // MBBF8MN5
+      trackGoal('MBBF8MN5', Math.round(metric.value * 1000));
+      break;
+    case 'FID':
+      // handle FID results
+      // PGZYOYWT
+      trackGoal('PGZYOYWT', Math.round(metric.value));
+      break;
+    case 'TTFB':
+      // handle TTFB results
+      // 5SRKSJRM
+      trackGoal('5SRKSJRM', Math.round(metric.value));
+      break;
+    default:
+      break;
+  }
+}
 
 export default MyApp;

--- a/packages/ui-docs/src/pages/getting-started.tsx
+++ b/packages/ui-docs/src/pages/getting-started.tsx
@@ -1,3 +1,4 @@
 import Homepage from './index';
+export * from './index';
 
 export default Homepage;

--- a/packages/ui-docs/src/pages/index.tsx
+++ b/packages/ui-docs/src/pages/index.tsx
@@ -1,8 +1,26 @@
 import React from 'react';
 import GettingStarted from './_getting-started.mdx';
+import { useAppState } from '@common/hooks/use-app-state';
+import { fetchLatestPackageVersion } from '@common/lib';
 
-const Homepage = () => {
+const Homepage = ({ version }: { version: string }) => {
+  const { version: _version, doSetVersion } = useAppState();
+  React.useEffect(() => {
+    if (version && _version !== version) {
+      doSetVersion(version);
+    }
+  }, [_version, version]);
   return <GettingStarted />;
 };
+
+export async function getStaticProps() {
+  return {
+    props: await fetchLatestPackageVersion(),
+    // we will attempt to re-generate the page:
+    // - when a request comes in
+    // - at most once every second
+    unstable_revalidate: 1,
+  };
+}
 
 export default Homepage;

--- a/packages/ui-docs/src/pages/theme.mdx
+++ b/packages/ui-docs/src/pages/theme.mdx
@@ -209,5 +209,4 @@ Except for breakpoints, colors, and spacing, all of the keys in the theme object
 map to one of Blockstack UI's core theme. All of these keys can be replaced or
 extended.
 
-See the <a href="https://styled-system.com/table" target="_blank">full reference
-table</a> of properties.
+See the [full reference table](https://styled-system.com/table) of properties.

--- a/packages/ui/src/highlighter/index.tsx
+++ b/packages/ui/src/highlighter/index.tsx
@@ -26,9 +26,9 @@ const Tokens = ({
   showLineNumbers?: boolean;
 }) => {
   const bsTheme = useTheme();
-  const pl = `calc(${showLineNumbers ? lineNumberWidth : '0'}px + ${
-    (bsTheme as any).sizes['base'] || '16px'
-  })`;
+  const pl = `calc(${showLineNumbers ? lineNumberWidth : '0'}px + ${(bsTheme as any).sizes[
+    'base'
+  ] || '16px'})`;
 
   return (
     <Box pl={pl} pr="base" position="relative" zIndex={2} {...rest}>

--- a/packages/ui/src/highlighter/index.tsx
+++ b/packages/ui/src/highlighter/index.tsx
@@ -10,6 +10,8 @@ import { GrammaticalToken, GetGrammaticalTokenProps, RenderProps, Language } fro
 import { theme } from './prism-theme';
 import './language-definition';
 
+export * from './types';
+
 const lineNumberWidth = 60;
 const getLineNumber = (n: number, length: number) => startPad(n + 1, length.toString().length);
 

--- a/packages/ui/src/highlighter/index.tsx
+++ b/packages/ui/src/highlighter/index.tsx
@@ -26,9 +26,9 @@ const Tokens = ({
   showLineNumbers?: boolean;
 }) => {
   const bsTheme = useTheme();
-  const pl = `calc(${showLineNumbers ? lineNumberWidth : '0'}px + ${(bsTheme as any).sizes[
-    'base'
-  ] || '16px'})`;
+  const pl = `calc(${showLineNumbers ? lineNumberWidth : '0'}px + ${
+    (bsTheme as any).sizes['base'] || '16px'
+  })`;
 
   return (
     <Box pl={pl} pr="base" position="relative" zIndex={2} {...rest}>

--- a/packages/ui/src/highlighter/language-definition.tsx
+++ b/packages/ui/src/highlighter/language-definition.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import Prism from 'prismjs';
 
-(function (Prism) {
+(function(Prism) {
   // Functions to construct regular expressions
   // simple form
   // e.g. (interactive ... or (interactive)

--- a/packages/ui/src/highlighter/language-definition.tsx
+++ b/packages/ui/src/highlighter/language-definition.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import Prism from 'prismjs';
 
-(function(Prism) {
+(function (Prism) {
   // Functions to construct regular expressions
   // simple form
   // e.g. (interactive ... or (interactive)

--- a/packages/ui/src/modal/index.tsx
+++ b/packages/ui/src/modal/index.tsx
@@ -79,7 +79,7 @@ interface ModalCardContainerProps extends FlexProps {
   isOpen: boolean;
   noAnimation: boolean;
 }
-// eslint-disable-next-line react/display-name
+
 const ModalCardContainer = React.forwardRef<any, ModalCardContainerProps>(
   ({ noAnimation, isOpen, ...rest }, ref) => (
     <Flex

--- a/packages/ui/src/utils/index.tsx
+++ b/packages/ui/src/utils/index.tsx
@@ -128,9 +128,7 @@ export function mergeRefs<T>(...refs: (ReactRef<T> | undefined)[]) {
 }
 
 export function genId(prefix: string) {
-  return `${prefix}-${Math.random()
-    .toString(32)
-    .substr(2, 8)}`;
+  return `${prefix}-${Math.random().toString(32).substr(2, 8)}`;
 }
 
 export const makeId = (id: string, index: number) => `${id}:${index}`;
@@ -217,7 +215,7 @@ export function error(options: { condition: boolean; message: string }) {
 export type FunctionArguments<T extends Function> = T extends (...args: infer R) => any ? R : never;
 
 export function callAllHandlers<T extends (event: any) => void>(...fns: (T | undefined)[]) {
-  return function(event: FunctionArguments<T>[0]) {
+  return function (event: FunctionArguments<T>[0]) {
     fns.some(fn => {
       fn && fn(event);
       return event && event.defaultPrevented;

--- a/packages/ui/src/utils/index.tsx
+++ b/packages/ui/src/utils/index.tsx
@@ -128,7 +128,9 @@ export function mergeRefs<T>(...refs: (ReactRef<T> | undefined)[]) {
 }
 
 export function genId(prefix: string) {
-  return `${prefix}-${Math.random().toString(32).substr(2, 8)}`;
+  return `${prefix}-${Math.random()
+    .toString(32)
+    .substr(2, 8)}`;
 }
 
 export const makeId = (id: string, index: number) => `${id}:${index}`;
@@ -215,7 +217,7 @@ export function error(options: { condition: boolean; message: string }) {
 export type FunctionArguments<T extends Function> = T extends (...args: infer R) => any ? R : never;
 
 export function callAllHandlers<T extends (event: any) => void>(...fns: (T | undefined)[]) {
-  return function (event: FunctionArguments<T>[0]) {
+  return function(event: FunctionArguments<T>[0]) {
     fns.some(fn => {
       fn && fn(event);
       return event && event.defaultPrevented;
@@ -338,11 +340,8 @@ export function split<T extends Dict, K extends keyof T>(object: T, keys: K[]) {
 export function get(obj: any, path: string | number, fallback?: any, index?: number) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   //@ts-ignore
-  // eslint-disable-next-line no-param-reassign
   path = (path?.split?.('.') ?? [path]) as string;
-  // eslint-disable-next-line no-param-reassign
   for (index = 0; index < path.length; index++) {
-    // eslint-disable-next-line no-param-reassign
     obj = obj ? obj[path[index]] : undefined;
   }
   return obj === undefined ? fallback : obj;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,7 +1598,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blockstack/eslint-config@^1.0.3", "@blockstack/eslint-config@^1.0.4":
+"@blockstack/eslint-config@^1.0.3", "@blockstack/eslint-config@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@blockstack/eslint-config/-/eslint-config-1.0.5.tgz#a745661123c5e6c2682b5eb7400a4bc72390959d"
   integrity sha512-fwqCVsfx6Ekqbb+Qai18Ff9Mkkj5P5fHiB28b+PY44SHpykPlu54FbbJJVBF6r4rMtImSMgjCF1RKznBTJ4JlQ==
@@ -1613,15 +1613,10 @@
     eslint-plugin-prettier ">=3.1.3"
     prettier ">=2.0.5"
 
-"@blockstack/prettier-config@0.0.6", "@blockstack/prettier-config@^0.0.6":
+"@blockstack/prettier-config@0.0.6", "@blockstack/prettier-config@^0.0.5", "@blockstack/prettier-config@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@blockstack/prettier-config/-/prettier-config-0.0.6.tgz#8a41cd378ba061b79770987f2a6ad0c92b64bd72"
   integrity sha512-ke0MdyblmoUqSJBEutsG8/6G7KAjCB+uOcgZHPJvJr4R+i5yRhT4GSe5nV/wREINuK0jj2GvaA6qlx4PQTKQUA==
-
-"@blockstack/prettier-config@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@blockstack/prettier-config/-/prettier-config-0.0.5.tgz#871bd2a38b5bc9aabb1cefeeba6199cc64098957"
-  integrity sha512-A+wfdVwD1Sxd/D3PPJI67Evo7q2fp15hCOFLB5jmzcS1MdN8BQdFm6j51Sti8xLN4qHmuYkicbFBUluGx2h63g==
 
 "@blockstack/stacks-transactions@^0.4.6":
   version "0.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8556,6 +8556,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fathom-client@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fathom-client/-/fathom-client-3.0.0.tgz#409c047cf1e2fea45b148e28d50fcd635e992893"
+  integrity sha512-d0oH2SHWCMIVLbbegB7nBIjSvbqbHrZBZxIOWSVAxlJL/roL0Ah9NNb6rTIcKMlA4gov9AjWQGEcZRzlnGc3XQ==
+
 faye-websocket@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@ampproject/toolbox-core@^2.5.1", "@ampproject/toolbox-core@^2.5.4":
+"@ampproject/toolbox-core@^2.4.0-alpha.1", "@ampproject/toolbox-core@^2.5.4":
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/@ampproject/toolbox-core/-/toolbox-core-2.5.4.tgz#8554c5398b6d65d240085a6b0abb94f9a3276dce"
   integrity sha512-KjHyR0XpQyloTu59IaatU2NCGT5zOhWJtVXQ4Uj/NUaRriN6LlJlzHBxtXmPIb0YHETdD63ITtDvqZizZPYFag==
@@ -10,30 +10,25 @@
     cross-fetch "3.0.5"
     lru-cache "5.1.1"
 
-"@ampproject/toolbox-optimizer@2.5.3":
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-optimizer/-/toolbox-optimizer-2.5.3.tgz#da24e0bad9350fded8a923c9e1c2402f0fe01e5b"
-  integrity sha512-D6j7nU02sLRaW+ZKd1UNyUESu9GVLhVrtGHQ/rORj87ZJS5s0DCpoIDbq1slKQDCDHl7RknQ3A6CVm14ihXV2A==
+"@ampproject/toolbox-optimizer@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-optimizer/-/toolbox-optimizer-2.4.0.tgz#16bde73913f8b58a9bf617d37cdc1f21a1222f38"
+  integrity sha512-Bmb+eMF9/VB3H0qPdZy0V5yPSkWe5RwuGbXiMxzqYdJgmMat+NL75EtozQnlpa0uBlESnOGe7bMojm/SA1ImrA==
   dependencies:
-    "@ampproject/toolbox-core" "^2.5.1"
-    "@ampproject/toolbox-runtime-version" "^2.5.1"
+    "@ampproject/toolbox-core" "^2.4.0-alpha.1"
+    "@ampproject/toolbox-runtime-version" "^2.4.0-alpha.1"
     "@ampproject/toolbox-script-csp" "^2.3.0"
     "@ampproject/toolbox-validator-rules" "^2.3.0"
-    abort-controller "3.0.0"
-    cross-fetch "3.0.4"
     cssnano "4.1.10"
-    dom-serializer "1.0.1"
     domhandler "3.0.0"
     domutils "2.1.0"
     htmlparser2 "4.1.0"
     lru-cache "5.1.1"
-    node-fetch "2.6.0"
     normalize-html-whitespace "1.0.0"
-    postcss "7.0.32"
     postcss-safe-parser "4.0.2"
-    terser "4.7.0"
+    terser "4.6.13"
 
-"@ampproject/toolbox-runtime-version@^2.5.1":
+"@ampproject/toolbox-runtime-version@^2.4.0-alpha.1":
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/@ampproject/toolbox-runtime-version/-/toolbox-runtime-version-2.5.4.tgz#ed6e77df3832f551337bca3706b5a4e2f36d66f9"
   integrity sha512-7vi/F91Zb+h1CwR8/on/JxZhp3Hhz6xJOOHxRA025aUFEFHV5c35B4QbTdt2MObWZrysogXFOT8M95dgU/hsKw==
@@ -1654,37 +1649,6 @@
   resolved "https://registry.yarnpkg.com/@blockstack/stats/-/stats-0.7.0.tgz#be39d3e76c2a16c1cd1283aa702d1e20b5e04645"
   integrity sha512-AS/UdJH/cJ7K8la3/TbQziEMlRrNI/4VEHSfYUsEzU7Nx892G6qE4uu/XvW9ycS0Jg2/TW2bjTnRijsyecaEJA==
 
-"@blockstack/ui@2.7.2-beta.2":
-  version "2.7.2-beta.2"
-  resolved "https://registry.yarnpkg.com/@blockstack/ui/-/ui-2.7.2-beta.2.tgz#883b87216b9ea3966b76942656d0a21ad9ecd491"
-  integrity sha512-tDsrv3yUazhrrFb2gBqB7yzoWISfKQZ+pTCJaoQq5FSQenDAbwbM/fn1ALXIQelghHuLj6N2hzAIGqR2WAJ5fw==
-  dependencies:
-    "@popperjs/core" "^2.4.0"
-    "@reach/alert" "^0.10.2"
-    "@reach/auto-id" "^0.10.0"
-    "@reach/rect" "^0.10.2"
-    "@styled-system/css" "5.1.5"
-    "@styled-system/should-forward-prop" "^5.1.5"
-    "@styled-system/theme-get" "^5.1.2"
-    "@types/react-transition-group" "^4.2.4"
-    "@types/styled-components" "^5.1.0"
-    "@types/styled-system" "^5.1.6"
-    "@types/styled-system__css" "^5.0.8"
-    "@types/styled-system__should-forward-prop" "^5.1.1"
-    "@types/styled-system__theme-get" "^5.0.0"
-    color "3.1.2"
-    flushable "^1.0.0"
-    prettier "^2.0.5"
-    prism-react-renderer "^1.0.2"
-    prismjs "^1.20.0"
-    prop-types "^15.7.2"
-    react-spring "8.0.27"
-    react-transition-group "^4.4.1"
-    styled-system "5.1.5"
-    type-fest "^0.15.1"
-    use-events "^1.4.1"
-    use-onclickoutside "^0.3.1"
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -3050,10 +3014,10 @@
   resolved "https://registry.yarnpkg.com/@next/mdx/-/mdx-9.4.4.tgz#ad1da5ecd2f3ee4b07fdf9a938441efffd58af6b"
   integrity sha512-d1WPPxube7kgQo5JjfiFxPoK+set0OBCNeIJnF8TN176v4SsFNngfB4I5RIxsdXqD7aPzWeFcxCGGGvbzjKa8A==
 
-"@next/react-dev-overlay@9.4.5-canary.22":
-  version "9.4.5-canary.22"
-  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-9.4.5-canary.22.tgz#e6af22c5f79a3e7829ad9463ce561f78343f7c3d"
-  integrity sha512-lvnpTE1szHckvD8GY0d6pBM3PphpAWXkxc4R7zKj1YsTMFvItEjlwOIQ0qCvhDwXqvTYj0mJDbAs+f3MCJe0Jg==
+"@next/react-dev-overlay@9.4.4":
+  version "9.4.4"
+  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-9.4.4.tgz#4ae03ac839ff022b3ce5c695bd24b179d4ef459d"
+  integrity sha512-UUAa8RbH7BeWDPCkagIkR4sUsyvTPlEdFrPZ9kGjf2+p8HkLHpcVY7y+XRnNvJQs4PsAF0Plh20FBz7t54U2iQ==
   dependencies:
     "@babel/code-frame" "7.8.3"
     ally.js "1.4.1"
@@ -3066,10 +3030,10 @@
     stacktrace-parser "0.1.10"
     strip-ansi "6.0.0"
 
-"@next/react-refresh-utils@9.4.5-canary.22":
-  version "9.4.5-canary.22"
-  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-9.4.5-canary.22.tgz#5038d501238beaf77d5ab2b2f52edc910e192866"
-  integrity sha512-hHHsw2cEMb7U+3XCWiKIE7e7HqvbFE6hdPVhYDziGFt8ygrq9GAHpjxcxCFD5Zo1dfYMhg/WeE0FvDztJuLYpg==
+"@next/react-refresh-utils@9.4.4":
+  version "9.4.4"
+  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-9.4.4.tgz#d94cbb3b354a07f1f5b80e554d6b9e34aba99e41"
+  integrity sha512-9nKENeWRI6kQk44TbeqleIVtNLfcS3klVUepzl/ZCqzR5Bi06uqBCD277hdVvG/wL1pxA+R/pgJQLqnF5E2wPQ==
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -4357,13 +4321,6 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
-abort-controller@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
 
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
@@ -6851,14 +6808,6 @@ cross-env@7.0.2, cross-env@^7.0.0:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-fetch@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
-  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
-  dependencies:
-    node-fetch "2.6.0"
-    whatwg-fetch "3.0.0"
-
 cross-fetch@3.0.5, cross-fetch@^3.0.4:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
@@ -7605,15 +7554,6 @@ dom-serializer@0, dom-serializer@^0.2.1:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
-dom-serializer@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.0.1.tgz#79695eb49af3cd8abc8d93a73da382deb1ca0795"
-  integrity sha512-1Aj1Qy3YLbdslkI75QEOfdp9TkQ3o8LRISAzxOibjBs/xWwr1WxZFOQphFkZuepHFGo+kB8e5FVJSS0faAJ4Rw==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
-    entities "^2.0.0"
-
 dom-serializer@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
@@ -8315,11 +8255,6 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -12952,10 +12887,10 @@ napi-build-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
   integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
 
-native-url@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.3.3.tgz#09300f35416a49f79f6f8ab9e3c05c53c2873666"
-  integrity sha512-EEHLiNEIgcTjctwlREZjUT1vdMlrmug+fr0sQ3hoP9+cO3cyhd5fJ0GTnINcnv9LtXL+NdovWNUMDIfW98l2eA==
+native-url@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.3.1.tgz#5045c65d0eb4c3ee548d48e3cb50797eec5a3c54"
+  integrity sha512-VL0XRW8nNBdSpxqZCbLJKrLHmIMn82FZ8pJzriJgyBmErjdEtrUX6eZAJbtHjlkMooEWUV+EtJ0D5tOP3+1Piw==
   dependencies:
     querystring "^0.2.0"
 
@@ -13006,12 +12941,12 @@ next-transpile-modules@^3.3.0:
     micromatch "^4.0.2"
     slash "^3.0.0"
 
-next@^9.4.5-canary.22:
-  version "9.4.5-canary.22"
-  resolved "https://registry.yarnpkg.com/next/-/next-9.4.5-canary.22.tgz#19fccbada8651eeaeaa763cafeaeb8583f755614"
-  integrity sha512-4auk4fGSiSdEsDZueJoBCRMWXNK1NmYhd29NnaseGsdTjNISqEsnzSoVc1bxYW71Nbh/YlD6QnnEgwL5rqH83w==
+next@^9.4.4:
+  version "9.4.4"
+  resolved "https://registry.yarnpkg.com/next/-/next-9.4.4.tgz#02ad9fea7f7016b6b42fc83b67835e4a0dd0c99a"
+  integrity sha512-ZT8bU2SAv5jkFQ+y8py+Rl5RJRJ6DnZDS+VUnB1cIscmtmUhDi7LYED7pYm4MCKkYhPbEEM1Lbpo7fnoZJGWNQ==
   dependencies:
-    "@ampproject/toolbox-optimizer" "2.5.3"
+    "@ampproject/toolbox-optimizer" "2.4.0"
     "@babel/code-frame" "7.8.3"
     "@babel/core" "7.7.7"
     "@babel/plugin-proposal-class-properties" "7.8.3"
@@ -13029,8 +12964,8 @@ next@^9.4.5-canary.22:
     "@babel/preset-typescript" "7.9.0"
     "@babel/runtime" "7.9.6"
     "@babel/types" "7.9.6"
-    "@next/react-dev-overlay" "9.4.5-canary.22"
-    "@next/react-refresh-utils" "9.4.5-canary.22"
+    "@next/react-dev-overlay" "9.4.4"
+    "@next/react-refresh-utils" "9.4.4"
     babel-plugin-syntax-jsx "6.18.0"
     babel-plugin-transform-define "2.0.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
@@ -13039,11 +12974,12 @@ next@^9.4.5-canary.22:
     chokidar "2.1.8"
     css-loader "3.5.3"
     find-cache-dir "3.3.1"
+    fork-ts-checker-webpack-plugin "3.1.1"
     jest-worker "24.9.0"
     loader-utils "2.0.0"
     mini-css-extract-plugin "0.8.0"
     mkdirp "0.5.3"
-    native-url "0.3.3"
+    native-url "0.3.1"
     neo-async "2.6.1"
     pnp-webpack-plugin "1.6.4"
     postcss "7.0.29"
@@ -14561,7 +14497,7 @@ postcss@7.0.29:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@7.0.32, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.5, postcss@^7.0.6:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.32"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
   integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
@@ -17391,10 +17327,10 @@ terser-webpack-plugin@^2.3.5:
     terser "^4.6.12"
     webpack-sources "^1.4.3"
 
-terser@4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.7.0.tgz#15852cf1a08e3256a80428e865a2fa893ffba006"
-  integrity sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==
+terser@4.6.13:
+  version "4.6.13"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.13.tgz#e879a7364a5e0db52ba4891ecde007422c56a916"
+  integrity sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -18975,7 +18911,7 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
-whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==


### PR DESCRIPTION
### What this does

#### Incremental Static Regeneration
This PR fixes the way that the version was being fetched. Previously, the version was being fetched in the getInitialProps in the `_app.tsx` file. This was not ideal as it forces the application to never use [Incremental Static Regeneration](https://nextjs.org/blog/next-9-4#incremental-static-regeneration-beta). We are now exporting a `getStaticProps` method from the homepage that fetches the version to be displayed in the hero component on that page. This should also improve generate page speeds.

#### Fathom
I have also added a `useFathom` hook that adds fathom tracking to these docs. Additionally, I am trying out the "goals" feature of fathom to track [web vitals](https://web.dev/vitals/) metrics that [next.js exposes](https://nextjs.org/docs/advanced-features/measuring-performance#web-vitals). The odd thing about Fathom is that it exposes a cents param for each goal, which formats as a value of currency. The TS for each metric shows up as a dollar value:

![Screen Shot 2020-07-06 at 2 29 51 PM](https://user-images.githubusercontent.com/11803153/86633506-5a58f380-bf96-11ea-8a6a-0ed69a65a049.png)
