### PR TITLE
fix: textStyles not being typed

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/ui",
   "description": "Blockstack UI components built using React and styled-components with styled-system.",
-  "version": "2.8.4",
+  "version": "2.9.4",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.org/)",
   "bundlesize": [
     {

--- a/packages/ui/src/box/types.ts
+++ b/packages/ui/src/box/types.ts
@@ -2,6 +2,7 @@ import * as StyledSystem from 'styled-system';
 import * as React from 'react';
 import { Omit } from '../common-types';
 import * as CSS from 'csstype';
+import { TextStylesLiteral } from '../theme/typography';
 
 export type FontSizeValues =
   | 'xs'
@@ -70,20 +71,8 @@ export interface TextTransform {
     | CSS.TextTransformProperty;
 }
 
-export type TextStyleValues =
-  | 'display.large'
-  | 'display.small'
-  | 'body.large.medium'
-  | 'body.large'
-  | 'body.small.medium'
-  | 'body.small'
-  | 'caption'
-  | 'caption.medium';
-
 export interface TextStyle {
-  textStyle?:
-    | StyledSystem.ResponsiveValue<TextStyleValues>
-    | StyledSystem.TextStyleProps['textStyle'];
+  textStyle?: TextStylesLiteral | StyledSystem.ResponsiveValue<TextStylesLiteral>;
 }
 
 export type AsType = React.ElementType<any>;

--- a/packages/ui/src/theme/types.ts
+++ b/packages/ui/src/theme/types.ts
@@ -1,11 +1,12 @@
 import { Theme as StyledSystemTheme } from 'styled-system';
 import { LiteralUnion } from 'type-fest';
+import { TextStylesLiteral } from './typography';
 
 interface CustomTheme {
   opacity?: {
     [key: string]: string;
   };
-  textStyles?: any;
+  textStyles?: TextStylesLiteral;
   fonts: {
     [key: string]: string;
   };

--- a/packages/ui/src/theme/typography.ts
+++ b/packages/ui/src/theme/typography.ts
@@ -37,55 +37,78 @@ const typography = {
   fontSizes: [12, 14, 16, 20, 24, 28, 32, 36, 48, 64, 96, 128],
 };
 
-const textStyles = {
-  display: {
-    large: {
-      fontWeight: typography.fontWeights.semibold,
-      fontSize: typography.fontSizes[4],
-      lineHeight: typography.lineHeights.shorter, // 1.333
-      letterSpacing: '-0.02em',
-    },
-    small: {
-      fontWeight: typography.fontWeights.medium,
-      fontSize: typography.fontSizes[3],
-      lineHeight: typography.lineHeights.short, // 1.4
-      letterSpacing: '-0.02em',
-    },
-  },
-  body: {
-    large: {
-      fontWeight: typography.fontWeights.normal,
-      fontSize: typography.fontSizes[2],
-      lineHeight: typography.lineHeights.base, // 1.5 (24)
-      letterSpacing: '-0.01em',
-    },
-    small: {
-      fontWeight: typography.fontWeights.normal,
-      fontSize: typography.fontSizes[1],
-      lineHeight: typography.lineHeights.short, // 1.4 (19.6)
-      letterSpacing: '-0.01em',
-    },
-  },
-  caption: {
-    fontSize: typography.fontSizes[0],
-    lineHeight: typography.lineHeights.shorter, // 1.333 (16)
-    letterSpacing: '0.00em',
-  },
+const displayLarge = {
+  fontWeight: typography.fontWeights.semibold,
+  fontSize: typography.fontSizes[4],
+  lineHeight: typography.lineHeights.shorter, // 1.333
+  letterSpacing: '-0.02em',
 };
-(textStyles.body.large as any).medium = {
-  ...textStyles.body.large,
+const displaySmall = {
+  fontWeight: typography.fontWeights.medium,
+  fontSize: typography.fontSizes[3],
+  lineHeight: typography.lineHeights.short, // 1.4
+  letterSpacing: '-0.02em',
+};
+const bodyLarge = {
+  fontWeight: typography.fontWeights.normal,
+  fontSize: typography.fontSizes[2],
+  lineHeight: typography.lineHeights.base, // 1.5 (24)
+  letterSpacing: '-0.01em',
+};
+const bodyLargeMedium = {
+  ...bodyLarge,
   fontWeight: typography.fontWeights.medium,
 };
-(textStyles.body.small as any).medium = {
-  ...textStyles.body.small,
+const bodySmall = {
+  fontWeight: typography.fontWeights.normal,
+  fontSize: typography.fontSizes[1],
+  lineHeight: typography.lineHeights.short, // 1.4 (19.6)
+  letterSpacing: '-0.01em',
+};
+const bodySmallMedium = {
+  ...bodySmall,
   fontWeight: typography.fontWeights.medium,
 };
-(textStyles.caption as any).medium = {
-  ...textStyles.body.small,
+const caption = {
+  fontSize: typography.fontSizes[0],
+  lineHeight: typography.lineHeights.shorter, // 1.333 (16)
+  letterSpacing: '0.00em',
+};
+const captionMedium = {
+  ...bodySmall,
   fontWeight: typography.fontWeights.medium,
 };
 
-export { textStyles };
+export const textStyles = {
+  display: {
+    large: {
+      ...displayLarge,
+      medium: bodyLargeMedium,
+    },
+    small: displaySmall,
+  },
+  body: {
+    large: bodyLarge,
+    small: {
+      ...bodySmall,
+      medium: bodySmallMedium,
+    },
+  },
+  caption: {
+    ...caption,
+    medium: captionMedium,
+  },
+} as const;
+
+export type TextStylesLiteral =
+  | 'display.large'
+  | 'display.small'
+  | 'body.large'
+  | 'body.large.medium'
+  | 'body.small'
+  | 'body.small.medium'
+  | 'caption'
+  | 'caption.medium';
 
 export default {
   ...typography,


### PR DESCRIPTION
This PR changes the types so that suggestions are made for the `textStyles` prop.

@aulneau we don't ever need to input free text to this field, right?