### PR TITLE
feat: expose profile url in auth response

### DIFF
--- a/src/common/hooks/use-wallet.ts
+++ b/src/common/hooks/use-wallet.ts
@@ -113,7 +113,7 @@ export const useWallet = () => {
             name: appName as string,
           },
         });
-        const authResponse = await makeAuthResponse({
+        const authResponseToken = await makeAuthResponse({
           gaiaHubUrl: gaiaUrl,
           appDomain: appURL.origin,
           transitPublicKey: decodedAuthRequest.public_keys[0],
@@ -121,7 +121,7 @@ export const useWallet = () => {
           account,
         });
         set(currentAccountIndexStore, accountIndex);
-        finalizeAuthResponse({ decodedAuthRequest, authRequest, authResponse });
+        finalizeAuthResponse({ decodedAuthRequest, authRequest, authResponseToken });
       },
     [decodedAuthRequest, authRequest, appName, appIcon]
   );

--- a/src/extension/message-types.ts
+++ b/src/extension/message-types.ts
@@ -1,4 +1,8 @@
-import { FinishedTxPayload, SponsoredFinishedTxPayload } from '@stacks/connect';
+import {
+  FinishedAuthPayload,
+  FinishedTxPayload,
+  SponsoredFinishedTxPayload,
+} from '@stacks/connect';
 /**
  * Content Script <-> Background messaging
  */
@@ -43,7 +47,7 @@ export type AuthenticationResponseMessage = Message<
   Methods.authenticationResponse,
   {
     authenticationRequest: string;
-    authenticationResponse: string;
+    authenticationResponse: FinishedAuthPayload;
   }
 >;
 

--- a/test-app/src/components/app.tsx
+++ b/test-app/src/components/app.tsx
@@ -47,11 +47,12 @@ export const App: React.FC = () => {
     manifestPath: '/static/manifest.json',
     redirectTo: '/',
     userSession,
-    finished: ({ userSession, authResponse }) => {
+    finished: ({ authResponse, authResponseToken, userSession }) => {
       const userData = userSession.loadUserData();
       setAppPrivateKey(userSession.loadUserData().appPrivateKey);
-      setAuthResponse(authResponse);
+      setAuthResponse(authResponseToken);
       setState({ userData });
+      console.log(authResponse.profile_url);
     },
     onCancel: () => {
       console.log('popup closed!');


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/878680727).<!-- Sticky Header Marker -->

## Description

This PR exposes the `profile_url` and other properties in the auth response.

For details refer to `connect` issue #127
Related PR in `connect` is [#131](https://github.com/blockstack/connect/pull/131)

cc/ @aulneau @kyranjamie @fbwoolf
