### PR TITLE
feat: update extension build instructions

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -50,11 +50,8 @@ Then, open [localhost:8080](http://localhost:8080).
 Clone this repository, install dependencies and build the extension:
 
 ~~~bash
-git clone https://github.com/blockstack/ux
-cd ux
-yarn
-cd packages/app
-yarn prod:ext
+git clone https://github.com/blockstack/ux && cd ux && yarn
+cd packages/app && yarn lerna run build --scope @stacks/connect-ui && yarn lerna run prod:ext
 ~~~
 
 Then if installing for Chrome or Brave:


### PR DESCRIPTION
Per https://github.com/blockstack/ux/issues/656#issuecomment-732130164, this PR updates the extension build instructions, which are currently out-of-date.