### PR TITLE
fix: update opts -> options, finished -> onFinish

### DIFF
--- a/packages/connect-react/src/react/hooks/use-connect.ts
+++ b/packages/connect-react/src/react/hooks/use-connect.ts
@@ -9,6 +9,7 @@ import {
   openContractDeploy,
   openSTXTransfer,
   showBlockstackConnect,
+  FinishedData,
 } from '@stacks/connect';
 import { ConnectContext, ConnectDispatchContext, States } from '../components/connect/context';
 
@@ -24,20 +25,30 @@ export const useConnect = () => {
   const { isOpen, isAuthenticating, authData, authOptions, userSession } = useContext(
     ConnectContext
   );
+  const finishedCallback = authOptions.onFinish || authOptions.finished;
   const dispatch = useConnectDispatch();
 
   const doUpdateAuthOptions = (payload: Partial<AuthOptions>) => {
     return dispatch({ type: States.UPDATE_AUTH_OPTIONS, payload });
   };
 
-  const doOpenAuth = (signIn?: boolean, opts?: Partial<AuthOptions>) => {
+  /**
+   *
+   * @param signIn Whether the user should be sent to sign in
+   * @param options
+   */
+  const doOpenAuth = (signIn?: boolean, options?: Partial<AuthOptions>) => {
     if (signIn) {
-      const options: AuthOptions = {
+      const _options: AuthOptions = {
         ...authOptions,
-        ...opts,
+        ...options,
+        finished: undefined,
+        onFinish: (payload: FinishedData) => {
+          finishedCallback?.(payload);
+        },
         sendToSignIn: true,
       };
-      void authenticate(options);
+      void authenticate(_options);
       return;
     } else {
       showBlockstackConnect({
@@ -51,26 +62,30 @@ export const useConnect = () => {
     void authenticate({
       ...authOptions,
       ...options,
+      finished: undefined,
+      onFinish: (payload: FinishedData) => {
+        finishedCallback?.(payload);
+      },
     });
   };
 
-  const doContractCall = (opts: ContractCallOptions) =>
+  const doContractCall = (options: ContractCallOptions) =>
     openContractCall({
-      ...opts,
+      ...options,
       authOrigin: authOptions.authOrigin,
       appDetails: authOptions.appDetails,
     });
 
-  const doContractDeploy = (opts: ContractDeployOptions) =>
+  const doContractDeploy = (options: ContractDeployOptions) =>
     openContractDeploy({
-      ...opts,
+      ...options,
       authOrigin: authOptions.authOrigin,
       appDetails: authOptions.appDetails,
     });
 
-  const doSTXTransfer = (opts: STXTransferOptions) =>
+  const doSTXTransfer = (options: STXTransferOptions) =>
     openSTXTransfer({
-      ...opts,
+      ...options,
       authOrigin: authOptions.authOrigin,
       appDetails: authOptions.appDetails,
     });

--- a/packages/connect/src/auth.ts
+++ b/packages/connect/src/auth.ts
@@ -18,7 +18,7 @@ export interface AuthOptions {
   /** The URL you want the user to be redirected to after authentication. */
   redirectTo?: string;
   manifestPath?: string;
-  /** DEPRECATED: use `onFinish` */
+  /** @deprecated use `onFinish` */
   finished?: (payload: FinishedData) => void;
   /**
    * This callback is fired after authentication is finished.
@@ -30,10 +30,13 @@ export interface AuthOptions {
   /** This callback is fired if the user exits before finishing */
   onCancel?: () => void;
   authOrigin?: string;
+  /** If `sendToSignIn` is `true`, then the user will be sent through the sign in flow. */
   sendToSignIn?: boolean;
   userSession?: UserSession;
   appDetails: {
+    /** A human-readable name for your application */
     name: string;
+    /** A full URL that resolves to an image icon for your application */
     icon: string;
   };
 }

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -38,9 +38,9 @@ const signPayload = async (payload: TransactionPayload, privateKey: string) => {
   return tokenSigner.signAsync(payload as any);
 };
 
-const openTransactionPopup = async ({ token, opts }: TransactionPopup) => {
+const openTransactionPopup = async ({ token, options }: TransactionPopup) => {
   const extensionURL = await window.BlockstackProvider?.getURL();
-  const authURL = new URL(extensionURL || opts.authOrigin || defaultAuthURL);
+  const authURL = new URL(extensionURL || options.authOrigin || defaultAuthURL);
   const urlParams = new URLSearchParams();
   urlParams.set('request', token);
 
@@ -53,17 +53,16 @@ const openTransactionPopup = async ({ token, opts }: TransactionPopup) => {
     popup,
     authURL,
     onFinish: data => {
-      if (opts.finished) {
-        opts.finished(data);
-      }
+      const finishedCallback = options.finished || options.onFinish;
+      finishedCallback?.(data);
     },
     messageParams: {},
   });
   return popup;
 };
 
-export const makeContractCallToken = async (opts: ContractCallOptions) => {
-  const { functionArgs, appDetails, userSession, ...options } = opts;
+export const makeContractCallToken = async (options: ContractCallOptions) => {
+  const { functionArgs, appDetails, userSession, ..._options } = options;
   const { privateKey, publicKey } = getKeys(userSession);
 
   const args: string[] = functionArgs.map(arg => {
@@ -74,7 +73,7 @@ export const makeContractCallToken = async (opts: ContractCallOptions) => {
   });
 
   const payload: ContractCallPayload = {
-    ...options,
+    ..._options,
     functionArgs: args,
     txType: TransactionTypes.ContractCall,
     publicKey,
@@ -87,12 +86,12 @@ export const makeContractCallToken = async (opts: ContractCallOptions) => {
   return signPayload(payload, privateKey);
 };
 
-export const makeContractDeployToken = async (opts: ContractDeployOptions) => {
-  const { appDetails, userSession, ...options } = opts;
+export const makeContractDeployToken = async (options: ContractDeployOptions) => {
+  const { appDetails, userSession, ..._options } = options;
   const { privateKey, publicKey } = getKeys(userSession);
 
   const payload: ContractDeployPayload = {
-    ...options,
+    ..._options,
     publicKey,
     txType: TransactionTypes.ContractDeploy,
   };
@@ -104,12 +103,12 @@ export const makeContractDeployToken = async (opts: ContractDeployOptions) => {
   return signPayload(payload, privateKey);
 };
 
-export const makeSTXTransferToken = async (opts: STXTransferOptions) => {
-  const { amount, appDetails, userSession, ...options } = opts;
+export const makeSTXTransferToken = async (options: STXTransferOptions) => {
+  const { amount, appDetails, userSession, ..._options } = options;
   const { privateKey, publicKey } = getKeys(userSession);
 
   const payload: STXTransferPayload = {
-    ...options,
+    ..._options,
     amount: amount.toString(10),
     publicKey,
     txType: TransactionTypes.STXTransfer,
@@ -123,18 +122,18 @@ export const makeSTXTransferToken = async (opts: STXTransferOptions) => {
 };
 
 async function generateTokenAndOpenPopup<T extends TransactionOptions>(
-  opts: T,
-  makeTokenFn: (opts: T) => Promise<string>
+  options: T,
+  makeTokenFn: (options: T) => Promise<string>
 ) {
-  const token = await makeTokenFn(opts);
-  return openTransactionPopup({ token, opts });
+  const token = await makeTokenFn(options);
+  return openTransactionPopup({ token, options });
 }
 
-export const openContractCall = async (opts: ContractCallOptions) =>
-  generateTokenAndOpenPopup(opts, makeContractCallToken);
+export const openContractCall = async (options: ContractCallOptions) =>
+  generateTokenAndOpenPopup(options, makeContractCallToken);
 
-export const openContractDeploy = async (opts: ContractDeployOptions) =>
-  generateTokenAndOpenPopup(opts, makeContractDeployToken);
+export const openContractDeploy = async (options: ContractDeployOptions) =>
+  generateTokenAndOpenPopup(options, makeContractDeployToken);
 
-export const openSTXTransfer = async (opts: STXTransferOptions) =>
-  generateTokenAndOpenPopup(opts, makeSTXTransferToken);
+export const openSTXTransfer = async (options: STXTransferOptions) =>
+  generateTokenAndOpenPopup(options, makeSTXTransferToken);

--- a/packages/connect/src/transactions/types.ts
+++ b/packages/connect/src/transactions/types.ts
@@ -52,7 +52,9 @@ export interface ContractCallBase extends TxBase {
 export interface ContractCallOptions extends ContractCallBase {
   authOrigin?: string;
   userSession?: UserSession;
+  /** @deprecated use `onFinish` */
   finished?: (data: FinishedTxData) => void;
+  onFinish?: (data: FinishedTxData) => void;
 }
 
 export interface ContractCallArgument {
@@ -77,7 +79,9 @@ export interface ContractDeployBase extends TxBase {
 export interface ContractDeployOptions extends ContractDeployBase {
   authOrigin?: string;
   userSession?: UserSession;
+  /** @deprecated use `onFinish` */
   finished?: (data: FinishedTxData) => void;
+  onFinish?: (data: FinishedTxData) => void;
 }
 
 export interface ContractDeployPayload extends ContractDeployOptions {
@@ -98,7 +102,9 @@ export interface STXTransferBase extends TxBase {
 export interface STXTransferOptions extends STXTransferBase {
   authOrigin?: string;
   userSession?: UserSession;
+  /** @deprecated use `onFinish` */
   finished?: (data: FinishedTxData) => void;
+  onFinish?: (data: FinishedTxData) => void;
 }
 
 export interface STXTransferPayload extends STXTransferOptions {
@@ -116,5 +122,5 @@ export type TransactionPayload = ContractCallPayload | ContractDeployPayload | S
 
 export interface TransactionPopup {
   token: string;
-  opts: TransactionOptions;
+  options: TransactionOptions;
 }


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/473058863), the [hosted version](https://pr-658.app.stacks.engineering), or the [Stacks testnet demo app](https://pr-658.testnet-demo.stacks.engineering)<!-- Sticky Header Marker -->

## Description

This changes the name of any instance of `opts` to the more specific `options` and additionally adds in `onFinish` to our tx methods.

For details refer to issue #654

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
Nope!