### PR TITLE
Adding emoji to board name

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           project-location: blockstack
-          project-name: UserX Kanban
+          project-name: 👟 UserX Kanban
           column-name: 📥 Backlog
           issue-number: ${{ steps.create-firefox-issue.outputs.number }}
 


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/878740114).<!-- Sticky Header Marker -->

Project board is named `👟 UserX Kanban`, not `UserX Kanban`.
This PR should resolve the failed action step here. 

cc/ @aulneau @kyranjamie @fbwoolf
