### PR TITLE
fix: Use only one font-feature setting

### DIFF
--- a/.changeset/cyan-bears-arrive.md
+++ b/.changeset/cyan-bears-arrive.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Some text are displayed with font-feature ss01 on, some off. This removes all those font-features to keep the font display consistent across pages.

--- a/src/components/typography.tsx
+++ b/src/components/typography.tsx
@@ -101,7 +101,6 @@ export const titleStyles = (as: Headings) => {
 export const Title = forwardRefWithAs<BoxProps, Headings>((props, ref) => (
   <BaseText
     userSelect="none"
-    fontFeatureSettings={`'ss01' on`}
     letterSpacing="-0.01em"
     fontFamily="'Open Sauce One'"
     color={color('text-title')}
@@ -129,7 +128,6 @@ export const Pretitle = (props: BoxProps) => (
 
 export const Text = forwardRefWithAs<BoxProps, 'span'>((props, ref) => (
   <BaseText
-    fontFeatureSettings={`'ss01' on`}
     letterSpacing="-0.01em"
     color={color('text-body')}
     display="block"
@@ -144,7 +142,6 @@ export const Body: React.FC<BoxProps> = props => <Text css={c1} {...props} />;
 export const Caption = forwardRefWithAs<{ variant?: 'c1' | 'c2' | 'c3' } & BoxProps, 'span'>(
   ({ variant, ...props }, ref) => (
     <BaseText
-      fontFeatureSettings={`'ss01' on`}
       letterSpacing="-0.01em"
       css={captionStyles(variant)}
       color={color('text-caption')}


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1049078447).<!-- Sticky Header Marker -->

Removed all ss01 from font-settings

See #1257 
