### PR TITLE
Update action to create issue in kanban board

### DIFF
--- a/.github/FIREFOX_ISSUE_TEMPLATE.md
+++ b/.github/FIREFOX_ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+---
+title: Publish Firefox Extension
+---
+1. Add "Version notes" with the same content as found in [the CHANGELOG.md file](https://github.com/blockstack/stacks-wallet-web/blob/main/CHANGELOG.md) for the release.
+2. Add the following for "Notes for Reviewers": 
+    Please use this command to build the extension with Docker:
+    ```
+        docker build -f Dockerfile -t stacks-wallet-web . \
+        && docker run -d --name stacks-wallet-web stacks-wallet-web \
+        && docker cp stacks-wallet-web:stacks-wallet-chromium.zip . \
+        && docker rm -f stacks-wallet-web
+    ``` 
+    You can test the extension by selecting "Get started" on https://boom.money.
+3. Download [the ZIP file](https://github.com/blockstack/stacks-wallet-web/archive/refs/heads/main.zip) of the repository main branch and upload to "Source code".
+4. Submit by clicking "Save changes".
+

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -100,6 +100,29 @@ jobs:
           WEB_EXT_API_KEY: ${{ secrets.FIREFOX_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.FIREFOX_API_SECRET }}
 
+      - name: Create Issue for Firefox Manual Step 
+        id: create-firefox-issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/FIREFOX_ISSUE_TEMPLATE.md
+          update_existing: true
+
+      - name: Add Issue to Backlog
+        uses: peter-evans/create-or-update-project-card@v1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          project-location: hirosystems
+          project-name: UserX Kanban
+          column-name: 📥 Backlog
+          issue-number: ${{ steps.create-firefox-issue.outputs.number }}
+
+      - name: Firefox Issue Status
+        run: |
+          echo "Created issue number: ${{ steps.create-firefox-issue.outputs.number }}"
+          echo "Created: ${{ steps.create-firefox-issue.outputs.url }}"
+
   post_run:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -113,7 +113,7 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v1
         with:
           token: ${{ secrets.GH_TOKEN }}
-          project-location: hirosystems
+          project-location: blockstack
           project-name: UserX Kanban
           column-name: 📥 Backlog
           issue-number: ${{ steps.create-firefox-issue.outputs.number }}


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/875966519).<!-- Sticky Header Marker -->

This PR updates the github action to create a new issue for firefox from the template .github/FIREFOX_ISSUE_TEMPLATE.md in the current repo.
Additionally, it adds this issue to the Kanban board https://github.com/orgs/blockstack/projects/44 in the Backlog column.

Note: If the issue is currently open, it won't add a new issue - it will attempt to update the issue (in the case where the content is different). this can be disabled by setting update_existing: true in the step Create Issue for Firefox Manual Step.

https://github.com/hirosystems/devops/issues/705

cc/ @aulneau @kyranjamie @fbwoolf


