### PR TITLE
fix: reference to connect

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -8,7 +8,7 @@ Source code is available on Github at https://github.com/blockstack/ux/tree/mast
 
 The Blockstack App is an application for interacting and authenticating with [Blockstack](https://blockstack.org) apps. It can be used as a hosted web app (available at [app.blockstack.org](https://app.blockstack.org)) or as a browser extension.
 
-To use this application with your own Blockstack App, we recommend using [Blockstack Connect](https://github.com/blockstack/connect).
+To use this application with your own Blockstack App, we recommend using [Blockstack Connect](https://github.com/blockstack/ux/packages/connect).
 
 Table of Contents:
 


### PR DESCRIPTION
## Description
As a developer I want to know how to interact with the authenticator.
The link to connect shows an archived repo. Therefore, updating to the correct url.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Check the link

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated

