### PR TITLE
Fix/stale balances switch account

### DIFF
--- a/.changeset/early-ties-attack.md
+++ b/.changeset/early-ties-attack.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This fixes a bug where if a user switched accounts while on a page like the receive or view secret key, and navigated home, their balances would show stale data related to the previous account they were on.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "history": "5.0.0",
     "http-server": "0.12.3",
     "jotai": "1.1.3",
-    "jotai-query-toolkit": "0.1.2",
+    "jotai-query-toolkit": "0.1.3",
     "jsontokens": "3.0.0",
     "mdi-react": "7.5.0",
     "object-hash": "2.2.0",

--- a/src/components/popup/balances-and-activity.tsx
+++ b/src/components/popup/balances-and-activity.tsx
@@ -11,6 +11,7 @@ import { useAccountActivity } from '@common/hooks/account/use-account-activity';
 import { useHomeTabs } from '@common/hooks/use-home-tabs';
 import { createTxDateFormatList } from '@common/group-txs-by-date';
 import { TransactionList } from './transaction-list';
+import { HomePageSelectors } from '@tests/page-objects/home-page.selectors';
 
 function EmptyActivity() {
   return (
@@ -62,7 +63,14 @@ export function BalancesAndActivity(props: StackProps) {
         <React.Suspense fallback={<Loading />}>
           <SlideFade in={activeTab === 0}>
             {styles => (
-              <TokenAssets position="absolute" top={0} left={0} width="100%" style={styles} />
+              <TokenAssets
+                data-testid={HomePageSelectors.BalancesList}
+                position="absolute"
+                top={0}
+                left={0}
+                width="100%"
+                style={styles}
+              />
             )}
           </SlideFade>
           <SlideFade in={activeTab === 1}>

--- a/src/pages/send-tokens/send-tokens.spec.tsx
+++ b/src/pages/send-tokens/send-tokens.spec.tsx
@@ -5,6 +5,7 @@ import { ProviderWitHeySelectedAsset } from '@tests/state-utils';
 import { render } from '@testing-library/react';
 import { SendTokensForm } from '@pages/send-tokens/send-tokens';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
+import { SendFormErrorMessages } from '@pages/send-tokens/hooks/use-send-form-validation';
 
 describe('Send form tests', () => {
   setupHeystackEnv();
@@ -40,7 +41,7 @@ describe('Send form tests', () => {
     userEvent.paste(recipientField, 'ST1P72Z3704VMT3DMHPP2CB8TGQWGDBHD3RD69GE2');
     expect((amountField as HTMLInputElement).value).toEqual('0.123');
     userEvent.click(previewBtn);
-    await findByText('This token does not support decimal places.');
+    await findByText(SendFormErrorMessages.DoesNotSupportDecimals);
   });
 
   it('shows an error message when user tries to send more than their balance', async () => {
@@ -59,6 +60,82 @@ describe('Send form tests', () => {
     userEvent.paste(amountField, '999999999');
     userEvent.paste(recipientField, 'ST1P72Z3704VMT3DMHPP2CB8TGQWGDBHD3RD69GE2');
     userEvent.click(previewBtn);
-    await findByText('Cannot transfer more than balance');
+    await findByText(SendFormErrorMessages.InsufficientBalance, { exact: false });
+  });
+
+  it('shows an error message when user enters invalid address', async () => {
+    const { getByTestId, findByText } = render(
+      <React.Suspense fallback={<>loading</>}>
+        <ProviderWitHeySelectedAsset>
+          <SendTokensForm />
+        </ProviderWitHeySelectedAsset>
+      </React.Suspense>
+    );
+    await findByText('Preview');
+    const amountField: HTMLElement = getByTestId(SendFormSelectors.InputAmountField);
+    const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
+    const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
+
+    userEvent.paste(amountField, '1');
+    userEvent.paste(recipientField, 'asdasda');
+    userEvent.click(previewBtn);
+    await findByText(SendFormErrorMessages.InvalidAddress);
+  });
+
+  it('shows an error message when user enters address of different mode', async () => {
+    const { getByTestId, findByText } = render(
+      <React.Suspense fallback={<>loading</>}>
+        <ProviderWitHeySelectedAsset>
+          <SendTokensForm />
+        </ProviderWitHeySelectedAsset>
+      </React.Suspense>
+    );
+    await findByText('Preview');
+    const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
+    const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
+    const amountField: HTMLElement = getByTestId(SendFormSelectors.InputAmountField);
+
+    userEvent.paste(amountField, '1');
+    userEvent.paste(recipientField, 'SP1WFVXMKC8FYZ556BF3ZA7NSRNPS2GAR1TR83E6B');
+    userEvent.click(previewBtn);
+    await findByText(SendFormErrorMessages.IncorrectAddressMode);
+  });
+
+  it('shows an error message when user enters their address', async () => {
+    const { getByTestId, findByText } = render(
+      <React.Suspense fallback={<>loading</>}>
+        <ProviderWitHeySelectedAsset>
+          <SendTokensForm />
+        </ProviderWitHeySelectedAsset>
+      </React.Suspense>
+    );
+    await findByText('Preview');
+    const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
+    const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
+    const amountField: HTMLElement = getByTestId(SendFormSelectors.InputAmountField);
+
+    userEvent.paste(amountField, '1');
+    userEvent.paste(recipientField, 'ST2PHCPANVT8DVPSY5W2ZZ81M285Q5Z8Y6DQMZE7Z');
+    userEvent.click(previewBtn);
+    await findByText(SendFormErrorMessages.SameAddress);
+  });
+
+  it('shows an error message when user enters 0 amount', async () => {
+    const { getByTestId, findByText } = render(
+      <React.Suspense fallback={<>loading</>}>
+        <ProviderWitHeySelectedAsset>
+          <SendTokensForm />
+        </ProviderWitHeySelectedAsset>
+      </React.Suspense>
+    );
+    await findByText('Preview');
+    const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
+    const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
+    const amountField: HTMLElement = getByTestId(SendFormSelectors.InputAmountField);
+
+    userEvent.paste(amountField, '0');
+    userEvent.paste(recipientField, 'ST1P72Z3704VMT3DMHPP2CB8TGQWGDBHD3RD69GE2');
+    userEvent.click(previewBtn);
+    await findByText(SendFormErrorMessages.MustNotBeZero);
   });
 });

--- a/src/store/accounts/nonce.ts
+++ b/src/store/accounts/nonce.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
-import { atomFamily, atomWithStorage, waitForAll } from 'jotai/utils';
+import { atomFamily, atomWithStorage } from 'jotai/utils';
 
 import { accountDataState, currentAccountStxAddressState, accountInfoState } from '@store/accounts';
 import { currentNetworkState } from '@store/networks';
@@ -11,12 +11,8 @@ export const localNoncesState = atomFamily<[string, string], number, number>(
 );
 
 export const latestNonceState = atom(get => {
-  const { network, address } = get(
-    waitForAll({
-      network: currentNetworkState,
-      address: currentAccountStxAddressState,
-    })
-  );
+  const network = get(currentNetworkState);
+  const address = get(currentAccountStxAddressState);
   return get(localNoncesState([network.url, address || '']));
 });
 

--- a/src/store/assets/tokens.ts
+++ b/src/store/assets/tokens.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai';
 import deepEqual from 'fast-deep-equal';
 import { atomFamily, waitForAll } from 'jotai/utils';
-import { accountBalancesState } from '@store/accounts';
+import { accountBalancesState, accountDataState } from '@store/accounts';
 import { transformAssets } from '@store/assets/utils';
 import { Asset, AssetWithMeta, ContractPrincipal } from '@common/asset-types';
 import { assetMetaDataState } from '@store/assets/fungible-tokens';
@@ -54,15 +54,9 @@ const assetItemState = atomFamily<Asset, AssetWithMeta>(asset => {
   return anAtom;
 }, deepEqual);
 
-export const baseAssetsState = atom(get => {
-  const balance = get(accountBalancesState);
-  return balance ? transformAssets(balance) : undefined;
-});
-
-export const assetsState = atom(get => {
-  const assets = get(baseAssetsState) || [];
-  return get(waitForAll(assets.map(assetItemState)));
-});
+export const assetsState = atom(get =>
+  get(waitForAll(transformAssets(get(accountDataState)?.balances).map(assetItemState)))
+);
 
 export const transferableAssetsState = atom(get =>
   get(assetsState)?.filter(asset => asset.canTransfer)
@@ -88,7 +82,6 @@ export const stxTokenState = atom(get => {
   } as AssetWithMeta;
 });
 
-baseAssetsState.debugLabel = 'baseAssetsState';
 assetsState.debugLabel = 'assetsState';
 transferableAssetsState.debugLabel = 'transferableAssetsState';
 fungibleTokensState.debugLabel = 'fungibleTokensState';

--- a/src/store/assets/utils.ts
+++ b/src/store/assets/utils.ts
@@ -134,7 +134,7 @@ export async function getSip10Status(params: {
 export const getMatchingFunction = (name: MetaDataNames) => (func: ContractInterfaceFunction) =>
   (func.name === `get-${name}` || func.name === name) && func.access === 'read_only';
 
-export function transformAssets(balances: AddressBalanceResponse) {
+export function transformAssets(balances?: AddressBalanceResponse) {
   const _assets: Asset[] = [];
   if (!balances) return _assets;
   _assets.push({

--- a/src/store/networks.ts
+++ b/src/store/networks.ts
@@ -1,4 +1,4 @@
-import { atomWithStorage, waitForAll } from 'jotai/utils';
+import { atomWithStorage } from 'jotai/utils';
 import { atom } from 'jotai';
 import { ChainID } from '@stacks/transactions';
 import { StacksMainnet, StacksNetwork, StacksTestnet } from '@stacks/network';
@@ -18,12 +18,9 @@ export const networksState = atomWithStorage<Networks>('networks', defaultNetwor
 const localCurrentNetworkKeyState = atomWithStorage('networkKey', 'mainnet');
 export const currentNetworkKeyState = atom<string, string>(
   get => {
-    const { networks, txNetwork } = get(
-      waitForAll({
-        networks: networksState,
-        txNetwork: transactionRequestNetwork,
-      })
-    );
+    const networks = get(networksState);
+    const txNetwork = get(transactionRequestNetwork);
+
     // if txNetwork, default to this always, users cannot currently change networks when signing a transaction
     // @see https://github.com/blockstack/stacks-wallet-web/issues/1281
     if (txNetwork) {
@@ -39,15 +36,7 @@ export const currentNetworkKeyState = atom<string, string>(
 );
 
 // the `Network` object for the current key selected
-export const currentNetworkState = atom(get => {
-  const { networks, key } = get(
-    waitForAll({
-      networks: networksState,
-      key: currentNetworkKeyState,
-    })
-  );
-  return networks[key];
-});
+export const currentNetworkState = atom(get => get(networksState)[get(currentNetworkKeyState)]);
 
 // a `StacksNetwork` instance using the current network
 export const currentStacksNetworkState = atom<StacksNetwork>(get => {

--- a/src/store/transactions/contract-call.ts
+++ b/src/store/transactions/contract-call.ts
@@ -1,10 +1,10 @@
 import { atom } from 'jotai';
-import { waitForAll } from 'jotai/utils';
 import { requestTokenPayloadState } from '@store/transactions/requests';
 import { TransactionTypes } from '@stacks/connect';
 import { ContractInterfaceResponse } from '@stacks/blockchain-api-client';
 import { ContractInterfaceFunction } from '@stacks/rpc-client';
 import { contractInterfaceState, contractSourceState } from '@store/contracts';
+import { waitForAll } from 'jotai/utils';
 
 type ContractInterfaceResponseWithFunctions = Omit<ContractInterfaceResponse, 'functions'> & {
   functions: ContractInterfaceFunction[];

--- a/src/store/transactions/fungible-token-transfer.ts
+++ b/src/store/transactions/fungible-token-transfer.ts
@@ -7,19 +7,14 @@ import {
 } from '@store/accounts';
 import { currentStacksNetworkState } from '@store/networks';
 import { correctNonceState } from '@store/accounts/nonce';
-import { waitForAll } from 'jotai/utils';
 
 export const makeFungibleTokenTransferState = atom(get => {
-  const { asset, currentAccount, network, balances, stxAddress, nonce } = get(
-    waitForAll({
-      asset: selectedAssetStore,
-      currentAccount: currentAccountState,
-      network: currentStacksNetworkState,
-      balances: accountBalancesState,
-      stxAddress: currentAccountStxAddressState,
-      nonce: correctNonceState,
-    })
-  );
+  const asset = get(selectedAssetStore);
+  const currentAccount = get(currentAccountState);
+  const network = get(currentStacksNetworkState);
+  const balances = get(accountBalancesState);
+  const stxAddress = get(currentAccountStxAddressState);
+  const nonce = get(correctNonceState);
 
   if (asset && currentAccount && stxAddress) {
     const { contractName, contractAddress, name: assetName } = asset;

--- a/src/store/transactions/index.ts
+++ b/src/store/transactions/index.ts
@@ -1,5 +1,4 @@
 import { atom } from 'jotai';
-import { waitForAll } from 'jotai/utils';
 
 import { AuthType, ChainID, TransactionVersion } from '@stacks/transactions';
 
@@ -14,13 +13,10 @@ import { stacksTransactionToHex } from '@common/transactions/transaction-utils';
 import { postConditionsState } from '@store/transactions/post-conditions';
 
 export const pendingTransactionState = atom(get => {
-  const { payload, postConditions, network } = get(
-    waitForAll({
-      payload: requestTokenPayloadState,
-      postConditions: postConditionsState,
-      network: currentStacksNetworkState,
-    })
-  );
+  const payload = get(requestTokenPayloadState);
+  const postConditions = get(postConditionsState);
+  const network = get(currentStacksNetworkState);
+
   if (!payload) return;
   return { ...payload, postConditions, network };
 });
@@ -28,13 +24,9 @@ export const pendingTransactionState = atom(get => {
 export const transactionAttachmentState = atom(get => get(pendingTransactionState)?.attachment);
 
 export const signedStacksTransactionState = atom(get => {
-  const { account, txData, nonce } = get(
-    waitForAll({
-      account: currentAccountState,
-      txData: pendingTransactionState,
-      nonce: correctNonceState,
-    })
-  );
+  const account = get(currentAccountState);
+  const txData = get(pendingTransactionState);
+  const nonce = get(correctNonceState);
   if (!account || !txData) return;
   return generateSignedTransaction({
     senderKey: account.stxPrivateKey,

--- a/src/store/transactions/post-conditions.ts
+++ b/src/store/transactions/post-conditions.ts
@@ -1,16 +1,11 @@
 import { atom } from 'jotai';
-import { waitForAll } from 'jotai/utils';
 import { requestTokenPayloadState } from '@store/transactions/requests';
 import { currentAccountStxAddressState } from '@store/accounts';
 import { getPostCondition, handlePostConditions } from '@common/transactions/postcondition-utils';
 
 export const postConditionsState = atom(get => {
-  const { payload, address } = get(
-    waitForAll({
-      payload: requestTokenPayloadState,
-      address: currentAccountStxAddressState,
-    })
-  );
+  const payload = get(requestTokenPayloadState);
+  const address = get(currentAccountStxAddressState);
 
   if (!payload || !address) return;
 

--- a/src/store/transactions/requests.ts
+++ b/src/store/transactions/requests.ts
@@ -1,5 +1,4 @@
 import { atom } from 'jotai';
-import { waitForAll } from 'jotai/utils';
 import { getPayloadFromToken } from '@store/transactions/utils';
 import { walletState } from '@store/wallet';
 import { verifyTxRequest } from '@common/transactions/requests';
@@ -25,13 +24,9 @@ export const requestTokenOriginState = atom(get => {
 });
 
 export const transactionRequestValidationState = atom(async get => {
-  const { requestToken, wallet, origin } = get(
-    waitForAll({
-      requestToken: requestTokenState,
-      wallet: walletState,
-      origin: requestTokenOriginState,
-    })
-  );
+  const requestToken = get(requestTokenState);
+  const wallet = get(walletState);
+  const origin = get(requestTokenOriginState);
   if (!origin || !wallet || !requestToken) return;
   try {
     const valid = await verifyTxRequest({

--- a/tests/integration/send-tokens/send-tokens.spec.ts
+++ b/tests/integration/send-tokens/send-tokens.spec.ts
@@ -16,6 +16,7 @@ describe(`Send tokens flow`, () => {
     browser = await setupBrowser();
     walletPage = await WalletPage.init(browser, ScreenPaths.INSTALLED);
     await walletPage.signUp();
+    await walletPage.waitForHomePage();
     await walletPage.goToSendForm();
     sendForm = new SendPage(walletPage.page);
   }, 30_000);

--- a/tests/page-objects/home-page.selectors.ts
+++ b/tests/page-objects/home-page.selectors.ts
@@ -1,0 +1,3 @@
+export enum HomePageSelectors {
+  BalancesList = 'home-page-balances-list',
+}

--- a/tests/page-objects/wallet.page.ts
+++ b/tests/page-objects/wallet.page.ts
@@ -4,6 +4,7 @@ import { createTestSelector, wait, BrowserDriver } from '../integration/utils';
 import { USERNAMES_ENABLED } from '@common/constants';
 import { WalletPageSelectors } from './wallet.selectors';
 import { InitialPageSelectors } from '@tests/integration/initial-page.selectors';
+import { HomePageSelectors } from '@tests/page-objects/home-page.selectors';
 
 export class WalletPage {
   static url = 'http://localhost:8081/index.html#';
@@ -27,6 +28,7 @@ export class WalletPage {
   password = 'mysecretreallylongpassword';
   $settingsButton = createTestSelector('menu-button');
   $settingsViewSecretKey = createTestSelector('settings-view-secret-key');
+  $homePageBalancesList = createTestSelector(HomePageSelectors.BalancesList);
   page: Page;
 
   constructor(page: Page) {
@@ -57,7 +59,7 @@ export class WalletPage {
   }
 
   async waitForHomePage() {
-    await this.page.waitForSelector(this.homePage, { timeout: 30000 });
+    await this.page.waitForSelector(this.$homePageBalancesList, { timeout: 30000 });
   }
 
   async waitForLoginPage() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10374,12 +10374,13 @@ joi@^17.3.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
-jotai-query-toolkit@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/jotai-query-toolkit/-/jotai-query-toolkit-0.1.2.tgz#13cab17d6423608ee46895b7b459cc3457b5b24b"
-  integrity sha512-Z799GoAdzQxtwpjiLY0IfbBE8qb9HLg7q/uS+6u9pWD99bhYqzmrdjdEuJVmMtj+YliM+gbHTm6Nhm8QbRLw3g==
+jotai-query-toolkit@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/jotai-query-toolkit/-/jotai-query-toolkit-0.1.3.tgz#3fc3b0146a04c52fc06a967e89c9ed3ecc0c6513"
+  integrity sha512-hKRUDK9czd55zPNTlHd4LpBG0jZrUO/OoVShD3ErTefMPOk9Q4GqFE4sZwITRBcbE1Vv/hhiUKxJpWnnVwX1nA==
   dependencies:
     fast-deep-equal "3.1.3"
+    proxy-memoize "^0.3.5"
 
 jotai@1.1.3:
   version "1.1.3"
@@ -12531,10 +12532,22 @@ proxy-addr@~2.0.5:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-compare@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.0.1.tgz#3ae19cf47f64e89bd60fe4f57afd124f733ef64f"
+  integrity sha512-uXj3TtWdR1S2SNwJKbgJB+1FJm9HM3sFzlVc8W6PZvU6ogt9mlkb1WwZQpuKFLkDS6LKY4+FBE18K6ZArphnHA==
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxy-memoize@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/proxy-memoize/-/proxy-memoize-0.3.5.tgz#d139c196ea88d20f0cb0d2073a66f87af4f1cbe6"
+  integrity sha512-eJFgHxMkFir/J25rCNZE48kDLsjGOQ1O6bRqDUStw/Wcwi+l5nm+siATZkhnFbV4foSWOXa0Dcb4Fq1ZhrqWwQ==
+  dependencies:
+    proxy-compare "2.0.1"
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1031229930).<!-- Sticky Header Marker -->

- https://github.com/blockstack/stacks-wallet-web/commit/285ea1f1e6f1c81251b09ed13b7303f6f7964a3e resolves https://github.com/blockstack/stacks-wallet-web/issues/1436
- https://github.com/blockstack/stacks-wallet-web/pull/1437/commits/dd346710b4de155e1a85d3b9650eff32b0227105 fixes an issue where the send-tokens test didn't wait for the balances to load before navigating to the send page
- https://github.com/blockstack/stacks-wallet-web/pull/1437/commits/6440eb685f062717bb51f57eb55208db5eb746ab removed extra un-needed use of the async helper util `waitForAll`
