### PR TITLE
fix: add Content Security Policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,4 +8,4 @@
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
-    Content-Security-Policy = "default-src 'self'; style-src 'unsafe-inline'; object-src 'none'; frame-src 'none';"
+    Content-Security-Policy = "frame-src 'none';"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,4 +8,4 @@
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
-    Content-Security-Policy = "default-src *; script-src 'self'; frame-src 'none';"
+    Content-Security-Policy = "frame-src 'none';"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,4 +8,4 @@
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
-    Content-Security-Policy = "script-src 'self'; frame-src 'none';"
+    Content-Security-Policy = "default-src *; script-src 'self'; frame-src 'none';"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,4 +8,4 @@
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
-    Content-Security-Policy = "frame-src 'none';"
+    Content-Security-Policy = "script-src 'self'; frame-src 'none';"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,4 @@
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
+    Content-Security-Policy = "default-src 'self'; img-src https://*; style-src 'unsafe-inline'; object-src 'none'; frame-src 'none'; connect-src 'self' stats.blockstack.xyz hub.blockstack.org core.blockstack.org registrar.blockstack.org gaia.blockstack.org;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,4 +8,4 @@
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
-    Content-Security-Policy = "default-src 'self'; img-src https://*; style-src 'unsafe-inline'; object-src 'none'; frame-src 'none'; connect-src 'self' stats.blockstack.xyz hub.blockstack.org core.blockstack.org registrar.blockstack.org gaia.blockstack.org;"
+    Content-Security-Policy = "default-src 'self'; style-src 'unsafe-inline'; object-src 'none'; frame-src 'none';"

--- a/packages/app/src/common/hooks/use-dispatch.ts
+++ b/packages/app/src/common/hooks/use-dispatch.ts
@@ -1,7 +1,7 @@
 import { useDispatch as rUseDispatch } from 'react-redux';
 
 /**
- * In the extension, all dispatch calls are asyncronous.
+ * In the extension, all dispatch calls are asynchronous.
  * This is a wrapper hook to get an async-typed dispatch.
  */
 export const useDispatch = () => {

--- a/packages/app/src/components/icons/chrome-icon.tsx
+++ b/packages/app/src/components/icons/chrome-icon.tsx
@@ -24,7 +24,7 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
       <path
         d="M5.93731 10.7863L2.3164 4.57629L2.26367 4.6672L5.85822 10.8308L5.93731 10.7863Z"
         fill="#3E2723"
-        fill-opacity="0.15"
+        fillOpacity="0.15"
       />
       <path d="M1 17H8.61545L12.15 13.4654V10.8182H5.85091L1 2.49817V17Z" fill="#0F9D58" />
       <path
@@ -34,7 +34,7 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
       <path
         d="M12.0764 10.939L12.001 10.8954L8.51099 16.9999H8.61553L12.0792 10.9417L12.0764 10.939Z"
         fill="#263238"
-        fill-opacity="0.15"
+        fillOpacity="0.15"
       />
       <path d="M9.00002 5.36365L12.15 10.8182L8.61548 17H17V5.36365H9.00002Z" fill="#FFCD40" />
       <path
@@ -79,12 +79,12 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
       <path
         d="M8.99989 5.27283C6.99171 5.27283 5.36353 6.90101 5.36353 8.90919V9.0001C5.36353 6.99192 6.99171 5.36374 8.99989 5.36374H16.9999V5.27283H8.99989Z"
         fill="#3E2723"
-        fill-opacity="0.2"
+        fillOpacity="0.2"
       />
       <path
         d="M12.1455 10.8182C11.5164 11.9036 10.3445 12.6364 9 12.6364C7.65455 12.6364 6.48273 11.9036 5.85364 10.8182H5.85L1 2.49817V2.58908L5.85091 10.9091H5.85455C6.48364 11.9945 7.65546 12.7273 9.00091 12.7273C10.3455 12.7273 11.5173 11.9954 12.1464 10.9091H12.1509V10.8182H12.1455Z"
         fill="white"
-        fill-opacity="0.1"
+        fillOpacity="0.1"
       />
       <path
         opacity="0.1"
@@ -94,17 +94,17 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
       <path
         d="M12.1818 10.9393C12.4909 10.4047 12.67 9.78654 12.67 9.12473C12.67 8.74109 12.61 8.372 12.5 8.02563C12.5864 8.33654 12.6364 8.66291 12.6364 9.00109C12.6364 9.66291 12.4573 10.2811 12.1482 10.8156L12.15 10.8193L8.61548 17.0011H8.72093L10.3637 13.9436L12.1837 10.9429L12.1818 10.9393Z"
         fill="white"
-        fill-opacity="0.2"
+        fillOpacity="0.2"
       />
       <path
         d="M9 1.09091C13.4027 1.09091 16.9745 4.64818 16.9991 9.04545C16.9991 9.03 17 9.01546 17 9C17 4.58182 13.4182 1 9 1C4.58182 1 1 4.58182 1 9C1 9.01546 1.00091 9.03 1.00091 9.04545C1.02545 4.64818 4.59727 1.09091 9 1.09091Z"
         fill="white"
-        fill-opacity="0.2"
+        fillOpacity="0.2"
       />
       <path
         d="M9 16.9091C13.4027 16.9091 16.9745 13.3519 16.9991 8.95459C16.9991 8.97004 17 8.98459 17 9.00004C17 13.4182 13.4182 17 9 17C4.58182 17 1 13.4182 1 9.00004C1 8.98459 1.00091 8.97004 1.00091 8.95459C1.02545 13.3519 4.59727 16.9091 9 16.9091Z"
         fill="#3E2723"
-        fill-opacity="0.15"
+        fillOpacity="0.15"
       />
       <path
         d="M9 17C13.4183 17 17 13.4183 17 9C17 4.58172 13.4183 1 9 1C4.58172 1 1 4.58172 1 9C1 13.4183 4.58172 17 9 17Z"
@@ -120,8 +120,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         y2="4.30491"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stop-color="#A52714" stop-opacity="0.6" />
-        <stop offset="0.66" stop-color="#A52714" stop-opacity="0" />
+        <stop stopColor="#A52714" stopOpacity="0.6" />
+        <stop offset="0.66" stopColor="#A52714" stopOpacity="0" />
       </linearGradient>
       <linearGradient
         id="paint1_linear"
@@ -131,8 +131,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         y2="12.1209"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stop-color="#055524" stop-opacity="0.4" />
-        <stop offset="0.33" stop-color="#055524" stop-opacity="0" />
+        <stop stopColor="#055524" stopOpacity="0.4" />
+        <stop offset="0.33" stopColor="#055524" stopOpacity="0" />
       </linearGradient>
       <linearGradient
         id="paint2_linear"
@@ -142,8 +142,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         y2="10.6482"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stop-color="#EA6100" stop-opacity="0.3" />
-        <stop offset="0.66" stop-color="#EA6100" stop-opacity="0" />
+        <stop stopColor="#EA6100" stopOpacity="0.3" />
+        <stop offset="0.66" stopColor="#EA6100" stopOpacity="0" />
       </linearGradient>
       <linearGradient
         id="paint3_linear"
@@ -153,8 +153,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         y2="10.6482"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stop-color="#EA6100" stop-opacity="0.3" />
-        <stop offset="0.66" stop-color="#EA6100" stop-opacity="0" />
+        <stop stopColor="#EA6100" stopOpacity="0.3" />
+        <stop offset="0.66" stopColor="#EA6100" stopOpacity="0" />
       </linearGradient>
       <linearGradient
         id="paint4_linear"
@@ -164,8 +164,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         y2="4.30491"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stop-color="#A52714" stop-opacity="0.6" />
-        <stop offset="0.66" stop-color="#A52714" stop-opacity="0" />
+        <stop stopColor="#A52714" stopOpacity="0.6" />
+        <stop offset="0.66" stopColor="#A52714" stopOpacity="0" />
       </linearGradient>
       <radialGradient
         id="paint5_radial"
@@ -175,8 +175,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(8.65273 5.35892) scale(7.64345)"
       >
-        <stop stop-color="#3E2723" stop-opacity="0.2" />
-        <stop offset="1" stop-color="#3E2723" stop-opacity="0" />
+        <stop stopColor="#3E2723" stopOpacity="0.2" />
+        <stop offset="1" stopColor="#3E2723" stopOpacity="0" />
       </radialGradient>
       <linearGradient
         id="paint6_linear"
@@ -186,8 +186,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         y2="12.121"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stop-color="#055524" stop-opacity="0.4" />
-        <stop offset="0.33" stop-color="#055524" stop-opacity="0" />
+        <stop stopColor="#055524" stopOpacity="0.4" />
+        <stop offset="0.33" stopColor="#055524" stopOpacity="0" />
       </linearGradient>
       <radialGradient
         id="paint7_radial"
@@ -197,8 +197,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(2.26184 4.68361) scale(7.09491)"
       >
-        <stop stop-color="#3E2723" stop-opacity="0.2" />
-        <stop offset="1" stop-color="#3E2723" stop-opacity="0" />
+        <stop stopColor="#3E2723" stopOpacity="0.2" />
+        <stop offset="1" stopColor="#3E2723" stopOpacity="0" />
       </radialGradient>
       <radialGradient
         id="paint8_radial"
@@ -208,8 +208,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(8.98539 9.0125) scale(7.98818)"
       >
-        <stop stop-color="#263238" stop-opacity="0.2" />
-        <stop offset="1" stop-color="#263238" stop-opacity="0" />
+        <stop stopColor="#263238" stopOpacity="0.2" />
+        <stop offset="1" stopColor="#263238" stopOpacity="0" />
       </radialGradient>
       <radialGradient
         id="paint9_radial"
@@ -219,8 +219,8 @@ export const ChromeIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(3.38964 3.18309) scale(16.0682)"
       >
-        <stop stop-color="white" stop-opacity="0.1" />
-        <stop offset="1" stop-color="white" stop-opacity="0" />
+        <stop stopColor="white" stopOpacity="0.1" />
+        <stop offset="1" stopColor="white" stopOpacity="0" />
       </radialGradient>
     </defs>
   </Svg>

--- a/packages/app/src/components/icons/firefox-icon.tsx
+++ b/packages/app/src/components/icons/firefox-icon.tsx
@@ -61,14 +61,14 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         y2="16.386"
         gradientUnits="userSpaceOnUse"
       >
-        <stop offset="0.048" stop-color="#FFF44F" />
-        <stop offset="0.111" stop-color="#FFE847" />
-        <stop offset="0.225" stop-color="#FFC830" />
-        <stop offset="0.368" stop-color="#FF980E" />
-        <stop offset="0.401" stop-color="#FF8B16" />
-        <stop offset="0.462" stop-color="#FF672A" />
-        <stop offset="0.534" stop-color="#FF3647" />
-        <stop offset="0.705" stop-color="#E31587" />
+        <stop offset="0.048" stopColor="#FFF44F" />
+        <stop offset="0.111" stopColor="#FFE847" />
+        <stop offset="0.225" stopColor="#FFC830" />
+        <stop offset="0.368" stopColor="#FF980E" />
+        <stop offset="0.401" stopColor="#FF8B16" />
+        <stop offset="0.462" stopColor="#FF672A" />
+        <stop offset="0.534" stopColor="#FF3647" />
+        <stop offset="0.705" stopColor="#E31587" />
       </linearGradient>
       <radialGradient
         id="paint1_radial"
@@ -78,15 +78,15 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(14.7462 2.83123) scale(16.6982 16.6712)"
       >
-        <stop offset="0.129" stop-color="#FFBD4F" />
-        <stop offset="0.186" stop-color="#FFAC31" />
-        <stop offset="0.247" stop-color="#FF9D17" />
-        <stop offset="0.283" stop-color="#FF980E" />
-        <stop offset="0.403" stop-color="#FF563B" />
-        <stop offset="0.467" stop-color="#FF3750" />
-        <stop offset="0.71" stop-color="#F5156C" />
-        <stop offset="0.782" stop-color="#EB0878" />
-        <stop offset="0.86" stop-color="#E50080" />
+        <stop offset="0.129" stopColor="#FFBD4F" />
+        <stop offset="0.186" stopColor="#FFAC31" />
+        <stop offset="0.247" stopColor="#FF9D17" />
+        <stop offset="0.283" stopColor="#FF980E" />
+        <stop offset="0.403" stopColor="#FF563B" />
+        <stop offset="0.467" stopColor="#FF3750" />
+        <stop offset="0.71" stopColor="#F5156C" />
+        <stop offset="0.782" stopColor="#EB0878" />
+        <stop offset="0.86" stopColor="#E50080" />
       </radialGradient>
       <radialGradient
         id="paint2_radial"
@@ -96,11 +96,11 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(8.64449 9.64693) scale(16.6982 16.6712)"
       >
-        <stop offset="0.3" stop-color="#960E18" />
-        <stop offset="0.351" stop-color="#B11927" stop-opacity="0.74" />
-        <stop offset="0.435" stop-color="#DB293D" stop-opacity="0.343" />
-        <stop offset="0.497" stop-color="#F5334B" stop-opacity="0.094" />
-        <stop offset="0.53" stop-color="#FF3750" stop-opacity="0" />
+        <stop offset="0.3" stopColor="#960E18" />
+        <stop offset="0.351" stopColor="#B11927" stopOpacity="0.74" />
+        <stop offset="0.435" stopColor="#DB293D" stopOpacity="0.343" />
+        <stop offset="0.497" stopColor="#F5334B" stopOpacity="0.094" />
+        <stop offset="0.53" stopColor="#FF3750" stopOpacity="0" />
       </radialGradient>
       <radialGradient
         id="paint3_radial"
@@ -110,10 +110,10 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(10.6576 -0.952194) scale(12.0971 12.0776)"
       >
-        <stop offset="0.132" stop-color="#FFF44F" />
-        <stop offset="0.252" stop-color="#FFDC3E" />
-        <stop offset="0.506" stop-color="#FF9D12" />
-        <stop offset="0.526" stop-color="#FF980E" />
+        <stop offset="0.132" stopColor="#FFF44F" />
+        <stop offset="0.252" stopColor="#FFDC3E" />
+        <stop offset="0.506" stopColor="#FF9D12" />
+        <stop offset="0.526" stopColor="#FF980E" />
       </radialGradient>
       <radialGradient
         id="paint4_radial"
@@ -123,10 +123,10 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(6.79737 14.0015) scale(7.95075 7.93791)"
       >
-        <stop offset="0.353" stop-color="#3A8EE6" />
-        <stop offset="0.472" stop-color="#5C79F0" />
-        <stop offset="0.669" stop-color="#9059FF" />
-        <stop offset="1" stop-color="#C139E6" />
+        <stop offset="0.353" stopColor="#3A8EE6" />
+        <stop offset="0.472" stopColor="#5C79F0" />
+        <stop offset="0.669" stopColor="#9059FF" />
+        <stop offset="1" stopColor="#C139E6" />
       </radialGradient>
       <radialGradient
         id="paint5_radial"
@@ -136,10 +136,10 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(9.55682 8.28064) rotate(-13.5704) scale(4.21507 4.9277)"
       >
-        <stop offset="0.206" stop-color="#9059FF" stop-opacity="0" />
-        <stop offset="0.278" stop-color="#8C4FF3" stop-opacity="0.064" />
-        <stop offset="0.747" stop-color="#7716A8" stop-opacity="0.45" />
-        <stop offset="0.975" stop-color="#6E008B" stop-opacity="0.6" />
+        <stop offset="0.206" stopColor="#9059FF" stopOpacity="0" />
+        <stop offset="0.278" stopColor="#8C4FF3" stopOpacity="0.064" />
+        <stop offset="0.747" stopColor="#7716A8" stopOpacity="0.45" />
+        <stop offset="0.975" stopColor="#6E008B" stopOpacity="0.6" />
       </radialGradient>
       <radialGradient
         id="paint6_radial"
@@ -149,12 +149,12 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(8.43366 2.14913) scale(5.71976 5.71053)"
       >
-        <stop stop-color="#FFE226" />
-        <stop offset="0.121" stop-color="#FFDB27" />
-        <stop offset="0.295" stop-color="#FFC82A" />
-        <stop offset="0.502" stop-color="#FFA930" />
-        <stop offset="0.732" stop-color="#FF7E37" />
-        <stop offset="0.792" stop-color="#FF7139" />
+        <stop stopColor="#FFE226" />
+        <stop offset="0.121" stopColor="#FFDB27" />
+        <stop offset="0.295" stopColor="#FFC82A" />
+        <stop offset="0.502" stopColor="#FFA930" />
+        <stop offset="0.732" stopColor="#FF7E37" />
+        <stop offset="0.792" stopColor="#FF7139" />
       </radialGradient>
       <radialGradient
         id="paint7_radial"
@@ -164,11 +164,11 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(12.9294 -1.47307) scale(24.4037 24.3642)"
       >
-        <stop offset="0.113" stop-color="#FFF44F" />
-        <stop offset="0.456" stop-color="#FF980E" />
-        <stop offset="0.622" stop-color="#FF5634" />
-        <stop offset="0.716" stop-color="#FF3647" />
-        <stop offset="0.904" stop-color="#E31587" />
+        <stop offset="0.113" stopColor="#FFF44F" />
+        <stop offset="0.456" stopColor="#FF980E" />
+        <stop offset="0.622" stopColor="#FF5634" />
+        <stop offset="0.716" stopColor="#FF3647" />
+        <stop offset="0.904" stopColor="#E31587" />
       </radialGradient>
       <radialGradient
         id="paint8_radial"
@@ -178,14 +178,14 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(10.8728 -0.118248) rotate(83.9663) scale(17.8575 11.7382)"
       >
-        <stop stop-color="#FFF44F" />
-        <stop offset="0.06" stop-color="#FFE847" />
-        <stop offset="0.168" stop-color="#FFC830" />
-        <stop offset="0.304" stop-color="#FF980E" />
-        <stop offset="0.356" stop-color="#FF8B16" />
-        <stop offset="0.455" stop-color="#FF672A" />
-        <stop offset="0.57" stop-color="#FF3647" />
-        <stop offset="0.737" stop-color="#E31587" />
+        <stop stopColor="#FFF44F" />
+        <stop offset="0.06" stopColor="#FFE847" />
+        <stop offset="0.168" stopColor="#FFC830" />
+        <stop offset="0.304" stopColor="#FF980E" />
+        <stop offset="0.356" stopColor="#FF8B16" />
+        <stop offset="0.455" stopColor="#FF672A" />
+        <stop offset="0.57" stopColor="#FF3647" />
+        <stop offset="0.737" stopColor="#E31587" />
       </radialGradient>
       <radialGradient
         id="paint9_radial"
@@ -195,11 +195,11 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(8.29873 4.26424) scale(15.2356 15.211)"
       >
-        <stop offset="0.137" stop-color="#FFF44F" />
-        <stop offset="0.48" stop-color="#FF980E" />
-        <stop offset="0.592" stop-color="#FF5634" />
-        <stop offset="0.655" stop-color="#FF3647" />
-        <stop offset="0.904" stop-color="#E31587" />
+        <stop offset="0.137" stopColor="#FFF44F" />
+        <stop offset="0.48" stopColor="#FF980E" />
+        <stop offset="0.592" stopColor="#FF5634" />
+        <stop offset="0.655" stopColor="#FF3647" />
+        <stop offset="0.904" stopColor="#E31587" />
       </radialGradient>
       <radialGradient
         id="paint10_radial"
@@ -209,10 +209,10 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         gradientUnits="userSpaceOnUse"
         gradientTransform="translate(12.3208 5.1545) scale(16.6753 16.6483)"
       >
-        <stop offset="0.094" stop-color="#FFF44F" />
-        <stop offset="0.231" stop-color="#FFE141" />
-        <stop offset="0.509" stop-color="#FFAF1E" />
-        <stop offset="0.626" stop-color="#FF980E" />
+        <stop offset="0.094" stopColor="#FFF44F" />
+        <stop offset="0.231" stopColor="#FFE141" />
+        <stop offset="0.509" stopColor="#FFAF1E" />
+        <stop offset="0.626" stopColor="#FF980E" />
       </radialGradient>
       <linearGradient
         id="paint11_linear"
@@ -222,10 +222,10 @@ export const FirefoxIcon: React.FC<BoxProps> = props => (
         y2="14.8018"
         gradientUnits="userSpaceOnUse"
       >
-        <stop offset="0.167" stop-color="#FFF44F" stop-opacity="0.8" />
-        <stop offset="0.266" stop-color="#FFF44F" stop-opacity="0.634" />
-        <stop offset="0.489" stop-color="#FFF44F" stop-opacity="0.217" />
-        <stop offset="0.6" stop-color="#FFF44F" stop-opacity="0" />
+        <stop offset="0.167" stopColor="#FFF44F" stopOpacity="0.8" />
+        <stop offset="0.266" stopColor="#FFF44F" stopOpacity="0.634" />
+        <stop offset="0.489" stopColor="#FFF44F" stopOpacity="0.217" />
+        <stop offset="0.6" stopColor="#FFF44F" stopOpacity="0" />
       </linearGradient>
     </defs>
   </Svg>

--- a/packages/app/src/manifest.json
+++ b/packages/app/src/manifest.json
@@ -8,7 +8,7 @@
     "256": "assets/logo-128@2x.png",
     "512": "assets/logo-128@3x.png"
   },
-  "content_security_policy": "script-src 'self'<% DEV_CSR %>; object-src 'self'; frame-src 'none'",
+  "content_security_policy": "script-src 'self'<% DEV_CSR %>; object-src 'self'; frame-src 'none';",
   "permissions": [
     "activeTab"
   ],

--- a/packages/app/src/manifest.json
+++ b/packages/app/src/manifest.json
@@ -8,7 +8,7 @@
     "256": "assets/logo-128@2x.png",
     "512": "assets/logo-128@3x.png"
   },
-  "content_security_policy": "script-src 'self'<% DEV_CSR %>; object-src 'self'",
+  "content_security_policy": "script-src 'self'<% DEV_CSR %>; object-src 'self'; frame-src 'none'",
   "permissions": [
     "activeTab"
   ],

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -10,7 +10,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src *; script-src 'self'; frame-src 'none';"
+          "value": "frame-src 'none';"
         }
       ]
     }

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -10,7 +10,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; img-src https://*; style-src 'unsafe-inline'; object-src 'none'; frame-src 'none'; connect-src 'self' stats.blockstack.xyz hub.blockstack.org core.blockstack.org registrar.blockstack.org gaia.blockstack.org;"
+          "value": "default-src 'self'; style-src 'unsafe-inline'; object-src 'none'; frame-src 'none';"
         }
       ]
     }

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -2,11 +2,17 @@
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {
-      "src": "/*",
-      "headers": {
-        "X-Frame-Options": "DENY"
-      },
-      "continue": true
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; img-src https://*; style-src 'unsafe-inline'; object-src 'none'; frame-src 'none'; connect-src 'self' stats.blockstack.xyz hub.blockstack.org core.blockstack.org registrar.blockstack.org gaia.blockstack.org;"
+        }
+      ]
     }
   ]
 }

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -10,7 +10,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; style-src 'unsafe-inline'; object-src 'none'; frame-src 'none';"
+          "value": "frame-src 'none';"
         }
       ]
     }

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -10,7 +10,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "script-src 'self'; frame-src 'none';"
+          "value": "default-src *; script-src 'self'; frame-src 'none';"
         }
       ]
     }

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -10,7 +10,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-src 'none';"
+          "value": "script-src 'self'; frame-src 'none';"
         }
       ]
     }

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -237,7 +237,6 @@ module.exports = {
       SEGMENT_KEY: JSON.stringify(segmentKey),
       STATS_URL: JSON.stringify(statsURL),
     }),
-    new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime-.+[.]js/]),
     isDevelopment &&
       extEnv === 'web' &&
       new ReactRefreshWebpackPlugin({ disableRefreshCheck: true }),

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -53,7 +53,7 @@ const hmtlProdOpts = !isDevelopment
 
 const getSourceMap = () => {
   if (extEnv === 'web') {
-    return nodeEnv === 'production' ? 'eval' : 'cheap-module-source-map';
+    return 'cheap-module-source-map';
   }
   return 'none';
 };

--- a/packages/test-app/components/counter-actions.tsx
+++ b/packages/test-app/components/counter-actions.tsx
@@ -3,7 +3,7 @@ import { Button, ButtonGroup, Box, Text } from '@blockstack/ui';
 import { AppContext } from '@common/context';
 import { getAuthOrigin, getRPCClient } from '@common/utils';
 import { useConnect } from '@blockstack/connect';
-import { deserializeCV, IntCV } from '@blockstack/stacks-transactions';
+import { deserializeCV, IntCV, StacksTestnet } from '@blockstack/stacks-transactions';
 import { ExplorerLink } from '@components/explorer-link';
 
 export const CounterActions: React.FC = () => {
@@ -18,6 +18,8 @@ export const CounterActions: React.FC = () => {
     setError('');
     setLoading(true);
     const authOrigin = getAuthOrigin();
+    const network = new StacksTestnet();
+    network.coreApiUrl = 'https://stacks-node-api.blockstack.org';
     await doContractCall({
       authOrigin,
       contractAddress: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',


### PR DESCRIPTION
Adds a CSP to accompany `X-Frame-Options` header, to further restrict what scripts can be executed on `app.blockstack.org`

This PR un-inlines the runtime script. This might have a negative perf effect, but it's the more secure way of doing it (unless we also generate a sha256 with webpack and add it to the CSP dynamically). 

Note `style-src 'unsafe-inline'`. Not sure how to work around this because `styled-components` inlines the styles.

cc/ @wileyj @CharlieC3 
I read that it's good practice to have CSP violations reported to the given [`report-to` url.](https://w3c.github.io/reporting/#examples) Do we have any infrastructure set up for this kind of reporting? Do you think it's valuable having this reporting enabled?