### PR TITLE
feat: changes to Connect intro modal

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -31,7 +31,7 @@ jobs:
           source: 'packages/app/vercel.json'
           target: 'packages/app/dist/vercel.json'
       - name: Deploy Blockstack App with Vercel
-      - uses: aulneau/vercel-action@v19.0.2+3
+        uses: aulneau/vercel-action@v19.0.2+3
         id: vercel-deployment-blockstack-app
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,7 +145,7 @@ jobs:
           scope: ${{ secrets.VERCEL_SCOPE }}
           working-directory: packages/test-app/dist
       - uses: amondnet/vercel-action@v19.0.1+2
-        id: vercel-deployment-production
+        id: vercel-deployment-production-ui-docs
         if: github.event_name == 'push' ||  github.event_name == 'release'
         name: Deploy UI documentation to production
         with:

--- a/packages/app/tests/integration/page-objects/demo.page.ts
+++ b/packages/app/tests/integration/page-objects/demo.page.ts
@@ -7,14 +7,14 @@ export class DemoPage {
   $openAuthButton = createTestSelector('button-skip-connect');
   authResponse = '#auth-response';
   appPriivateKey = '#app-private-key';
-  getStarted = '//span[text()="Get Started"]';
-  getStartedPopUp = 'css=button>span >> text="Get started"';
+  getStarted = '//span[text()="Get your Secret Key"]';
+  getStartedPopUp = 'css=button>span >> text="Get your Secret Key"';
   skipBtn = 'text="Skip"';
   postTextarea = 'div.DraftEditor-root';
   postBtn = '//span[text()="Post"]';
   profileBtn = '//*[@title="Your Profile"]';
   logoutBtn = '//*[contains(text(),"Log out")]';
-  alreadyHaveSecretKeyLink = '//span[text()="I already have a Secret Key"]';
+  alreadyHaveSecretKeyLink = '//span[text()="Sign in"]';
   openConnectBtn = createTestSelector('sign-up');
   openSignInBtn = createTestSelector('sign-in');
 
@@ -49,7 +49,10 @@ export class DemoPage {
   async waitForAuthResponse() {
     await this.page.waitForSelector('#auth-response', { state: 'attached', timeout: 15000 });
     const authResponseEl = await this.page.$('#auth-response');
-    const authResponse = (await this.page.evaluate(el => el?.getAttribute('value'), authResponseEl)) as string;
+    const authResponse = (await this.page.evaluate(
+      el => el?.getAttribute('value'),
+      authResponseEl
+    )) as string;
     return authResponse;
   }
 

--- a/packages/connect/src/react/components/screens/intro.tsx
+++ b/packages/connect/src/react/components/screens/intro.tsx
@@ -69,7 +69,7 @@ export const Intro = () => {
       <ScreenFooter>
         <Stack mb="base-loose" mt="base-tight" spacing="base" isInline>
           <Link textStyle="caption" color="blue" onClick={() => doAuth({ sendToSignIn: true })}>
-            I already have a Secret Key
+            Sign in
           </Link>
           <Link
             color="blue"
@@ -79,6 +79,15 @@ export const Intro = () => {
             }}
           >
             How it works
+          </Link>
+          <Link
+            color="blue"
+            textStyle="caption"
+            onClick={() => {
+              window.open('https://www2.blockstack.org/install-extension', '_blank');
+            }}
+          >
+            Install extension
           </Link>
         </Stack>
       </ScreenFooter>

--- a/packages/connect/src/react/components/screens/intro.tsx
+++ b/packages/connect/src/react/components/screens/intro.tsx
@@ -63,7 +63,7 @@ export const Intro = () => {
       />
       <ScreenActions>
         <Button width="100%" size="lg" mt="tight" onClick={() => doAuth()}>
-          Get started
+          Get your Secret Key
         </Button>
       </ScreenActions>
       <ScreenFooter>


### PR DESCRIPTION
Assigning @markmhx for QA since this is quite simple, and more of a visual change. I also changed 'I already have a Secret Key' to 'Sign in', since it doesn't fit in the current width, or on small mobile, as @jasperjansz mentioned.

I also changed the CTA from 'Get started' to 'Get your Secret Key', per #466 