### PR TITLE
fix: no longer export BlockstackProvider

### DIFF
--- a/.changeset/wild-penguins-suffer.md
+++ b/.changeset/wild-penguins-suffer.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This update removes the `BlockstackProvider` that the extension would inejct into apps. This is to allow apps that are still using legacy auth (`app.blockstack.org`) to work without needing to update to the extension. Other apps should be on the latest versions of connect that no longer use `BlockstackProvider`, but instead use `StacksProvider`.

--- a/src/extension/inpage.ts
+++ b/src/extension/inpage.ts
@@ -102,4 +102,3 @@ const provider: StacksProvider = {
 };
 
 window.StacksProvider = provider;
-window.BlockstackProvider = provider;


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/861287611).<!-- Sticky Header Marker -->

This should make it easier for apps that are not using the extension for the authenticator. I've tested it with blocksurvey and this works well.