### PR TITLE
fix: disappearing mempool txs

### DIFF
--- a/.changeset/little-moose-kick.md
+++ b/.changeset/little-moose-kick.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Fixes issue where pending transactions aren't always shown

--- a/src/common/api/accounts.ts
+++ b/src/common/api/accounts.ts
@@ -33,12 +33,8 @@ export const fetchAllAccountData =
     const [balances, transactions, pendingTransactions] = await Promise.all([
       fetchBalances(apiServer)(principal),
       fetchTransactions(apiServer)(principal),
-      fetchPendingTxs(apiServer)({ query: principal, type: 'principal' }),
+      fetchPendingTxs(apiServer)({ query: principal }),
     ]);
 
-    return {
-      balances,
-      transactions,
-      pendingTransactions: pendingTransactions as MempoolTransaction[],
-    };
+    return { balances, transactions, pendingTransactions };
   };

--- a/src/common/api/transactions.ts
+++ b/src/common/api/transactions.ts
@@ -1,68 +1,15 @@
-import {
-  MempoolTransaction,
-  MempoolTransactionListResponse,
-} from '@blockstack/stacks-blockchain-api-types';
+import { MempoolTransactionListResponse } from '@blockstack/stacks-blockchain-api-types';
 import { fetcher } from '@common/api/wrapped-fetch';
 
-interface GetKeyOptions {
-  index: number;
-  type: 'tx' | 'block';
-  limit: number;
-  pending?: boolean;
-  types?: string[];
-  apiServer?: string;
+function makeMempoolTransactionApiUrl(apiServer: string) {
+  return `${apiServer}/extended/v1/tx/mempool`;
 }
 
-export const constructLimitAndOffsetQueryParams = (limit: number, offset?: number): string =>
-  `limit=${limit}${offset ? `&offset=${offset}` : ''}`;
-
-const generateTypesQueryString = (types?: string[]) => {
-  if (types?.length) {
-    return `&${types
-      .map(type => `${encodeURIComponent('type[]')}=${encodeURIComponent(type)}`)
-      .join('&')}`;
-  }
-  return '';
-};
-
-export const makeKey = (options: GetKeyOptions) => {
-  const { index, type, limit, pending, types, apiServer } = options;
-  return `${apiServer as string}/extended/v1/${type}${
-    pending ? '/mempool' : ''
-  }?${constructLimitAndOffsetQueryParams(limit, index + 1 === 1 ? 0 : limit * index + 1)}${
-    types ? generateTypesQueryString(types) : ''
-  }`;
-};
-
-export const fetchPendingTxs =
-  (apiServer: string) =>
-  async ({ query, type }: { query: string; type: 'principal' | 'tx_id' }) => {
-    const path = makeKey({
-      type: 'tx',
-      limit: 30,
-      pending: true,
-      index: 0,
-      apiServer,
-    });
-
+export function fetchPendingTxs(apiServer: string) {
+  return async ({ query }: { query: string }) => {
+    const path = makeMempoolTransactionApiUrl(apiServer) + `&address=${query}`;
     const res = await fetcher(path);
     const mempool: MempoolTransactionListResponse = await res.json();
-
-    if (type === 'principal') {
-      const pendingTransactions =
-        mempool?.results?.filter(
-          (tx: MempoolTransaction) =>
-            ((tx.tx_type === 'smart_contract' ||
-              tx.tx_type === 'contract_call' ||
-              tx.tx_type === 'token_transfer') &&
-              tx.sender_address === query) ||
-            (tx.tx_type === 'token_transfer' && tx.token_transfer.recipient_address === query)
-        ) || [];
-
-      return pendingTransactions;
-    } else {
-      return mempool?.results?.find(
-        (tx: MempoolTransaction) => tx.tx_id === query
-      ) as MempoolTransaction;
-    }
+    return mempool.results;
   };
+}


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/922843407).<!-- Sticky Header Marker -->

Closes #1253

By using address filter, we're much less likely to end up with missing pending txs (only if one principal has > 96 txs in mempool)

Some code I found confusing
- The method `makeKey` was quite an ambiguous name 
- Some arguments were unused
- `block` could be passed into the transaction path key maker
- Method  for confirmed/mempool txs was passing in a flag that modifies behaviour, which goes against Open–Closed principle

Most it was was unused anyway 🤷🏼  so has been killed accordingly