### PR TITLE
fix(connect): use authOrigin from authOptions

### DIFF
--- a/packages/connect/src/react/hooks/use-connect.ts
+++ b/packages/connect/src/react/hooks/use-connect.ts
@@ -75,18 +75,21 @@ export const useConnect = () => {
   const doContractCall = async (opts: ContractCallOptions) =>
     openContractCall({
       ...opts,
+      authOrigin: authOptions.authOrigin,
       appDetails: authOptions.appDetails,
     });
 
   const doContractDeploy = async (opts: ContractDeployOptions) =>
     openContractDeploy({
       ...opts,
+      authOrigin: authOptions.authOrigin,
       appDetails: authOptions.appDetails,
     });
 
   const doSTXTransfer = async (opts: STXTransferOptions) =>
     openSTXTransfer({
       ...opts,
+      authOrigin: authOptions.authOrigin,
       appDetails: authOptions.appDetails,
     });
 


### PR DESCRIPTION
As a react app developer, I want to use the same auth origin for authentication and transaction signing..

This PR
* adds authOrigin parameters for `doContractCall`, `doContractDeploy`, `doSTXTransfer`
* fixes #619 