### PR TITLE
fix: alternating address derivation

### DIFF
--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/keychain",
-  "version": "0.7.5",
+  "version": "0.8.5",
   "description": "A package for managing Blockstack keychains",
   "main": "./dist/index.js",
   "umd:main": "./dist/keychain.umd.production.js",

--- a/packages/keychain/src/address-derivation/index.ts
+++ b/packages/keychain/src/address-derivation/index.ts
@@ -1,10 +1,16 @@
-import { ChainID, getAddressFromPrivateKey } from '@blockstack/stacks-transactions';
+import {
+  ChainID,
+  getAddressFromPrivateKey,
+  TransactionVersion,
+} from '@blockstack/stacks-transactions';
 import { BIP32Interface, ECPair } from 'bitcoinjs-lib';
 import { ecPairToHexString } from 'blockstack';
 
+const networkDerivationPath = `m/44'/5757'/0'/0/0`;
+
 export const derivationPaths = {
-  [ChainID.Mainnet]: `m/44'/5757'/0'/0/0`,
-  [ChainID.Testnet]: `m/44'/1'/0'/0/0`,
+  [ChainID.Mainnet]: networkDerivationPath,
+  [ChainID.Testnet]: networkDerivationPath,
 };
 
 export function getDerivationPath(chain: ChainID) {
@@ -19,9 +25,11 @@ export function deriveStxAddressChain(chain: ChainID) {
     }
     const ecPair = ECPair.fromPrivateKey(childKey.privateKey);
     const privateKey = ecPairToHexString(ecPair);
+    const txVersion =
+      chain === ChainID.Mainnet ? TransactionVersion.Mainnet : TransactionVersion.Testnet;
     return {
       childKey,
-      address: getAddressFromPrivateKey(privateKey),
+      address: getAddressFromPrivateKey(privateKey, txVersion),
       privateKey,
     };
   };

--- a/packages/keychain/tests/address-derivation/address-derivation.test.ts
+++ b/packages/keychain/tests/address-derivation/address-derivation.test.ts
@@ -1,13 +1,13 @@
 import { ChainID } from '@blockstack/stacks-transactions';
+import { BIP32Interface } from 'bitcoinjs-lib';
 
 import { deriveStxAddressChain } from '../../src/address-derivation';
 import { deriveRootKeychainFromMnemonic } from '../../src/mnemonic';
 
-const phrase =
-  'humble ramp winner eagle stumble follow gravity roast receive quote buddy start demise issue egg jewel return hurdle ball blind pulse physical uncle room';
-
 describe('deriveStxAddressChain()', () => {
-  test('it returns mainnet derived keys', async () => {
+  test('it returns mainnet derived keys, pt. 1', async () => {
+    const phrase =
+      'humble ramp winner eagle stumble follow gravity roast receive quote buddy start demise issue egg jewel return hurdle ball blind pulse physical uncle room';
     const deriveStxMainnetAddressChain = deriveStxAddressChain(ChainID.Mainnet);
     const rootNode = await deriveRootKeychainFromMnemonic(phrase);
     const result = deriveStxMainnetAddressChain(rootNode);
@@ -16,12 +16,90 @@ describe('deriveStxAddressChain()', () => {
     );
   });
 
-  test('it returns testnet derived keys', async () => {
-    const deriveStxTestnetAddressChain = deriveStxAddressChain(ChainID.Testnet);
+  test('it returns mainnet derived keys, pt. 2', async () => {
+    const phrase =
+      'oblige boat easily source clip remind steel hockey nut arrow swallow keep run fragile fresh river expire stay monster black defy box fiber wave';
+    const deriveStxMainnetAddressChain = deriveStxAddressChain(ChainID.Mainnet);
     const rootNode = await deriveRootKeychainFromMnemonic(phrase);
-    const result = deriveStxTestnetAddressChain(rootNode);
+    const result = deriveStxMainnetAddressChain(rootNode);
     expect(result.privateKey).toEqual(
-      '4cf240ef1e9b467c64b196b6ff3d24d9709f287f667939056fbcfc54e4a1642901'
+      'd7c71a427b8a9ed870c9552f67beadc2710dbee7f29a0cf6cfd1dd96a703bf1801'
     );
+    expect(result.address).toEqual('SP2JSAXXTH90R04677F6JDS5D4DXWNW4T3KWNFDR5');
   });
+
+  describe('it behaves according to CLI library for mainnet', () => {
+    const phrase =
+      'parade vacant kitten museum voice shift tell embrace security page praise cloud stove canal sketch huge ignore cotton island hand wall blush empower movie';
+    const deriveStxTestnetAddressChain = deriveStxAddressChain(ChainID.Mainnet);
+    let rootNode: BIP32Interface;
+    let result: ReturnType<typeof deriveStxTestnetAddressChain>;
+
+    beforeEach(async () => {
+      rootNode = await deriveRootKeychainFromMnemonic(phrase);
+      result = deriveStxTestnetAddressChain(rootNode);
+    });
+
+    test('private key is derive accurately for cli  mainnet', () => {
+      expect(result.privateKey).toEqual(
+        '4587afc14878fd97aa01032bfae21ab01ae9a087abeecc7d867d39393e22ce2101'
+      );
+    });
+
+    test('address is derived accurately for cli mainnet', () => {
+      expect(result.address).toEqual('SP398525PZNCJTPNM6K4NW0T40YXJFEZ9DEQR12TR');
+    });
+  });
+
+  //
+  // This test should pass if testnet key derivation is
+  // supposed to use derivation path `m/44'/5757'/0'/0/0`,
+  describe(`should pass if testnet should use derivation path "m/44'/5757'/0'/0/0"`, () => {
+    const phrase =
+      'decorate confirm shoulder gain develop name tone source potato march maple company blanket discover ship clown virus broccoli room adapt praise oak west canoe';
+    const deriveStxTestnetAddressChain = deriveStxAddressChain(ChainID.Testnet);
+    let rootNode: BIP32Interface;
+    let result: ReturnType<typeof deriveStxTestnetAddressChain>;
+
+    beforeEach(async () => {
+      rootNode = await deriveRootKeychainFromMnemonic(phrase);
+      result = deriveStxTestnetAddressChain(rootNode);
+    });
+
+    test('private key is derive accurately for cli  testnet', () => {
+      expect(result.privateKey).toEqual(
+        'cbaa7cbb821fdd17077fa24529803d351eb038fd6ec8eb14fc92344dbb244da901'
+      );
+    });
+
+    test('address is derived accurately for cli testnet', () => {
+      expect(result.address).toEqual('ST8SHKQXP59D65B1X0PHDHTWMKKPM94N9A2RNXE6');
+    });
+  });
+
+  //
+  // This test should pass if testnet key derivation is
+  // supposed to use derivation path `m/44'/1'/0'/0/0`,
+  // describe(`should pass if testnet should use derivation path "m/44'/1'/0'/0/0"`, () => {
+  //   const phrase =
+  //     'trumpet hole school slim beauty advance evoke chapter random broom account twice state panel grant unfair empower spy asset depend acquire potato scatter atom';
+  //   const deriveStxTestnetAddressChain = deriveStxAddressChain(ChainID.Testnet);
+  //   let rootNode: BIP32Interface;
+  //   let result: ReturnType<typeof deriveStxTestnetAddressChain>;
+
+  //   beforeEach(async () => {
+  //     rootNode = await deriveRootKeychainFromMnemonic(phrase);
+  //     result = deriveStxTestnetAddressChain(rootNode);
+  //   });
+
+  //   test('private key is derive accurately for cli  testnet', () => {
+  //     expect(result.privateKey).toEqual(
+  //       '65d49e09d57c07951b34cdac6b4ef6bdb8ee18ac7884c31a6876b086e7131b2d01'
+  //     );
+  //   });
+
+  //   test('address is derived accurately for cli testnet', () => {
+  //     expect(result.address).toEqual('ST1MED1C7R0V4FAZBAEF3FPD3JVHBP000FKTTG64T');
+  //   });
+  // });
 });


### PR DESCRIPTION
Adding some tests here to highlight how the keychain code doesn't derive keys/addresses the same as the cli. I'm a little confused how it should work, as not all our code handles the differing bip32 derivation paths. I've discussed this with a few of you but we haven't come to any conclusions.

<details>
<summary>Failing test details</summary>

```
 FAIL  tests/address-derivation/address-derivation.test.ts
  deriveStxAddressChain()
    ✓ it returns mainnet derived keys, pt. 1 (82ms)
    ✓ it returns mainnet derived keys, pt. 2 (73ms)
    ✕ it derives addresses according to CLI library (72ms)
    ✓ it derives addresses according to testnet derivation path (67ms)

  ● deriveStxAddressChain() › it derives addresses according to CLI library

    expect(received).toEqual(expected) // deep equality

    Expected: "6a2dd0396513452a91bec57c6a2f7f369ff54ffbdb41b48cd3f0a0021c88555e01"
    Received: "dbb8c0383cde8c02b816a7ab70bfb6dd4fe0efbcf58b32c84cfaae99a85187ef01"

      34 |     const rootNode = await deriveRootKeychainFromMnemonic(phrase);
      35 |     const result = deriveStxTestnetAddressChain(rootNode);
    > 36 |     expect(result.privateKey).toEqual(
         |                               ^
      37 |       '6a2dd0396513452a91bec57c6a2f7f369ff54ffbdb41b48cd3f0a0021c88555e01'
      38 |     );
      39 |     expect(result.address).toEqual('ST34WBD6JEC2T51RA64N9MBFVQBQHGF20A0B5PP0F');

      at tests/address-derivation/address-derivation.test.ts:36:31
      at fulfilled (tests/address-derivation/address-derivation.test.ts:5:58)
```

</details>

Afaik, the cli, stacks-transaction lib, and blockstack.js generate testnet addresses with the mainnet derivation path `m/44'/5757'/0'/0/0`. As I understand, testnet addresses are just mainnet address [coerced to testnet ones](https://github.com/blockstack/cli-blockstack/blob/master/src/cli.ts#L2396-L2399). 
According to [the spec given to zondax for the ledger integration](https://paper.dropbox.com/doc/Zondax-Ledger-Pre-budget-Analysis-mL3vnagw0pIp9Mp3TOhII), testnet uses a different derivation path (the same as btc the testnet). ~@diwakergupta wrote this, though can't find where it's mentioned in a SIP/whitepaper.~ As Matt says, Zondax are likely following the common practice of using `m/44'/1'/0'...` for testnets.

**Questions:**
- Is there a hard decision on whether we're using the differing bip32 derivation paths for mainnet/testnet?
- Are there/do we need to make plans to migrate all of our code to respect the different derivations paths?
- Would the [`coerceAddress` functionality of blockstack.js](https://github.com/blockstack/blockstack.js/blob/52420a4df53b2690cfbc585ee7819af5ded9c2e7/src/network.ts#L98-L113) no longer be possible?

Would love input on what the expected behaviour should be here, or whether I'm misunderstanding how address derivation should work.

cc/ @yknl @zone117x @hstove @reedrosenbluth 

Edit: my initial implementation was missing handling `TransactionVersion` in the `getAddressFromPrivateKey` function, so was incorrect. Though despite this, the question remains whether or not we're using separate derivation paths.
