### PR TITLE
fix: allow tx to update core api url

### DIFF
--- a/src/common/transaction-utils.ts
+++ b/src/common/transaction-utils.ts
@@ -129,6 +129,7 @@ export const generateTransaction = async ({
       txData.network?.version === TransactionVersion.Mainnet
         ? new StacksMainnet()
         : new StacksTestnet();
+    if (txData.network?.coreApiUrl) network.coreApiUrl = txData.network?.coreApiUrl;
     txData.network = network;
   }
   switch (txData.txType) {

--- a/src/store/recoil/transaction.ts
+++ b/src/store/recoil/transaction.ts
@@ -1,4 +1,5 @@
 import {
+  ChainID,
   createAddress,
   createAssetInfo,
   FungibleConditionCode,
@@ -20,6 +21,7 @@ import { selectedAssetStore } from './asset-search';
 import BN from 'bn.js';
 import { stxToMicroStx } from '@common/stacks-utils';
 import { getAssetStringParts } from '@stacks/ui-utils';
+import { StacksMainnet, StacksTestnet } from '@stacks/network';
 
 export type TransactionPayloadWithAttachment = TransactionPayload & {
   attachment?: string;
@@ -57,9 +59,15 @@ export const pendingTransactionStore = selector({
     const requestToken = get(requestTokenStore);
     const tx = getPayload(requestToken);
     if (!tx) return undefined;
-    const stacksNetwork = get(stacksNetworkStore);
+    let stacksNetwork = get(stacksNetworkStore);
     const postConditions = get(postConditionsStore);
     tx.postConditions = [...postConditions];
+    if (tx.network) {
+      stacksNetwork =
+        tx.network.chainId === ChainID.Testnet ? new StacksTestnet() : new StacksMainnet();
+      // update the network with the coreApiUrl passed by app
+      stacksNetwork.coreApiUrl = tx.network.coreApiUrl;
+    }
     tx.network = stacksNetwork;
     return tx;
   },


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/820992846).<!-- Sticky Header Marker -->

This is a small update to allow a transaction to update the core api url for a given transaction. 

I'd like for us to discuss this and see if it's something we want to do. I needed to change this in order to make use of the regtest network.