### PR TITLE
ci: add publish statuses

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -6,10 +6,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  pre_run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0
+        with:
+          access_token: ${{ github.token }}
+
   publish_chrome_extension:
     name: Publish Chrome extension
     runs-on: ubuntu-latest
     if: "contains(github.event.head_commit.message, 'Version Packages')"
+    needs:
+      - pre_run
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -28,7 +38,10 @@ jobs:
 
       - name: Sign and Upload Production Chrome extension
         continue-on-error: true
-        run: yarn webstore upload --source stacks-wallet-chromium.zip --auto-publish
+        id: publish-chrome
+        run: |
+          yarn webstore upload --source stacks-wallet-chromium.zip --auto-publish
+          echo "::set-output name=PUBLISH_STATUS::${?}"
         env:
           EXTENSION_ID: ${{ secrets.CHROME_APP_ID }}
           CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
@@ -41,6 +54,8 @@ jobs:
     env:
       MINIFY_PRODUCTION_BUILD: true
     if: "contains(github.event.head_commit.message, 'Version Packages')"
+    needs:
+      - pre_run
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,7 +74,21 @@ jobs:
 
       - name: Sign and Upload Production Firefox extension
         continue-on-error: true
-        run: yarn web-ext-submit --channel=listed
+        id: publish-firefox
+        run: |
+          yarn web-ext-submit --channel=listed
+          echo "::set-output name=PUBLISH_STATUS::${?}"
         env:
           WEB_EXT_API_KEY: ${{ secrets.FIREFOX_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.FIREFOX_API_SECRET }}
+
+  post-run:
+    runs-on: ubuntu-latest
+    needs:
+      - publish_chrome_extension
+      - publish_firefox_extension
+    steps:
+      - name: Publish Statuses
+        run: |
+          echo "::warning::Firefox Publish Status: $([[ ${{ steps.publish-firefox.outputs.PUBLISH_STATUS }} = 0 ]] && echo 'SUCCESS' || echo 'FAILED')"
+          echo "::warning::Chrome Publish Status: $([[ ${{ steps.publish-chrome.outputs.PUBLISH_STATUS }} = 0 ]] && echo 'SUCCESS' || echo 'FAILED')"

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -82,7 +82,7 @@ jobs:
           WEB_EXT_API_KEY: ${{ secrets.FIREFOX_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.FIREFOX_API_SECRET }}
 
-  post-run:
+  post_run:
     runs-on: ubuntu-latest
     needs:
       - publish_chrome_extension

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0
+        uses: styfle/cancel-workflow-action@ad6cb1b847ffb509a69b745b6ee2f1d14dfe14b8
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0
+        uses: styfle/cancel-workflow-action@ad6cb1b847ffb509a69b745b6ee2f1d14dfe14b8
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,10 +2,20 @@ name: Pull Request
 on: [pull_request, workflow_dispatch]
 
 jobs:
+  pre_run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0
+        with:
+          access_token: ${{ github.token }}
+
   commitlint:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs:
+      - pre_run
     steps:
       - uses: actions/checkout@v2
         with:
@@ -16,6 +26,8 @@ jobs:
   code_checks:
     name: Code checks
     runs-on: ubuntu-latest
+    needs:
+      - pre_run
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -51,6 +63,8 @@ jobs:
   integration_tests:
     name: Integration tests
     runs-on: ubuntu-latest
+    needs:
+      - pre_run
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -83,6 +97,8 @@ jobs:
   build_chrome_extnsion:
     name: Build Chrome extension
     runs-on: ubuntu-latest
+    needs:
+      - pre_run
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -102,6 +118,8 @@ jobs:
   publish_firefox_beta:
     name: Publish beta firefox extension
     runs-on: ubuntu-latest
+    needs:
+      - pre_run
     env:
       MINIFY_PRODUCTION_BUILD: true
     # Don't run on forks

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,10 +10,20 @@ env:
   COMMIT_EMAIL: 45208873+blockstack-devops@users.noreply.github.com
 
 jobs:
+  pre_run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0
+        with:
+          access_token: ${{ github.token }}
+
   code_checks:
     name: Code checks
-    if: "!contains(github.event.head_commit.message, 'Version Packages')"
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'Version Packages')"
+    needs:
+      - pre_run
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,6 +50,8 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Version Packages')"
+    needs:
+      - pre_run
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -65,7 +77,9 @@ jobs:
   version:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Version Packages')"
-    needs: [integration_tests, code_checks]
+    needs:
+      - integration_tests
+      - code_checks
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0
+        uses: styfle/cancel-workflow-action@ad6cb1b847ffb509a69b745b6ee2f1d14dfe14b8
         with:
           access_token: ${{ github.token }}
 


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/836760806).<!-- Sticky Header Marker -->

## Description

1. Adds a `post_run` action to the `publish-extensions` workflow to expose the publish status of a workflow run.
1. Adds a `pre_run` action to most workflows to cancel previous workflow runs for a particular branch or commit SHA to prevent too many workflows from running at once.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No.

## Checklist
- [x] Tag 1 @aulneau for review
