### PR TITLE
fix: refresh on mount

### DIFF
--- a/.changeset/pretty-walls-peel.md
+++ b/.changeset/pretty-walls-peel.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This update enables quicker and more responsive refreshing of an accounts remote data

--- a/src/features/devtool/devtools.tsx
+++ b/src/features/devtool/devtools.tsx
@@ -1,7 +1,15 @@
-import { useAtomDevtools } from 'jotai/devtools';
-import { walletState } from '@store/wallet';
+import React from 'react';
+
+import { ReactQueryDevtools } from 'react-query/devtools';
+import { QueryClientProvider } from 'react-query';
+import { useAtomValue } from 'jotai/utils';
+import { getQueryClientAtom } from 'jotai/query';
 
 export function Devtools() {
-  useAtomDevtools(walletState);
-  return null;
+  const client = useAtomValue(getQueryClientAtom);
+  return client ? (
+    <QueryClientProvider client={client}>
+      <ReactQueryDevtools position={'top-left'} />
+    </QueryClientProvider>
+  ) : null;
 }

--- a/src/store/accounts/index.ts
+++ b/src/store/accounts/index.ts
@@ -121,7 +121,12 @@ const accountDataResponseState = atomFamilyWithQuery<[string, string], AllAccoun
   async function accountDataResponseQueryFn(_get, [address, networkUrl]) {
     return fetchAllAccountData(networkUrl)(address);
   },
-  { refetchInterval: QueryRefreshRates.MEDIUM }
+  {
+    refetchInterval: QueryRefreshRates.MEDIUM,
+    refetchOnMount: 'always',
+    refetchOnReconnect: 'always',
+    refetchOnWindowFocus: 'always',
+  }
 );
 // external API data associated with the current account's address
 export const accountDataState = atom(get => {


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1027596173).<!-- Sticky Header Marker -->

This is a small fix for a bug where sometimes balances when switching between accounts would be stale. It's very hard to get into this state, but I believe this update will make it less likely for there to be stale data when switching between accounts/networks.

should hopefully resolve https://github.com/blockstack/stacks-wallet-web/issues/1336

cc/ @aulneau @kyranjamie @fbwoolf
