### PR TITLE
fix: runtime error in <CurrentUserAvatar/>

### DIFF
--- a/src/components/current-user/current-user-avatar.tsx
+++ b/src/components/current-user/current-user-avatar.tsx
@@ -9,15 +9,14 @@ const UserAvatarSuspense = memo((props: BoxProps) => {
   const currentAccount = useCurrentAccount();
   const names = useAccountNames();
   if (!currentAccount || typeof currentAccount.index === 'undefined') return null;
-  const name =
-    names?.[currentAccount.index]?.names?.[0] || getAccountDisplayName(currentAccount as any);
+  const name = names?.[currentAccount.index]?.names?.[0] || getAccountDisplayName(currentAccount);
   return <AccountAvatar name={name} flexShrink={0} account={currentAccount} {...props} />;
 });
 
 export const CurrentUserAvatar = memo((props: BoxProps) => {
   const currentAccount = useCurrentAccount();
-  const defaultName = getAccountDisplayName(currentAccount as any);
   if (!currentAccount) return null;
+  const defaultName = getAccountDisplayName(currentAccount);
   return (
     <React.Suspense
       fallback={


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/971859754).<!-- Sticky Header Marker -->

![image](https://user-images.githubusercontent.com/1618764/123446777-7efc1000-d5d9-11eb-8ab9-e869e05ae120.png)

Guess this was introduced with jotai changes? 🤔  

Line switch anyway, as we can't pass `undefined` to `getAccountDisplayName`