### PR TITLE
fix(keychain): silently broken build, not emitting types

### DIFF
--- a/packages/keychain/jest.config.js
+++ b/packages/keychain/jest.config.js
@@ -1,3 +1,10 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const { pathsToModuleNameMapper } = require('ts-jest/utils');
+// In the following statement, replace `./tsconfig` with the path to your `tsconfig` file
+// which contains the path mapping (ie the `compilerOptions.paths` option):
+const { compilerOptions } = require('./tsconfig.tests');
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
@@ -10,6 +17,7 @@ module.exports = {
       },
     },
   },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
   moduleFileExtensions: ['js', 'ts', 'd.ts'],
   setupFiles: ['./tests/global-setup.ts'],
   setupFilesAfterEnv: ['./tests/setup.ts'],

--- a/packages/keychain/tsconfig.json
+++ b/packages/keychain/tsconfig.json
@@ -4,14 +4,11 @@
     "module": "es2015",
     "moduleResolution": "node",
     "declaration": true,
-    "outDir": "/lib",
+    "outDir": "./lib",
     "strict": true,
     "skipLibCheck": true,
     "baseUrl": "./src",
     "allowSyntheticDefaultImports": true,
-    "paths": {
-      "@blockstack/rpc-client": ["../../rpc-client/src"]
-    },
     "lib": [
       "es2017",
       "dom"

--- a/packages/keychain/tsconfig.tests.json
+++ b/packages/keychain/tsconfig.tests.json
@@ -10,10 +10,10 @@
     "baseUrl": "./src",
     "allowSyntheticDefaultImports": true,
     "lib": ["es2017", "dom"],
-    "sourceMap": true,
     "paths": {
       "@blockstack/rpc-client": ["../../rpc-client/src"]
-    }
+    },
+    "sourceMap": true
   },
   "include": ["./src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5714,7 +5714,16 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@5.6.0, buffer@^4.3.0, buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
+buffer@^4.3.0:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
+buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
   integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
@@ -8048,7 +8057,7 @@ eslint-plugin-flowtype@^4.7.0:
   dependencies:
     lodash "^4.17.15"
 
-eslint-plugin-import@2.21.2, eslint-plugin-import@>=2.20.2, eslint-plugin-import@^2.18.2, "eslint-plugin-import@^2.21.2 ":
+eslint-plugin-import@>=2.20.2, eslint-plugin-import@^2.18.2, "eslint-plugin-import@^2.21.2 ":
   version "2.21.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.21.2.tgz#8fef77475cc5510801bedc95f84b932f7f334a7c"
   integrity sha512-FEmxeGI6yaz+SnEB6YgNHlQK1Bs2DKLM+YF+vuTk5H8J9CLbJLtlPvRFgZZ2+sXiKAlN5dpdlrWOjK8ZoZJpQA==


### PR DESCRIPTION
a448ce61419584b17eeedd9fce2df963d0d0f46d introduced to the tsconfig to build into the root `/lib` directory, not the relative `./lib` directory.

This, along with an direct inter-package dependency, silently prevented the build from outputting the typing files.