### PR TITLE
fix: alignment title with content, closes #1259

### DIFF
--- a/src/features/account-switch-drawer/switch-accounts.tsx
+++ b/src/features/account-switch-drawer/switch-accounts.tsx
@@ -86,7 +86,7 @@ const AccountListItem = memo(
         }}
         cursor="pointer"
         py="base"
-        px="loose"
+        px="extra-loose"
         onClick={handleClick}
         position="relative"
       >


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1003636816).<!-- Sticky Header Marker -->

Fix alignment in switch account drawer.
![wallet-issue-1259](https://user-images.githubusercontent.com/1501454/124564529-75787080-de41-11eb-8661-d06b841e459f.png)


cc/ @aulneau @kyranjamie @fbwoolf
