### PR TITLE
fix: only modify post conditions for tx sender

### DIFF
--- a/.changeset/stale-turkeys-argue.md
+++ b/.changeset/stale-turkeys-argue.md
@@ -1,0 +1,21 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This update resolves these issues:
+- fixes [#969](https://github.com/blockstack/stacks-wallet-web/issues/969)
+- fixes [#1093](https://github.com/blockstack/stacks-wallet-web/issues/1093)
+
+**Changes**
+
+refactors the hook `use-setup-tx` ([before](https://github.com/blockstack/stacks-wallet-web/blob/35bb9d7a786ffe236322a7c96eb091cc3b94fa49/src/common/hooks/use-setup-tx.ts#L28), [after](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/use-setup-tx.ts)) into smaller, more manageable parts. From the original hook, there are a few new ones that each take care of their own responsibility:
+- [useAccountSwitchCallback](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/callbacks/use-account-switch-callback.ts)
+- [useDecodeRequestCallback](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/callbacks/use-decode-request-callback.ts)
+- [useNetworkSwitchCallback](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/callbacks/use-network-switch-callback.ts)
+- [usePostConditionsCallback](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/callbacks/use-post-conditions-callback.ts) (the one we care about for this PR)
+  - [post-conditions-utils.ts](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/post-condition-utils.ts#L16)
+  - [postConditionFromString](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/utils.ts#L168)
+
+**Other misc fixes**
+- There was a bug where if a `token_transfer` had post conditions defined (which it should not), it would not display them. [This fixes that bug.](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/components/transactions/post-conditions/list.tsx#L33)
+- Very briefly refactored the base component that displays the post conditions, [see component](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/components/transactions/post-conditions/single.tsx#L88).

--- a/src/common/hooks/callbacks/use-account-switch-callback.ts
+++ b/src/common/hooks/callbacks/use-account-switch-callback.ts
@@ -1,0 +1,38 @@
+import { CallbackInterface, useRecoilCallback } from 'recoil';
+import { transactionPayloadStore } from '@store/recoil/transaction';
+import { currentAccountIndexStore, walletStore } from '@store/recoil/wallet';
+import { getStxAddress } from '@stacks/wallet-sdk';
+
+function accountSwitchCallback({ snapshot, set }: CallbackInterface) {
+  return async () => {
+    const payload = await snapshot.getPromise(transactionPayloadStore);
+    if (!payload?.stxAddress || !payload.network) return;
+    const wallet = await snapshot.getPromise(walletStore);
+    if (!wallet) return;
+    const transactionVersion = payload.network.version;
+    let foundIndex: number | undefined = undefined;
+    wallet.accounts.forEach((account, index) => {
+      const address = getStxAddress({ account, transactionVersion });
+      if (address === payload.stxAddress) {
+        foundIndex = index;
+      }
+    });
+    if (foundIndex !== undefined) {
+      console.debug('switching to index', foundIndex);
+      set(currentAccountIndexStore, foundIndex);
+    } else {
+      console.warn(
+        'No account matches the STX address provided in transaction request:',
+        payload.stxAddress
+      );
+    }
+  };
+}
+
+/**
+ * Apps can specify a `stxAddress` in a transaction request.
+ * If the user has a matching account, use that account by default.
+ */
+export function useAccountSwitchCallback() {
+  return useRecoilCallback(accountSwitchCallback, []);
+}

--- a/src/common/hooks/callbacks/use-decode-request-callback.ts
+++ b/src/common/hooks/callbacks/use-decode-request-callback.ts
@@ -1,0 +1,20 @@
+import { useRecoilCallback } from 'recoil';
+import { requestTokenStore } from '@store/recoil/transaction';
+import { useLocation } from 'react-router-dom';
+
+export function useDecodeRequestCallback() {
+  const location = useLocation();
+  return useRecoilCallback(
+    ({ set }) => () => {
+      const urlParams = new URLSearchParams(location.search);
+      const requestToken = urlParams.get('request');
+      if (requestToken) {
+        set(requestTokenStore, requestToken);
+      } else if (!requestToken) {
+        console.error('Unable to find contract call parameter');
+        throw 'Invalid transaction request parameter';
+      }
+    },
+    [location.search]
+  );
+}

--- a/src/common/hooks/callbacks/use-network-switch-callback.ts
+++ b/src/common/hooks/callbacks/use-network-switch-callback.ts
@@ -1,0 +1,52 @@
+import { useRecoilCallback } from 'recoil';
+import { transactionPayloadStore } from '@store/recoil/transaction';
+import {
+  currentNetworkKeyStore,
+  currentNetworkStore,
+  Network,
+  networksStore,
+} from '@store/recoil/networks';
+
+export function useNetworkSwitchCallback() {
+  return useRecoilCallback(
+    ({ snapshot, set }) => async () => {
+      const payload = await snapshot.getPromise(transactionPayloadStore);
+      if (!payload || !payload.network) return;
+
+      let foundNetwork = false;
+
+      const [currentNetwork, networks] = await Promise.all([
+        snapshot.getPromise(currentNetworkStore),
+        snapshot.getPromise(networksStore),
+      ]);
+
+      // try to find an exact url match
+      if (payload.network.coreApiUrl !== currentNetwork.url) {
+        const newNetworkKey = Object.keys(networks).find(key => {
+          const network = networks[key] as Network;
+          return network.url === payload.network?.coreApiUrl;
+        });
+
+        if (newNetworkKey) {
+          console.debug('Changing to new network to match node URL', newNetworkKey);
+          set(currentNetworkKeyStore, newNetworkKey);
+          foundNetwork = true;
+        }
+      }
+      // try to find a network that matches chain id
+      if (!foundNetwork && payload.network.chainId !== currentNetwork.chainId) {
+        const newNetworkKey = Object.keys(networks).find(key => {
+          const network = networks[key] as Network;
+          return network.chainId === payload.network?.chainId;
+        });
+
+        if (newNetworkKey) {
+          console.debug('Changing to new network from chainID', newNetworkKey);
+          set(currentNetworkKeyStore, newNetworkKey);
+          return;
+        }
+      }
+    },
+    []
+  );
+}

--- a/src/common/hooks/callbacks/use-post-conditions-callback.ts
+++ b/src/common/hooks/callbacks/use-post-conditions-callback.ts
@@ -1,0 +1,47 @@
+import { CallbackInterface, useRecoilCallback } from 'recoil';
+import { postConditionsStore, transactionPayloadStore } from '@store/recoil/transaction';
+import { getPostCondition, handlePostConditions } from '@common/post-condition-utils';
+
+export function usePostConditionsCallback() {
+  return useRecoilCallback(postConditionsCallback, []);
+}
+
+function postConditionsCallback({ snapshot, set }: CallbackInterface) {
+  return async (currentAddress?: string) => {
+    const [payload, existingPostConditions] = await Promise.all([
+      snapshot.getPromise(transactionPayloadStore),
+      snapshot.getPromise(postConditionsStore),
+    ]);
+    if (!payload) return;
+
+    const { stxAddress, postConditions } = payload;
+
+    if (existingPostConditions.length) {
+      if (stxAddress && currentAddress) {
+        // we have existing post conditions, lets ensure
+        // the principal(s) are set correctly
+        const newConditions = handlePostConditions(
+          existingPostConditions,
+          stxAddress,
+          currentAddress
+        );
+        set(postConditionsStore, newConditions);
+        return;
+      }
+    } else if (postConditions && postConditions.length) {
+      if (stxAddress && currentAddress) {
+        // we have yet to set the post conditions to the store
+        // let's ensure the principal(s) are set correctly
+        const newConditions = handlePostConditions(postConditions, stxAddress, currentAddress);
+        set(postConditionsStore, newConditions);
+        return;
+      }
+      // there is no `stxAddress` set, but it might be
+      // the case that a post condition is of string type
+      // so let's map over them and deserialize them
+      const newConditions = postConditions.map(getPostCondition);
+      set(postConditionsStore, newConditions);
+      return;
+    }
+  };
+}

--- a/src/common/hooks/use-setup-tx.ts
+++ b/src/common/hooks/use-setup-tx.ts
@@ -1,163 +1,41 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
-import {
-  transactionPayloadStore,
-  postConditionsStore,
-  requestTokenStore,
-} from '@store/recoil/transaction';
-import { useRecoilCallback, useRecoilValue } from 'recoil';
-import {
-  currentNetworkStore,
-  networksStore,
-  Network,
-  currentNetworkKeyStore,
-} from '@store/recoil/networks';
-import {
-  currentAccountIndexStore,
-  walletStore,
-  currentAccountStxAddressStore,
-} from '@store/recoil/wallet';
-import { getStxAddress } from '@stacks/wallet-sdk';
-import {
-  PostCondition,
-  parsePrincipalString,
-  deserializePostCondition,
-  BufferReader,
-} from '@stacks/transactions';
+import { useRecoilValue } from 'recoil';
+import { usePrevious } from '@stacks/ui';
+
+import { requestTokenStore } from '@store/recoil/transaction';
+import { currentAccountStxAddressStore } from '@store/recoil/wallet';
+
+import { useAccountSwitchCallback } from '@common/hooks/callbacks/use-account-switch-callback';
+import { usePostConditionsCallback } from '@common/hooks/callbacks/use-post-conditions-callback';
+import { useNetworkSwitchCallback } from '@common/hooks/callbacks/use-network-switch-callback';
+import { useDecodeRequestCallback } from '@common/hooks/callbacks/use-decode-request-callback';
 
 export const useSetupTx = () => {
   const currentAccountStxAddress = useRecoilValue(currentAccountStxAddressStore);
+  const previousAccountStxAddress = usePrevious(currentAccountStxAddress);
   const requestToken = useRecoilValue(requestTokenStore);
-  const location = useLocation();
 
-  const decodeRequest = useRecoilCallback(
-    ({ set }) => () => {
-      const urlParams = new URLSearchParams(location.search);
-      const requestToken = urlParams.get('request');
-      if (requestToken) {
-        set(requestTokenStore, requestToken);
-      } else if (!requestToken) {
-        console.error('Unable to find contract call parameter');
-        throw 'Invalid transaction request parameter';
-      }
-    },
-    [location.search]
-  );
+  const handleDecodeRequest = useDecodeRequestCallback();
+  const handleNetworkSwitch = useNetworkSwitchCallback();
+  const handleAccountSwitch = useAccountSwitchCallback();
+  const handlePostConditions = usePostConditionsCallback();
 
   useEffect(() => {
-    decodeRequest();
-  }, [decodeRequest]);
-
-  const handleNetworkSwitch = useRecoilCallback(
-    ({ snapshot, set }) => async () => {
-      const payload = await snapshot.getPromise(transactionPayloadStore);
-      if (!payload?.network) return;
-      const currentNetwork = await snapshot.getPromise(currentNetworkStore);
-      const networks = await snapshot.getPromise(networksStore);
-      let foundNetwork = false;
-      if (payload.network.coreApiUrl !== currentNetwork.url) {
-        const newNetworkKey = Object.keys(networks).find(key => {
-          const network = networks[key] as Network;
-          return network.url === payload.network?.coreApiUrl;
-        });
-        if (newNetworkKey) {
-          console.debug('Changing to new network to match node URL', newNetworkKey);
-          set(currentNetworkKeyStore, newNetworkKey);
-          foundNetwork = true;
-        }
-      }
-      if (!foundNetwork && payload.network.chainId !== currentNetwork.chainId) {
-        const newNetworkKey = Object.keys(networks).find(key => {
-          const network = networks[key] as Network;
-          return network.chainId === payload.network?.chainId;
-        });
-        if (newNetworkKey) {
-          console.debug('Changing to new network from chainID', newNetworkKey);
-          set(currentNetworkKeyStore, newNetworkKey);
-          return;
-        }
-      }
-    },
-    []
-  );
-
-  /**
-   * Apps can specify a `stxAddress` in a transaction request.
-   * If the user has a matching account, use that account by default.
-   */
-  const handleAccountSwitch = useRecoilCallback(
-    ({ snapshot, set }) => async () => {
-      const payload = await snapshot.getPromise(transactionPayloadStore);
-      if (!payload?.stxAddress || !payload.network) return;
-      const wallet = await snapshot.getPromise(walletStore);
-      if (!wallet) return;
-      const transactionVersion = payload.network.version;
-      let foundIndex: number | undefined = undefined;
-      wallet.accounts.forEach((account, index) => {
-        const address = getStxAddress({ account, transactionVersion });
-        if (address === payload.stxAddress) {
-          foundIndex = index;
-        }
-      });
-      if (foundIndex !== undefined) {
-        console.debug('switching to index', foundIndex);
-        set(currentAccountIndexStore, foundIndex);
-      } else {
-        console.warn(
-          'No account matches the STX address provided in transaction request:',
-          payload.stxAddress
-        );
-      }
-    },
-    []
-  );
+    if (!requestToken) {
+      handleDecodeRequest();
+    }
+  }, [requestToken, handleDecodeRequest]);
 
   useEffect(() => {
     void handleNetworkSwitch();
     void handleAccountSwitch();
   }, [requestToken, handleNetworkSwitch, handleAccountSwitch]);
 
-  const handlePostConditions = useRecoilCallback(
-    ({ snapshot, set }) => async (currentAddress?: string) => {
-      const payload = await snapshot.getPromise(transactionPayloadStore);
-      if (!payload) return;
-      if (!currentAddress) return;
-      const existingPostConditions = await snapshot.getPromise(postConditionsStore);
-      // change existing post conditions to current account
-      if (existingPostConditions.length) {
-        console.debug('Swapping post conditions address');
-        const newConditions: PostCondition[] = existingPostConditions.map(postCondition => {
-          return {
-            ...postCondition,
-            principal: parsePrincipalString(currentAddress),
-          };
-        });
-        set(postConditionsStore, newConditions);
-        return;
-      } else if (payload.postConditions?.length) {
-        console.debug('Setting up post conditions for transaction request');
-        const newConditions: PostCondition[] = payload.postConditions.map(postCondition => {
-          let payloadCondition: PostCondition;
-          if (typeof postCondition === 'string') {
-            const reader = BufferReader.fromBuffer(Buffer.from(postCondition, 'hex'));
-            payloadCondition = deserializePostCondition(reader);
-          } else {
-            payloadCondition = { ...postCondition };
-          }
-          // override principal with current user
-          const newCondition = {
-            ...payloadCondition,
-            principal: parsePrincipalString(currentAddress),
-          };
-          return newCondition;
-        });
-        set(postConditionsStore, newConditions);
-      }
-    },
-    []
-  );
-
   useEffect(() => {
-    void handlePostConditions(currentAccountStxAddress);
-  }, [requestToken, currentAccountStxAddress, handlePostConditions]);
+    if (currentAccountStxAddress) {
+      if (!previousAccountStxAddress || previousAccountStxAddress !== currentAccountStxAddress) {
+        void handlePostConditions(currentAccountStxAddress);
+      }
+    }
+  }, [previousAccountStxAddress, requestToken, currentAccountStxAddress, handlePostConditions]);
 };

--- a/src/common/post-condition-utils.ts
+++ b/src/common/post-condition-utils.ts
@@ -22,9 +22,12 @@ export function handlePostConditions(
   const currentAddressPrincipal = parsePrincipalString(currentAddress);
 
   console.debug('Setting up post conditions for transaction request');
-  return postConditions.map(postCondition => {
+  return postConditions.map((postCondition, index) => {
     const { principal, ...payload } = getPostCondition(postCondition);
-    const isOriginatorAddress = payloadPrincipal.address === principal.address;
+    const sameType = payloadPrincipal.address.type === principal.address.type;
+    const sameHash = payloadPrincipal.address.hash160 === principal.address.hash160;
+    const isOriginatorAddress = sameHash && sameType;
+    console.debug(`[Post Conditions #${index + 1}]: isOriginatorAddress: ${isOriginatorAddress}`);
     return {
       ...payload,
       principal: isOriginatorAddress ? currentAddressPrincipal : principal,

--- a/src/common/post-condition-utils.ts
+++ b/src/common/post-condition-utils.ts
@@ -1,0 +1,37 @@
+import { parsePrincipalString, PostCondition } from '@stacks/transactions';
+import { postConditionFromString } from '@common/utils';
+
+/**
+ * This method will update a post conditions principal
+ * value to the current address principal if and only if
+ * the `stxAddress` value from the original tx payload
+ * matches the address in the original post condition
+ *
+ * This is used when a user might switch accounts during
+ * the signing process. One can assume that if the post
+ * condition has the principal set to the same value as the
+ * `stxAddress` value, it should be updated when they switch
+ * accounts.
+ */
+export function handlePostConditions(
+  postConditions: (PostCondition | string)[],
+  payloadAddress: string,
+  currentAddress: string
+): PostCondition[] {
+  const payloadPrincipal = parsePrincipalString(payloadAddress);
+  const currentAddressPrincipal = parsePrincipalString(currentAddress);
+
+  console.debug('Setting up post conditions for transaction request');
+  return postConditions.map(postCondition => {
+    const { principal, ...payload } = getPostCondition(postCondition);
+    const isOriginatorAddress = payloadPrincipal.address === principal.address;
+    return {
+      ...payload,
+      principal: isOriginatorAddress ? currentAddressPrincipal : principal,
+    };
+  });
+}
+
+export function getPostCondition(postCondition: string | PostCondition): PostCondition {
+  return typeof postCondition === 'string' ? postConditionFromString(postCondition) : postCondition;
+}

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -10,6 +10,7 @@ import {
   Methods,
   TransactionResponseMessage,
 } from '@extension/message-types';
+import { BufferReader, deserializePostCondition, PostCondition } from '@stacks/transactions';
 import { KEBAB_REGEX } from '@common/constants';
 
 function kebabCase(str: string) {
@@ -185,4 +186,9 @@ export function getTicker(value: string) {
     name = `${getLetters(name, 3)}`;
   }
   return name.toUpperCase();
+}
+
+export function postConditionFromString(postCondition: string): PostCondition {
+  const reader = BufferReader.fromBuffer(Buffer.from(postCondition, 'hex'));
+  return deserializePostCondition(reader);
 }

--- a/src/components/transactions/post-conditions/list.tsx
+++ b/src/components/transactions/post-conditions/list.tsx
@@ -28,7 +28,10 @@ export const PostConditions: React.FC = () => {
   });
 
   const getPostConditionsContent = () => {
-    if (pendingTransaction?.txType === TransactionTypes.STXTransfer) {
+    if (
+      pendingTransaction?.txType === TransactionTypes.STXTransfer &&
+      postConditions.length === 0
+    ) {
       return (
         <PostConditionBase
           title="transfer exactly"

--- a/src/components/transactions/post-conditions/single.tsx
+++ b/src/components/transactions/post-conditions/single.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Box, Flex, Text, DynamicColorCircle } from '@stacks/ui';
+import { Text, Stack, StackProps } from '@stacks/ui';
 import { addressToString, PostCondition, PostConditionType } from '@stacks/transactions';
 import { useSetRecoilState } from 'recoil';
 import { postConditionsStore, currentPostConditionIndexStore } from '@store/recoil/transaction';
@@ -9,6 +9,7 @@ import { Asset, selectedAssetStore } from '@store/recoil/asset-search';
 import { useFetchBalances } from '@common/hooks/use-account-info';
 import { toHumanReadableStx, truncateMiddle } from '@stacks/ui-utils';
 import { getPostConditionTitle, stacksValue } from '@common/stacks-utils';
+import { AssetAvatar } from '@components/stx-avatar';
 
 interface PostConditionBaseProps {
   title: string;
@@ -19,62 +20,79 @@ interface PostConditionBaseProps {
   edit?: () => void;
   remove?: () => void;
 }
-export const PostConditionBase: React.FC<PostConditionBaseProps> = props => {
-  const { edit, remove } = props;
+
+type PostConditionDetailsProps = Pick<PostConditionBaseProps, 'iconString' | 'amount' | 'ticker'> &
+  StackProps;
+
+const PostConditionDetails: React.FC<PostConditionDetailsProps> = ({
+  iconString,
+  amount,
+  ticker,
+  ...rest
+}) => {
   return (
-    <Box mb="base">
-      <Flex flexDirection="column">
-        <Box mb="base">
-          <Text fontSize={2}>You {props.title}</Text>
-        </Box>
-        <Box>
-          <Flex flexDirection="row">
-            <Box>
-              <DynamicColorCircle mr="base" size="32px" string={props.iconString}>
-                {props.iconChar}
-              </DynamicColorCircle>
-            </Box>
-            <Box pt="extra-tight" flexGrow={1}>
-              <Text fontWeight="600" fontSize={2}>
-                {props.amount}
-              </Text>
-            </Box>
-            <Box pt="extra-tight">
-              <Text fontWeight="500" fontSize={2}>
-                {props.ticker}
-              </Text>
-            </Box>
-          </Flex>
-        </Box>
-        {edit || remove ? (
-          <Box mt="base">
-            <Text
-              fontWeight="500"
-              color="blue"
-              mr="base-tight"
-              onClick={edit}
-              cursor="pointer"
-              _hover={{
-                textDecoration: 'underline',
-              }}
-            >
-              Edit
-            </Text>
-            <Text
-              fontWeight="500"
-              color="red"
-              cursor="pointer"
-              _hover={{
-                textDecoration: 'underline',
-              }}
-              onClick={remove}
-            >
-              Remove
-            </Text>
-          </Box>
-        ) : null}
-      </Flex>
-    </Box>
+    <Stack isInline alignItems="center" flexGrow={1} width="100%" {...rest}>
+      <AssetAvatar
+        size="32px"
+        useStx={iconString === 'STX'}
+        gradientString={
+          // TODO: use fully realized asset name
+          iconString
+        }
+      />
+      <Text fontWeight="600" fontSize={2}>
+        {amount}
+      </Text>
+
+      <Text fontWeight="500" fontSize={2} ml="auto">
+        {ticker}
+      </Text>
+    </Stack>
+  );
+};
+
+type PostConditionActionsProps = Pick<PostConditionBaseProps, 'edit' | 'remove'> & StackProps;
+const PostConditionActions: React.FC<PostConditionActionsProps> = ({ edit, remove, ...rest }) => {
+  return (
+    <Stack spacing="base-tight" isInline {...rest}>
+      {edit && (
+        <Text
+          fontWeight="500"
+          color="blue"
+          onClick={edit}
+          cursor="pointer"
+          _hover={{
+            textDecoration: 'underline',
+          }}
+        >
+          Edit
+        </Text>
+      )}
+      {remove && (
+        <Text
+          fontWeight="500"
+          color="red"
+          cursor="pointer"
+          _hover={{
+            textDecoration: 'underline',
+          }}
+          onClick={remove}
+        >
+          Remove
+        </Text>
+      )}
+    </Stack>
+  );
+};
+
+export const PostConditionBase: React.FC<PostConditionBaseProps> = props => {
+  const { edit, remove, iconString, amount, ticker } = props;
+  return (
+    <Stack spacing="base-loose">
+      <Text fontSize={2}>You {props.title}</Text>
+      <PostConditionDetails iconString={iconString} amount={amount} ticker={ticker} />
+      {(edit || remove) && <PostConditionActions edit={edit} remove={remove} />}
+    </Stack>
   );
 };
 
@@ -119,6 +137,7 @@ interface PostConditionProps {
   pc: PostCondition;
   index: number;
 }
+
 export const PostConditionComponent: React.FC<PostConditionProps> = ({ pc, index }) => {
   const setCurrentPostConditionIndex = useSetRecoilState(currentPostConditionIndexStore);
   const setSelectedAsset = useSetRecoilState(selectedAssetStore);

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -13,6 +13,8 @@ import {
   standardPrincipalCV,
   trueCV,
   makeStandardSTXPostCondition,
+  makeStandardFungiblePostCondition,
+  createAssetInfo,
   FungibleConditionCode,
 } from '@stacks/transactions';
 import { ExplorerLink } from './explorer-link';
@@ -58,6 +60,16 @@ export const Debugger = () => {
           address || '',
           FungibleConditionCode.LessEqual,
           new BN('100', 10)
+        ),
+        makeStandardFungiblePostCondition(
+          'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+          FungibleConditionCode.Equal,
+          new BN(1234),
+          createAssetInfo(
+            'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+            'connect-token',
+            'connect-token'
+          )
         ),
       ],
       finished: data => {


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/691431922).<!-- Sticky Header Marker -->

## what this does

This PR works to resolve these issues:
- fixes #969
- fixes #1093

### Changes

As part of getting familiar with the code, I've done some work to refactor the hook `use-setup-tx` ([before](https://github.com/blockstack/stacks-wallet-web/blob/35bb9d7a786ffe236322a7c96eb091cc3b94fa49/src/common/hooks/use-setup-tx.ts#L28), [after](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/use-setup-tx.ts)) into smaller, more manageable parts. From the original hook, I've now made a few new ones that each take care of their own responsibility:
- [useAccountSwitchCallback](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/callbacks/use-account-switch-callback.ts)
- [useDecodeRequestCallback](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/callbacks/use-decode-request-callback.ts)
- [useNetworkSwitchCallback](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/callbacks/use-network-switch-callback.ts)
- [usePostConditionsCallback](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/hooks/callbacks/use-post-conditions-callback.ts) (the one we care about for this PR)
  - [post-conditions-utils.ts](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/post-condition-utils.ts#L16)
  - [postConditionFromString](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/common/utils.ts#L168)

### Other misc fixes
- There was a bug where if a `token_transfer` had post conditions defined, it would not display them. [This fixes that bug.](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/components/transactions/post-conditions/list.tsx#L33)
- Very briefly refactored the base component that displays the post conditions, [see component](https://github.com/blockstack/stacks-wallet-web/blob/cafd37b6737960df4542490eeb74dcbcc7f1881e/src/components/transactions/post-conditions/single.tsx#L88).