### PR TITLE
feat: use provided network

### DIFF
--- a/packages/app/src/common/transaction-utils.ts
+++ b/packages/app/src/common/transaction-utils.ts
@@ -53,6 +53,7 @@ export const generateContractCallTx = ({
     nonce,
     postConditionMode: txData.postConditionMode,
     postConditions: getPostConditions(txData.postConditions),
+    network: txData.network,
   });
 };
 
@@ -75,6 +76,7 @@ export const generateContractDeployTx = ({
     nonce,
     postConditionMode: txData.postConditionMode,
     postConditions: getPostConditions(txData.postConditions),
+    network: txData.network,
   });
 };
 
@@ -93,6 +95,7 @@ export const generateSTXTransferTx = ({
     memo,
     amount,
     nonce,
+    network: txData.network,
   });
 };
 

--- a/packages/app/src/pages/transaction/index.tsx
+++ b/packages/app/src/pages/transaction/index.tsx
@@ -101,7 +101,7 @@ export const Transaction: React.FC = () => {
 
   const setupWithState = async (tx: TransactionPayload) => {
     if (tx.network) {
-      let network =
+      const network =
         tx.network.version == TransactionVersion.Mainnet
           ? new StacksMainnet()
           : new StacksTestnet();

--- a/packages/app/src/pages/transaction/index.tsx
+++ b/packages/app/src/pages/transaction/index.tsx
@@ -14,7 +14,12 @@ import { Button, Box, Text } from '@blockstack/ui';
 import { useLocation } from 'react-router-dom';
 import { decodeToken } from 'jsontokens';
 import { useWallet } from '@common/hooks/use-wallet';
-import { TransactionVersion, StacksTransaction } from '@blockstack/stacks-transactions';
+import {
+  TransactionVersion,
+  StacksTransaction,
+  StacksMainnet,
+  StacksTestnet,
+} from '@blockstack/stacks-transactions';
 import { TestnetBanner } from '@components/transactions/testnet-banner';
 import { TxError } from '@components/transactions/tx-error';
 import { TabbedCard, Tab } from '@components/tabbed-card';
@@ -95,6 +100,14 @@ export const Transaction: React.FC = () => {
   };
 
   const setupWithState = async (tx: TransactionPayload) => {
+    if (tx.network) {
+      let network =
+        tx.network.version == TransactionVersion.Mainnet
+          ? new StacksMainnet()
+          : new StacksTestnet();
+      Object.assign(network, tx.network);
+      tx.network = network;
+    }
     if (tx.txType === TransactionTypes.ContractCall) {
       const contractSource = await client.fetchContractSource({
         contractName: tx.contractName,

--- a/packages/app/src/pages/transaction/index.tsx
+++ b/packages/app/src/pages/transaction/index.tsx
@@ -102,7 +102,7 @@ export const Transaction: React.FC = () => {
   const setupWithState = async (tx: TransactionPayload) => {
     if (tx.network) {
       const network =
-        tx.network.version == TransactionVersion.Mainnet
+        tx.network.version === TransactionVersion.Mainnet
           ? new StacksMainnet()
           : new StacksTestnet();
       tx.network = { ...network, ...tx.network };

--- a/packages/app/src/pages/transaction/index.tsx
+++ b/packages/app/src/pages/transaction/index.tsx
@@ -105,8 +105,7 @@ export const Transaction: React.FC = () => {
         tx.network.version == TransactionVersion.Mainnet
           ? new StacksMainnet()
           : new StacksTestnet();
-      Object.assign(network, tx.network);
-      tx.network = network;
+      tx.network = { ...network, ...tx.network };
     }
     if (tx.txType === TransactionTypes.ContractCall) {
       const contractSource = await client.fetchContractSource({

--- a/packages/keychain/src/wallet/signer.ts
+++ b/packages/keychain/src/wallet/signer.ts
@@ -90,6 +90,7 @@ export class WalletSigner {
     nonce,
     postConditionMode,
     postConditions,
+    network,
   }: ContractCallOptions) {
     const tx = await makeContractCall({
       contractAddress,
@@ -98,7 +99,7 @@ export class WalletSigner {
       functionArgs,
       senderKey: this.getSTXPrivateKey().toString('hex'),
       nonce: new BN(nonce),
-      network: this.getNetwork(),
+      network: network || this.getNetwork(),
       postConditionMode,
       postConditions,
     });
@@ -111,12 +112,13 @@ export class WalletSigner {
     nonce,
     postConditionMode,
     postConditions,
+    network,
   }: ContractDeployOptions) {
     const tx = await makeContractDeploy({
       contractName,
       codeBody: codeBody,
       senderKey: this.getSTXPrivateKey().toString('hex'),
-      network: this.getNetwork(),
+      network: network || this.getNetwork(),
       nonce: new BN(nonce),
       postConditionMode,
       postConditions,
@@ -131,13 +133,14 @@ export class WalletSigner {
     nonce,
     postConditionMode,
     postConditions,
+    network,
   }: STXTransferOptions) {
     const tx = await makeSTXTokenTransfer({
       recipient,
       amount: new BN(amount),
       memo,
       senderKey: this.getSTXPrivateKey().toString('hex'),
-      network: this.getNetwork(),
+      network: network || this.getNetwork(),
       nonce: new BN(nonce),
       postConditionMode,
       postConditions,


### PR DESCRIPTION
As an app developer, I would like to use a mocknet node with Connect

This PR
* uses the specified network in `makeContractCall`, `makeContractDeploy`, `makeSTXTokenTransfer` in `keychain`
* uses the specified network in transaction payloads in `app`
* fixes #618 

Developers can now specify the network that the app should use in the transaction payload by specifying the network parameter e.g. in a stx transfer call:
```        
await doSTXTransfer({
   ...
   network: NETWORK,
})
```

Similarly, this works for the other `do..` methods and the non-react methods `open..`