### PR TITLE
Fix: "Create an account" broken

### DIFF
--- a/.changeset/gold-grapes-turn.md
+++ b/.changeset/gold-grapes-turn.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': minor
+---
+
+Fixed a bug where clicking 'create an account' did not properly update the wallet state.

--- a/src/components/drawer/accounts/create-account.tsx
+++ b/src/components/drawer/accounts/create-account.tsx
@@ -42,7 +42,13 @@ export const CreateAccount: React.FC<CreateAccountProps> = ({ close }) => {
         <Text fontSize={2}>Your new account has been created.</Text>
       </Box>
       <Flex width="100%" flexGrow={1} mt="base">
-        <Button width="100%" ml={2} onClick={close}>
+        <Button
+          width="100%"
+          onClick={close}
+          isLoading={setting}
+          isDisabled={setting}
+          data-test={setting ? undefined : 'create-account-done-button'}
+        >
           Done
         </Button>
       </Flex>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -27,6 +27,7 @@ const MenuButton: React.FC<BoxProps> = memo(props => {
       _hover={{
         color: color('text-title'),
       }}
+      data-test="menu-button"
       icon={IconDots}
       {...props}
     />

--- a/src/components/popup/settings-popover.tsx
+++ b/src/components/popup/settings-popover.tsx
@@ -104,6 +104,7 @@ export const SettingsPopover: React.FC = () => {
                 </MenuItem>
               )}
               <MenuItem
+                data-test="settings-create-an-account"
                 onClick={wrappedCloseCallback(() => {
                   setAccountStep(AccountStep.Create);
                   setShowAccounts(true);

--- a/src/extension/background/vault-manager.ts
+++ b/src/extension/background/vault-manager.ts
@@ -124,7 +124,8 @@ export const vaultReducer = async (message: MessageFromApp): Promise<Vault> => {
       await updateConfig();
       return {
         ...vault,
-        wallet,
+        wallet: newWallet,
+        currentAccountIndex: newWallet.accounts.length - 1,
       };
     }
     case Methods.signOut: {

--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -42,7 +42,12 @@ export const PopupHome: React.FC = memo(() => {
     <PopupContainer>
       <Stack mt="loose" data-test="home-page" spacing="loose">
         <Stack alignItems="flex-start" spacing="base">
-          <Title lineHeight="1rem" fontSize={4} fontWeight={500}>
+          <Title
+            lineHeight="1rem"
+            fontSize={4}
+            fontWeight={500}
+            data-test="home-current-display-name"
+          >
             {getAccountDisplayName(currentAccount)}
           </Title>
           <Caption>{truncateMiddle(currentAccountStxAddress, 8)}</Caption>

--- a/tests/integration/home.test.ts
+++ b/tests/integration/home.test.ts
@@ -1,0 +1,32 @@
+import { BrowserDriver, createTestSelector, setupBrowser } from './utils';
+import { WalletPage } from './page-objects/wallet.page';
+import { ScreenPaths } from '@store/onboarding/types';
+
+jest.setTimeout(20_000);
+jest.retryTimes(process.env.CI ? 2 : 0);
+describe(`Installation integration tests`, () => {
+  let browser: BrowserDriver;
+  let wallet: WalletPage;
+
+  beforeEach(async () => {
+    browser = await setupBrowser();
+    wallet = await WalletPage.init(browser, ScreenPaths.INSTALLED);
+  }, 10000);
+
+  afterEach(async () => {
+    try {
+      await browser.context.close();
+    } catch (error) {}
+  });
+
+  it('should be able to create a new account', async () => {
+    await wallet.signUp();
+    await wallet.page.click(wallet.settingsButton);
+    await wallet.page.click(createTestSelector('settings-create-an-account'));
+    await wallet.page.click(createTestSelector('create-account-done-button'));
+    const displayName = await wallet.page.textContent(
+      createTestSelector('home-current-display-name')
+    );
+    expect(displayName).toEqual('Account 2');
+  });
+});

--- a/tests/integration/page-objects/wallet.page.ts
+++ b/tests/integration/page-objects/wallet.page.ts
@@ -52,7 +52,7 @@ export class WalletPage {
       if (attempt > 3) {
         throw new Error('Unable to get auth page popup');
       }
-      await wait(50);
+      await wait(250);
       return this.recursiveGetAuthPopup(browser, attempt + 1);
     }
     return page;

--- a/tests/integration/page-objects/wallet.page.ts
+++ b/tests/integration/page-objects/wallet.page.ts
@@ -23,6 +23,7 @@ export class WalletPage {
     'text="You can only use lowercase letters (a–z), numbers (0–9), and underscores (_)."';
   signInKeyError = createTestSelector('sign-in-seed-error');
   password = 'mysecretreallylongpassword';
+  settingsButton = createTestSelector('menu-button');
   page: Page;
 
   constructor(page: Page) {
@@ -136,5 +137,16 @@ export class WalletPage {
 
   chooseAccount(username: string) {
     return this.page.click(`[data-test="account-${username}"]`);
+  }
+
+  /** Sign up with a randomly generated seed phrase */
+  async signUp() {
+    await this.clickSignUp();
+    await this.saveKey();
+    await this.waitForHomePage();
+  }
+
+  async openSettings() {
+    return this.page.click(this.settingsButton);
   }
 }


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/644353231).<!-- Sticky Header Marker -->

Fixes #1011

The root cause was an unhandled state return in the vault reducer. We were creating a new account, but not returning that new state properly.

I've fixed the issue, and added a test for it as well.

https://user-images.githubusercontent.com/1109058/110864628-3eb99180-8277-11eb-8f0c-a17928ea5175.mp4

QA steps:

- Create a new wallet
- Open settings, click "Create new account"
- You should automatically switch to that new account ("Account 2")
- You should be able to switch account now when you open settings
- If you restore this seed phrase, the second account should be there