### PR TITLE
test: use alias

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 const { version } = require('./package.json');
+const { pathsToModuleNameMapper } = require('ts-jest/utils');
 
 const { compilerOptions } = require('./tsconfig');
 const pathNames = {};
@@ -28,7 +29,11 @@ module.exports = {
     VERSION: version,
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node', 'd.ts'],
-  moduleNameMapper: pathNames,
+
+  moduleNameMapper: {
+    ...pathNames,
+    ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
+  },
   roots: ['<rootDir>/tests', '<rootDir>/src'],
   preset: 'ts-jest',
   testMatch: ['**/?(*.)+(spec).(js|ts|tsx)'],

--- a/src/pages/home/components/actions.tsx
+++ b/src/pages/home/components/actions.tsx
@@ -4,7 +4,7 @@ import React, { memo, useCallback, useRef } from 'react';
 import { useDoChangeScreen } from '@common/hooks/use-do-change-screen';
 import { IconArrowUp, IconQrcode } from '@tabler/icons';
 import { useTransferableAssets } from '@common/hooks/use-assets';
-import { WalletPageSelectors } from '../../../../tests/integration/page-objects/wallet.selectors';
+import { WalletPageSelectors } from '@tests/integration/page-objects/wallet.selectors';
 
 interface TxButtonProps extends ButtonProps {
   kind: 'send' | 'receive';

--- a/src/pages/home/components/user-area.tsx
+++ b/src/pages/home/components/user-area.tsx
@@ -7,7 +7,7 @@ import { truncateMiddle } from '@stacks/ui-utils';
 import { FiCopy } from 'react-icons/fi';
 import { CurrentUserAvatar } from '@features/current-user/current-user-avatar';
 import { CurrentUsername } from '@features/current-user/current-user-name';
-import { UserAreaSelectors } from '../../../../tests/integration/user-area.selectors';
+import { UserAreaSelectors } from '@tests/integration/user-area.selectors';
 
 const UserAddress = memo((props: StackProps) => {
   const currentAccount = useCurrentAccount();

--- a/src/pages/send-tokens/components/amount-field.tsx
+++ b/src/pages/send-tokens/components/amount-field.tsx
@@ -8,7 +8,7 @@ import { ErrorLabel } from '@components/error-label';
 
 import { useSendAmountFieldActions } from '../hooks/use-send-form';
 import { SendMaxWithSuspense } from './send-max-button';
-import { SendFormSelectors } from '../../../../tests/integration/page-objects/send-form.selectors';
+import { SendFormSelectors } from '@tests/integration/page-objects/send-form.selectors';
 
 interface AmountFieldProps extends StackProps {
   value: number;

--- a/src/pages/send-tokens/components/recipient-field.tsx
+++ b/src/pages/send-tokens/components/recipient-field.tsx
@@ -1,7 +1,7 @@
 import { Input, InputGroup, Stack, StackProps, Text } from '@stacks/ui';
 import { ErrorLabel } from '@components/error-label';
 import React, { memo } from 'react';
-import { SendFormSelectors } from '../../../../tests/integration/page-objects/send-form.selectors';
+import { SendFormSelectors } from '@tests/integration/page-objects/send-form.selectors';
 
 interface RecipientField extends StackProps {
   value: string;

--- a/src/pages/transaction-signing/components/post-conditions/single.tsx
+++ b/src/pages/transaction-signing/components/post-conditions/single.tsx
@@ -14,7 +14,7 @@ import {
   getSymbolFromPostCondition,
   useAssetInfoFromPostCondition,
 } from '@common/transactions/postcondition-utils';
-import { useTransactionRequest } from '../../../../common/hooks/use-transaction-request';
+import { useTransactionRequest } from '@common/hooks/use-transaction-request';
 import { TransactionEventCard } from '../event-card';
 
 interface PostConditionProps {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,8 @@
       "@content-scripts/*": ["content-scripts/*"],
       "@inpage/*": ["inpage/*"],
       "@pages/*": ["pages/*"],
-      "@features/*": ["features/*"]
+      "@features/*": ["features/*"],
+      "@tests/*": ["../tests/*"]
     },
     "baseUrl": "src",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/993933035).<!-- Sticky Header Marker -->

~~I think next steps from here would be to have two tsconfigs: `default` and `tsconfig.tests.json`, where defaut contains `tests/**/*.selectors.ts` only.~~ We already do have this, actually 😅 

We can probs kill the `tests/integration` folder, too. As this folder is implicitly for integration tests