### PR TITLE
fix(ui): force prism as prop 

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -31,7 +31,7 @@ jobs:
           source: 'packages/app/vercel.json'
           target: 'packages/app/dist/vercel.json'
       - name: Deploy Blockstack App with Vercel
-        uses: amondnet/vercel-action@v19.0.1+1
+      - uses: aulneau/vercel-action@v19.0.2+3
         id: vercel-deployment-blockstack-app
         if: github.event_name == 'pull_request'
         with:
@@ -41,6 +41,7 @@ jobs:
           scope: ${{ secrets.VERCEL_SCOPE }}
           working-directory: packages/app/dist
           github-comment: false
+          alias-domains: pr-{{ PR_NUMBER }}.app.stacks.engineering
       - name: Build Blockstack Test App
         env:
           AUTH_ORIGIN: ${{ steps.vercel-deployment-blockstack-app.outputs.preview-url }}
@@ -52,7 +53,7 @@ jobs:
           source: 'packages/test-app/vercel.json'
           target: 'packages/test-app/dist/vercel.json'
       - name: Deploy Blockstack Test App with Vercel
-        uses: amondnet/vercel-action@v19.0.1+1
+        uses: aulneau/vercel-action@v19.0.2+3
         id: vercel-deployment-blockstack-test-app
         if: github.event_name == 'pull_request'
         with:
@@ -62,6 +63,7 @@ jobs:
           scope: ${{ secrets.VERCEL_SCOPE }}
           working-directory: packages/test-app/dist
           github-comment: false
+          alias-domains: pr-{{ PR_NUMBER }}.testnet-demo.stacks.engineering
       - name: Comment on PR
         uses: actions/github-script@v2
         id: comment
@@ -83,7 +85,7 @@ jobs:
             ${firstLine}
 
             - [Blockstack App](${{ steps.vercel-deployment-blockstack-app.outputs.preview-url }})
-            - [Blockstack Test App](${{ steps.vercel-deployment-blockstack-test-app.outputs.preview-url }})
+            - [Blockstack Testnet Demo App](${{ steps.vercel-deployment-blockstack-test-app.outputs.preview-url }})
 
             Built with commit ${context.sha}.
             `;

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,13 +1,6 @@
 name: Deploy UI Docs
 on:
-  push:
-    branches:
-      - master
   pull_request:
-    paths:
-      - packages/ui-docs/**
-      - packages/ui/**
-  release:
     paths:
       - packages/ui-docs/**
       - packages/ui/**
@@ -17,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: amondnet/vercel-action@v19.0.1+1
+      - uses: aulneau/vercel-action@v19.0.2+3
         id: vercel-deployment-preview
         if: github.event_name == 'pull_request'
         with:
@@ -25,16 +18,7 @@ jobs:
           vercel-org-id: ${{ secrets.ORG_ID }}
           vercel-project-id: ${{ secrets.PROJECT_ID }}
           scope: ${{ secrets.VERCEL_SCOPE }}
-          working-directory: packages/ui-docs
-      - uses: amondnet/vercel-action@v19.0.1+1
-        id: vercel-deployment-production
-        if: github.event_name == 'push' ||  github.event_name == 'release'
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID }}
-          vercel-project-id: ${{ secrets.PROJECT_ID }}
-          vercel-args: '--prod'
-          scope: ${{ secrets.VERCEL_SCOPE }}
+          alias-domains: pr-{{ PR_NUMBER }}.ui.stacks.engineering
           working-directory: packages/ui-docs
       - name: Comment on PR
         uses: actions/github-script@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,83 +5,83 @@ jobs:
   test_keychain:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set Node Version
-      uses: actions/setup-node@v1.4.2
-      with:
-        node-version: 12.16.1
-    - name: Restore lerna cache
-      id: lerna-cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          node_modules
-          */*/node_modules
-        key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-    - name: Install monorepo deps
-      run: yarn --frozen-lockfile
-      if: steps.lerna-cache.outputs.cache-hit != 'true'
-    - name: Keychain tests
-      run: yarn lerna run test --scope @blockstack/keychain
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set Node Version
+        uses: actions/setup-node@v1.4.2
+        with:
+          node-version: 12.16.1
+      - name: Restore lerna cache
+        id: lerna-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install monorepo deps
+        run: yarn --frozen-lockfile
+        if: steps.lerna-cache.outputs.cache-hit != 'true'
+      - name: Keychain tests
+        run: yarn lerna run test --scope @blockstack/keychain
 
   codecheck:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set Node Version
-      uses: actions/setup-node@v1.4.2
-      with:
-        node-version: 12.16.1
-    - name: Restore lerna cache
-      id: lerna-cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          node_modules
-          */*/node_modules
-        key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-    - name: Install monorepo deps
-      run: yarn --frozen-lockfile
-      if: steps.lerna-cache.outputs.cache-hit != 'true'
-    - name: Lint
-      run: yarn lint
-    - name: Typecheck
-      run: yarn typecheck
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set Node Version
+        uses: actions/setup-node@v1.4.2
+        with:
+          node-version: 12.16.1
+      - name: Restore lerna cache
+        id: lerna-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install monorepo deps
+        run: yarn --frozen-lockfile
+        if: steps.lerna-cache.outputs.cache-hit != 'true'
+      - name: Lint
+        run: yarn lint
+      - name: Typecheck
+        run: yarn typecheck
 
   publish:
     needs: [test_keychain, codecheck]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Checkout master
-      run: git checkout master
-    - name: Set Node Version
-      uses: actions/setup-node@v1.4.2
-      with:
-        node-version: 12.16.1
-    - name: Install monorepo deps (no cache)
-      run: yarn --frozen-lockfile
-      if: steps.lerna-cache.outputs.cache-hit != 'true'
-    - name: Setup .npmrc
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-    - name: Setup git
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-    - name: Lerna Version
-      run: yarn lerna version --conventional-commits --no-push --yes
-    - name: Publish
-      run: yarn lerna publish from-git --conventional-commits --yes
-    - name: Push changes
-      uses: ad-m/github-push-action@fe38f0a
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout master
+        run: git checkout master
+      - name: Set Node Version
+        uses: actions/setup-node@v1.4.2
+        with:
+          node-version: 12.16.1
+      - name: Install monorepo deps (no cache)
+        run: yarn --frozen-lockfile
+        if: steps.lerna-cache.outputs.cache-hit != 'true'
+      - name: Setup .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+      - name: Setup git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      - name: Lerna Version
+        run: yarn lerna version --conventional-commits --no-push --yes
+      - name: Publish
+        run: yarn lerna publish from-git --conventional-commits --yes
+      - name: Push changes
+        uses: ad-m/github-push-action@fe38f0a
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-prod-apps:
     needs: [publish]
@@ -112,7 +112,7 @@ jobs:
         with:
           source: 'packages/app/vercel.json'
           target: 'packages/app/dist/vercel.json'
-      - uses: amondnet/vercel-action@v19.0.1+1
+      - uses: amondnet/vercel-action@v19.0.1+2
         id: vercel-deployment-app-production
         if: github.event_name == 'push' ||  github.event_name == 'release'
         name: Deploy authenticator app to production
@@ -133,7 +133,7 @@ jobs:
         with:
           source: 'packages/test-app/vercel.json'
           target: 'packages/test-app/dist/vercel.json'
-      - uses: amondnet/vercel-action@v19.0.1+1
+      - uses: amondnet/vercel-action@v19.0.1+2
         id: vercel-deployment-production
         name: Deploy test app to production
         if: github.event_name == 'push' ||  github.event_name == 'release'
@@ -144,3 +144,14 @@ jobs:
           vercel-args: '--prod'
           scope: ${{ secrets.VERCEL_SCOPE }}
           working-directory: packages/test-app/dist
+      - uses: amondnet/vercel-action@v19.0.1+2
+        id: vercel-deployment-production
+        if: github.event_name == 'push' ||  github.event_name == 'release'
+        name: Deploy UI documentation to production
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.ORG_ID }}
+          vercel-project-id: ${{ secrets.PROJECT_ID }}
+          vercel-args: '--prod'
+          scope: ${{ secrets.VERCEL_SCOPE }}
+          working-directory: packages/ui-docs

--- a/packages/ui-docs/src/pages/index.tsx
+++ b/packages/ui-docs/src/pages/index.tsx
@@ -19,7 +19,7 @@ export async function getStaticProps() {
     // we will attempt to re-generate the page:
     // - when a request comes in
     // - at most once every second
-    unstable_revalidate: 1,
+    revalidate: 1,
   };
 }
 

--- a/packages/ui/src/codeblock/index.tsx
+++ b/packages/ui/src/codeblock/index.tsx
@@ -6,7 +6,7 @@ export type CodeBlockProps = HighlighterProps & BoxProps;
 
 export const CodeBlock = React.forwardRef(
   (
-    { code, showLineNumbers, hideLineHover, style = {}, language, ...rest }: CodeBlockProps,
+    { code, showLineNumbers, hideLineHover, style = {}, language, Prism, ...rest }: CodeBlockProps,
     ref: React.Ref<HTMLDivElement>
   ) => (
     <Box
@@ -29,6 +29,7 @@ export const CodeBlock = React.forwardRef(
         code={code.toString().trim()}
         showLineNumbers={showLineNumbers}
         hideLineHover={hideLineHover}
+        Prism={Prism}
       />
     </Box>
   )

--- a/packages/ui/src/highlighter/clarity.tsx
+++ b/packages/ui/src/highlighter/clarity.tsx
@@ -1,5 +1,4 @@
 // @ts-nocheck
-import Prism from 'prismjs';
 
 (function (Prism) {
   // Functions to construct regular expressions
@@ -112,4 +111,4 @@ buff|hash160|sha256|sha512|sha512/256|keccak256|true|false|none)' +
   };
 
   Prism.languages.clarity = language;
-})(Prism);
+});

--- a/packages/ui/src/highlighter/index.tsx
+++ b/packages/ui/src/highlighter/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Prism from 'prismjs';
 import Highlight from 'prism-react-renderer';
 import { Box } from '../box';
 import { Flex } from '../flex';
@@ -122,16 +121,30 @@ const Lines = ({
     </Box>
   );
 };
+type PrismToken = {
+  type: string;
+  content: (PrismToken | string)[] | string;
+};
+type PrismGrammar = {
+  [key: string]: any;
+};
+type LanguageDict = { [lang in Language]: PrismGrammar };
+type PrismLib = {
+  languages: LanguageDict;
+  tokenize: (code: string, grammar: PrismGrammar, language: Language) => PrismToken[] | string[];
+  highlight: (code: string, grammar: PrismGrammar, language: Language) => string;
+};
 
 export interface HighlighterProps {
   code: string;
   language?: Language;
   showLineNumbers?: boolean;
   hideLineHover?: boolean;
+  Prism: PrismLib;
 }
 
 export const Highlighter = React.memo(
-  ({ code, language = 'clarity', showLineNumbers, hideLineHover }: HighlighterProps) => {
+  ({ code, language = 'clarity', showLineNumbers, hideLineHover, Prism }: HighlighterProps) => {
     return (
       <Highlight theme={theme} code={code} language={language as any} Prism={Prism as any}>
         {props => (

--- a/packages/ui/src/highlighter/index.tsx
+++ b/packages/ui/src/highlighter/index.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '../hooks';
 
 import { GrammaticalToken, GetGrammaticalTokenProps, RenderProps, Language } from './types';
 import { theme } from './prism-theme';
-import './language-definition';
+import './clarity';
 
 export * from './types';
 


### PR DESCRIPTION
This forces each app to include their version of Prism manually. Typically the workflow would be if the app needs this highlighting component, they'd choose which version of Prims to use, either `prism-react-renerer/prism` which does not pollute the `window`/global space, or they'd do `import Prism from 'prismjs'` which does, and does an annoying thing of automatically highlighting any code on dom load, no matter what. Even when it's not imported (the need for this change).