### PR TITLE
fix: background script loading in content script

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -5,14 +5,19 @@
  needed and unloaded when it goes idle.
  https://developer.chrome.com/docs/extensions/mv3/architecture-overview/#background_script
  */
-import { popupCenter } from '@background/popup';
-import { ScreenPaths } from '@store/common/types';
 import { storePayload, StorageKey } from '@common/storage';
+import { ScreenPaths } from '@store/common/types';
+import {
+  CONTENT_SCRIPT_PORT,
+  ExternalMethods,
+  MessageFromContentScript,
+} from '@common/message-types';
+
+import type { VaultActions } from '@background/vault-types';
+import { popupCenter } from '@background/popup';
 import { vaultMessageHandler } from '@background/vault';
-import { IS_TEST_ENV } from '@common/constants';
-import { CONTENT_SCRIPT_PORT } from '@content-scripts/content-script';
-import { VaultActions } from '@background/vault-types';
-import { ExternalMethods, MessageFromContentScript } from '@content-scripts/message-types';
+
+const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 
 // Listen for install event
 chrome.runtime.onInstalled.addListener(async details => {

--- a/src/background/vault-types.ts
+++ b/src/background/vault-types.ts
@@ -1,4 +1,4 @@
-import { ExtensionMethods, InternalMethods, Message } from '@content-scripts/message-types';
+import { ExtensionMethods, InternalMethods, Message } from '@common/message-types';
 
 /**
  * Vault <-> Background Script

--- a/src/background/vault.ts
+++ b/src/background/vault.ts
@@ -8,10 +8,10 @@ import {
   Wallet as SDKWallet,
 } from '@stacks/wallet-sdk';
 import { gaiaUrl } from '@common/constants';
-import { VaultActions } from '@background/vault-types';
+import type { VaultActions } from '@background/vault-types';
 import { decryptMnemonic, encryptMnemonic } from '@background/crypto/mnemonic-encryption';
 import { DEFAULT_PASSWORD } from '@store/common/types';
-import { InternalMethods } from '@content-scripts/message-types';
+import { InternalMethods } from '@common/message-types';
 
 // In-memory (background) wallet instance
 export interface InMemoryVault {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -7,6 +7,7 @@ export const STX_TRANSFER_TX_SIZE_BYTES = 180;
 export const transition = 'all .2s cubic-bezier(.215,.61,.355,1)';
 
 export const USERNAMES_ENABLED = process.env.USERNAMES_ENABLED === 'true';
+
 export const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 
 export const STX_DECIMALS = 6;

--- a/src/common/hooks/use-vault-messenger.ts
+++ b/src/common/hooks/use-vault-messenger.ts
@@ -14,11 +14,11 @@ import {
   hasRehydratedVaultStore,
 } from '@store/wallet';
 import { InMemoryVault } from '@background/vault';
-import { InternalMethods } from '@content-scripts/message-types';
+import { InternalMethods } from '@common/message-types';
+import { currentAccountIndexState } from '@store/accounts';
 import { textToBytes } from '@store/common/utils';
 import { useAtomCallback } from 'jotai/utils';
 import { useCallback } from 'react';
-import { currentAccountIndexState } from '@store/accounts';
 
 const useInnerMessageWrapper = () => {
   return useAtomCallback<void, VaultActions>(

--- a/src/common/message-types.ts
+++ b/src/common/message-types.ts
@@ -2,6 +2,8 @@ import { FinishedTxPayload, SponsoredFinishedTxPayload } from '@stacks/connect';
 
 export const MESSAGE_SOURCE = 'stacks-wallet' as const;
 
+export const CONTENT_SCRIPT_PORT = 'content-script' as const;
+
 export enum ExternalMethods {
   transactionRequest = 'transactionRequest',
   transactionResponse = 'transactionResponse',

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -10,7 +10,7 @@ import {
   MESSAGE_SOURCE,
   TransactionResponseMessage,
   TxResult,
-} from '@content-scripts/message-types';
+} from '@common/message-types';
 
 import { KEBAB_REGEX, Network } from '@common/constants';
 import { StacksNetwork } from '@stacks/network';

--- a/src/content-scripts/content-script.ts
+++ b/src/content-scripts/content-script.ts
@@ -6,11 +6,12 @@
  */
 import { getEventSourceWindow } from '@common/utils';
 import {
+  CONTENT_SCRIPT_PORT,
   ExternalMethods,
   MessageFromContentScript,
   MessageToContentScript,
   MESSAGE_SOURCE,
-} from '@content-scripts/message-types';
+} from '@common/message-types';
 import {
   AuthenticationRequestEvent,
   DomEventName,
@@ -38,8 +39,6 @@ window.addEventListener('message', event => {
     }
   }
 });
-
-export const CONTENT_SCRIPT_PORT = 'content-script' as const;
 
 // Connection to background script - fires onConnect event in background script
 // and establishes two-way communication

--- a/src/inpage/inpage.ts
+++ b/src/inpage/inpage.ts
@@ -10,7 +10,7 @@ import {
   MessageToContentScript,
   MESSAGE_SOURCE,
   TransactionResponseMessage,
-} from '@content-scripts/message-types';
+} from '@common/message-types';
 
 type CallableMethods = keyof typeof ExternalMethods;
 


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/965280351).<!-- Sticky Header Marker -->

Noticed a funky behaviour looking into the messaging changes.

The import structure, where the types were imported in the _background_ from the _content script_. As an import pulls in the full contents of the file, a `console.log` in the content, logged in the bg. 

This PR moves the logic around so that shared messaging code is imported from common, not from sibling folders.

No changeset as this covers a non user-facing bug
