### PR TITLE
Feat/version display

### DIFF
--- a/.changeset/fifty-elephants-smoke.md
+++ b/.changeset/fifty-elephants-smoke.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This update adds the current version number next to the logo for better debugging and information display.

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -48,12 +48,20 @@ export const Header: React.FC<HeaderProps> = memo(props => {
       {...rest}
     >
       {!title ? (
-        <StacksWalletLogo pt="7px" onClick={() => doChangeScreen(ScreenPaths.HOME)} />
-        {VERSION ? (
-          <Caption pt="extra-tight" variant="c2" fontFamily="mono">
-            v{VERSION}
-          </Caption>
-        ) : null}
+        <Stack alignItems="center" pt="7px" isInline>
+          <StacksWalletLogo onClick={() => doChangeScreen(ScreenPaths.HOME)} />
+          {VERSION ? (
+            <Caption
+              pt="extra-tight"
+              color="#8D929A"
+              variant="c3"
+              marginRight="10px"
+              fontFamily="mono"
+            >
+              v{VERSION}
+            </Caption>
+          ) : null}
+        </Stack>
       ) : (
         <Box pt={onClose ? 'loose' : 'unset'} pr="tight">
           {onClose ? (

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -7,7 +7,7 @@ import { useDoChangeScreen } from '@common/hooks/use-do-change-screen';
 import { useDrawers } from '@common/hooks/use-drawers';
 import { NetworkModeBadge } from '@components/network-mode-badge';
 import { ScreenPaths } from '@store/common/types';
-import { Title } from '@components/typography';
+import { Caption, Title } from '@components/typography';
 
 const MenuButton: React.FC<BoxProps> = memo(props => {
   const { showSettings, setShowSettings } = useDrawers();
@@ -49,6 +49,11 @@ export const Header: React.FC<HeaderProps> = memo(props => {
     >
       {!title ? (
         <StacksWalletLogo pt="7px" onClick={() => doChangeScreen(ScreenPaths.HOME)} />
+        {VERSION ? (
+          <Caption pt="extra-tight" variant="c2" fontFamily="mono">
+            v{VERSION}
+          </Caption>
+        ) : null}
       ) : (
         <Box pt={onClose ? 'loose' : 'unset'} pr="tight">
           {onClose ? (

--- a/src/components/typography.tsx
+++ b/src/components/typography.tsx
@@ -54,14 +54,23 @@ const c1 = capsize({
   fontSize: 14,
   leading: 20,
 });
+
 const c2 = capsize({
   fontMetrics: interMetrics,
   fontSize: 12,
   leading: 16,
 });
 
-const captionStyles = (variant?: 'c1' | 'c2') => {
+const c3 = capsize({
+  fontMetrics: interMetrics,
+  fontSize: 10,
+  leading: 16,
+});
+
+const captionStyles = (variant?: 'c1' | 'c2' | 'c3') => {
   switch (variant) {
+    case 'c3':
+      return c3;
     case 'c2':
       return c2;
     default:
@@ -132,7 +141,7 @@ export const Text = forwardRefWithAs<BoxProps, 'span'>((props, ref) => (
 
 export const Body: React.FC<BoxProps> = props => <Text css={c1} {...props} />;
 
-export const Caption = forwardRefWithAs<{ variant?: 'c1' | 'c2' } & BoxProps, 'span'>(
+export const Caption = forwardRefWithAs<{ variant?: 'c1' | 'c2' | 'c3' } & BoxProps, 'span'>(
   ({ variant, ...props }, ref) => (
     <BaseText
       fontFeatureSettings={`'ss01' on`}


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/970720970).<!-- Sticky Header Marker -->

Adds the current version next to the logo on the home screen.

<img width="451" alt="Screen Shot 2021-06-14 at 5 25 05 PM" src="https://user-images.githubusercontent.com/11803153/121967188-8ac41880-cd35-11eb-802e-7ddda199eeef.png">

@jasperjansz any better suggestion?

cc/   @kyranjamie @fbwoolf
