### PR TITLE
fix: add blockstack jwt validation

### DIFF
--- a/packages/app/src/common/hooks/use-wallet.ts
+++ b/packages/app/src/common/hooks/use-wallet.ts
@@ -29,7 +29,7 @@ import {
 } from '@store/onboarding/actions';
 import { doTrackScreenChange } from '@common/track';
 import { AppManifest, DecodedAuthRequest } from '@common/dev/types';
-import { decodeToken } from 'blockstack';
+import { decodeToken, verifyAuthRequest } from 'blockstack';
 import { chainInfoStore } from '@store/recoil/api';
 import { useLoadable } from '@common/hooks/use-loadable';
 
@@ -197,6 +197,8 @@ export const useWallet = () => {
 
   const doSaveAuthRequest = useCallback(
     async (authRequest: string) => {
+      const isValidPayload = await verifyAuthRequest(authRequest);
+      if (!isValidPayload) throw new Error('JWT auth token is not valid');
       const { payload } = decodeToken(authRequest);
       const decodedAuthRequest = (payload as unknown) as DecodedAuthRequest;
       let appName = decodedAuthRequest.appDetails?.name;


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/474188175), the [hosted version](https://pr-752.app.stacks.engineering), or the [Stacks testnet demo app](https://pr-752.testnet-demo.stacks.engineering)<!-- Sticky Header Marker -->

> I thought we should add payload validation. Thinking there may be a schema in auth to validate against, realised there's a validation function exposed by the library itself.

Same code as #669 but we've refactored the `doSaveAuthRequest` method to inside `useWallet`.