### PR TITLE
fix: schema-inspector update

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "redux": "4.0.5",
     "redux-thunk": "2.3.0",
     "safe-compare": "1.1.4",
+    "schema-inspector": "2.0.0",
     "swr": "0.5.0",
     "use-events": "1.4.2",
     "use-latest": "1.2.0",
@@ -185,7 +186,8 @@
     "@stacks/ui-utils": "7.5.0",
     "@tabler/icons": "npm:tabler-icons-peer-deps@1.39.3",
     "bn.js": "^5.2.0",
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "schema-inspector": "2.0.0"
   },
   "keywords": [
     "blockstack",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12225,6 +12225,13 @@ scheduler@^0.20.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+schema-inspector@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/schema-inspector/-/schema-inspector-2.0.0.tgz#f124f2d66e2d68c93d38d3dd7e0f4cf3d1e4ccd7"
+  integrity sha512-Qa0fZ8vfCNzwPWZPfXVtjqYKN7rC2jFrHia2UvBvmaXTdwiA9hnTnWh30MP47Tw5ZejkuH0QqUpDK4NqPoBk4w==
+  dependencies:
+    async "~2.6.3"
+
 schema-inspector@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/schema-inspector/-/schema-inspector-1.7.0.tgz#b3f8b97fc26ba930ef16cd7b8fcf77201ce468db"


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/690665108).<!-- Sticky Header Marker -->

Upgrades `schema-inspector` to latest version. [related `yarn audit` issue](https://www.npmjs.com/advisories/1656)