### PR TITLE
fix: issue #1290, Set Password dialogue misaligned

### DIFF
--- a/.changeset/good-badgers-dance.md
+++ b/.changeset/good-badgers-dance.md
@@ -2,4 +2,4 @@
 '@stacks/wallet-web': patch
 ---
 
-fixed set-password page alignment issues
+This update fixes a regression where the set-password page became mis-aligned.

--- a/.changeset/good-badgers-dance.md
+++ b/.changeset/good-badgers-dance.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+fixed set-password page alignment issues

--- a/src/pages/set-password.tsx
+++ b/src/pages/set-password.tsx
@@ -93,14 +93,14 @@ export const SetPasswordPage: React.FC<SetPasswordProps> = ({
   });
 
   return (
-    <Formik
-      initialValues={{ password: '' }}
-      validationSchema={validationSchema}
-      onSubmit={handleSubmit}
-    >
-      {formik => (
-        <Form>
-          <PopupContainer header={<Header hideActions title="Set a password" />} requestType="auth">
+    <PopupContainer header={<Header hideActions title="Set a password" />} requestType="auth">
+      <Formik
+        initialValues={{ password: '' }}
+        validationSchema={validationSchema}
+        onSubmit={handleSubmit}
+      >
+        {formik => (
+          <Form>
             <Body className="onboarding-text">
               This password is for this device only. To access your account on a new device you will
               use your Secret Key.
@@ -135,9 +135,9 @@ export const SetPasswordPage: React.FC<SetPasswordProps> = ({
                 </Button>
               </Stack>
             </Box>
-          </PopupContainer>
-        </Form>
-      )}
-    </Formik>
+          </Form>
+        )}
+      </Formik>
+    </PopupContainer>
   );
 };


### PR DESCRIPTION
<!--
PR reminders:
  - Link issues to PR
  - Update UserX board
  - Use checkmarks for progress
  - Link PRs in other issues

Tips for good PR etiquette https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/
-->

Changes:
- https://github.com/blockstack/stacks-wallet-web/issues/1290 investigated and fixed `set-password` page alignment issues

Results:

https://user-images.githubusercontent.com/34238697/121941507-0c2ca280-cd58-11eb-8980-d65eecc3c7bc.mp4



cc/ @aulneau @kyranjamie @fbwoolf @andresgalante 
