### PR TITLE
feat: initial name display support

### DIFF
--- a/.changeset/many-teachers-fetch.md
+++ b/.changeset/many-teachers-fetch.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This update adds initial support for fetching and dispaying names associated with a given account stx address.

--- a/src/common/hooks/use-account-names.ts
+++ b/src/common/hooks/use-account-names.ts
@@ -1,0 +1,6 @@
+import { accountNameState } from '@store/names';
+import { useLoadable } from '@common/hooks/use-loadable';
+
+export function useAccountNames() {
+  return useLoadable(accountNameState);
+}

--- a/src/common/hooks/use-setup-tx.ts
+++ b/src/common/hooks/use-setup-tx.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { usePrevious } from '@stacks/ui';
 
@@ -24,7 +24,7 @@ export const useSetupTx = () => {
   const handleAccountSwitch = useAccountSwitchCallback();
   const handlePostConditions = usePostConditionsCallback();
 
-  const handleInit = async () => {
+  const handleInit = useCallback(async () => {
     if (!hasRehydratedVault) return;
     if (!requestToken) {
       await handleDecodeRequest();
@@ -44,7 +44,19 @@ export const useSetupTx = () => {
         }
       }
     }
-  };
+  }, [
+    hasRehydratedVault,
+    hasMounted,
+    payload,
+    requestToken,
+    previousAccountStxAddress,
+    setHasMounted,
+    currentAccountStxAddress,
+    handlePostConditions,
+    handleDecodeRequest,
+    handleNetworkSwitch,
+    handleAccountSwitch,
+  ]);
 
   useEffect(() => {
     void handleInit();

--- a/src/common/hooks/use-vault-messenger.ts
+++ b/src/common/hooks/use-vault-messenger.ts
@@ -89,7 +89,11 @@ export const useVaultMessenger = () => {
     method: Methods.createNewAccount,
     payload: undefined,
   });
-  const doSignOut = messageWrapper({ method: Methods.signOut, payload: undefined });
+  const handleSignOut = messageWrapper({ method: Methods.signOut, payload: undefined });
+  const doSignOut = async () => {
+    await handleSignOut();
+    localStorage.clear();
+  };
   const doLockWallet = messageWrapper({ method: Methods.lockWallet, payload: undefined });
 
   return {

--- a/src/components/account-avatar.tsx
+++ b/src/components/account-avatar.tsx
@@ -4,14 +4,18 @@ import { Account, getAccountDisplayName } from '@stacks/wallet-sdk';
 
 import { useAccountGradient } from '@common/hooks/use-account-gradient';
 
-export const AccountAvatar: React.FC<{ account: Account } & BoxProps> = ({ account, ...props }) => {
-  const displayName = getAccountDisplayName(account);
+export const AccountAvatar: React.FC<{ account: Account; name?: string } & BoxProps> = ({
+  account,
+  name,
+  ...props
+}) => {
+  const displayName = name && name.includes('.') ? name : getAccountDisplayName(account);
   const gradient = useAccountGradient(account);
 
   const circleText = displayName?.includes('Account') ? displayName.split(' ')[1] : displayName[0];
   return (
     <Circle backgroundImage={gradient} color={color('bg')} {...props}>
-      {circleText}
+      {circleText.toUpperCase()}
     </Circle>
   );
 };

--- a/src/components/drawer/accounts/switch-accounts.tsx
+++ b/src/components/drawer/accounts/switch-accounts.tsx
@@ -10,6 +10,7 @@ import { truncateMiddle } from '@stacks/ui-utils';
 import { SpaceBetween } from '@components/space-between';
 import { IconCheck } from '@tabler/icons';
 import { AccountAvatar } from '@components/account-avatar';
+import { useAccountNames } from '@common/hooks/use-account-names';
 
 interface SwitchAccountProps {
   close: () => void;
@@ -39,11 +40,15 @@ const useSwitchAccount = (handleClose: () => void) => {
 // eslint-disable-next-line no-warning-comments
 // TODO: this page is nearly identical to the network switcher abstract it out into a shared component
 const AccountList: React.FC<{ handleClose: () => void }> = memo(({ handleClose }) => {
+  const names = useAccountNames();
   const { accounts, handleSwitchAccount, transactionVersion, getIsActive } =
     useSwitchAccount(handleClose);
+  if (!names.value) return null;
   return (
     <>
       {accounts.map((account, index) => {
+        const name = names.value?.[index]?.names?.[0] || getAccountDisplayName(account);
+
         return (
           <SpaceBetween
             width="100%"
@@ -57,10 +62,10 @@ const AccountList: React.FC<{ handleClose: () => void }> = memo(({ handleClose }
             onClick={() => handleSwitchAccount(index)}
           >
             <Stack isInline alignItems="center" spacing="base">
-              <AccountAvatar account={account} />
+              <AccountAvatar name={name} account={account} />
               <Stack spacing="base-tight">
                 <Title fontSize={2} lineHeight="1rem" fontWeight="400">
-                  {getAccountDisplayName(account)}
+                  {name}
                 </Title>
                 <Caption>
                   {truncateMiddle(

--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -15,6 +15,7 @@ import { useAssets } from '@common/hooks/use-assets';
 import { AccountAvatar } from '@components/account-avatar';
 import { truncateString } from '@common/utils';
 import { Header } from '@components/header';
+import { useAccountNames } from '@common/hooks/use-account-names';
 
 interface TxButtonProps extends ButtonProps {
   kind: 'send' | 'receive';
@@ -105,19 +106,21 @@ const TxButton: React.FC<TxButtonProps> = memo(({ kind, path, ...rest }) => {
 });
 
 const UserAccount: React.FC<StackProps> = memo(props => {
+  const names = useAccountNames();
   const { currentAccount, currentAccountStxAddress } = useWallet();
-  if (!currentAccount || !currentAccountStxAddress) {
+  if (!currentAccount || !currentAccountStxAddress || !names.value) {
     console.error('Error! Homepage rendered without account state, which should never happen.');
     return null;
   }
   const nameCharLimit = 18;
-  const name = getAccountDisplayName(currentAccount);
+  const name =
+    names.value?.[currentAccount.index]?.names?.[0] || getAccountDisplayName(currentAccount);
   const isLong = name.length > nameCharLimit;
   const displayName = truncateString(name, nameCharLimit);
 
   return (
     <Stack spacing="base-tight" alignItems="center" isInline {...props}>
-      <AccountAvatar flexShrink={0} account={currentAccount} />
+      <AccountAvatar name={name} flexShrink={0} account={currentAccount} />
       <Stack overflow="hidden" display="block" alignItems="flex-start" spacing="base-tight">
         <Box>
           <Tooltip label={isLong ? name : undefined}>

--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -108,13 +108,13 @@ const TxButton: React.FC<TxButtonProps> = memo(({ kind, path, ...rest }) => {
 const UserAccount: React.FC<StackProps> = memo(props => {
   const names = useAccountNames();
   const { currentAccount, currentAccountStxAddress } = useWallet();
-  if (!currentAccount || !currentAccountStxAddress || !names.value) {
+  if (!currentAccount || !currentAccountStxAddress) {
     console.error('Error! Homepage rendered without account state, which should never happen.');
     return null;
   }
   const nameCharLimit = 18;
   const name =
-    names.value?.[currentAccount.index]?.names?.[0] || getAccountDisplayName(currentAccount);
+    names?.value?.[currentAccount.index]?.names?.[0] || getAccountDisplayName(currentAccount);
   const isLong = name.length > nameCharLimit;
   const displayName = truncateString(name, nameCharLimit);
 

--- a/src/store/names.ts
+++ b/src/store/names.ts
@@ -1,33 +1,87 @@
 import { selector } from 'recoil';
-import { accountsStore } from '@store/wallet';
-import { currentNetworkStore, currentTransactionVersion } from '@store/networks';
 import { getStxAddress } from '@stacks/wallet-sdk';
 
-async function fetchNamesByAddress(networkUrl: string, address: string) {
-  const res = await fetch(networkUrl + `/v1/addresses/stacks/${address}`);
+import { fetcher } from '@common/wrapped-fetch';
+
+import { accountsStore } from '@store/wallet';
+import { currentNetworkStore, currentTransactionVersion } from '@store/networks';
+
+async function fetchNamesByAddress(networkUrl: string, address: string): Promise<string[]> {
+  const res = await fetcher(networkUrl + `/v1/addresses/stacks/${address}`);
   const data = await res.json();
-  return data.names;
+  return data?.names || [];
 }
 
-export const accountNameState = selector({
+function makeKey(networkUrl: string, address: string): string {
+  return `${networkUrl}__${address}`;
+}
+
+function getLocalNames(networkUrl: string, address: string): string[] | null {
+  const key = makeKey(networkUrl, address);
+  const value = localStorage.getItem(key);
+  return value ? JSON.parse(value) : null;
+}
+
+function setLocalNames(networkUrl: string, address: string, names: string[]): void {
+  const key = makeKey(networkUrl, address);
+  return localStorage.setItem(key, JSON.stringify(names));
+}
+
+interface AccountName {
+  address: string;
+  index: number;
+  names: string[];
+}
+
+type AccountNameState = AccountName[] | null;
+
+export const accountNameState = selector<AccountNameState>({
   key: 'names',
   get: async ({ get }) => {
     const accounts = get(accountsStore);
     const network = get(currentNetworkStore);
     const transactionVersion = get(currentTransactionVersion);
-    const promises = accounts?.map(async account => {
+
+    if (!network || !accounts) return null;
+
+    const promises = accounts.map(async account => {
       const address = getStxAddress({
         account: account,
         transactionVersion,
       });
-      const names = await fetchNamesByAddress(network.url, address);
-      return {
-        address,
-        index: account.index,
-        names,
-      };
+
+      // let's try to find any saved names first
+      const localNames = getLocalNames(network.url, address);
+
+      if (localNames?.length) {
+        return {
+          address,
+          index: account.index,
+          names: localNames,
+        };
+      }
+
+      try {
+        const names = await fetchNamesByAddress(network.url, address);
+        if (names?.length) {
+          // persist them for next time
+          setLocalNames(network.url, address, names);
+        }
+        return {
+          address,
+          index: account.index,
+          names: names || [],
+        };
+      } catch (e) {
+        console.error(e);
+        return {
+          address,
+          index: account.index,
+          names: [],
+        };
+      }
     });
-    if (!promises) return;
+    if (!promises) return null;
     return Promise.all(promises);
   },
 });

--- a/src/store/names.ts
+++ b/src/store/names.ts
@@ -1,0 +1,33 @@
+import { selector } from 'recoil';
+import { accountsStore } from '@store/wallet';
+import { currentNetworkStore, currentTransactionVersion } from '@store/networks';
+import { getStxAddress } from '@stacks/wallet-sdk';
+
+async function fetchNamesByAddress(networkUrl: string, address: string) {
+  const res = await fetch(networkUrl + `/v1/addresses/stacks/${address}`);
+  const data = await res.json();
+  return data.names;
+}
+
+export const accountNameState = selector({
+  key: 'names',
+  get: async ({ get }) => {
+    const accounts = get(accountsStore);
+    const network = get(currentNetworkStore);
+    const transactionVersion = get(currentTransactionVersion);
+    const promises = accounts?.map(async account => {
+      const address = getStxAddress({
+        account: account,
+        transactionVersion,
+      });
+      const names = await fetchNamesByAddress(network.url, address);
+      return {
+        address,
+        index: account.index,
+        names,
+      };
+    });
+    if (!promises) return;
+    return Promise.all(promises);
+  },
+});


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/861591527).<!-- Sticky Header Marker -->

This is something I wanted to do for fun in my free time, and was really quick to implement. I'm working on a BNS app, and there is the .BTC app coming soon, figured this would help them out too!

I'm sure in the future we should adjust this to enable users to select which name they want to display. It currently will simply default to the first name in the response if they own multiple names.

![Screen Shot 2021-05-19 at 7 04 17 PM](https://user-images.githubusercontent.com/11803153/118899755-17b1b880-b8d5-11eb-9e96-44b946d726a3.png)

cc @GinaAbrams @MarvinJanssen 