### PR TITLE
fix: verify tx request

### DIFF
--- a/.changeset/smooth-plants-clap.md
+++ b/.changeset/smooth-plants-clap.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': minor
+---
+
+This update improves the error handling we have around unauthorized transactions and expired requests.

--- a/src/common/hooks/use-origin.ts
+++ b/src/common/hooks/use-origin.ts
@@ -1,8 +1,6 @@
 import { useRecoilValue } from 'recoil';
-import { getRequestOrigin, StorageKey } from '@common/storage';
-import { requestTokenState } from '@store/transactions/requests';
+import { requestTokenOriginState } from '@store/transactions/requests';
 
 export function useOrigin() {
-  const requestToken = useRecoilValue(requestTokenState);
-  return requestToken ? getRequestOrigin(StorageKey.transactionRequests, requestToken) : null;
+  return useRecoilValue(requestTokenOriginState);
 }

--- a/src/common/hooks/use-scroll-lock.ts
+++ b/src/common/hooks/use-scroll-lock.ts
@@ -1,0 +1,56 @@
+// https://github.com/moldy530/react-use-scroll-lock/blob/master/src/use-scroll-lock.ts
+import { useEffect, useState } from 'react';
+
+declare global {
+  // tslint:disable-next-line: interface-name
+  interface Window {
+    __useScrollLockStyle: string | undefined | null;
+    __useScrollLockInstances: Set<{}> | undefined | null;
+  }
+}
+
+let instances: Set<{}> = new Set();
+
+if (typeof window !== 'undefined') {
+  // this is necessary because we may share instances of this file on a page so we store these globally
+  window.__useScrollLockInstances = window.__useScrollLockInstances || new Set<{}>();
+  instances = window.__useScrollLockInstances;
+}
+
+const registerInstance = (instance: {}) => {
+  if (instances.size === 0) {
+    setBodyOverflow(true);
+  }
+
+  instances.add(instance);
+};
+
+const unregisterInstance = (instance: {}) => {
+  instances.delete(instance);
+
+  if (instances.size === 0) {
+    setBodyOverflow(false);
+  }
+};
+
+const setBodyOverflow = (shouldLock: boolean) => {
+  if (shouldLock) {
+    document.body.classList.add('no-scroll');
+  } else {
+    document.body.classList.remove('no-scroll');
+  }
+};
+
+export const useScrollLock = (shouldLock: boolean) => {
+  // we generate a unique reference to the component that uses this thing
+  const [elementId] = useState({});
+
+  useEffect(() => {
+    if (shouldLock) {
+      registerInstance(elementId);
+    }
+
+    // Re-enable scrolling when component unmounts
+    return () => unregisterInstance(elementId);
+  }, [elementId, shouldLock]); // ensures effect is only run on mount, unmount, and on shouldLock change
+};

--- a/src/components/global-styles.tsx
+++ b/src/components/global-styles.tsx
@@ -5,16 +5,24 @@ import { Global, css } from '@emotion/react';
 const SizeStyles = css`
   body {
     display: flex;
+
+    &.no-scroll .main-content {
+      overflow: hidden;
+      pointer-events: none;
+    }
   }
+
   #actions-root {
     flex-grow: 1;
     display: flex;
     min-height: 100vh;
   }
+
   .container-outer {
     min-height: 100vh;
     height: 100vh;
   }
+
   .mode__extension {
     &,
     body {

--- a/src/components/popup/container.tsx
+++ b/src/components/popup/container.tsx
@@ -59,6 +59,7 @@ export const PopupContainer: React.FC<PopupHomeProps> = memo(
           flexDirection="column"
           flexGrow={1}
           className="main-content"
+          id="main-content"
           as="main"
           position="relative"
           width="100%"

--- a/src/components/transactions/actions.tsx
+++ b/src/components/transactions/actions.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useCallback } from 'react';
 import { Box, Button, color, Stack, StackProps } from '@stacks/ui';
 import { LOADING_KEYS, useLoading } from '@common/hooks/use-loading';
-import { useDrawers } from '@common/hooks/use-drawers';
 import { SpaceBetween } from '@components/space-between';
 import { Caption } from '@components/typography';
 import { NetworkRowItem } from '@components/network-row-item';
@@ -49,7 +48,6 @@ const MinimalErrorMessage = memo((props: StackProps) => {
 export const TransactionsActions = memo((props: StackProps) => {
   const handleBroadcastTransaction = useTransactionBroadcast();
   const signedTransaction = useSignedTransaction();
-  const { setShowNetworks } = useDrawers();
   const error = useTransactionError();
   const { setIsLoading, setIsIdle, isLoading } = useLoading(LOADING_KEYS.SUBMIT_TRANSACTION);
 
@@ -72,7 +70,7 @@ export const TransactionsActions = memo((props: StackProps) => {
         </SpaceBetween>
         <SpaceBetween>
           <Caption>Network</Caption>
-          <NetworkRowItem onClick={() => setShowNetworks(true)} />
+          <NetworkRowItem />
         </SpaceBetween>
       </Stack>
       <MinimalErrorMessage />

--- a/src/components/transactions/error.tsx
+++ b/src/components/transactions/error.tsx
@@ -38,6 +38,7 @@ export const ErrorMessage = memo(({ title, body, actions, ...rest }: ErrorMessag
       border="4px solid #FCEEED"
       spacing="extra-loose"
       color={color('feedback-error')}
+      bg={color('bg')}
       {...rest}
     >
       <Stack spacing="base-loose">

--- a/src/components/transactions/transaction-errors.tsx
+++ b/src/components/transactions/transaction-errors.tsx
@@ -93,7 +93,6 @@ export const NoContractErrorMessage = memo(props => {
       body={`The contract (${truncateMiddle(pendingTransaction.contractAddress)}.${
         pendingTransaction.contractName
       }) that you are trying to call cannot be found on ${network.mode}.`}
-      actions={[{ onClick: () => window.close(), label: 'Switch network' }]}
       {...props}
     />
   );

--- a/src/components/transactions/transaction-errors.tsx
+++ b/src/components/transactions/transaction-errors.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import { useCurrentAccount } from '@common/hooks/account/use-current-account';
-import { color, Stack, useClipboard } from '@stacks/ui';
+import { color, Flex, Stack, useClipboard, Fade } from '@stacks/ui';
 import { useTransactionRequest } from '@common/hooks/transaction/use-transaction';
 import { useFetchBalances } from '@common/hooks/account/use-account-info';
 import { Caption } from '@components/typography';
@@ -13,6 +13,7 @@ import { ErrorMessage } from '@components/transactions/error';
 import { useDrawers } from '@common/hooks/use-drawers';
 import { useRecoilValue } from 'recoil';
 import { transactionBroadcastErrorState } from '@store/transactions';
+import { useScrollLock } from '@common/hooks/use-scroll-lock';
 
 export const FeeInsufficientFundsErrorMessage = memo(props => {
   const currentAccount = useCurrentAccount();
@@ -99,12 +100,78 @@ export const NoContractErrorMessage = memo(props => {
 });
 
 export const UnauthorizedErrorMessage = memo(props => {
+  useScrollLock(true);
   return (
-    <ErrorMessage
-      title="Unauthorized request"
-      body="The transaction request was not properly authorized by any of your accounts. If you've logged in to this app before, then you might need to re-authenticate into this application before attempting to sign a transaction with the Stacks Wallet."
-      {...props}
-    />
+    <Fade in>
+      {styles => (
+        <Flex
+          position="absolute"
+          width="100%"
+          height="100vh"
+          zIndex={99}
+          left={0}
+          top={0}
+          alignItems="center"
+          justifyContent="center"
+          p="loose"
+          bg="rgba(0,0,0,0.35)"
+          backdropFilter="blur(10px)"
+          style={styles}
+        >
+          <ErrorMessage
+            title="Unauthorized request"
+            body="The transaction request was not properly authorized by any of your accounts. If you've logged in to this app before, then you might need to re-authenticate into this application before attempting to sign a transaction with the Stacks Wallet."
+            border={'1px solid'}
+            borderColor={color('border')}
+            boxShadow="high"
+            css={{
+              '& > *': {
+                pointerEvents: 'all',
+              },
+            }}
+            {...props}
+          />
+        </Flex>
+      )}
+    </Fade>
+  );
+});
+
+export const ExpiredRequestErrorMessage = memo(props => {
+  useScrollLock(true);
+  return (
+    <Fade in>
+      {styles => (
+        <Flex
+          position="fixed"
+          width="100%"
+          height="100vh"
+          zIndex={99}
+          left={0}
+          top={0}
+          alignItems="center"
+          justifyContent="center"
+          p="loose"
+          bg="rgba(0,0,0,0.35)"
+          backdropFilter="blur(10px)"
+          style={styles}
+        >
+          <ErrorMessage
+            title="Expired request"
+            body="This transaction request has expired or cannot be validated, please try to re-initiate this transaction request from the original app."
+            border={'1px solid'}
+            borderColor={color('border')}
+            boxShadow="high"
+            css={{
+              '& > *': {
+                pointerEvents: 'all',
+              },
+            }}
+            {...props}
+          />
+        </Flex>
+      )}
+    </Fade>
   );
 });
 

--- a/src/pages/transaction/transaction-error.tsx
+++ b/src/pages/transaction/transaction-error.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import { useTransactionError } from '@common/hooks/transaction/use-transaction-error';
 import {
   BroadcastErrorMessage,
+  ExpiredRequestErrorMessage,
   FeeInsufficientFundsErrorMessage,
   NoContractErrorMessage,
   StxTransferInsufficientFundsErrorMessage,
@@ -15,6 +16,7 @@ export enum TransactionErrorReason {
   BroadcastError = 4,
   Unauthorized = 5,
   NoContract = 6,
+  ExpiredRequest = 7,
 }
 
 export const TransactionError = memo(() => {
@@ -31,6 +33,8 @@ export const TransactionError = memo(() => {
       return <FeeInsufficientFundsErrorMessage />;
     case TransactionErrorReason.Unauthorized:
       return <UnauthorizedErrorMessage />;
+    case TransactionErrorReason.ExpiredRequest:
+      return <ExpiredRequestErrorMessage />;
     default:
       return null;
   }


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/937395877).<!-- Sticky Header Marker -->

In the state refactor, I left out the validation we had for transaction requests. 

To test these changes, sign into https://stacks-wallet-web.vercel.app/ with one account, and then in the extension, sign out completely and sign in with a new seed phrase, and then try to do one of the actions from the test app. It should present you with an error overlay.

I also added error handling for if the transaction request is no longer valid due to a page refresh or something else. You can test this by refreshing the extension window when trying to sign something. We probably want to allow this in the future, but it will take a bit more time to dig into how best to do this (due to message passing from the original app).

cc/ @aulneau @kyranjamie @fbwoolf
