### PR TITLE
Fix/bundle size reduction

### DIFF
--- a/.changeset/nice-hairs-accept.md
+++ b/.changeset/nice-hairs-accept.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This change removes our dependency on @tabler/icons and uses `react-icons/fi` for all our icon needs, which matches our figma designs. Additionally, this reduces our minified package from over 4mb to under 3.5mb

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@stacks/ui-utils": "7.5.0",
     "@stacks/wallet-sdk": "1.0.0-wallet-sdk.4",
     "@styled-system/theme-get": "5.1.2",
-    "@tabler/icons": "1.41.2",
     "@tippyjs/react": "4.2.5",
     "@vkontakte/vk-qr": "2.0.12",
     "are-passive-events-supported": "1.1.1",

--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useCallback, memo } from 'react';
 import { Flex, useEventListener, IconButton, color, transition } from '@stacks/ui';
-import { IconX } from '@tabler/icons';
+import { FiX as IconX } from 'react-icons/fi';
 import useOnClickOutside from '@common/hooks/use-onclickoutside';
 import { Title } from '@components/typography';
 

--- a/src/components/error-label.tsx
+++ b/src/components/error-label.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, color, StackProps, Stack } from '@stacks/ui';
-import { IconAlertTriangle } from '@tabler/icons';
+import { FiAlertTriangle as IconAlertTriangle } from 'react-icons/fi';
 
 export const ErrorLabel: React.FC<StackProps> = ({ children, ...rest }) => (
   <Stack spacing="tight" color={color('feedback-error')} isInline alignItems="flex-start" {...rest}>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import { Box, BoxProps, color, Flex, FlexProps, IconButton, Stack } from '@stacks/ui';
-import { IconArrowLeft, IconDots } from '@tabler/icons';
+import { FiMoreHorizontal as IconDots, FiArrowLeft as IconArrowLeft } from 'react-icons/fi';
 
 import { StacksWalletLogo } from '@components/stacks-wallet-logo';
 import { useDoChangeScreen } from '@common/hooks/use-do-change-screen';

--- a/src/components/network-mode-badge.tsx
+++ b/src/components/network-mode-badge.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useMemo } from 'react';
-import { Box, color, Flex, FlexProps, Text } from '@stacks/ui';
+import { color, Flex, FlexProps, Text } from '@stacks/ui';
 import { ChainID } from '@stacks/transactions';
-import { IconFlask } from '@tabler/icons';
 import { useDrawers } from '@common/hooks/use-drawers';
 import { useCurrentNetwork } from '@common/hooks/use-current-network';
 
@@ -27,7 +26,6 @@ export const NetworkModeBadge: React.FC<FlexProps> = memo(props => {
       onClick={() => setShowNetworks(true)}
       {...props}
     >
-      <Box as={IconFlask} mr="extra-tight" color={color('brand')} size="16px" />
       <Text fontSize="11px" fontWeight="500">
         Testnet mode
       </Text>

--- a/src/components/qr-code-icon.tsx
+++ b/src/components/qr-code-icon.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import type { BoxProps } from '@stacks/ui';
+import { Box } from '@stacks/ui';
+
+export function QrCodeIcon({ strokeWidth = 1.5, ...props }: BoxProps) {
+  return (
+    <Box viewBox="0 0 14 14" fill="none" strokeWidth={strokeWidth} {...props} as="svg">
+      <path
+        d="M5.66667 1L1 1L1 5.66667H5.66667V1Z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth as any}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 1L8.33337 1V5.66667H13V1Z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth as any}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.33337 8.33301H8.33337V9.33301H9.33337V8.33301Z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth as any}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.33337 12H8.33337V13H9.33337V12Z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth as any}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 8.33301H12V9.33301H13V8.33301Z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth as any}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 12H12V13H13V12Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5.66667 8.33301H1L1 12.9997H5.66667V8.33301Z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth as any}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Box>
+  );
+}

--- a/src/components/tx-icon.tsx
+++ b/src/components/tx-icon.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {
-  IconArrowDown,
-  IconArrowUp,
-  IconCode,
-  IconLayoutList,
-  IconMoodSad,
-  IconPlus,
-} from '@tabler/icons';
+  FiArrowDown as IconArrowDown,
+  FiArrowUp as IconArrowUp,
+  FiCode as IconCode,
+  FiList as IconLayoutList,
+  FiAlertOctagon as IconMoodSad,
+  FiPlus as IconPlus,
+} from 'react-icons/fi';
 import { Box, BoxProps, Circle, color, DynamicColorCircle, StxNexus } from '@stacks/ui';
 import FunctionIcon from 'mdi-react/FunctionIcon';
 import type { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';

--- a/src/features/account-switch-drawer/switch-accounts.tsx
+++ b/src/features/account-switch-drawer/switch-accounts.tsx
@@ -6,7 +6,7 @@ import { accountDrawerStep, AccountStep } from '@store/ui';
 import { getAccountDisplayName } from '@stacks/wallet-sdk';
 import { truncateMiddle } from '@stacks/ui-utils';
 import { SpaceBetween } from '@components/space-between';
-import { IconCheck } from '@tabler/icons';
+import { FiCheck as IconCheck } from 'react-icons/fi';
 import { AccountAvatar } from '@features/account-avatar/account-avatar';
 import { useAccountDisplayName } from '@common/hooks/account/use-account-names';
 import { useSwitchAccount } from '@common/hooks/account/use-switch-account';

--- a/src/features/network-drawer/networks-drawer.tsx
+++ b/src/features/network-drawer/networks-drawer.tsx
@@ -12,7 +12,7 @@ import { useDrawers } from '@common/hooks/use-drawers';
 import { Caption, Title } from '@components/typography';
 import { getUrlHostname } from '@common/utils';
 import { useAtomValue, useUpdateAtom } from 'jotai/utils';
-import { IconCloudOff } from '@tabler/icons';
+import { FiCloudOff as IconCloudOff } from 'react-icons/fi';
 import { SettingsSelectors } from '@tests/integration/settings.selectors';
 
 const NetworkListItem: React.FC<{ item: string } & BoxProps> = memo(({ item, ...props }) => {

--- a/src/pages/home/components/actions.tsx
+++ b/src/pages/home/components/actions.tsx
@@ -2,9 +2,10 @@ import { Box, Button, ButtonProps, Stack, StackProps } from '@stacks/ui';
 import { ScreenPaths } from '@common/types';
 import React, { memo, useCallback, useRef } from 'react';
 import { useDoChangeScreen } from '@common/hooks/use-do-change-screen';
-import { IconArrowUp, IconQrcode } from '@tabler/icons';
+import { FiArrowUp } from 'react-icons/fi';
 import { useTransferableAssets } from '@common/hooks/use-assets';
 import { WalletPageSelectors } from '@tests/page-objects/wallet.selectors';
+import { QrCodeIcon } from '@components/qr-code-icon';
 
 interface TxButtonProps extends ButtonProps {
   kind: 'send' | 'receive';
@@ -38,9 +39,10 @@ const TxButton: React.FC<TxButtonProps> = memo(({ kind, path, ...rest }) => {
         {...rest}
       >
         <Box
-          as={isSend ? IconArrowUp : IconQrcode}
+          as={isSend ? FiArrowUp : QrCodeIcon}
           transform={isSend ? 'unset' : 'scaleY(-1)'}
-          size="16px"
+          size={isSend ? '16px' : '14px'}
+          mr={isSend ? 0 : '2px'}
         />
         <Box as="span" ml="extra-tight" fontSize="14px">
           {label}

--- a/src/pages/transaction-signing/components/event-card.tsx
+++ b/src/pages/transaction-signing/components/event-card.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, color, IconButton, Stack, Text } from '@stacks/ui';
 import { SpaceBetween } from '@components/space-between';
-import { IconDots } from '@tabler/icons';
+import { FiMoreHorizontal as IconDots } from 'react-icons/fi';
 import { Caption } from '@components/typography';
 import { AssetItem } from '@pages/transaction-signing/components/asset-item';
 

--- a/src/pages/transaction-signing/components/post-conditions/list.tsx
+++ b/src/pages/transaction-signing/components/post-conditions/list.tsx
@@ -3,7 +3,7 @@ import { Box, Circle, color, Flex, Stack } from '@stacks/ui';
 
 import { TransactionTypes } from '@stacks/connect';
 import { stacksValue } from '@common/stacks-utils';
-import { IconLock } from '@tabler/icons';
+import { FiLock as IconLock } from 'react-icons/fi';
 import { Body } from '@components/typography';
 import { truncateMiddle } from '@stacks/ui-utils';
 


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1031518793).<!-- Sticky Header Marker -->

before
```
Entrypoints:
  background (941 KiB)
      background.js
  index (4.02 MiB)
      index.js
```
after
```
Entrypoints:
  background (941 KiB)
      background.js
  index (3.23 MiB)
      index.js
```

cc/ @aulneau @kyranjamie @fbwoolf
