### PR TITLE
fix: unclear network target

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -308,3 +308,7 @@ export const slugify = (...args: (string | number)[]): string => {
     .replace(/[^a-z0-9 ]/g, '') // remove all chars not letters, numbers and spaces (to be replaced)
     .replace(/\s+/g, '-'); // separator
 };
+
+export function getUrlHostname(url: string) {
+  return new URL(url).hostname;
+}

--- a/src/components/drawer/networks-drawer.tsx
+++ b/src/components/drawer/networks-drawer.tsx
@@ -10,6 +10,7 @@ import { currentNetworkKeyState } from '@store/networks';
 import { showNetworksStore } from '@store/ui';
 import { useDrawers } from '@common/hooks/use-drawers';
 import { Caption, Title } from '@components/typography';
+import { getUrlHostname } from '@common/utils';
 
 const NetworkListItem: React.FC<{ item: string } & BoxProps> = memo(({ item, ...props }) => {
   const { setShowNetworks } = useDrawers();
@@ -43,7 +44,7 @@ const NetworkListItem: React.FC<{ item: string } & BoxProps> = memo(({ item, ...
           <Title fontWeight={400} lineHeight="1rem" fontSize={2} display="block">
             {network.name}
           </Title>
-          <Caption>{network.url.split('//')[1]}</Caption>
+          <Caption>{getUrlHostname(network.url)}</Caption>
         </Stack>
         {item === currentNetworkKey ? <CheckmarkIcon /> : null}
       </Flex>

--- a/src/components/transactions/page-top.tsx
+++ b/src/components/transactions/page-top.tsx
@@ -4,14 +4,25 @@ import { useOrigin } from '@common/hooks/use-origin';
 import { useTransactionPageTitle } from '@common/hooks/transaction/use-transaction-page-title';
 import { Stack } from '@stacks/ui';
 import { Caption, Title } from '@components/typography';
+import { useCurrentNetwork } from '@common/hooks/use-current-network';
 
 export const TransactionPageTop = memo(() => {
   const transactionRequest = useTransactionRequest();
   const origin = useOrigin();
   const pageTitle = useTransactionPageTitle();
+  const network = useCurrentNetwork();
   if (!transactionRequest) return null;
 
   const appName = transactionRequest?.appDetails?.name;
+
+  const testnetAddition = network.isTestnet ? (
+    <>
+      {' '}
+      on <br />
+      {network.url}
+    </>
+  ) : null;
+
   return (
     <Stack pt="extra-loose" spacing="base">
       <Title fontWeight="bold" as="h1">
@@ -20,6 +31,7 @@ export const TransactionPageTop = memo(() => {
       {appName ? (
         <Caption>
           Requested by {appName} {origin ? `(${origin?.split('//')[1]})` : null}
+          {testnetAddition}
         </Caption>
       ) : null}
     </Stack>

--- a/src/components/transactions/page-top.tsx
+++ b/src/components/transactions/page-top.tsx
@@ -5,6 +5,7 @@ import { useTransactionPageTitle } from '@common/hooks/transaction/use-transacti
 import { Stack } from '@stacks/ui';
 import { Caption, Title } from '@components/typography';
 import { useCurrentNetwork } from '@common/hooks/use-current-network';
+import { getUrlHostname } from '@common/utils';
 
 export const TransactionPageTop = memo(() => {
   const transactionRequest = useTransactionRequest();
@@ -19,7 +20,7 @@ export const TransactionPageTop = memo(() => {
     <>
       {' '}
       on <br />
-      {network.url}
+      {getUrlHostname(network.url)}
     </>
   ) : null;
 
@@ -30,7 +31,7 @@ export const TransactionPageTop = memo(() => {
       </Title>
       {appName ? (
         <Caption>
-          Requested by {appName} {origin ? `(${origin?.split('//')[1]})` : null}
+          Requested by {appName} {origin ? `(${getUrlHostname(origin)})` : null}
           {testnetAddition}
         </Caption>
       ) : null}


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/938460516).<!-- Sticky Header Marker -->

Closes #1279

![image](https://user-images.githubusercontent.com/1618764/121522015-fa17d080-c9f4-11eb-89a9-6490c6f5e1c4.png)

Open for other ways to fix this, but considering I'm one of the software's contributors and I've used Heystack before, I shouldn't be getting confused lol. The only way to know that this app is targeting a different testnet is to click on the testnet switcher (that doesn't even look clickable until you hover). 

Auto-switching network away from a users current setting is a _really_ confusing behaviour. Imo this PR doesn't go far enough. We should have a warning screen first where the user has to explicitly agree that **This app wants to change your node URL — Accept**, even if it is in your list of pre-saved networks. 