### PR TITLE
feat: add test for locking and unlocking

### DIFF
--- a/.changeset/tender-boats-double.md
+++ b/.changeset/tender-boats-double.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Added an integration test for creating an account, locking the wallet, and unlocking

--- a/src/components/popup/settings-popover.tsx
+++ b/src/components/popup/settings-popover.tsx
@@ -154,6 +154,7 @@ export const SettingsPopover: React.FC = () => {
                     void doLockWallet();
                     doChangeScreen(ScreenPaths.POPUP_HOME);
                   })}
+                  data-test="settings-lock"
                 >
                   Lock
                 </MenuItem>
@@ -163,6 +164,7 @@ export const SettingsPopover: React.FC = () => {
                   void doSignOut();
                   doChangeScreen(ScreenPaths.INSTALLED);
                 })}
+                data-test="settings-sign-out"
               >
                 Sign Out
               </MenuItem>

--- a/tests/integration/installation.test.ts
+++ b/tests/integration/installation.test.ts
@@ -1,4 +1,4 @@
-import { BrowserDriver, SECRET_KEY, setupBrowser } from './utils';
+import { BrowserDriver, createTestSelector, randomString, SECRET_KEY, setupBrowser } from './utils';
 import { WalletPage } from './page-objects/wallet.page';
 import { ScreenPaths } from '@store/onboarding/types';
 
@@ -35,5 +35,26 @@ describe(`Installation integration tests`, () => {
     await installPage.waitForHomePage();
     const secretKey = await installPage.getSecretKey();
     expect(secretKey).toEqual(SECRET_KEY);
+  });
+
+  it('should be able to sign up, restore, lock and unlock the extension', async () => {
+    await installPage.clickSignUp();
+    await installPage.saveKey();
+    await installPage.waitForHomePage();
+    await installPage.goToSecretKey();
+    const secretKey = await installPage.getSecretKey();
+    await installPage.openSettings();
+    await installPage.page.click(createTestSelector('settings-sign-out'));
+
+    await installPage.clickSignIn();
+    await installPage.enterSecretKey(secretKey);
+    const password = randomString(15);
+    await installPage.enterPassword(password);
+    await installPage.openSettings();
+    await installPage.page.click(createTestSelector('settings-lock'));
+    await installPage.enterPassword(password);
+    await installPage.goToSecretKey();
+    const decryptedSecretKey = await installPage.getSecretKey();
+    expect(decryptedSecretKey).toEqual(secretKey);
   });
 });

--- a/tests/integration/page-objects/wallet.page.ts
+++ b/tests/integration/page-objects/wallet.page.ts
@@ -118,8 +118,8 @@ export class WalletPage {
     await this.goTo(ScreenPaths.SETTINGS_KEY);
   }
 
-  async enterPassword() {
-    await this.page.fill('input[type="password"]', this.password);
+  async enterPassword(password?: string) {
+    await this.page.fill('input[type="password"]', password ?? this.password);
     await this.page.click(this.setPasswordDone);
   }
 


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/659426440).<!-- Sticky Header Marker -->

This takes the new test from #1039 and applies it to our existing test infrastructure. @timstackblock I've taken the test you wrote, and simply added it to our existing test infrastructure.

Thanks for putting this test together! It's a great one to have.