### PR TITLE
Updating Dockerfile/script for extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM nikolaik/python-nodejs:python3.9-nodejs14 as build
+FROM debian:buster-slim as builder
 LABEL maintainer="ux@blockstack.com"
 
 COPY . .
+RUN apt-get update -y && apt-get install -y build-essential python3 nodejs zip curl \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg |  apt-key add - \
+  && sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list' \
+  && apt-get update -y && apt-get install -y yarn \
+  && ./build-ext.sh
 
-# Build browser extensions
-RUN apt-get update && \
-    apt-get install -y zip make && \
-    ./build-ext.sh
 
 FROM alpine:latest
-COPY --from=build extension.zip .
+COPY --from=builder /extension.zip .
 
 # Wait for extension.zip to be copied into local
-CMD sleep 60
+CMD sleep 30

--- a/build-ext.sh
+++ b/build-ext.sh
@@ -1,11 +1,15 @@
+#!/bin/sh
 echo "🛠  Installing dependencies."
 yarn
 echo "🛠  Building internal packages."
 yarn lerna run build --scope @stacks/connect-ui
 echo "🛠  Compiling extension."
-yarn lerna run prod:ext
+cd packages/app && yarn lerna run prod:ext
 echo "🛠  Packaging Browser Extension"
-cd packages/app/dist
-zip -r ../../../extension.zip *
+cd dist
+TS=$(date +%Y)$(date +%m)010000
+find -print | while read file; do
+    touch -t $TS "$file"
+done
+zip -Xro /extension.zip *
 echo "✅  Extension packaged as extension.zip"
-


### PR DESCRIPTION
Firefox extension submission was failing due to the `extension.zip` not *matching* when built locally and compared to the docker build process. 
sha1sums of the files were identical, however I was able to reproduce the files not matching due to the inclusion of the timestamps of the files in the zipfile, which altered the subsequent sha1sum. 

To resolve, I've added a little code to the `/build-ext.sh` script that will determine the current month and year, then change the dates of all the files being zipped to something like `202012010000` which is the first day of the current month at 00:00. 
Multiple tests of the build process create an identical sha1sum: `b35861386dc68c1a887f9078417cc371cb3f6473  /extension.zip`

Additionally, I've updated the Dockerfile to use standard images from debian to keep a consistent baseline. 

```
- use a standard debian image for building
- update build script to set the timestamp of all files to first day of the current month with time of 00:00
  - md5sum wasn't matching for identical files if zip was created at different times
- update script slightly based on new insructions to create ./dist directory
```