### PR TITLE
fix: dont append extra version on main branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: lucasmotta/pull-request-sticky-header@1.0.0
         if: needs.check_fork.outputs.is_not_fork == 'true'
         with:
-          header: '> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/${{ github.run_id }}) or the [Stacks testnet demo app](https://pr-${{ github.event.number }}.testnet-demo.stacks.engineering)'
+          header: '> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set Node Version
         uses: actions/setup-node@v2-beta

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -1,18 +1,18 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const webpack = require('webpack');
-const {version: _version} = require('../package.json');
-const {execSync} = require('child_process');
+const { version: _version } = require('../package.json');
+const { execSync } = require('child_process');
 
 // plugins
 const WebpackBarPlugin = require('webpackbar');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const {CleanWebpackPlugin} = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
-const {ESBuildPlugin} = require('esbuild-loader');
+const { ESBuildPlugin } = require('esbuild-loader');
 
 // utils
 const getSegmentKey = () => {
@@ -25,12 +25,12 @@ const getSegmentKey = () => {
 };
 
 const getBranch = () => {
-  const branch = execSync(`git rev-parse --abbrev-ref HEAD`, {encoding: 'utf8'}).trim();
+  const branch = execSync(`git rev-parse --abbrev-ref HEAD`, { encoding: 'utf8' }).trim();
   return branch;
 };
 
 const getCommit = () => {
-  const commit = execSync('git rev-parse --short HEAD', {encoding: 'utf8'}).trim();
+  const commit = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
   return commit;
 };
 
@@ -39,7 +39,7 @@ const getCommit = () => {
  */
 const getVersion = () => {
   const branch = getBranch();
-  if (!branch || branch.includes('master')) return _version;
+  if (!branch || branch.includes('main')) return _version;
   return `${_version}.${Math.floor(Math.floor(Math.random() * 1000))}`;
 };
 
@@ -76,28 +76,28 @@ const HTML_OPTIONS = {
 const HTML_PROD_OPTIONS = IS_DEV
   ? HTML_OPTIONS
   : {
-    ...HTML_OPTIONS,
-    minify: {
-      removeComments: true,
-      collapseWhitespace: true,
-      removeRedundantAttributes: true,
-      useShortDoctype: true,
-      removeEmptyAttributes: true,
-      removeStyleLinkTypeAttributes: true,
-      keepClosingSlash: true,
-      minifyJS: true,
-      minifyCSS: true,
-      minifyURLs: true,
-    },
-  };
+      ...HTML_OPTIONS,
+      minify: {
+        removeComments: true,
+        collapseWhitespace: true,
+        removeRedundantAttributes: true,
+        useShortDoctype: true,
+        removeEmptyAttributes: true,
+        removeStyleLinkTypeAttributes: true,
+        keepClosingSlash: true,
+        minifyJS: true,
+        minifyCSS: true,
+        minifyURLs: true,
+      },
+    };
 
 const aliases = IS_DEV
   ? {}
   : {
-    react: 'preact/compat',
-    'react-dom/test-utils': 'preact/test-utils',
-    'react-dom': 'preact/compat',
-  };
+      react: 'preact/compat',
+      'react-dom/test-utils': 'preact/test-utils',
+      'react-dom': 'preact/compat',
+    };
 
 const config = {
   entry: {
@@ -149,13 +149,13 @@ const config = {
               presets: [
                 [
                   '@babel/preset-env',
-                  {targets: {browsers: 'last 2 versions'}}, // or whatever your project requires
+                  { targets: { browsers: 'last 2 versions' } }, // or whatever your project requires
                 ],
                 '@babel/preset-typescript',
                 '@babel/preset-react',
               ],
               plugins: [
-                ['@babel/plugin-proposal-class-properties', {loose: true}],
+                ['@babel/plugin-proposal-class-properties', { loose: true }],
                 '@babel/plugin-transform-runtime',
                 '@babel/plugin-proposal-nullish-coalescing-operator',
                 '@babel/plugin-proposal-optional-chaining',
@@ -182,12 +182,10 @@ const config = {
   watch: false,
   plugins: [
     new WebpackBarPlugin({}),
-    new webpack.IgnorePlugin(
-      {
-        resourceRegExp: /^\.\/wordlists\/(?!english)/,
-        contextRegExp: /bip39\/src$/,
-      }
-    ),
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^\.\/wordlists\/(?!english)/,
+      contextRegExp: /bip39\/src$/,
+    }),
     new ESBuildPlugin(),
     new HtmlWebpackPlugin({
       template: path.join(SRC_ROOT_PATH, '../', 'public', 'html', 'extension.html'),
@@ -232,7 +230,7 @@ const config = {
             return Buffer.from(content);
           },
         },
-      ]
+      ],
     }),
     new webpack.DefinePlugin({
       NODE_ENV: JSON.stringify(NODE_ENV),
@@ -258,6 +256,6 @@ module.exports = smp.wrap(config);
 
 if (IS_PROD) {
   module.exports.plugins.push(
-    new CleanWebpackPlugin({verbose: true, dry: false, cleanStaleWebpackAssets: false})
+    new CleanWebpackPlugin({ verbose: true, dry: false, cleanStaleWebpackAssets: false })
   );
 }


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/644067051).<!-- Sticky Header Marker -->

The only change is only line 42. The rest are linting fixes. The webpack config has logic to append a random number after the version - this fixes conflicting versions on PRs. It was configured to look for `master`, but now we're on `main`.