### PR TITLE
feat: organise txs with date grouping 

### DIFF
--- a/.changeset/spicy-boxes-shave.md
+++ b/.changeset/spicy-boxes-shave.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': minor
+---
+
+Changes transaction activity screen to order transactions by date, rather than in a single list

--- a/src/common/group-txs-by-date.test.ts
+++ b/src/common/group-txs-by-date.test.ts
@@ -1,0 +1,48 @@
+import { Transaction } from '@blockstack/stacks-blockchain-api-types';
+import { createTxDateFormatList } from './group-txs-by-date';
+
+function createFakeTx(tx: Partial<Transaction>) {
+  return { tx_status: 'success', ...tx } as Transaction;
+}
+
+describe(createTxDateFormatList.name, () => {
+  test('grouping by date', () => {
+    const mockTx = createFakeTx({
+      burn_block_time_iso: '1991-02-08T13:48:04.699Z',
+    });
+    expect(createTxDateFormatList([mockTx])).toEqual([
+      {
+        date: '1991-02-08',
+        displayDate: 'Feb 8th, 1991',
+        txs: [mockTx],
+      },
+    ]);
+  });
+
+  test('relative dates todays date', () => {
+    const today = new Date().toISOString();
+    const mockTx = createFakeTx({ burn_block_time_iso: today });
+    const result = createTxDateFormatList([mockTx]);
+    expect(result[0].date).toEqual(today.split('T')[0]);
+    expect(result[0].displayDate).toEqual('Today');
+  });
+
+  test('relative dates yesterdays date', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const mockTx = createFakeTx({ burn_block_time_iso: yesterday.toISOString() });
+    const result = createTxDateFormatList([mockTx]);
+    expect(result[0].date).toEqual(yesterday.toISOString().split('T')[0]);
+    expect(result[0].displayDate).toEqual('Yesterday');
+  });
+
+  test('dates from this year omit year', () => {
+    const date = new Date();
+    date.setFullYear(date.getFullYear());
+    date.setMonth(6);
+    const mockTx = createFakeTx({ burn_block_time_iso: date.toISOString() });
+    const result = createTxDateFormatList([mockTx]);
+    expect(result[0].date).toEqual(date.toISOString().split('T')[0]);
+    expect(result[0].displayDate).not.toContain(new Date().getFullYear());
+  });
+});

--- a/src/common/group-txs-by-date.ts
+++ b/src/common/group-txs-by-date.ts
@@ -1,0 +1,54 @@
+import { MempoolTransaction, Transaction } from '@blockstack/stacks-blockchain-api-types';
+import dayjs from 'dayjs';
+import isToday from 'dayjs/plugin/isToday';
+import isYesterday from 'dayjs/plugin/isYesterday';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+
+dayjs.extend(isToday);
+dayjs.extend(isYesterday);
+dayjs.extend(advancedFormat);
+
+type Tx = MempoolTransaction | Transaction;
+
+function todaysIsoDate() {
+  return new Date().toISOString().split('T')[0];
+}
+
+function groupTxsByDateMap(txs: Tx[]) {
+  return txs.reduce((txsByDate, tx) => {
+    if (tx.tx_status === 'success' && tx.burn_block_time_iso) {
+      const [date] = tx.burn_block_time_iso.split('T');
+      if (!txsByDate.has(date)) {
+        txsByDate.set(date, []);
+      }
+      txsByDate.set(date, [...(txsByDate.get(date) || []), tx]);
+    }
+    if (!('burn_block_time_iso' in tx)) {
+      const today = todaysIsoDate();
+      txsByDate.set(today, [...(txsByDate.get(today) || []), tx]);
+    }
+    return txsByDate;
+  }, new Map<string, Tx[]>());
+}
+
+function displayDate(txDate: string) {
+  const date = dayjs(txDate);
+  if (date.isToday()) return 'Today';
+  if (date.isYesterday()) return 'Yesterday';
+  if (dayjs().isSame(date, 'year')) {
+    return date.format('MMM Do');
+  }
+  return date.format('MMM Do, YYYY');
+}
+
+function formatTxDateMapAsList(txMap: Map<string, Tx[]>) {
+  return [...txMap.keys()].map(date => ({
+    date,
+    displayDate: displayDate(date),
+    txs: txMap.get(date) ?? [],
+  }));
+}
+
+export function createTxDateFormatList(txs: Tx[]) {
+  return formatTxDateMapAsList(groupTxsByDateMap(txs));
+}

--- a/src/components/popup/balances-and-activity.tsx
+++ b/src/components/popup/balances-and-activity.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Box, Stack, SlideFade } from '@stacks/ui';
+import type { StackProps } from '@stacks/ui';
 import { TokenAssets } from '@components/popup/token-assets';
 
-import type { StackProps } from '@stacks/ui';
 import { Caption } from '@components/typography';
 import { NoActivityIllustration } from '@components/vector/no-activity';
 import { Tabs } from '@components/tabs';
+
 import { useAccountActivity } from '@common/hooks/account/use-account-activity';
-import { TxItem } from '@components/popup/tx-item';
 import { useHomeTabs } from '@common/hooks/use-home-tabs';
+import { createTxDateFormatList } from '@common/group-txs-by-date';
+import { TransactionList } from './transaction-list';
 
 function EmptyActivity() {
   return (
@@ -25,23 +27,26 @@ function EmptyActivity() {
 }
 
 function ActivityList() {
-  const { isLoading, value: data } = useAccountActivity();
+  const { isLoading, value: transactions } = useAccountActivity();
+
+  const groupedTxs = useMemo(
+    () => (transactions ? createTxDateFormatList(transactions) : []),
+    [transactions]
+  );
+
   if (isLoading) return null;
-  return !data || data.length === 0 ? (
+
+  return !transactions || transactions.length === 0 ? (
     <EmptyActivity />
   ) : (
-    <Stack pb="extra-loose" spacing="extra-loose">
-      {data.map(tx => (
-        <TxItem transaction={tx} />
-      ))}
-    </Stack>
+    <TransactionList txsByDate={groupedTxs} />
   );
 }
 
-export function BalancesAndActivity({ ...rest }: StackProps) {
+export function BalancesAndActivity(props: StackProps) {
   const { activeTab, setActiveTab } = useHomeTabs();
   return (
-    <Stack flexGrow={1} spacing="extra-loose" {...rest}>
+    <Stack flexGrow={1} spacing="extra-loose" {...props}>
       <Tabs
         tabs={[
           { slug: 'balances', label: 'Balances' },

--- a/src/components/popup/transaction-list.tsx
+++ b/src/components/popup/transaction-list.tsx
@@ -1,0 +1,26 @@
+import { createTxDateFormatList } from '@common/group-txs-by-date';
+import { Box, Stack, Text, color } from '@stacks/ui';
+import React from 'react';
+import { TxItem } from './tx-item';
+
+interface TransactionListProps {
+  txsByDate: ReturnType<typeof createTxDateFormatList>;
+}
+export function TransactionList({ txsByDate }: TransactionListProps) {
+  return (
+    <Stack pb="extra-loose" spacing="extra-loose">
+      {txsByDate.map(({ date, displayDate, txs }) => (
+        <Box key={date}>
+          <Text textStyle="body.small" color={color('text-caption')}>
+            {displayDate}
+          </Text>
+          <Stack mt="base-loose" spacing="loose">
+            {txs.map(tx => (
+              <TxItem transaction={tx} key={tx.tx_id} />
+            ))}
+          </Stack>
+        </Box>
+      ))}
+    </Stack>
+  );
+}

--- a/src/components/vector/no-assets.tsx
+++ b/src/components/vector/no-assets.tsx
@@ -3,7 +3,7 @@ import { Box, BoxProps } from '@stacks/ui';
 
 export const NoAssetsEmptyIllustration = (props: BoxProps) => (
   <Box as="svg" viewBox="0 0 86 49" fill="none" {...props}>
-    <g clip-path="url(#clip0)">
+    <g clipPath="url(#clip0)">
       <path
         d="M25.75 48.6C39.1705 48.6 50.05 37.7205 50.05 24.3C50.05 10.8795 39.1705 0 25.75 0C12.3294 0 1.44995 10.8795 1.44995 24.3C1.44995 37.7205 12.3294 48.6 25.75 48.6Z"
         fill="#F5F5F7"


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/922847317).<!-- Sticky Header Marker -->

**Pop up showing ordering by date**
![image](https://user-images.githubusercontent.com/1618764/121044089-876ce200-c7b5-11eb-8617-9021586a426e.png)

**Full screen showing pending tx that has no date, assumes today**
![image](https://user-images.githubusercontent.com/1618764/121048149-d6674700-c7b6-11eb-99d6-99e64b9cfbe7.png)

Closes #1264