### PR TITLE
fix: race condition and nonce calculation

### DIFF
--- a/.changeset/fifty-pears-do.md
+++ b/.changeset/fifty-pears-do.md
@@ -1,0 +1,11 @@
+---
+'@stacks/wallet-web': patch
+---
+
+**This fixes two issues:**
+
+There was a race condition such that sometimes when a transaction would be generated from the requestToken, the
+postCondition hook would run before the token was decoded, and as such always returned an empty postConditions array.
+
+There was a bug where if the account had a pending function call transaction, the nonce store would never be correct
+while the tx was still pending.

--- a/src/common/hooks/use-setup-tx.ts
+++ b/src/common/hooks/use-setup-tx.ts
@@ -11,7 +11,7 @@ import { useNetworkSwitchCallback } from '@common/hooks/callbacks/use-network-sw
 import { useDecodeRequestCallback } from '@common/hooks/callbacks/use-decode-request-callback';
 
 export const useSetupTx = () => {
-  const [mount, setMount] = useState(false);
+  const [hasMounted, setHasMounted] = useState(false);
   const currentAccountStxAddress = useRecoilValue(currentAccountStxAddressStore);
   const previousAccountStxAddress = usePrevious(currentAccountStxAddress);
   const requestToken = useRecoilValue(requestTokenStore);
@@ -28,12 +28,6 @@ export const useSetupTx = () => {
   }, [requestToken, handleDecodeRequest]);
 
   useEffect(() => {
-    if (requestToken && !mount) {
-      setMount(true);
-    }
-  }, [requestToken, mount]);
-
-  useEffect(() => {
     void handleNetworkSwitch();
     void handleAccountSwitch();
   }, [requestToken, handleNetworkSwitch, handleAccountSwitch]);
@@ -41,15 +35,18 @@ export const useSetupTx = () => {
   useEffect(() => {
     if (requestToken && currentAccountStxAddress) {
       if (
-        !mount ||
+        !hasMounted ||
         !previousAccountStxAddress ||
         previousAccountStxAddress !== currentAccountStxAddress
       ) {
+        if (!hasMounted) {
+          setHasMounted(true);
+        }
         void handlePostConditions(currentAccountStxAddress);
       }
     }
   }, [
-    mount,
+    hasMounted,
     previousAccountStxAddress,
     requestToken,
     currentAccountStxAddress,

--- a/src/common/hooks/use-setup-tx.ts
+++ b/src/common/hooks/use-setup-tx.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { usePrevious } from '@stacks/ui';
 
@@ -11,6 +11,7 @@ import { useNetworkSwitchCallback } from '@common/hooks/callbacks/use-network-sw
 import { useDecodeRequestCallback } from '@common/hooks/callbacks/use-decode-request-callback';
 
 export const useSetupTx = () => {
+  const [mount, setMount] = useState(false);
   const currentAccountStxAddress = useRecoilValue(currentAccountStxAddressStore);
   const previousAccountStxAddress = usePrevious(currentAccountStxAddress);
   const requestToken = useRecoilValue(requestTokenStore);
@@ -27,15 +28,31 @@ export const useSetupTx = () => {
   }, [requestToken, handleDecodeRequest]);
 
   useEffect(() => {
+    if (requestToken && !mount) {
+      setMount(true);
+    }
+  }, [requestToken, mount]);
+
+  useEffect(() => {
     void handleNetworkSwitch();
     void handleAccountSwitch();
   }, [requestToken, handleNetworkSwitch, handleAccountSwitch]);
 
   useEffect(() => {
-    if (currentAccountStxAddress) {
-      if (!previousAccountStxAddress || previousAccountStxAddress !== currentAccountStxAddress) {
+    if (requestToken && currentAccountStxAddress) {
+      if (
+        !mount ||
+        !previousAccountStxAddress ||
+        previousAccountStxAddress !== currentAccountStxAddress
+      ) {
         void handlePostConditions(currentAccountStxAddress);
       }
     }
-  }, [previousAccountStxAddress, requestToken, currentAccountStxAddress, handlePostConditions]);
+  }, [
+    mount,
+    previousAccountStxAddress,
+    requestToken,
+    currentAccountStxAddress,
+    handlePostConditions,
+  ]);
 };

--- a/src/components/drawer/confirm-send-drawer.tsx
+++ b/src/components/drawer/confirm-send-drawer.tsx
@@ -48,7 +48,11 @@ const TransactionDetails: React.FC<
       </Stack>
       <Stack width="100%" px="extra-loose">
         <Caption>Nonce</Caption>
-        {nonce ? <Text>{nonce}</Text> : <LoadingRectangle height="14px" width="80px" />}
+        {typeof nonce !== 'undefined' ? (
+          <Text>{String(nonce)}</Text>
+        ) : (
+          <LoadingRectangle height="14px" width="80px" />
+        )}
       </Stack>
       <Stack width="100%" px="extra-loose">
         <Caption>Fee</Caption>

--- a/src/store/recoil/wallet.ts
+++ b/src/store/recoil/wallet.ts
@@ -56,8 +56,8 @@ export const latestNonceStore = selector({
   get: ({ get }) => {
     const network = get(currentNetworkStore);
     const address = get(currentAccountStxAddressStore);
-    const nonce = get(latestNoncesStore([network.url, address || '']));
-    return nonce;
+
+    return get(latestNoncesStore([network.url, address || '']));
   },
 });
 
@@ -90,8 +90,7 @@ export const currentAccountStxAddressStore = selector({
     const account = get(currentAccountStore);
     if (!account) return undefined;
     const transactionVersion = get(currentTransactionVersion);
-    const address = getStxAddress({ account, transactionVersion });
-    return address;
+    return getStxAddress({ account, transactionVersion });
   },
 });
 
@@ -109,8 +108,7 @@ export const walletConfigStore = selector<WalletConfig | null>({
       return null;
     }
     const gaiaHubConfig = await createWalletGaiaConfig({ wallet, gaiaHubUrl: gaiaUrl });
-    const walletConfig = await fetchWalletConfig({ wallet, gaiaHubConfig });
-    return walletConfig;
+    return fetchWalletConfig({ wallet, gaiaHubConfig });
   },
 });
 


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/820990327).<!-- Sticky Header Marker -->

## What this does

This fixes two things:

### Post condition race condition
There was a race condition such that sometimes when a transaction would be generated from the `requestToken`, the postCondition hook would run before the token was decoded, and as such always returned an empty postConditions array.

### Nonce not always correct
I found a bug where if the account had a pending function call transaction, the nonce store would never be correct while the tx was still pending.

The new logic is as such:
- fetch the current nonce from the account endpoint
- fetch the last confirmed transaction
- fetch any pending transactions that have been sent by the account
- use the greater value out of these nonces