### PR TITLE
fix: stx display rounding error

### DIFF
--- a/.changeset/new-sloths-raise.md
+++ b/.changeset/new-sloths-raise.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This updates fixes a display bug that rounded STX values incorrectly. This bug had no effect on values used in transactions, only with the display of the amounts.

--- a/src/common/stacks-utils.ts
+++ b/src/common/stacks-utils.ts
@@ -17,9 +17,7 @@ export const stacksValue = ({
   abbreviate?: boolean;
 }) => {
   const stacks = microStxToStx(value);
-  const stxAmount = fixedDecimals
-    ? parseFloat(stacks.toFormat(STX_DECIMALS))
-    : stacks.decimalPlaces(STX_DECIMALS).toNumber();
+  const stxAmount = stacks.toNumber();
   return `${
     abbreviate && stxAmount > 10000
       ? abbreviateNumber(stxAmount)


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/944473484).<!-- Sticky Header Marker -->

There was a bug present such that STX amounts when displayed in certain places were rounded incorrectly. This bug had no effect on the true STX values used in transactions.

cc/ @aulneau @kyranjamie @fbwoolf
