### PR TITLE
fix: React key props error in network drawer

### DIFF
--- a/src/features/network-drawer/networks-drawer.tsx
+++ b/src/features/network-drawer/networks-drawer.tsx
@@ -68,8 +68,8 @@ const NetworkList: React.FC<FlexProps> = memo(props => {
   return (
     <Flex flexWrap="wrap" flexDirection="column" {...props}>
       {items.map(item => (
-        <React.Suspense fallback={<>Loading</>}>
-          <NetworkListItem data-testid={SettingsSelectors.NetworkListItem} item={item} key={item} />
+        <React.Suspense fallback={<>Loading</>} key={item}>
+          <NetworkListItem data-testid={SettingsSelectors.NetworkListItem} item={item} />
         </React.Suspense>
       ))}
     </Flex>


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1036718769).<!-- Sticky Header Marker -->

This fixes a react key prop error

<img width="830" alt="react-console-error" src="https://user-images.githubusercontent.com/1501454/125912218-84786bf0-dd42-4337-8d48-daef01a6444d.png">

