### PR TITLE
ci: don't use cache on publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,15 +63,7 @@ jobs:
       uses: actions/setup-node@v1.4.2
       with:
         node-version: 12.16.1
-    - name: Restore lerna cache
-      id: lerna-cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          node_modules
-          */*/node_modules
-        key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-    - name: Install monorepo deps
+    - name: Install monorepo deps (no cache)
       run: yarn --frozen-lockfile
       if: steps.lerna-cache.outputs.cache-hit != 'true'
     - name: Setup .npmrc


### PR DESCRIPTION
This fixes a bug with our new caching in our actions by not using caching for our publish action. The cache seems to add a new yarn.lock file which causes it to fail, as there are uncommitted files. 