### PR TITLE
fix(send-form): prohibit sending balances greater than balance

### DIFF
--- a/.changeset/nice-cheetahs-argue.md
+++ b/.changeset/nice-cheetahs-argue.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Adds validation to prevent a user from being able to send more than their SIP-10 balance. Fixes #1400

--- a/src/pages/send-tokens/hooks/use-send-form-validation.ts
+++ b/src/pages/send-tokens/hooks/use-send-form-validation.ts
@@ -43,6 +43,11 @@ export const useSendFormValidation = ({ setAssetError }: UseSendFormValidationAr
             errors.amount = `Insufficient balance. Your available balance is ${availableBalance.toString()} STX`;
           }
         }
+        const assetBalance = new BigNumber(selectedAsset.balance);
+        const assetAmountToTransfer = new BigNumber(amount);
+        if (assetAmountToTransfer.isGreaterThan(assetBalance)) {
+          errors.amount = 'Cannot transfer more than balance';
+        }
       }
     } else {
       setAssetError('You must select a valid token to transfer');


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1014545670).<!-- Sticky Header Marker -->

Adds validation when trying to send SIP-10 token amount > balance