### PR TITLE
chore: use enums, test more error paths

### DIFF
--- a/src/pages/send-tokens/send-tokens.spec.tsx
+++ b/src/pages/send-tokens/send-tokens.spec.tsx
@@ -5,6 +5,7 @@ import { ProviderWitHeySelectedAsset } from '@tests/state-utils';
 import { render } from '@testing-library/react';
 import { SendTokensForm } from '@pages/send-tokens/send-tokens';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
+import { SendFormErrorMessages } from '@pages/send-tokens/hooks/use-send-form-validation';
 
 describe('Send form tests', () => {
   setupHeystackEnv();
@@ -40,7 +41,7 @@ describe('Send form tests', () => {
     userEvent.paste(recipientField, 'ST1P72Z3704VMT3DMHPP2CB8TGQWGDBHD3RD69GE2');
     expect((amountField as HTMLInputElement).value).toEqual('0.123');
     userEvent.click(previewBtn);
-    await findByText('This token does not support decimal places.');
+    await findByText(SendFormErrorMessages.DoesNotSupportDecimals);
   });
 
   it('shows an error message when user tries to send more than their balance', async () => {
@@ -59,6 +60,82 @@ describe('Send form tests', () => {
     userEvent.paste(amountField, '999999999');
     userEvent.paste(recipientField, 'ST1P72Z3704VMT3DMHPP2CB8TGQWGDBHD3RD69GE2');
     userEvent.click(previewBtn);
-    await findByText('Cannot transfer more than balance');
+    await findByText(SendFormErrorMessages.InsufficientBalance, { exact: false });
+  });
+
+  it('shows an error message when user enters invalid address', async () => {
+    const { getByTestId, findByText } = render(
+      <React.Suspense fallback={<>loading</>}>
+        <ProviderWitHeySelectedAsset>
+          <SendTokensForm />
+        </ProviderWitHeySelectedAsset>
+      </React.Suspense>
+    );
+    await findByText('Preview');
+    const amountField: HTMLElement = getByTestId(SendFormSelectors.InputAmountField);
+    const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
+    const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
+
+    userEvent.paste(amountField, '1');
+    userEvent.paste(recipientField, 'asdasda');
+    userEvent.click(previewBtn);
+    await findByText(SendFormErrorMessages.InvalidAddress);
+  });
+
+  it('shows an error message when user enters address of different mode', async () => {
+    const { getByTestId, findByText } = render(
+      <React.Suspense fallback={<>loading</>}>
+        <ProviderWitHeySelectedAsset>
+          <SendTokensForm />
+        </ProviderWitHeySelectedAsset>
+      </React.Suspense>
+    );
+    await findByText('Preview');
+    const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
+    const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
+    const amountField: HTMLElement = getByTestId(SendFormSelectors.InputAmountField);
+
+    userEvent.paste(amountField, '1');
+    userEvent.paste(recipientField, 'SP1WFVXMKC8FYZ556BF3ZA7NSRNPS2GAR1TR83E6B');
+    userEvent.click(previewBtn);
+    await findByText(SendFormErrorMessages.IncorrectAddressMode);
+  });
+
+  it('shows an error message when user enters their address', async () => {
+    const { getByTestId, findByText } = render(
+      <React.Suspense fallback={<>loading</>}>
+        <ProviderWitHeySelectedAsset>
+          <SendTokensForm />
+        </ProviderWitHeySelectedAsset>
+      </React.Suspense>
+    );
+    await findByText('Preview');
+    const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
+    const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
+    const amountField: HTMLElement = getByTestId(SendFormSelectors.InputAmountField);
+
+    userEvent.paste(amountField, '1');
+    userEvent.paste(recipientField, 'ST2PHCPANVT8DVPSY5W2ZZ81M285Q5Z8Y6DQMZE7Z');
+    userEvent.click(previewBtn);
+    await findByText(SendFormErrorMessages.SameAddress);
+  });
+
+  it('shows an error message when user enters 0 amount', async () => {
+    const { getByTestId, findByText } = render(
+      <React.Suspense fallback={<>loading</>}>
+        <ProviderWitHeySelectedAsset>
+          <SendTokensForm />
+        </ProviderWitHeySelectedAsset>
+      </React.Suspense>
+    );
+    await findByText('Preview');
+    const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
+    const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
+    const amountField: HTMLElement = getByTestId(SendFormSelectors.InputAmountField);
+
+    userEvent.paste(amountField, '0');
+    userEvent.paste(recipientField, 'ST1P72Z3704VMT3DMHPP2CB8TGQWGDBHD3RD69GE2');
+    userEvent.click(previewBtn);
+    await findByText(SendFormErrorMessages.MustNotBeZero);
   });
 });


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1031030188).<!-- Sticky Header Marker -->

This PR extends the unit tests for the send form. It also implements the error messages as enums so we can better check them if they change in the future.

cc/ @aulneau @kyranjamie @fbwoolf
