### PR TITLE
fix(app): prefix hex with 0x in tx result

### DIFF
--- a/packages/app/src/common/transaction-utils.ts
+++ b/packages/app/src/common/transaction-utils.ts
@@ -136,7 +136,6 @@ export const finishTransaction = async ({
   pendingTransaction: TransactionPayload;
 }) => {
   const serialized = tx.serialize();
-  const txRaw = serialized.toString('hex');
   const client = getRPCClient();
   const res = await client.broadcastTX(serialized);
 
@@ -145,7 +144,9 @@ export const finishTransaction = async ({
       txType: pendingTransaction?.txType,
       appName: pendingTransaction?.appDetails?.name,
     });
-    const txId: string = await res.json();
+    const txIdJson: string = await res.json();
+    const txId = `0x${txIdJson}`;
+    const txRaw = `0x${serialized.toString('hex')}`;
     finalizeTxSignature({ txId, txRaw });
   } else {
     const response = await res.json();


### PR DESCRIPTION
Same code as #617, I'm opening this so all CI runs (ugh still need to try and fix that)

As a developer, I don't want to learn whether a tx id or other hex strings have a hex identifier as prefix in some method results.

This PR

- adds 0x prefixes to hex strings in transaction results
- fixes #595
