### PR TITLE
fix: send to sign in when using showBlockstackConnect, fixes #507

### DIFF
--- a/packages/connect/src/ui.tsx
+++ b/packages/connect/src/ui.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { useConnect, Connect } from './react';
-import { AuthOptions } from './auth';
+import { AuthOptions, authenticate } from './auth';
 
 const Base: React.FC = () => {
   const { doOpenAuth } = useConnect();
@@ -19,6 +19,9 @@ const Base: React.FC = () => {
 };
 
 export const showBlockstackConnect = (authOptions: AuthOptions) => {
+  if (authOptions.sendToSignIn) {
+    return authenticate(authOptions);
+  }
   const baseDiv = document.createElement('div');
   document.body.appendChild(baseDiv);
   ReactDOM.render(
@@ -27,4 +30,5 @@ export const showBlockstackConnect = (authOptions: AuthOptions) => {
     </Connect>,
     baseDiv
   );
+  return;
 };


### PR DESCRIPTION
When you pass `sendToSignIn: true` to `showBlockstackConnect`, it still shows the intro modal. This change will send the user straight to sign in if they pass `sendToSignIn: true`. The dev could just use `authenticate`, but this improves the DX a bit. Fixes #507 