### PR TITLE
fix: remove storage permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,7 @@
     "512": "assets/connect-logo/Stacks512w.png"
   },
   "content_security_policy": "script-src 'self'<% DEV_CSR %>; object-src <% DEV_OBJECT_SRC %>; frame-src 'none'; frame-ancestors 'none';",
-  "permissions": ["activeTab", "storage"],
+  "permissions": ["activeTab"],
   "manifest_version": 2,
   "background": {
     "scripts": ["background.js"],


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/786263463).<!-- Sticky Header Marker -->

While submitting to the stores, there was a request to justify the `storage` permission. We added this to our `manifest.json` because we were using that API, but then usage of that was removed. We no longer use that API, so we should remove this permission.