### PR TITLE
chore: Add unit test for date parsing

### DIFF
--- a/src/common/date-utils.spec.ts
+++ b/src/common/date-utils.spec.ts
@@ -1,0 +1,19 @@
+import { isoDateToLocalDate } from '@common/date-utils';
+
+test('ISO date to local date (based on timezone)', () => {
+  const today = new Date().toISOString();
+  const datesToTestOk = [
+    '2021-07-07T04:02:50.000Z',
+    '2021-07-13T04:02:50.000Z',
+    '2021-12-31T04:02:50.000Z',
+    today,
+  ];
+  datesToTestOk.forEach(date => {
+    let [year, month, day] = isoDateToLocalDate(date).split('-');
+    expect(year.length).toEqual(4);
+    expect(+month).toBeGreaterThanOrEqual(1);
+    expect(+month).toBeLessThanOrEqual(12);
+    expect(+day).toBeGreaterThanOrEqual(1);
+    expect(+day).toBeLessThanOrEqual(31);
+  });
+});

--- a/src/common/date-utils.ts
+++ b/src/common/date-utils.ts
@@ -1,0 +1,32 @@
+import dayjs from 'dayjs';
+import isToday from 'dayjs/plugin/isToday';
+import isYesterday from 'dayjs/plugin/isYesterday';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(isToday);
+dayjs.extend(isYesterday);
+dayjs.extend(advancedFormat);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export function todaysIsoDate() {
+  return new Date().toISOString().split('T')[0];
+}
+
+// Convert ISO date to locale date taking into account user timezone
+export function isoDateToLocalDate(isoDate: string): string {
+  return dayjs.tz(isoDate).format('YYYY-MM-DD');
+}
+
+// txDate is of the form YYYY-MM-DD
+export function displayDate(txDate: string): string {
+  const date = dayjs(txDate);
+  if (date.isToday()) return 'Today';
+  if (date.isYesterday()) return 'Yesterday';
+  if (dayjs().isSame(date, 'year')) {
+    return date.format('MMM Do');
+  }
+  return date.format('MMM Do, YYYY');
+}

--- a/src/common/group-txs-by-date.ts
+++ b/src/common/group-txs-by-date.ts
@@ -1,27 +1,12 @@
 import type { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
-import dayjs from 'dayjs';
-import isToday from 'dayjs/plugin/isToday';
-import isYesterday from 'dayjs/plugin/isYesterday';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-
-dayjs.extend(isToday);
-dayjs.extend(isYesterday);
-dayjs.extend(advancedFormat);
-dayjs.extend(utc);
-dayjs.extend(timezone);
+import { todaysIsoDate, isoDateToLocalDate, displayDate } from '@common/date-utils';
 
 type Tx = MempoolTransaction | Transaction;
-
-function todaysIsoDate() {
-  return new Date().toISOString().split('T')[0];
-}
 
 function groupTxsByDateMap(txs: Tx[]) {
   return txs.reduce((txsByDate, tx) => {
     if ('burn_block_time_iso' in tx && tx.burn_block_time_iso) {
-      const date = dayjs.tz(tx.burn_block_time_iso).format('YYYY-MM-DD');
+      const date = isoDateToLocalDate(tx.burn_block_time_iso);
       if (!txsByDate.has(date)) {
         txsByDate.set(date, []);
       }
@@ -33,16 +18,6 @@ function groupTxsByDateMap(txs: Tx[]) {
     }
     return txsByDate;
   }, new Map<string, Tx[]>());
-}
-
-function displayDate(txDate: string) {
-  const date = dayjs(txDate);
-  if (date.isToday()) return 'Today';
-  if (date.isYesterday()) return 'Yesterday';
-  if (dayjs().isSame(date, 'year')) {
-    return date.format('MMM Do');
-  }
-  return date.format('MMM Do, YYYY');
 }
 
 function formatTxDateMapAsList(txMap: Map<string, Tx[]>) {


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1034355018).<!-- Sticky Header Marker -->

Test timezone parsing
refactored all dates functions into date-utils
related to #1426 
