### PR TITLE
ci: add git-tag workflow

### DIFF
--- a/.github/workflows/beta-extensions.yml
+++ b/.github/workflows/beta-extensions.yml
@@ -70,7 +70,8 @@ jobs:
       - pre_run
     env:
       MINIFY_PRODUCTION_BUILD: true
-    # only run on commits with message 'Version release'
+    # only run on commits with message 'Version release' because this will often fail on PRs 
+    # due to reasons out of our control in the Firefox submission process
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.head_commit.message == 'Version release'
     steps:
       - name: Checkout

--- a/.github/workflows/beta-extensions.yml
+++ b/.github/workflows/beta-extensions.yml
@@ -72,7 +72,7 @@ jobs:
       MINIFY_PRODUCTION_BUILD: true
     # only run on commits with message 'Version release' because this will often fail on PRs 
     # due to reasons out of our control in the Firefox submission process
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.head_commit.message == 'Version release'
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.commits[0].message == 'Version release'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules
@@ -165,7 +165,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules

--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -1,0 +1,34 @@
+name: Git Tag
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'CHANGELOG.md'
+  workflow_dispatch:
+
+jobs:
+  git_tag:
+    name: Create git tag
+    runs-on: ubuntu-latest
+    if: github.event.head_commit.message == 'Version release'
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Get tag version
+        id: release_info
+        run: |
+          version="$(cat package.json | jq -r '.version')"
+          release_body="$(sed -n "/## ${version}/,/## [0-9]/p" CHANGELOG.md | sed \$d| sed 's/##/#/g')"
+
+          echo "::set-output name=version::${version}"
+          echo "::set-output name=release_body::${release_body}"
+
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          body: ${{ steps.release_info.outputs.release_body }}
+          commit: ${{ github.sha }}
+          tag: v${{ steps.release_info.outputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
         dir: ${{fromJson(needs.directories.outputs.dir)}}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         name: Cache node_modules

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - 'main'
+    tags:
+      - "v*"
   workflow_dispatch:
 
 jobs:
@@ -17,14 +19,14 @@ jobs:
   publish_chrome_extension:
     name: Publish Chrome extension
     runs-on: ubuntu-latest
-    if: github.event.head_commit.message == 'Version release'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - pre_run
     outputs:
       publish_status: ${{ steps.publish-chrome.outputs.publish_status }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules
@@ -63,14 +65,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MINIFY_PRODUCTION_BUILD: true
-    if: github.event.head_commit.message == 'Version release'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - pre_run
     outputs:
       publish_status: ${{ steps.publish-firefox.outputs.publish_status }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.event.head_commit.message != 'Version release'
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         id: cache-node-modules


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1057439479).<!-- Sticky Header Marker -->

* Adds a new workflow which creates a git tag and a GH release following the merge of a changeset-created PR into `main`.
* The GH release body contains the most recent version's changes from the CHANGELOG.md file.
* Minor updates to other workflows

# Details

While these changes implement the automatic creation of Git tags and trigger the publish of the extensions from that tag's creation, there isn't much I can do to remove the dependency some tasks have on the messages in git commits.

It doesn't seem we can avoid needing to parse commit messages without a fully automated release process, or through making larger modifications. Since `changeset` determines if a release is needed [at this step](https://github.com/blockstack/stacks-wallet-web/blob/main/.github/workflows/version.yml#L21-L48), the required manual PR review after this point causes us to lose the ability to automate further events (like GH tag creation) from `changeset`'s determination, and end up having to rely on the commit message text from the PR's merge.

If you're interested in fully automating this process to remove this dependency, feel free to open another issue and I can set up a meeting.

Closes https://github.com/hirosystems/devops/issues/740

cc/ @aulneau @kyranjamie @fbwoolf
