### PR TITLE
refactor: change to hiro wallet branding

### DIFF
--- a/.changeset/shiny-actors-approve.md
+++ b/.changeset/shiny-actors-approve.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This updates the wallet name in all places to Hiro Wallet.

--- a/.github/workflows/beta-extensions.yml
+++ b/.github/workflows/beta-extensions.yml
@@ -1,5 +1,5 @@
 name: Build beta extensions
-on: [ pull_request, workflow_dispatch ]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   pre_run:
@@ -25,7 +25,7 @@ jobs:
         # Don't run on forks
         if: github.event.pull_request.head.repo.full_name == github.repository
         with:
-          header: '> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/${{ github.run_id }}).'
+          header: '> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_chrome_extension:

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -13,7 +13,7 @@ jobs:
         uses: peter-evans/close-issue@v1
         with:
           comment: |
-            First, check to make sure you're using the latest version of Stacks Wallet for Web,
+            First, check to make sure you're using the latest version of Hiro Wallet for Web,
             which can be found at https://www.hiro.so/wallet/install-web
 
             If you're using the latest version, please make sure to include more relevant information about

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stacks Wallet for Web
+# Hiro Wallet for Web
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/stars/ldinpeekobnhjjdofggfgjlcehhmanlj?label=Chrome%20Web%20Store)](https://chrome.google.com/webstore/detail/stacks-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj)
 [![Mozilla Add-on](https://img.shields.io/amo/stars/stacks-wallet?label=Firefox%20Add-on)](https://addons.mozilla.org/en-US/firefox/addon/stacks-wallet/)
@@ -6,7 +6,7 @@
 
 [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/blockstack/stacks-wallet-web)
 
-Stacks Wallet is a browser extension for managing your digital assets and connecting to apps built with the Stacks blockchain.
+Hiro Wallet is a browser extension for managing your digital assets and connecting to apps built with the Stacks blockchain.
 
 Source code is available on GitHub at https://github.com/blockstack/stacks-wallet-web/tree/main
 
@@ -73,7 +73,7 @@ yarn dev:test-app
 
 ### Add extension to your browser
 
-After starting development mode, you'll have to add it to your browser of choice. Stacks Wallet for web currently only
+After starting development mode, you'll have to add it to your browser of choice. Hiro Wallet for web currently only
 supports chromium and firefox browsers. When you run `yarn dev`, it will compile the application to the `/dist` folder
 within the project.
 
@@ -114,6 +114,7 @@ sh build-ext.sh
 Alternatively, run the following if you've downloaded the source code as a zip file from GitHub:
 
 #### Optional: Use docker
+
 ```
 docker build -f Dockerfile -t stacks-wallet-web . \
   && docker run -d --name stacks-wallet-web stacks-wallet-web \
@@ -155,7 +156,6 @@ Please note this email is strictly for reporting security vulnerabilities. For s
 
 ### Audit Report
 
-In Q1 2021, Hiro partnered with [Least Authority](https://leastauthority.com/), a leading security consultancy with experience in the crypto space, to audit Hiro's Stacks Wallet for Web. On April 29th 2021, after addressing the major concerns described in the initial findings, as well as a concluding sign off from the Least Authority team, a final report was delivered.
+In Q1 2021, Hiro partnered with [Least Authority](https://leastauthority.com/), a leading security consultancy with experience in the crypto space, to audit Hiro Wallet for Web. On April 29th 2021, after addressing the major concerns described in the initial findings, as well as a concluding sign off from the Least Authority team, a final report was delivered.
 
-[Download and read the full report here](https://github.com/blockstack/stacks-wallet-web/blob/main/public/docs/least-authority-security-audit-report.pdf
-)
+[Download and read the full report here](https://github.com/blockstack/stacks-wallet-web/blob/main/public/docs/least-authority-security-audit-report.pdf)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/wallet-web",
-  "description": "The Stacks Wallet is browser extension for interacting with Stacks apps.",
+  "description": "The Hiro Wallet is browser extension for interacting with Stacks apps.",
   "private": true,
   "scripts": {
     "dev": "node webpack/dev-server.js",

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -5,7 +5,7 @@ const IS_DEV = process.env.NODE_ENV === 'development';
 const manifest = {
   author: 'Hiro PBC',
   description:
-    'Stacks Wallet. Use the Stacks blockchain to access privacy-friendly apps, and keep data in your control.',
+    'Hiro Wallet. Use the Stacks blockchain to access privacy-friendly apps, and keep data in your control.',
   permissions: ['activeTab'],
   manifest_version: 2,
   background: {
@@ -44,7 +44,7 @@ const manifest = {
 };
 
 const devManifest = {
-  name: 'Stacks Wallet Dev',
+  name: 'Hiro Wallet Dev',
   content_security_policy:
     "script-src 'self' 'unsafe-eval'; object-src 'self'; frame-src 'none'; frame-ancestors 'none';",
   icons: {
@@ -58,7 +58,7 @@ const devManifest = {
 };
 
 const prodManifest = {
-  name: 'Stacks Wallet',
+  name: 'Hiro Wallet',
   content_security_policy:
     "script-src 'self' 'wasm-eval'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
   icons: {

--- a/src/components/stacks-wallet-logo.tsx
+++ b/src/components/stacks-wallet-logo.tsx
@@ -29,7 +29,7 @@ export const StacksWalletLogo: React.FC<StackProps> = memo(props => {
     >
       <HiroSvg size="23px" />
       <Title lineHeight="1rem" fontSize={2} fontWeight={500}>
-        Stacks Wallet
+        Hiro Wallet
       </Title>
     </Stack>
   );

--- a/src/features/errors/utils.ts
+++ b/src/features/errors/utils.ts
@@ -30,11 +30,11 @@ export const openGithubIssue = ({
   PLEASE READ:
   Thanks for creating an issue. Please include as much detail as possible,
   including screenshots, operating system, browser, and steps to recreate.
-  
+
   Please make sure to update the TITLE of this issue.
 -->
 
-An error occurred while using Stacks Wallet for Web (\`${VERSION}\`).
+An error occurred while using Hiro Wallet for Web (\`${VERSION}\`).
 
 ### Error
 > ${message}

--- a/src/inpage/inpage.ts
+++ b/src/inpage/inpage.ts
@@ -110,7 +110,7 @@ const provider: StacksProvider = {
   getProductInfo() {
     return {
       version: VERSION,
-      name: 'Stacks Wallet for Web',
+      name: 'Hiro Wallet for Web',
       meta: {
         tag: BRANCH,
         commit: COMMIT_SHA,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,26 +2,20 @@
   "name": "<% NAME %>",
   "author": "Hiro PBC",
   "version": "<% VERSION %>",
-  "description": "Stacks Wallet. Use the Stacks blockchain to access privacy-friendly apps, and keep data in your control.",
+  "description": "Hiro Wallet. Use the Stacks blockchain to access privacy-friendly apps, and keep data in your control.",
   "icons": {
     "128": "assets/connect-logo/Stacks128w.png",
     "256": "assets/connect-logo/Stacks256w.png",
     "512": "assets/connect-logo/Stacks512w.png"
   },
   "content_security_policy": "script-src 'self'<% DEV_CSR %>; object-src <% DEV_OBJECT_SRC %>; frame-src 'none'; frame-ancestors 'none';",
-  "permissions": [
-    "activeTab"
-  ],
+  "permissions": ["activeTab"],
   "manifest_version": 2,
   "background": {
-    "scripts": [
-      "background.js"
-    ],
+    "scripts": ["background.js"],
     "persistent": true
   },
-  "web_accessible_resources": [
-    "inpage.js"
-  ],
+  "web_accessible_resources": ["inpage.js"],
   "browser_action": {
     "default_title": "Stacks",
     "default_icon": "assets/connect-logo/Stacks128w.png",
@@ -42,12 +36,8 @@
   },
   "content_scripts": [
     {
-      "js": [
-        "content-script.js"
-      ],
-      "matches": [
-        "*://*/*"
-      ]
+      "js": ["content-script.js"],
+      "matches": ["*://*/*"]
     }
   ],
   "browser_specific_settings": {

--- a/src/pages/install/index.tsx
+++ b/src/pages/install/index.tsx
@@ -48,7 +48,7 @@ export const Installed: React.FC = memo(() => (
     <Stack spacing="extra-loose" flexGrow={1} justifyContent="center">
       <Stack width="100%" spacing="loose" textAlign="center" alignItems="center">
         <Title as="h1" fontWeight={500}>
-          Stacks Wallet is installed
+          Hiro Wallet is installed
         </Title>
         <Body maxWidth="28ch">Are you new to Stacks or do you already have a Secret Key?</Body>
       </Stack>

--- a/src/pages/transaction-signing/components/transaction-errors.tsx
+++ b/src/pages/transaction-signing/components/transaction-errors.tsx
@@ -120,7 +120,7 @@ export const UnauthorizedErrorMessage = memo(props => {
         >
           <ErrorMessage
             title="Unauthorized request"
-            body="The transaction request was not properly authorized by any of your accounts. If you've logged in to this app before, then you might need to re-authenticate into this application before attempting to sign a transaction with the Stacks Wallet."
+            body="The transaction request was not properly authorized by any of your accounts. If you've logged in to this app before, then you might need to re-authenticate into this application before attempting to sign a transaction with the Hiro Wallet."
             border={'1px solid'}
             borderColor={color('border')}
             boxShadow="high"

--- a/test-app/src/components/auth.tsx
+++ b/test-app/src/components/auth.tsx
@@ -7,7 +7,7 @@ export const Auth: React.FC = () => {
   return (
     <Box>
       <Text display="block" textStyle="body.large">
-        Sign in with your Stacks Wallet to try out a demo of the Stacks 2.0 blockchain.
+        Sign in with your Hiro Wallet to try out a demo of the Stacks 2.0 blockchain.
       </Text>
       <ButtonGroup spacing={'base'} mt={'base-loose'}>
         <Button size="lg" mode="primary" onClick={() => doOpenAuth()} data-testid="sign-up">

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -42,7 +42,7 @@ const smp = new SpeedMeasurePlugin({
   granularLoaderData: true,
 });
 
-const APP_TITLE = 'Stacks Wallet for Web';
+const APP_TITLE = 'Hiro Wallet for Web';
 
 const HTML_OPTIONS = {
   inject: 'body',


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1045838658).<!-- Sticky Header Marker -->

This PR updates the wallet name to `Hiro Wallet`.

cc/ @aulneau @kyranjamie @beguene