### PR TITLE
fix: centering

### DIFF
--- a/.changeset/famous-roses-act.md
+++ b/.changeset/famous-roses-act.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': minor
+---
+
+This update fixes the positioning of the popup in relation to the primary window that fired the action

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -9,3 +9,6 @@ export const STX_DECIMALS = 6;
 export const STACKS_MARKETS_URL = 'https://coinmarketcap.com/currencies/stacks/markets/';
 
 export const KEBAB_REGEX = /[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g;
+
+export const POPUP_WIDTH = 442;
+export const POPUP_HEIGHT = 580;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -11,4 +11,4 @@ export const STACKS_MARKETS_URL = 'https://coinmarketcap.com/currencies/stacks/m
 export const KEBAB_REGEX = /[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g;
 
 export const POPUP_WIDTH = 442;
-export const POPUP_HEIGHT = 580;
+export const POPUP_HEIGHT = 646;

--- a/src/common/popup.ts
+++ b/src/common/popup.ts
@@ -8,19 +8,27 @@ interface PopupOptions {
   skipPopupFallback?: boolean;
 }
 
-export const popupCenter = ({ url, w = POPUP_WIDTH, h = POPUP_HEIGHT }: PopupOptions) => {
+export function popupCenter(options: PopupOptions) {
+  const { url, w = POPUP_WIDTH, h = POPUP_HEIGHT } = options;
+
+  // @see https://developer.chrome.com/docs/extensions/reference/windows/#method-getCurrent
   chrome.windows.getCurrent(win => {
     if (!win) throw Error('No chrome window available');
+
+    // these units take into account the distance from
+    // the farthest left/top sides of all displays
     const dualScreenLeft = win.left;
     const dualScreenTop = win.top;
 
+    // dimensions of the window that originated the action
     const width = win.width;
     const height = win.height;
 
+    // type safety
     if (!dualScreenLeft || !dualScreenTop || !width || !height)
       throw Error('No chrome window available');
 
-    const left = width / 2 - w / 2 + dualScreenLeft;
+    const left = Math.floor(width / 2 - w / 2 + dualScreenLeft);
     const top = Math.floor(height / 2 - h / 2 + dualScreenTop);
 
     chrome.windows.create({
@@ -29,7 +37,8 @@ export const popupCenter = ({ url, w = POPUP_WIDTH, h = POPUP_HEIGHT }: PopupOpt
       height: h,
       top,
       left,
+      focused: true,
       type: 'popup',
     });
   });
-};
+}

--- a/src/common/popup.ts
+++ b/src/common/popup.ts
@@ -1,3 +1,5 @@
+import { POPUP_HEIGHT, POPUP_WIDTH } from '@common/constants';
+
 interface PopupOptions {
   url?: string;
   title?: string;
@@ -6,49 +8,28 @@ interface PopupOptions {
   skipPopupFallback?: boolean;
 }
 
-// Width 2px wider than in-page dialog.
-// Ensures retina subpixel rounding
-// does not leave slightly blurry underlap
-const defaultWidth = 442;
-const defaultHeight = 580;
+export const popupCenter = ({ url, w = POPUP_WIDTH, h = POPUP_HEIGHT }: PopupOptions) => {
+  chrome.windows.getCurrent(win => {
+    if (!win) throw Error('No chrome window available');
+    const dualScreenLeft = win.left;
+    const dualScreenTop = win.top;
 
-// https://developer.mozilla.org/en-US/docs/Web/API/Window/open
-export const popupCenter = ({ url, w = defaultWidth, h = defaultHeight }: PopupOptions) => {
-  const win = window;
-  // Safari reports an incorrect browser height
-  const isSafari = (win as any).safari !== undefined;
+    const width = win.width;
+    const height = win.height;
 
-  const browserViewport = {
-    width: win.innerWidth,
-    height: win.outerHeight,
-  };
-  const browserToolbarHeight = win.outerHeight - win.innerHeight;
-  const browserSidepanelWidth = win.outerWidth - win.innerWidth;
+    if (!dualScreenLeft || !dualScreenTop || !width || !height)
+      throw Error('No chrome window available');
 
-  // Such as fixed operating system UI
-  const removeUnusableSpaceX = (coord: number) =>
-    coord - (win.screen.width - win.screen.availWidth);
-  const removeUnusableSpaceY = (coord: number) =>
-    coord - (win.screen.height - win.screen.availHeight);
+    const left = width / 2 - w / 2 + dualScreenLeft;
+    const top = Math.floor(height / 2 - h / 2 + dualScreenTop);
 
-  const browserPosition = {
-    x: removeUnusableSpaceX(win.screenX),
-    y: removeUnusableSpaceY(win.screenY),
-  };
-
-  const left = browserPosition.x + browserSidepanelWidth + (browserViewport.width - w) / 2;
-  const top =
-    browserPosition.y +
-    browserToolbarHeight +
-    (browserViewport.height - h) / 2 +
-    (isSafari ? 48 : 0);
-
-  chrome.windows.create({
-    url,
-    width: w,
-    height: h,
-    top,
-    left,
-    type: 'popup',
+    chrome.windows.create({
+      url,
+      width: w,
+      height: h,
+      top,
+      left,
+      type: 'popup',
+    });
   });
 };


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/839408952).<!-- Sticky Header Marker -->

This update fixes the positioning of the popup (for auth or transaction signing), so that it will open correctly centered in relation to the viewport of the window that the action originates from. This also handles multi-display positioning, too.

This seems to only work with chromium based browsers, where in firefox the popup is centered on the primary display.

fixes: https://github.com/blockstack/stacks-wallet-web/issues/697 https://github.com/blockstack/stacks-wallet-web/issues/1069