### PR TITLE
fix: re-add getSignUpComponent

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -40,7 +40,7 @@ export const Route: React.FC<RouteProps> = ({ path, element }) => {
 export const Routes: React.FC = () => {
   const { isSignedIn: signedIn, encryptedSecretKey } = useWallet();
   const { isOnboardingInProgress } = useOnboardingState();
-  const { pathname } = useLocation();
+  const { search, pathname } = useLocation();
   const setLastSeen = useUpdateAtom(lastSeenStore);
 
   const doChangeScreen = useDoChangeScreen();
@@ -73,6 +73,19 @@ export const Routes: React.FC = () => {
     return <InstalledSignIn />;
   };
 
+  const getSignUpElement = () => {
+    if (isLocked) return <Unlock />;
+    if (isSignedIn) {
+      return (
+        <Navigate
+          to={`${ScreenPaths.CHOOSE_ACCOUNT}${search}`}
+          screenPath={ScreenPaths.CHOOSE_ACCOUNT}
+        />
+      );
+    }
+    return <Installed />;
+  };
+
   return (
     <RoutesDom>
       <Route path={ScreenPaths.HOME} element={getHomeComponent()} />
@@ -95,6 +108,7 @@ export const Routes: React.FC = () => {
       <RouterRoute path={ScreenPaths.ADD_NETWORK} element={<AddNetwork />} />
       <Route path={ScreenPaths.SET_PASSWORD} element={<SetPasswordPage redirect />} />
       <Route path={ScreenPaths.USERNAME} element={<Username />} />
+      <Route path={ScreenPaths.GENERATION} element={getSignUpElement()} />
       {/*Sign In*/}
       <Route path={ScreenPaths.SIGN_IN} element={getSignInComponent()} />
       <Route path={ScreenPaths.RECOVERY_CODE} element={<MagicRecoveryCode />} />


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/965717517).<!-- Sticky Header Marker -->

In some of our cleanup, we accidentally removed the logic that correctly routed the user to a given location when coming from an app. Apps via connect use the `/sign-up` path, and this function sends them to where they need to go, otherwise we had just a blank screen. This was the commit this regression happened: https://github.com/blockstack/stacks-wallet-web/commit/08fe3e996428f23e7ede969d9ab03004ed0be6d0#diff-e12ee6c548fccc19335a7840f601df2ce3a5d5dfe8abd95ced414565bec45b69

I honestly don't know why the tests have been working.

cc/ @aulneau @kyranjamie @fbwoolf
