### PR TITLE
fix: display dates according to timezone, closes #1320

### DIFF
--- a/src/common/group-txs-by-date.ts
+++ b/src/common/group-txs-by-date.ts
@@ -17,7 +17,7 @@ function todaysIsoDate() {
 function groupTxsByDateMap(txs: Tx[]) {
   return txs.reduce((txsByDate, tx) => {
     if ('burn_block_time_iso' in tx && tx.burn_block_time_iso) {
-      const [date] = tx.burn_block_time_iso.split('T');
+      const [date] = new Date(tx.burn_block_time_iso).toLocaleDateString().split('T');
       if (!txsByDate.has(date)) {
         txsByDate.set(date, []);
       }


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/971288703).<!-- Sticky Header Marker -->

This fixes #1320 where the dates displayed in the Activity List was always in GMT time.
With this fix the user local timezone is correctly taken into account in the Activity List.