### PR TITLE
fix: various runtime errors

### DIFF
--- a/.changeset/thin-buses-eat.md
+++ b/.changeset/thin-buses-eat.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+A handful of UI-related errors were being thrown, this PR fixes them, as well as addressing unknown prop issues with the tooltip component

--- a/src/components/asset-item.tsx
+++ b/src/components/asset-item.tsx
@@ -39,7 +39,6 @@ export const AssetItem = memo(
           ref={ref as any}
           flexGrow={1}
           spacing="base"
-          isInline
           {...rest}
           {...bind}
         >
@@ -56,14 +55,16 @@ export const AssetItem = memo(
             <Stack flexGrow={1}>
               <SpaceBetween width="100%">
                 <Text>{title}</Text>
-                <Tooltip
-                  placement="left-start"
-                  label={formatted.isAbbreviated ? amount : undefined}
-                >
-                  <Text fontVariantNumeric="tabular-nums" textAlign="right">
-                    {formatted.value}
-                  </Text>
-                </Tooltip>
+                <Box>
+                  <Tooltip
+                    placement="left-start"
+                    label={formatted.isAbbreviated ? amount : undefined}
+                  >
+                    <Text fontVariantNumeric="tabular-nums" textAlign="right">
+                      {formatted.value}
+                    </Text>
+                  </Tooltip>
+                </Box>
               </SpaceBetween>
               {caption && <Caption>{caption}</Caption>}
             </Stack>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,12 +9,6 @@ import { NetworkModeBadge } from '@components/network-mode-badge';
 import { ScreenPaths } from '@store/common/types';
 import { Title } from '@components/typography';
 
-interface HeaderProps extends FlexProps {
-  onClose?: () => void;
-  hideActions?: boolean;
-  title?: string;
-}
-
 const MenuButton: React.FC<BoxProps> = memo(props => {
   const { showSettings, setShowSettings } = useDrawers();
   return (
@@ -24,9 +18,7 @@ const MenuButton: React.FC<BoxProps> = memo(props => {
       onMouseUp={showSettings ? undefined : () => setShowSettings(true)}
       pointerEvents={showSettings ? 'none' : 'all'}
       color={color('text-caption')}
-      _hover={{
-        color: color('text-title'),
-      }}
+      _hover={{ color: color('text-title') }}
       data-test="menu-button"
       icon={IconDots}
       {...props}
@@ -38,40 +30,43 @@ const HeaderTitle: React.FC<BoxProps> = props => (
   <Title fontSize="20px" lineHeight="28px" fontWeight={500} {...props} />
 );
 
+interface HeaderProps extends FlexProps {
+  onClose?: () => void;
+  hideActions?: boolean;
+  title?: string;
+}
 export const Header: React.FC<HeaderProps> = memo(props => {
-  const { onClose, title, hideActions } = props;
+  const { onClose, title, hideActions, ...rest } = props;
   const doChangeScreen = useDoChangeScreen();
 
   return (
-    <>
-      <Flex
-        p="loose"
-        alignItems={hideActions ? 'center' : 'flex-start'}
-        justifyContent="space-between"
-        position="relative"
-        {...props}
-      >
-        {!title ? (
-          <StacksWalletLogo pt="7px" onClick={() => doChangeScreen(ScreenPaths.HOME)} />
-        ) : (
-          <Box pt={onClose ? 'loose' : 'unset'} pr="tight">
-            {onClose ? (
-              <IconButton
-                top="base-tight"
-                position="absolute"
-                left="base"
-                onClick={onClose}
-                icon={IconArrowLeft}
-              />
-            ) : null}
-            <HeaderTitle>{title}</HeaderTitle>
-          </Box>
-        )}
-        <Stack flexShrink={0} pt={hideActions ? '7px' : 0} alignItems="center" isInline>
-          <NetworkModeBadge />
-          {!hideActions && <MenuButton />}
-        </Stack>
-      </Flex>
-    </>
+    <Flex
+      p="loose"
+      alignItems={hideActions ? 'center' : 'flex-start'}
+      justifyContent="space-between"
+      position="relative"
+      {...rest}
+    >
+      {!title ? (
+        <StacksWalletLogo pt="7px" onClick={() => doChangeScreen(ScreenPaths.HOME)} />
+      ) : (
+        <Box pt={onClose ? 'loose' : 'unset'} pr="tight">
+          {onClose ? (
+            <IconButton
+              top="base-tight"
+              position="absolute"
+              left="base"
+              onClick={onClose}
+              icon={IconArrowLeft}
+            />
+          ) : null}
+          <HeaderTitle>{title}</HeaderTitle>
+        </Box>
+      )}
+      <Stack flexShrink={0} pt={hideActions ? '7px' : 0} alignItems="center" isInline>
+        <NetworkModeBadge />
+        {!hideActions && <MenuButton />}
+      </Stack>
+    </Flex>
   );
 });

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -3,21 +3,25 @@ import Tippy, { TippyProps } from '@tippyjs/react';
 import { Box, BoxProps } from '@stacks/ui';
 import { memo, useMemo } from 'react';
 
-export const Tooltip: React.FC<
-  TippyProps & { label?: TippyProps['content']; labelProps?: BoxProps }
-> = memo(({ label, labelProps = {}, children, ...rest }) => {
-  if (!label) return <>{children}</>;
-  const content = useMemo(
-    () => (
-      <Box as="span" display="block" fontSize={0} {...labelProps}>
-        {label}
-      </Box>
-    ),
-    [labelProps, label]
-  );
-  return (
-    <Tippy content={content} trigger="mouseenter" hideOnClick={undefined} {...rest}>
-      {children}
-    </Tippy>
-  );
-});
+interface TooltipProps extends TippyProps {
+  label?: TippyProps['content'];
+  labelProps?: BoxProps;
+}
+export const Tooltip: React.FC<TooltipProps> = memo(
+  ({ label, labelProps = {}, children, ...rest }) => {
+    if (!label) return <>{children}</>;
+    const content = useMemo(
+      () => (
+        <Box as="span" display="block" fontSize={0} {...labelProps}>
+          {label}
+        </Box>
+      ),
+      [labelProps, label]
+    );
+    return (
+      <Tippy content={content} trigger="mouseenter" hideOnClick={undefined} {...rest}>
+        {children}
+      </Tippy>
+    );
+  }
+);

--- a/src/pages/popup/receive.tsx
+++ b/src/pages/popup/receive.tsx
@@ -64,9 +64,11 @@ export const PopupReceive: React.FC = () => {
             {getAccountDisplayName(currentAccount)}
           </Title>
         )}
-        <Tooltip interactive placement="bottom" label={address}>
-          <Caption userSelect="none">{truncateMiddle(address, 8)}</Caption>
-        </Tooltip>
+        <Box>
+          <Tooltip interactive placement="bottom" label={address}>
+            <Caption userSelect="none">{truncateMiddle(address, 8)}</Caption>
+          </Tooltip>
+        </Box>
       </Stack>
       <Box mt="auto">
         <Button width="100%" onClick={onCopy}>


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/938532790).<!-- Sticky Header Marker -->

There are quite a few runtime errors being thrown in the wallet right now. Would be great if we could test for these—not ideal to have errors thrown, regardless of whether they cause bugs/break the script

- Some were React errors where non-allowed props being passed to DOM elements.
- `Tippy` the tooltip lib has been throwing errors when `Stack` implicitly passes props to its children
  - @aulneau maybe `<Stack>` can wrap the children in `<Box>` elements, rather than implicitly passing props directly to the children. This would also allow components that don't pass props down.