### PR TITLE
fix: broken tx signing with extension

### DIFF
--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -45,7 +45,7 @@ const openTransactionPopup = async ({ token, opts }: TransactionPopup) => {
   urlParams.set('request', token);
 
   const popup = popupCenter({
-    url: `${authURL.origin}/#/transaction?${urlParams.toString()}`,
+    url: `${authURL.origin}/index.html#/transaction?${urlParams.toString()}`,
     h: 700,
   });
 


### PR DESCRIPTION
Transaction signing was broken in the extension. This is because transaction signing would open up the authenticator at the root path (`/`), but that's not a valid path in the extension. You have to explicitly use `/index.html`.'

Fixes #602 