### PR TITLE
fix: included confirmed failed txs

### DIFF
--- a/src/common/group-txs-by-date.ts
+++ b/src/common/group-txs-by-date.ts
@@ -16,7 +16,7 @@ function todaysIsoDate() {
 
 function groupTxsByDateMap(txs: Tx[]) {
   return txs.reduce((txsByDate, tx) => {
-    if (tx.tx_status === 'success' && tx.burn_block_time_iso) {
+    if ('burn_block_time_iso' in tx && tx.burn_block_time_iso) {
       const [date] = tx.burn_block_time_iso.split('T');
       if (!txsByDate.has(date)) {
         txsByDate.set(date, []);
@@ -52,8 +52,9 @@ function formatTxDateMapAsList(txMap: Map<string, Tx[]>) {
 function filterDuplicateTx(txs: Tx[]) {
   return txs.filter(tx => {
     const countOfCurrentTxid = txs.filter(({ tx_id }) => tx.tx_id === tx_id).length;
-    if (countOfCurrentTxid === 1) return true;
-    return tx.tx_status === 'success';
+    const isDropped = tx.tx_status.includes('dropped');
+    if (countOfCurrentTxid === 1 && !isDropped) return true;
+    return tx.tx_status === 'success' || tx.tx_status.includes('abort');
   });
 }
 


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/929841292).<!-- Sticky Header Marker -->

Building on top of https://github.com/blockstack/stacks-wallet-web/pull/1287 to fix https://github.com/blockstack/stacks-wallet-web/issues/1283, the logic previously would filter out confirmed but failing transactions, where we just want to filter out duplicate transactions that had been dropped.

cc/ @kyranjamie @fbwoolf
