### PR TITLE
fix: removes need for `unsafe-eval` CSR

### DIFF
--- a/packages/app/src/manifest.json
+++ b/packages/app/src/manifest.json
@@ -8,7 +8,7 @@
     "256": "assets/logo-128@2x.png",
     "512": "assets/logo-128@3x.png"
   },
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self'<% DEV_CSR %>; object-src 'self'",
   "permissions": [
     "activeTab"
   ],

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -209,6 +209,16 @@ module.exports = {
         from: path.join(sourceRootPath, 'manifest.json'),
         to: path.join(distRootPath, 'manifest.json'),
         toType: 'file',
+        transform(content, path) {
+          const tag = '<% DEV_CSR %>';
+          content = content.toString();
+          if (nodeEnv === 'development') {
+            content = content.replace(tag, " 'unsafe-eval'");
+          } else {
+            content = content.replace(tag, '');
+          }
+          return Buffer.from(content);
+        },
       },
     ]),
     new webpack.DefinePlugin({


### PR DESCRIPTION
The Firefox extension received a comment from a reviewer, asking why we needed the `unsafe-eval` content security policy in our manifest.json file. I had it there to be compatible with a webpack config for development, but it's not needed in production. This PR changes the manifest.json file so that `unsafe-eval` is only included in development builds.