### PR TITLE
feat(ui): better bundle size with esmodules

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -91,7 +91,7 @@
     ]
   },
   "main": "dist/index.js",
-  "module": "dist/ui.esm.js",
+  "module": "dist/index.esm.js",
   "peerDependencies": {
     "react": "16.x",
     "react-dom": "16.x",

--- a/packages/ui/tsdx.config.js
+++ b/packages/ui/tsdx.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  rollup(config, options) {
+    if (options.format === 'esm') {
+      config = { ...config, preserveModules: true };
+      config.output = { ...config.output, dir: 'dist/', entryFileNames: '[name].esm.js' };
+      delete config.output.file;
+    }
+    return config;
+  },
+};


### PR DESCRIPTION
### What this does
I was doing some work optimizing the bundle size of the docs site and kept seeing that all of the UI library was being bundled in with the application, and I know that we are using esmodules for the site, which I thought would lead to tree-shaking of any component not used. This was not the case. 

After digging into it, I found that rollup (which TSDX uses under the hood) offers an option for `preserveModules` which will let us output all of the components to their own folder under `dist/`. This has given us a good amount of savings on the docs site of ~46kb 🗡️ 🔥 You can read a good thread about this [here](https://github.com/formium/tsdx/issues/276#issuecomment-616200604).

### Before:
<img width="919" alt="Screen Shot 2020-07-23 at 11 44 43 AM" src="https://user-images.githubusercontent.com/11803153/88314577-c0ee4900-ccda-11ea-83a5-d5e02b88a3e3.png">

### After
<img width="950" alt="Screen Shot 2020-07-23 at 11 44 29 AM" src="https://user-images.githubusercontent.com/11803153/88314606-c9468400-ccda-11ea-9be7-2426c08268df.png">