### PR TITLE
fix: autocapitalize/autocorrect off on username, fixes #472

### DIFF
--- a/packages/app/src/pages/username.tsx
+++ b/packages/app/src/pages/username.tsx
@@ -154,15 +154,15 @@ export const Username: React.FC<{}> = () => {
               <Input
                 autoComplete="username"
                 data-test="input-username"
-                autoCapitalize="false"
                 paddingRight="100px"
                 autoFocus
                 fontSize="16px"
-                spellCheck={false}
                 value={username}
                 aria-invalid={error !== null}
                 onChange={handleInput}
+                spellCheck="false"
                 autoCorrect="off"
+                autoCapitalize="off"
               />
             </Box>
             {error && hasAttemptedSubmit && (


### PR DESCRIPTION
Fixes syntax for autoCorrect, also fixes syntax for autoCapitalize.

QA (only relates to mobile):

- No red squiggles should show up on the username field
- The first letter should not be capitalized