### PR TITLE
fix(ui): render bug with clipboard hook

### DIFF
--- a/packages/ui/src/use-clipboard/index.tsx
+++ b/packages/ui/src/use-clipboard/index.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
-interface Clipboard {
+interface UiClipboard {
   value: string;
   onCopy: () => void;
   hasCopied: boolean;
@@ -30,16 +30,17 @@ const copyToClipboard = (value: string) => {
   }
 };
 
-function useClipboard(value: string): Clipboard {
+export function useClipboard(value: string): UiClipboard {
   const [hasCopied, setHasCopied] = useState(false);
+  const timers = useRef<number[]>([]);
 
   const onCopy = () => {
     copyToClipboard(value);
     setHasCopied(true);
-    setTimeout(() => setHasCopied(false), 1500);
+    timers.current.push(setTimeout(() => setHasCopied(false), 1250));
   };
+
+  useEffect(() => () => timers.current.forEach(timer => clearTimeout(timer)), []);
 
   return { value, onCopy, hasCopied };
 }
-
-export { useClipboard };


### PR DESCRIPTION
Noticed this bug in the Stacks Wallet, when you copy to clipboard and close the modal.

The timeout can then fire and try to change state on a non-existent component. This PR introduces an effect with a teardown to clear the timer(s), if there are any in progress. Uses `useRef` to ensure we're pointing to same instance of array.

Also renames `Clipboard` as this is a global type.

<img src="https://user-images.githubusercontent.com/1618764/88654304-7bac8b80-d0cd-11ea-9881-6fac48f318eb.png" width="250px" />
