### PR TITLE
View secret key from settings popover

### DIFF
--- a/packages/app/src/components/popup/settings-popover.tsx
+++ b/packages/app/src/components/popup/settings-popover.tsx
@@ -100,14 +100,13 @@ export const SettingsPopover: React.FC = () => {
         </SettingsItem>
       ) : null}
 
-      {/* <SettingsItem
+      <SettingsItem
         onClick={() => {
-          const url = chrome.runtime.getURL(ScreenPaths.SETTINGS_KEY);
-          window.open(url, '_blank');
+          doChangeScreen(ScreenPaths.SETTINGS_KEY);
         }}
       >
         View Secret Key
-      </SettingsItem> */}
+      </SettingsItem>
       {currentIdentity && !currentIdentity.defaultUsername ? (
         <>
           <Divider />

--- a/packages/app/src/components/routes.tsx
+++ b/packages/app/src/components/routes.tsx
@@ -89,18 +89,11 @@ export const Routes: React.FC = () => {
       <AccountGateRoute path={ScreenPaths.POPUP_HOME} element={<PopupHome />} />
       <AccountGateRoute path={ScreenPaths.POPUP_SEND} element={<PopupSend />} />
       <AccountGateRoute path={ScreenPaths.POPUP_RECEIVE} element={<PopupReceive />} />
+      <AccountGateRoute path={ScreenPaths.SETTINGS_KEY} element={<SecretKey />} />
       <RouterRoute path={ScreenPaths.ADD_NETWORK} element={<AddNetwork />} />
-      <AccountGateRoute
-        path={ScreenPaths.EDIT_POST_CONDITIONS}
-        element={<EditPostConditionsPage />}
-      />
       <Route path={ScreenPaths.SET_PASSWORD} element={<SetPasswordPage redirect />} />
       {/*Sign Up*/}
       <Route path={ScreenPaths.GENERATION} element={getSignUpElement()} />
-      <Route
-        path={ScreenPaths.SECRET_KEY}
-        element={<SecretKey next={() => doChangeScreen(ScreenPaths.SAVE_KEY)} />}
-      />
       <Route
         path={ScreenPaths.SAVE_KEY}
         element={
@@ -150,10 +143,9 @@ export const Routes: React.FC = () => {
       />
       {/* Transactions */}
       <AccountGateRoute path={ScreenPaths.TRANSACTION_POPUP} element={<TransactionPage />} />
-      {/*Error/Misc*/}
       <AccountGateRoute
-        path={ScreenPaths.SETTINGS_KEY}
-        element={<SecretKey next={() => doChangeScreen(ScreenPaths.HOME)} />}
+        path={ScreenPaths.EDIT_POST_CONDITIONS}
+        element={<EditPostConditionsPage />}
       />
     </RoutesDom>
   );


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/474957435), the [hosted version](https://pr-755.app.stacks.engineering), or the [Stacks testnet demo app](https://pr-755.testnet-demo.stacks.engineering)<!-- Sticky Header Marker -->

I had yet to port over the "view secret key" page to the new designs. The previous design was also built with the assumption that it would be part of the onboarding flow, which it is not anymore.

![image](https://user-images.githubusercontent.com/1109058/104112974-f3e8c100-52a9-11eb-9b42-411d740d6251.png)
