### PR TITLE
feat: add attachment support

### DIFF
--- a/.changeset/quiet-guests-remain.md
+++ b/.changeset/quiet-guests-remain.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Add Atlas attachment support

--- a/src/components/transactions/attachment-row.tsx
+++ b/src/components/transactions/attachment-row.tsx
@@ -1,0 +1,27 @@
+import { useTxState } from '@common/hooks/use-tx-state';
+import { Flex, Box, Text } from '@stacks/ui';
+import React from 'react';
+
+function readable(data: string)
+	{
+	const text = Buffer.from(data,'hex').toString('ascii');
+	return /^[\x00-\x7F]*$/.test(text) ? text : data;
+	}
+
+export const AttachentRow: React.FC = () => {
+  const { pendingTransaction } = useTxState();
+  return pendingTransaction?.attachment ? (
+    <Flex my="base">
+      <Box flexGrow={1}>
+        <Text display="block" fontSize={1}>
+          attachment
+        </Text>
+      </Box>
+      <Box>
+          <Text fontSize={1} color="ink.600">
+            {readable(pendingTransaction.attachment)}
+          </Text>
+      </Box>
+    </Flex>
+  ) : (null);
+};

--- a/src/components/transactions/attachment-row.tsx
+++ b/src/components/transactions/attachment-row.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 function readable(data: string)
 	{
 	const text = Buffer.from(data,'hex').toString('ascii');
-	return /^[\x00-\x7F]*$/.test(text) ? text : data;
+	return /^[\x00-\x7F]*$/.test(text) ? text : `0x${data}`;
 	}
 
 export const AttachentRow: React.FC = () => {

--- a/src/components/transactions/attachment-row.tsx
+++ b/src/components/transactions/attachment-row.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 function readable(data: string)
 	{
 	const text = Buffer.from(data,'hex').toString('ascii');
-	return /^[\x00-\x7F]*$/.test(text) ? text : `0x${data}`;
+	return /^[^\x00-\x1F\x80-\x9F]+$/.test(text) ? text : `0x${data}`;
 	}
 
 export const AttachentRow: React.FC = () => {

--- a/src/components/transactions/contract-call-details.tsx
+++ b/src/components/transactions/contract-call-details.tsx
@@ -6,6 +6,7 @@ import { truncateMiddle } from '@stacks/ui-utils';
 import { deserializeCV, cvToString, ClarityType, getCVTypeString } from '@stacks/transactions';
 import { LoadingRectangle } from '@components/loading-rectangle';
 import { NonceRow } from './nonce-row';
+import { AttachentRow } from './attachment-row';
 import { Link } from '@components/link';
 import { useExplorerLink } from '@common/hooks/use-explorer-link';
 
@@ -101,6 +102,7 @@ export const ContractCallDetails: React.FC = () => {
         </Flex>
       </Box>
       <NonceRow />
+      <AttachentRow />
     </>
   );
 };

--- a/src/components/transactions/contract-deploy-details.tsx
+++ b/src/components/transactions/contract-deploy-details.tsx
@@ -5,6 +5,7 @@ import { truncateMiddle } from '@stacks/ui-utils';
 import { useWallet } from '@common/hooks/use-wallet';
 import { Prism } from '@common/clarity-prism';
 import { NonceRow } from './nonce-row';
+import { AttachentRow } from './attachment-row';
 
 export const ContractDeployDetails: React.FC = () => {
   const { pendingTransaction } = useTxState();
@@ -64,6 +65,7 @@ export const ContractDeployDetails: React.FC = () => {
               />
             </Flex>
             <NonceRow />
+            <AttachentRow />
           </Box>
         </Flex>
       </Box>

--- a/src/components/transactions/stx-transfer-details.tsx
+++ b/src/components/transactions/stx-transfer-details.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTxState } from '@common/hooks/use-tx-state';
 import { Box, Text, Flex } from '@stacks/ui';
 import { NonceRow } from './nonce-row';
+import { AttachentRow } from './attachment-row';
 
 export const StxTransferDetails: React.FC = () => {
   const { pendingTransaction } = useTxState();
@@ -51,6 +52,7 @@ export const StxTransferDetails: React.FC = () => {
               </Flex>
             )}
             <NonceRow />
+            <AttachentRow />
           </Box>
         </Flex>
       </Box>


### PR DESCRIPTION
## Description

Adds the ability to submit an attachment alongside a transaction. There is currently no indication of this in the transaction confirmation screen. Work in progress. See https://github.com/blockstack/connect/pull/105.

It displays the attachment in a separate row if present. It prints it as ascii if the attachment is composed of only readable characters, otherwise it displays it as a hex string.

The display could use some work. It looks a little messy like any other long parameter (like the zonefile-hash line.)

<img width="554" alt="Screenshot 2021-05-05 at 9 40 16 PM" src="https://user-images.githubusercontent.com/5727806/117242873-f936c200-adea-11eb-83f3-8054b8029c58.png">

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
Yes. TBD.

## Testing information

1. Successful submission of a transaction with attachment.

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Tag 1 of @hstove or @kyranjamie or @aulneau for review
