### PR TITLE
fix: center onboarding elements

### DIFF
--- a/.changeset/calm-pears-mate.md
+++ b/.changeset/calm-pears-mate.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This fixes onboarding elements from being pushed to the bottom of the screen and popup by removing the automatic margin-top spacing.

--- a/src/components/global-styles.tsx
+++ b/src/components/global-styles.tsx
@@ -21,8 +21,13 @@ const SizeStyles = css`
       width: 100%;
 
       main.main-content {
+        flex-grow: 1;
+        justify-content: center;
         max-width: 440px;
         margin: 0 auto;
+      }
+      .onboarding-text {
+        text-align: center;
       }
     }
   }

--- a/src/components/save-your-key-view.tsx
+++ b/src/components/save-your-key-view.tsx
@@ -9,7 +9,7 @@ export const SecretKeyMessage: React.FC<BoxProps> = props => {
   const { secretKey } = useWallet();
   const wordCount = (secretKey || '').split(' ').length;
   return (
-    <Body {...props}>
+    <Body {...props} className="onboarding-text">
       These {wordCount} words are your Secret Key. They create your account, and you sign in on
       different devices with them. Make sure to save these somewhere safe.{' '}
       <Text display="inline" fontWeight={500}>
@@ -68,7 +68,7 @@ export const SaveYourKeyView: React.FC<{
     hideActions={hideActions}
     title={title || 'Save your Secret Key'}
   >
-    <Stack flexGrow={1} spacing="loose">
+    <Stack spacing="loose">
       <SecretKeyMessage />
       <SecretKeyCard />
       <SecretKeyActions handleNext={handleNext || onClose} />

--- a/src/pages/install/index.tsx
+++ b/src/pages/install/index.tsx
@@ -37,7 +37,7 @@ const Actions: React.FC<StackProps> = props => {
 export const Installed: React.FC = memo(() => (
   <PopupContainer hideActions>
     <Stack spacing="extra-loose" flexGrow={1} justifyContent="center">
-      <Stack width="100%" spacing="loose" textAlign="center" alignItems="center" mt="extra-loose">
+      <Stack width="100%" spacing="loose" textAlign="center" alignItems="center">
         <Title as="h1" fontWeight={500}>
           Stacks Wallet is installed
         </Title>

--- a/src/pages/install/sign-in.tsx
+++ b/src/pages/install/sign-in.tsx
@@ -26,47 +26,51 @@ export const InstalledSignIn: React.FC = () => {
       hideActions
       key="sign-in"
     >
-      <Caption>Enter your 12 or 24 word Secret Key to continue.</Caption>
-      <Stack as="form" onSubmit={onSubmit} spacing="loose" mt="auto">
-        <Stack spacing="base">
-          {error && (
-            <ErrorLabel lineHeight="16px">
-              <Text
-                textAlign="left"
-                textStyle="caption"
-                color={color('feedback-error')}
-                data-test="sign-in-seed-error"
-              >
-                {error}
-              </Text>
-            </ErrorLabel>
-          )}
-          <Input
-            autoFocus
-            placeholder="Paste or type your Secret Key"
-            as="textarea"
-            fontSize="16px"
-            autoCapitalize="off"
-            spellCheck={false}
+      <Stack spacing="loose">
+        <Caption className="onboarding-text">
+          Enter your 12 or 24 word Secret Key to continue.
+        </Caption>
+        <Stack as="form" onSubmit={onSubmit} spacing="loose">
+          <Stack spacing="base">
+            {error && (
+              <ErrorLabel lineHeight="16px">
+                <Text
+                  textAlign="left"
+                  textStyle="caption"
+                  color={color('feedback-error')}
+                  data-test="sign-in-seed-error"
+                >
+                  {error}
+                </Text>
+              </ErrorLabel>
+            )}
+            <Input
+              autoFocus
+              placeholder="Paste or type your Secret Key"
+              as="textarea"
+              fontSize="16px"
+              autoCapitalize="off"
+              spellCheck={false}
+              width="100%"
+              style={{ resize: 'none' }}
+              minHeight="140px"
+              ref={ref as any} // need to fix type in UI lib
+              onKeyDown={onKeyDown as any} // need to fix type in UI lib
+              onPaste={onPaste}
+              onChange={onChange}
+              value={value}
+            />
+          </Stack>
+          <Button
             width="100%"
-            style={{ resize: 'none' }}
-            minHeight="140px"
-            ref={ref as any} // need to fix type in UI lib
-            onKeyDown={onKeyDown as any} // need to fix type in UI lib
-            onPaste={onPaste}
-            onChange={onChange}
-            value={value}
-          />
+            isLoading={isLoading}
+            isDisabled={isLoading}
+            data-test="sign-in-key-continue"
+            type="submit"
+          >
+            Continue
+          </Button>
         </Stack>
-        <Button
-          width="100%"
-          isLoading={isLoading}
-          isDisabled={isLoading}
-          data-test="sign-in-key-continue"
-          type="submit"
-        >
-          Continue
-        </Button>
       </Stack>
     </PopupContainer>
   );

--- a/src/pages/set-password.tsx
+++ b/src/pages/set-password.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react';
-import { Button, color, Input, Stack } from '@stacks/ui';
+import { Button, Input, Stack } from '@stacks/ui';
 import { PopupContainer } from '@components/popup/container';
 import { useDoChangeScreen } from '@common/hooks/use-do-change-screen';
 import { ScreenPaths } from '@store/onboarding/types';
@@ -92,39 +92,39 @@ export const SetPasswordPage: React.FC<SetPasswordProps> = ({
   return (
     <PopupContainer hideActions title="Set a password.">
       <Stack spacing="loose">
-        <Body color={color('feedback-success')} fontWeight="500">
-          This password is for this device only.
+        <Body className="onboarding-text">
+          This password is for this device only. To access your account on a new device you will use
+          your Secret Key.
         </Body>
-        <Body>To access your account on a new device you will use your Secret Key.</Body>
-      </Stack>
-      <Stack spacing="base" mt="auto" width="100%">
-        {showWarning ? (
-          <Caption fontSize={0}>
-            Please use a stronger password before continuing. Longer than 12 characters, with
-            symbols, numbers, and words.
-          </Caption>
-        ) : null}
-        <Input
-          ref={ref}
-          placeholder={placeholder || 'Set a password'}
-          key="password-input"
-          width="100%"
-          autoFocus
-          type="password"
-          data-test="set-password"
-          onChange={handlePasswordInput}
-          onKeyUp={buildEnterKeyEvent(handleSubmit)}
-        />
+        <Stack spacing="loose" width="100%">
+          {showWarning ? (
+            <Caption fontSize={0}>
+              Please use a stronger password before continuing. Longer than 12 characters, with
+              symbols, numbers, and words.
+            </Caption>
+          ) : null}
+          <Input
+            ref={ref}
+            placeholder={placeholder || 'Set a password'}
+            key="password-input"
+            width="100%"
+            autoFocus
+            type="password"
+            data-test="set-password"
+            onChange={handlePasswordInput}
+            onKeyUp={buildEnterKeyEvent(handleSubmit)}
+          />
 
-        <Button
-          width="100%"
-          isLoading={loading}
-          isDisabled={loading || showWarning}
-          onClick={handleSubmit}
-          data-test="set-password-done"
-        >
-          Done
-        </Button>
+          <Button
+            width="100%"
+            isLoading={loading}
+            isDisabled={loading || showWarning}
+            onClick={handleSubmit}
+            data-test="set-password-done"
+          >
+            Done
+          </Button>
+        </Stack>
       </Stack>
     </PopupContainer>
   );


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/829280317).<!-- Sticky Header Marker -->

## Description

Fix for the margin pushing the form to the bottom of the page/popup.

For details refer to issue #1133

![image](https://user-images.githubusercontent.com/6493321/117717080-f5ff5580-b19f-11eb-853f-2ca7c5c89ba3.png)

![image](https://user-images.githubusercontent.com/6493321/117717091-f992dc80-b19f-11eb-9e08-ccedc0002ef5.png)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other