### PR TITLE
build: publish sha for every commit

### DIFF
--- a/.github/workflows/publish-npm-betas.yml
+++ b/.github/workflows/publish-npm-betas.yml
@@ -1,0 +1,51 @@
+name: Publish NPM Betas
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  publish_npm_betas:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set Node Version
+        uses: actions/setup-node@v1.4.2
+        with:
+          node-version: 12.16.1
+      - name: Restore lerna cache
+        id: lerna-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install monorepo deps
+        run: yarn --frozen-lockfile
+        if: steps.lerna-cache.outputs.cache-hit != 'true'
+      - name: Setup .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+      - name: Get git branch
+        id: git-branch
+        run: echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"
+      - name: Get git commit
+        id: git-commit
+        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+      - name: print preid
+        env:
+          BRANCH: ${{ steps.git-branch.outputs.branch }}
+          SHA: ${{ steps.git-commit.outputs.sha }}
+        run: echo $BRANCH.$SHA
+      - name: Setup git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      - name: Publish to NPM
+        env:
+          BRANCH: ${{ steps.git-branch.outputs.branch }}
+          SHA: ${{ steps.git-commit.outputs.sha }}
+        run: yarn lerna publish prepatch --preid alpha.$SHA --dist-tag $BRANCH --yes --no-push

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": [
-    "packages/**"
+    "packages/*"
   ],
   "version": "independent",
   "npmClient": "yarn",

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -31,5 +31,8 @@
     "@stencil/sass": "^1.3.2",
     "@stencil/store": "^1.3.0",
     "@types/node": "^14.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Adds a Github Actions workflow to publish a prerelease for every non-master commit.

We'll be publishing a new alpha version for each commit, in the form of `${version}-alpha.${commit}` under the dist-tag of `${branch}`. This way, you can use a package from NPM by simply setting the version in your package.json to `${branch}`, i.e. `"@blockstack/connect": "feat/stencil"`