### PR TITLE
feat: disable username registrations

### DIFF
--- a/packages/app/src/common/constants.ts
+++ b/packages/app/src/common/constants.ts
@@ -9,3 +9,5 @@ if (document?.location.origin.includes('localhost')) {
 }
 
 export const transition = 'all .2s cubic-bezier(.215,.61,.355,1)';
+
+export const USERNAMES_ENABLED = process.env.USERNAMES_ENABLED === 'true';

--- a/packages/app/src/components/drawer/accounts/create-account.tsx
+++ b/packages/app/src/components/drawer/accounts/create-account.tsx
@@ -1,15 +1,12 @@
 import React, { useEffect } from 'react';
-import { useWallet } from '@common/hooks/use-wallet';
 import { Box, Flex, Text, Button } from '@stacks/ui';
-import { useSetRecoilState } from 'recoil';
-import { accountDrawerStep, AccountStep } from '@store/recoil/drawers';
+import { useWallet } from '@common/hooks/use-wallet';
 
 interface CreateAccountProps {
   close: () => void;
 }
 export const CreateAccount: React.FC<CreateAccountProps> = ({ close }) => {
   const { doCreateNewIdentity } = useWallet();
-  const setAccountDrawerStep = useSetRecoilState(accountDrawerStep);
   useEffect(() => {
     void doCreateNewIdentity();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -22,29 +19,11 @@ export const CreateAccount: React.FC<CreateAccountProps> = ({ close }) => {
         </Text>
       </Box>
       <Box py="base">
-        <Text fontSize={2}>
-          Your new account has been created. A username makes your account easy to recognize. Would
-          you like to add a username?
-        </Text>
+        <Text fontSize={2}>Your new account has been created.</Text>
       </Box>
       <Flex width="100%" flexGrow={1} mt="base">
-        <Button
-          color="blue"
-          width="50%"
-          mr={2}
-          customStyles={{
-            primary: {
-              backgroundColor: '#F2F2FF',
-            },
-            secondary: {},
-            tertiary: {},
-          }}
-          onClick={close}
-        >
-          Skip username
-        </Button>
-        <Button width="50%" ml={2} onClick={() => setAccountDrawerStep(AccountStep.Username)}>
-          Add username
+        <Button width="50%" ml={2} onClick={close}>
+          Done
         </Button>
       </Flex>
     </Box>

--- a/packages/app/src/components/popup/settings-popover.tsx
+++ b/packages/app/src/components/popup/settings-popover.tsx
@@ -7,6 +7,7 @@ import { useAnalytics } from '@common/hooks/use-analytics';
 import { ScreenPaths } from '@store/onboarding/types';
 import { AccountStep } from '@store/recoil/drawers';
 import { Divider } from '@components/divider';
+import { USERNAMES_ENABLED } from '@common/constants';
 
 const SettingsItem: React.FC<BoxProps> = ({ onClick, children, ...props }) => (
   <Box
@@ -107,7 +108,7 @@ export const SettingsPopover: React.FC = () => {
       >
         View Secret Key
       </SettingsItem>
-      {currentIdentity && !currentIdentity.defaultUsername ? (
+      {USERNAMES_ENABLED && currentIdentity && !currentIdentity.defaultUsername ? (
         <>
           <Divider />
           <SettingsItem

--- a/packages/app/src/pages/set-password.tsx
+++ b/packages/app/src/pages/set-password.tsx
@@ -6,6 +6,7 @@ import { ScreenPaths } from '@store/onboarding/types';
 import { useWallet } from '@common/hooks/use-wallet';
 import { buildEnterKeyEvent } from '@components/link';
 import { useOnboardingState } from '@common/hooks/use-onboarding-state';
+import { USERNAMES_ENABLED } from '@common/constants';
 
 interface SetPasswordProps {
   redirect?: boolean;
@@ -13,7 +14,7 @@ interface SetPasswordProps {
 export const SetPasswordPage: React.FC<SetPasswordProps> = ({ redirect }) => {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
-  const { doSetPassword, identities } = useWallet();
+  const { doSetPassword, identities, doFinishSignIn } = useWallet();
   const { doChangeScreen } = useAnalytics();
   const { decodedAuthRequest } = useOnboardingState();
 
@@ -25,13 +26,23 @@ export const SetPasswordPage: React.FC<SetPasswordProps> = ({ redirect }) => {
       console.log('should choose account?');
       if (identities && (identities.length > 1 || identities[0].defaultUsername)) {
         doChangeScreen(ScreenPaths.CHOOSE_ACCOUNT);
+      } else if (!USERNAMES_ENABLED) {
+        await doFinishSignIn(0);
       } else {
         doChangeScreen(ScreenPaths.USERNAME);
       }
     } else if (redirect) {
       doChangeScreen(ScreenPaths.INSTALLED);
     }
-  }, [doSetPassword, doChangeScreen, password, redirect, decodedAuthRequest, identities]);
+  }, [
+    doSetPassword,
+    doChangeScreen,
+    password,
+    redirect,
+    decodedAuthRequest,
+    identities,
+    doFinishSignIn,
+  ]);
 
   return (
     <PopupContainer hideActions title="Set a password">

--- a/packages/app/tests/integration/authentication.test.ts
+++ b/packages/app/tests/integration/authentication.test.ts
@@ -6,6 +6,7 @@ import { DemoPage } from './page-objects/demo.page';
 import { WalletPage } from './page-objects/wallet.page';
 import { Wallet } from '@stacks/keychain';
 import { ChainID } from '@blockstack/stacks-transactions';
+import { USERNAMES_ENABLED } from '@common/constants';
 
 const WRONG_SECRET_KEY =
   'invite helmet save lion indicate chuckle world pride afford hard broom yup';
@@ -93,6 +94,12 @@ environments.forEach(([browserType, deviceType]) => {
     });
 
     it('creating an account - negative scenarious', async () => {
+      if (!USERNAMES_ENABLED) {
+        console.log(
+          'Skipping username validation tests, because subdomain registration is disabled.'
+        );
+        return;
+      }
       await demoPage.goToPage();
       await demoPage.openConnect();
       await demoPage.clickConnectGetStarted();

--- a/packages/app/tests/integration/installation.test.ts
+++ b/packages/app/tests/integration/installation.test.ts
@@ -24,11 +24,15 @@ environments.forEach(([browserType, deviceType]) => {
       browser = await browserType.launch({
         args: launchArgs,
       });
-      console.log('[DEBUG]: Launched puppeteer browser');
+      if (process.env.CI) {
+        console.log('[DEBUG]: Launched puppeteer browser');
+      }
     });
 
     beforeEach(async () => {
-      console.log('[DEBUG]: Starting new browser context.');
+      if (process.env.CI) {
+        console.log('[DEBUG]: Starting new browser context.');
+      }
       if (deviceType) {
         context = await browser.newContext({
           viewport: deviceType.viewport,

--- a/packages/app/tests/integration/page-objects/wallet.page.ts
+++ b/packages/app/tests/integration/page-objects/wallet.page.ts
@@ -1,6 +1,7 @@
 import { ScreenPaths } from '@store/onboarding/types';
 import { Page, BrowserContext } from 'playwright-core';
 import { createTestSelector, wait } from '../utils';
+import { USERNAMES_ENABLED } from '@common/constants';
 
 export class WalletPage {
   static url = 'http://localhost:8081/index.html#';
@@ -123,8 +124,10 @@ export class WalletPage {
   }
 
   async enterUsername(username: string) {
-    await this.page.fill(this.usernameInput, username);
-    await this.page.click(this.setUsernameDone);
+    if (USERNAMES_ENABLED) {
+      await this.page.fill(this.usernameInput, username);
+      await this.page.click(this.setUsernameDone);
+    }
   }
 
   chooseAccount(username: string) {

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -265,6 +265,7 @@ module.exports = {
       VERSION: JSON.stringify(version),
       COMMIT_SHA: JSON.stringify(commit),
       BRANCH: JSON.stringify(branch),
+      'process.env.USERNAMES_ENABLED': JSON.stringify(process.env.USERNAMES_ENABLED || 'false'),
     }),
     isDevelopment &&
       extEnv === 'web' &&


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/479038718), the [hosted version](https://pr-754.app.stacks.engineering), or the [Stacks testnet demo app](https://pr-754.testnet-demo.stacks.engineering)<!-- Sticky Header Marker -->

This PR adds a configuration to disable username registration. When Stacks 2.0 launches, we likely won't have a subdomain registrar running, so username registrations will break.

There are two ways to register a username in the Stacks Wallet:

- When authenticating into an app
- From the "Add Username" option in the settings popover (in the top right)

To QA:

- Sign up in a clean account from the demo app. You should be asked for a password, and then you'll be sent right back to the app.
- When signed in to the Stacks Wallet (either hosted or extension, doesn't matter), the option to add a username should not be visible.

Resolves https://github.com/blockstack/ux/issues/753