### PR TITLE
Fix(keychain): use correct filepath when writing profiles

### DIFF
--- a/packages/keychain/src/identity.ts
+++ b/packages/keychain/src/identity.ts
@@ -69,7 +69,8 @@ export class Identity {
         profile.apps = {};
       }
       const challengeSigner = ECPair.fromPrivateKey(Buffer.from(appPrivateKey, 'hex'));
-      const storageUrl = `${hubInfo.read_url_prefix}${ecPairToAddress(challengeSigner)}/`;
+      const address = ecPairToAddress(challengeSigner);
+      const storageUrl = `${hubInfo.read_url_prefix}${address}/`;
       profile.apps[appDomain] = storageUrl;
       if (!profile.appsMeta) {
         profile.appsMeta = {};
@@ -83,7 +84,7 @@ export class Identity {
         privateKey: this.keyPair.key,
         gaiaHubUrl: gaiaUrl,
       });
-      const filePath = new URL(profileUrl).pathname.substr(1);
+      const filePath = this.gaiaReadUrlToWritePath(profileUrl, hubInfo.read_url_prefix, address);
       await signAndUploadProfile({
         profile,
         identity: this,
@@ -135,6 +136,10 @@ export class Identity {
       }
     }
     return `${gaiaUrl}${this.address}/profile.json`;
+  }
+
+  gaiaReadUrlToWritePath(gaiaReadUrl: string, read_url_prefix: string, address: string): string {
+    return gaiaReadUrl.substr(`${read_url_prefix}${address}/`.length);
   }
 
   async fetchNames() {

--- a/packages/keychain/tests/identity.test.ts
+++ b/packages/keychain/tests/identity.test.ts
@@ -105,6 +105,27 @@ test('can get a profile URL from a zone file', async () => {
   );
 });
 
+test('gets correct profile write URL', async () => {
+  const identity = await getIdentity();
+  const gaiaUrl = 'https://gaia.blockstack.org/hub/';
+
+  expect(
+    await identity.gaiaReadUrlToWritePath(
+      'https://gaia.blockstack.org/hub/1JeTQ5cQjsD57YGcsVFhwT7iuQUXJR6BSk/profile.json',
+      'https://gaia.blockstack.org/hub/',
+      '1JeTQ5cQjsD57YGcsVFhwT7iuQUXJR6BSk'
+    )
+  ).toEqual('profile.json');
+
+  expect(
+    await identity.gaiaReadUrlToWritePath(
+      'https://gaia.blockstack.org/hub/1J3PUxY5uDShUnHRrMyU6yKtoHEUPhKULs/0/myprofile',
+      'https://gaia.blockstack.org/hub/',
+      '1JeTQ5cQjsD57YGcsVFhwT7iuQUXJR6BSk'
+    )
+  ).toEqual('0/myprofile');
+});
+
 describe('refresh', () => {
   test('can fetch names for an identity', async () => {
     const identity = await getIdentity();


### PR DESCRIPTION
This PR
* uses a profile path when updating the profile derived from the read url of the profile
* fixes #589 introduced in #578 