### PR TITLE
feat: expose connect, app version

### DIFF
--- a/packages/app/src/common/dev/types/index.ts
+++ b/packages/app/src/common/dev/types/index.ts
@@ -12,6 +12,7 @@ export interface DecodedAuthRequest {
     icon: string;
   };
   client?: string;
+  connectVersion?: string;
 }
 
 export type AppManifest = JSONSchemaForWebApplicationManifestFiles;

--- a/packages/app/src/common/track.ts
+++ b/packages/app/src/common/track.ts
@@ -68,6 +68,8 @@ export const doTrackScreenChange = (
     await page({
       name: pageTrackingNameMap[screen],
       appName: decodedAuthRequest?.appDetails?.name,
+      connectVersion: decodedAuthRequest?.connectVersion,
+      version: (window as any).__APP_VERSION__,
       appDomain: appURL?.host,
     });
   }, 1);

--- a/packages/app/src/components/app.tsx
+++ b/packages/app/src/components/app.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ThemeProvider, theme, CSSReset } from '@blockstack/ui';
 import { createGlobalStyle } from 'styled-components';
 import { Routes } from '@components/routes';
 import { HashRouter as Router } from 'react-router-dom';
 import { useMessagePong } from '@common/hooks/use-message-pong';
+import { version } from '../../package.json';
 
 const GlobalStyles = createGlobalStyle`
 #actions-root{
@@ -15,6 +16,9 @@ flex-direction: column;
 
 export const App: React.FC = () => {
   useMessagePong();
+  useEffect(() => {
+    (window as any).__APP_VERSION__ = version;
+  }, []);
   return (
     <ThemeProvider theme={theme}>
       <React.Fragment>

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -19,6 +19,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "paths": {
       "@store/*": ["store/*"],
       "@store": ["store/index"],

--- a/packages/connect/src/auth.ts
+++ b/packages/connect/src/auth.ts
@@ -1,8 +1,13 @@
 import { UserSession, AppConfig } from 'blockstack';
 import './types';
 import { popupCenter, setupListener } from './popup';
+import { version } from '../package.json';
 
 export const defaultAuthURL = 'https://app.blockstack.org';
+
+if (typeof window !== 'undefined') {
+  (window as any).__CONNECT_VERSION__ = version;
+}
 
 export interface FinishedData {
   authResponse: string;
@@ -62,6 +67,7 @@ export const authenticate = async ({
     {
       sendToSignIn,
       appDetails,
+      connectVersion: version,
     }
   );
 

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -27,6 +27,7 @@
     },
     "jsx": "react",
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
   }
 }

--- a/packages/test-app/tsconfig.json
+++ b/packages/test-app/tsconfig.json
@@ -37,7 +37,8 @@
 		"noUnusedLocals": true,                		/* Report errors on unused locals. */
 		"noUnusedParameters": true,            		/* Report errors on unused parameters. */
 		"noImplicitReturns": true,             		/* Report error when not all code paths in function return a value. */
-		"noFallthroughCasesInSwitch": true,    		/* Report errors for fallthrough cases in switch statement. */
+    "noFallthroughCasesInSwitch": true,    		/* Report errors for fallthrough cases in switch statement. */
+    "resolveJsonModule": true,
 		
 		/* Module Resolution Options */
 		"moduleResolution": "node",           		/* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */


### PR DESCRIPTION
This PR:

- exposes `window.__CONNECT_VERSION__` in applications that import connect
- exposes `window.__APP_VERSION__` in the authenticator
- exposes `connectVersion` and `version` in all screen track calls