### PR TITLE
fix: show correct secret key on home screen, fixes #517

### DIFF
--- a/packages/app/src/common/hooks/use-wallet.ts
+++ b/packages/app/src/common/hooks/use-wallet.ts
@@ -23,7 +23,7 @@ export const useWallet = () => {
   const [secretKey, setSecretKey] = useState(onboardingSecretKey);
 
   const fetchSecretKey = async () => {
-    if (!secretKey && wallet) {
+    if (wallet) {
       const decryptedKey = await decrypt(wallet?.encryptedBackupPhrase, DEFAULT_PASSWORD);
       setSecretKey(decryptedKey);
     }

--- a/packages/app/src/store/transforms.ts
+++ b/packages/app/src/store/transforms.ts
@@ -30,6 +30,7 @@ export const WalletTransform = createTransform(
 
 interface InboundOnboardingState {
   onboardingPath?: string;
+  secretKey?: string;
 }
 
 /**
@@ -38,10 +39,11 @@ interface InboundOnboardingState {
  */
 export const OnboardingTransform = createTransform(
   (inboundState: InboundOnboardingState) => {
+    const { secretKey, ...state } = inboundState;
     return {
       onboardingPath: inboundState.onboardingPath,
       ...initialState,
-      ...inboundState,
+      ...state,
     };
   },
   outboundState => {


### PR DESCRIPTION
QA Steps:

- Sign in with an existing secret key
- View the home page for the authenticator
- Click 'view secret key'
- The displayed secret key should be the same as you used to sign in