### PR TITLE
chore: remove git commands

### DIFF
--- a/.changeset/tough-cycles-grin.md
+++ b/.changeset/tough-cycles-grin.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This removes any git commands and instead relies on default env vars provided by github actions. If they don't exist, they aren't used.


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/850153324).<!-- Sticky Header Marker -->

This removes our use of git commands and instead relies on github action env vars for git information.