### PR TITLE
Adding WORKDIR to address the build script running find on /

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,25 @@
 FROM debian:buster-slim as builder
 LABEL maintainer="ux@blockstack.com"
 
+ARG NODE_VERSION=12
 ENV MINIFY_PRODUCTION_BUILD=true
 ENV EXT_ENV="prod"
+ENV NODE_VERSION=${NODE_VERSION}
 WORKDIR /src
 
+
 COPY . .
-RUN apt-get update -y && apt-get install -y build-essential python3 nodejs zip curl \
-  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg |  apt-key add - \
-  && sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list' \
-  && apt-get update -y && apt-get install -y yarn \
-  && chmod +x build-ext.sh \
-  && ./build-ext.sh /stacks-wallet-chromium.zip
+RUN apt-get update -y \
+    && apt-get install -y build-essential python3 zip curl git \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg |  apt-key add - \
+    && curl -sL https://deb.nodesource.com/setup_${NODE_VERSION:-12}.x | bash - \
+    && sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list' \
+    && apt-get update -y \
+    && apt-get install -y yarn nodejs \
+    && chmod +x build-ext.sh \
+    && yarn \
+    && yarn build \
+    && ./build-ext.sh /stacks-wallet-chromium.zip
 
 
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="ux@blockstack.com"
 
 ENV MINIFY_PRODUCTION_BUILD=true
 ENV EXT_ENV="prod"
+WORKDIR /src
 
 COPY . .
 RUN apt-get update -y && apt-get install -y build-essential python3 nodejs zip curl \

--- a/build-ext.sh
+++ b/build-ext.sh
@@ -1,16 +1,4 @@
 #!/bin/sh
-# echo "🛠  Installing dependencies."
-# yarn
-# if [ $? -ne "0" ]; then 
-#   echo "yarn failed"
-#   exit 1
-# fi
-# echo "🛠  Compiling extension."
-# yarn build
-# if [ $? -ne "0" ]; then 
-#   echo "yarn build failed"
-#   exit 1
-# fi
 echo "🛠  Packaging Browser Extension"
 if [ -d ./dist ]; then
   cd dist

--- a/build-ext.sh
+++ b/build-ext.sh
@@ -1,15 +1,37 @@
 #!/bin/sh
-echo "🛠  Installing dependencies."
-yarn
-echo "🛠  Compiling extension."
-yarn build
+# echo "🛠  Installing dependencies."
+# yarn
+# if [ $? -ne "0" ]; then 
+#   echo "yarn failed"
+#   exit 1
+# fi
+# echo "🛠  Compiling extension."
+# yarn build
+# if [ $? -ne "0" ]; then 
+#   echo "yarn build failed"
+#   exit 1
+# fi
 echo "🛠  Packaging Browser Extension"
-cd dist
+if [ -d ./dist ]; then
+  cd dist
+else
+  echo "no ./dist dir found"
+  exit 1
+fi
 TS=$(date +%Y)$(date +%m)010000
 find -print | while read file; do
     touch -t $TS "$file"
+    if [ $? -ne "0" ]; then
+      echo "Error touching file ${file}"
+      exit 2
+    fi
 done
 DEFAULT_DEST="../stacks-wallet-chromium.zip"
 DEST=${1:-$DEFAULT_DEST}
 zip -Xro $DEST *
+if [ ! -f $DEST ]; then
+  echo "Failed to create zipfile ${DEST}"
+  exit 1
+fi
 echo "✅  Extension packaged as $(basename $DEST)"
+exit 0


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/839866153).<!-- Sticky Header Marker -->

Updates Dockerfile to use `/src` as the WORKDIR. 
This fixes an issue when creating the zipfile, where the build script runs `find .` - without the WORKDIR set, it was scanning the root filesystem, and attempting to touch read-only files (i.e. in `/proc`). 


Added some simple error checking to the build script, as well as moved the `yarn` commands into the dockerfile itself (no need to keep them in the build script i don't think). 

Testing build worked fine outside of intermittent npmjs network errors. 
