### PR TITLE
Ext auto publish

### DIFF
--- a/.changeset/swift-ants-glow.md
+++ b/.changeset/swift-ants-glow.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Updates our Github Actions to automatically publish production versions of the extension to the Chrome and Firefox stoes.

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -32,6 +32,16 @@ jobs:
         with:
           name: stacks-wallet-chromium
           path: stacks-wallet-chromium.zip
+
+      - uses: Klemensas/chrome-extension-upload-action@1
+        with:
+          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+          file-name: './stacks-wallet-chromium.zip'
+          app-id: ${{ secrets.CHROME_APP_ID }}
+          publish: true
+
       - name: Upload Chromium extension to production
         uses: google-github-actions/upload-cloud-storage@864317d33c42de84de94313c5f834802365977b0
         with:
@@ -40,25 +50,19 @@ jobs:
           destination: wallet-extensions
 
       # Firefox
-      - name: Sign Production Firefox version
+      - name: Sign and Upload Production Firefox version
         continue-on-error: true
-        run: yarn web-ext sign --channel=unlisted
+        run: yarn web-ext sign --channel=listed
         env:
-          WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
-          WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}
-      - uses: actions/upload-artifact@v2
-        name: Upload Artifact - Firefox Add-On XPI
-        with:
-          name: connect-addon
-          path: web-ext-artifacts/*.xpi
+          WEB_EXT_API_KEY: ${{ secrets.FIREFOX_API_KEY }}
+          WEB_EXT_API_SECRET: ${{ secrets.FIREFOX_API_SECRET }}
       - name: Get Firefox addon filename
         id: addon-file
         run: echo "::set-output name=addon_path::$(find ./web-ext-artifacts -type f -iname "*.xpi" | tail -n1)"
       - name: Rename Firefox addon file
         run: cp ${{ steps.addon-file.outputs.addon_path }} stacks-wallet-firefox.xpi
-      - name: Upload Firefox extension to GCS
-        uses: google-github-actions/upload-cloud-storage@864317d33c42de84de94313c5f834802365977b0
+      - name: Upload Artifact - Firefox Add-On XPI
+        uses: actions/upload-artifact@v2
         with:
-          credentials: ${{ secrets.GCS_BUCKET_CREDENTIALS }}
-          path: ./stacks-wallet-firefox.xpi
-          destination: wallet-extensions/
+          name: stacks-wallet-firefox
+          path: stacks-wallet-firefox.xpi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,22 +2,6 @@ name: Pull Request
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  check_fork:
-    name: Disable jobs for forks
-    runs-on: ubuntu-latest
-    outputs:
-      is_not_fork: ${{ steps.is_not_fork.outputs.is_not_fork }}
-    steps:
-      - name: Check for secret
-        id: is_not_fork
-        env:
-          WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
-          STABLE_WALLET_BRANCH: ${{ secrets.STABLE_WALLET_BRANCH }}
-        run: |
-          echo "Is a fork: ${{ env.WEB_EXT_API_KEY == '' }}"
-          echo "::set-output name=is_not_fork::${{ env.WEB_EXT_API_KEY != '' }}"
-          echo "::set-output name=stable_wallet_branch::${{ env.STABLE_WALLET_BRANCH }}"
-
   commitlint:
     runs-on: ubuntu-latest
     env:
@@ -29,7 +13,6 @@ jobs:
       - uses: wagoid/commitlint-github-action@v1
 
   code_checks:
-    needs: [check_fork]
     name: Code checks
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +21,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: lucasmotta/pull-request-sticky-header@1.0.0
-        if: needs.check_fork.outputs.is_not_fork == 'true'
+        # Don't run on forks
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: '> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,8 +77,8 @@ jobs:
   publish_firefox_beta:
     name: Publish beta firefox extension
     runs-on: ubuntu-latest
-    needs: [check_fork]
-    if: needs.check_fork.outputs.is_not_fork == 'true'
+    # Don't run on forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/786803296).<!-- Sticky Header Marker -->

## Description

Automates the upload and publish for Firefox and Chrome extensions.
@aulneau @hstove This has _not_ been tested yet. Would it be ok to try running this before this gets merged? Or should we attempt it on the next actual release?

Closes https://github.com/blockstack/stacks-wallet-web/issues/1056

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Checklist
- [x] Tag 1 of @hstove or @aulneau for review
