### PR TITLE
fix: docker build failing with bad file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update -y && apt-get install -y build-essential python3 nodejs zip c
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg |  apt-key add - \
   && sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list' \
   && apt-get update -y && apt-get install -y yarn \
+  && chmod +x build-ext.sh \
   && ./build-ext.sh /stacks-wallet-chromium.zip
 
 


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/817047763).<!-- Sticky Header Marker -->

Fixes `-> /bin/sh: 1: ./build-ext.sh: Permission denied` issue