### PR TITLE
test: send form validation, extend page object

### DIFF
--- a/src/pages/send-tokens/components/amount-field.tsx
+++ b/src/pages/send-tokens/components/amount-field.tsx
@@ -6,9 +6,9 @@ import { useFetchBalances } from '@common/hooks/account/use-account-info';
 import { useSelectedAsset } from '@common/hooks/use-selected-asset';
 import { ErrorLabel } from '@components/error-label';
 
-import { SendFormSelectors } from '../../../../tests/integration/page-objects/send-form.selectors';
 import { useSendAmountFieldActions } from '../hooks/use-send-form';
 import { SendMaxWithSuspense } from './send-max-button';
+import { SendFormSelectors } from '../../../../tests/integration/page-objects/send-form.selectors';
 
 interface AmountFieldProps extends StackProps {
   value: number;
@@ -59,7 +59,7 @@ export const AmountField = memo((props: AmountFieldProps) => {
         </Box>
       </InputGroup>
       {error && (
-        <ErrorLabel>
+        <ErrorLabel data-test={SendFormSelectors.InputAmountFieldErrorLabel}>
           <Text textStyle="caption">{error}</Text>
         </ErrorLabel>
       )}

--- a/src/pages/send-tokens/components/recipient-field.tsx
+++ b/src/pages/send-tokens/components/recipient-field.tsx
@@ -1,6 +1,7 @@
 import { Input, InputGroup, Stack, StackProps, Text } from '@stacks/ui';
 import { ErrorLabel } from '@components/error-label';
 import React, { memo } from 'react';
+import { SendFormSelectors } from '../../../../tests/integration/page-objects/send-form.selectors';
 
 interface RecipientField extends StackProps {
   value: string;
@@ -31,10 +32,11 @@ export const RecipientField = memo(({ value, onChange, error, ...rest }: Recipie
           onChange={onChange}
           placeholder="Enter an address"
           autoComplete="off"
+          data-test={SendFormSelectors.InputRecipientField}
         />
       </InputGroup>
       {error && (
-        <ErrorLabel>
+        <ErrorLabel data-test={SendFormSelectors.InputRecipientFieldErrorLabel}>
           <Text textStyle="caption">{error}</Text>
         </ErrorLabel>
       )}

--- a/src/pages/send-tokens/send-tokens.tsx
+++ b/src/pages/send-tokens/send-tokens.tsx
@@ -19,6 +19,7 @@ import { MemoField } from '@pages/send-tokens/components/memo-field';
 import { useTransferableAssets } from '@common/hooks/use-assets';
 import { useRefreshAccountData } from '@common/hooks/account/use-refresh-account-data';
 import { ConfirmSendDrawer } from '@pages/transaction-signing/components/confirm-send-drawer';
+import { SendFormSelectors } from '../../../tests/integration/page-objects/send-form.selectors';
 
 type Amount = number | '';
 
@@ -91,7 +92,13 @@ const SendForm = (props: SendFormProps) => {
               <Text textStyle="caption">{assetError}</Text>
             </ErrorLabel>
           )}
-          <Button borderRadius="12px" width="100%" onClick={onSubmit} isDisabled={!hasValues}>
+          <Button
+            borderRadius="12px"
+            width="100%"
+            onClick={onSubmit}
+            isDisabled={!hasValues}
+            data-test={SendFormSelectors.BtnPreviewSendTx}
+          >
             Preview
           </Button>
         </Box>

--- a/tests/integration/page-objects/send-form.page.ts
+++ b/tests/integration/page-objects/send-form.page.ts
@@ -2,16 +2,47 @@ import { Page } from 'playwright-core';
 import { createTestSelector } from '../utils';
 import { SendFormSelectors } from './send-form.selectors';
 
+const selectors = {
+  $btnSendMaxBalance: createTestSelector(SendFormSelectors.BtnSendMaxBalance),
+  $amountField: createTestSelector(SendFormSelectors.InputAmountField),
+  $amountFieldError: createTestSelector(SendFormSelectors.InputAmountFieldErrorLabel),
+  $stxAddressField: createTestSelector(SendFormSelectors.InputRecipientField),
+  $stxAddressFieldError: createTestSelector(SendFormSelectors.InputRecipientFieldErrorLabel),
+  $previewBtn: createTestSelector(SendFormSelectors.BtnPreviewSendTx),
+};
+
 export class SendPage {
+  selectors = selectors;
+
   constructor(public page: Page) {}
 
-  $amountField = createTestSelector(SendFormSelectors.InputAmountField);
+  async select(selector: keyof typeof selectors) {
+    return this.page.$(selectors[selector]);
+  }
+
+  getSelector(selector: keyof typeof selectors) {
+    return this.selectors[selector];
+  }
 
   async clickSendMaxBtn() {
-    await this.page.click(createTestSelector(SendFormSelectors.BtnSendMaxBalance));
+    await this.page.click(this.selectors.$btnSendMaxBalance);
+  }
+
+  async clickPreviewTxBtn() {
+    await this.page.click(this.selectors.$previewBtn);
   }
 
   async getAmountFieldValue() {
-    return this.page.$eval(this.$amountField, (el: HTMLInputElement) => el.value);
+    return this.page.$eval(this.selectors.$amountField, (el: HTMLInputElement) => el.value);
+  }
+
+  async inputToAmountField(input: string) {
+    const field = await this.page.$(this.selectors.$amountField);
+    await field?.type(input);
+  }
+
+  async inputToAddressField(input: string) {
+    const field = await this.page.$(this.selectors.$stxAddressField);
+    await field?.type(input);
   }
 }

--- a/tests/integration/page-objects/send-form.selectors.ts
+++ b/tests/integration/page-objects/send-form.selectors.ts
@@ -1,4 +1,11 @@
 export enum SendFormSelectors {
   BtnSendMaxBalance = 'btn-send-max-balance',
+
   InputAmountField = 'input-amount-field',
+  InputAmountFieldErrorLabel = 'input-amount-field-error-label',
+
+  InputRecipientField = 'input-recipient-field',
+  InputRecipientFieldErrorLabel = 'input-recipient-field-error-label',
+
+  BtnPreviewSendTx = 'bnt-preview-send-tx',
 }

--- a/tests/integration/send-tokens.spec.ts
+++ b/tests/integration/send-tokens.spec.ts
@@ -1,6 +1,6 @@
 import { ScreenPaths } from '@common/types';
-import { SendPage } from './page-objects/send-form.page';
 
+import { SendPage } from './page-objects/send-form.page';
 import { WalletPage } from './page-objects/wallet.page';
 import { BrowserDriver, setupBrowser } from './utils';
 
@@ -10,14 +10,14 @@ jest.retryTimes(process.env.CI ? 2 : 0);
 describe(`Send tokens flow`, () => {
   let browser: BrowserDriver;
   let walletPage: WalletPage;
-  let sendFormPage: SendPage;
+  let sendForm: SendPage;
 
   beforeEach(async () => {
     browser = await setupBrowser();
     walletPage = await WalletPage.init(browser, ScreenPaths.INSTALLED);
     await walletPage.signUp();
     await walletPage.goToSendForm();
-    sendFormPage = new SendPage(walletPage.page);
+    sendForm = new SendPage(walletPage.page);
   }, 30_000);
 
   afterEach(async () => {
@@ -26,12 +26,39 @@ describe(`Send tokens flow`, () => {
     } catch (error) {}
   });
 
-  it('should not set a fee below zero when the account balance is 0 STX', async () => {
-    await sendFormPage.clickSendMaxBtn();
-    const amount = await sendFormPage.getAmountFieldValue();
+  describe('Set max button', () => {
+    it('does not set a fee below zero, when the account balance is 0 STX', async () => {
+      await sendForm.clickSendMaxBtn();
+      const amount = await sendForm.getAmountFieldValue();
+      expect(amount).toEqual('');
+      expect(amount).not.toEqual('-0.00018');
+      expect(Number(amount)).not.toBeLessThan(0);
+    });
+  });
 
-    expect(amount).toEqual('');
-    expect(amount).not.toEqual('-0.00018');
-    expect(Number(amount)).not.toBeLessThan(0);
+  describe('Form validation', () => {
+    it('validates against an invalid address', async () => {
+      await sendForm.inputToAmountField('100000000');
+      await sendForm.inputToAddressField('slkfjsdlkfjs');
+      await sendForm.clickPreviewTxBtn();
+      const errorMsg = await sendForm.page.isVisible(sendForm.getSelector('$stxAddressFieldError'));
+      expect(errorMsg).toBeTruthy();
+    });
+
+    it('does not prohibit valid addresses', async () => {
+      await sendForm.inputToAmountField('100000000');
+      await sendForm.inputToAddressField('SP15DFMYE5JDDKRMAZSC6947TCERK36JM4KD5VKZD');
+      await sendForm.clickPreviewTxBtn();
+      const errorMsg = await sendForm.page.isVisible(sendForm.getSelector('$stxAddressFieldError'));
+      expect(errorMsg).toBeFalsy();
+    });
+
+    it('validates against a negative amount of tokens', async () => {
+      await sendForm.inputToAmountField('-9999');
+      await sendForm.inputToAddressField('ess-pee');
+      await sendForm.clickPreviewTxBtn();
+      const errorMsg = await sendForm.page.isVisible(sendForm.getSelector('$amountFieldError'));
+      expect(errorMsg).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/993823115).<!-- Sticky Header Marker -->

Send form validation integration tests