### PR TITLE
fix: Display addresses consistently

### DIFF
--- a/.changeset/clever-tools-tie.md
+++ b/.changeset/clever-tools-tie.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Some addresses were displayed with 6 or 4 char on both side of the ellipsis. This makes it consistent with 4 char.

--- a/src/features/account-switch-drawer/switch-accounts.tsx
+++ b/src/features/account-switch-drawer/switch-accounts.tsx
@@ -96,7 +96,7 @@ const AccountListItem = memo(
           <AccountAvatarItem account={account} />
           <Stack spacing="base-tight">
             <AccountName account={account} />
-            <Caption>{truncateMiddle(account.address)}</Caption>
+            <Caption>{truncateMiddle(account.address, 4)}</Caption>
           </Stack>
         </Stack>
         <Fade in={isLoading}>

--- a/src/pages/choose-account/components/account-item.tsx
+++ b/src/pages/choose-account/components/account-item.tsx
@@ -17,7 +17,7 @@ export const AccountItem = memo(({ account, ...rest }: { account: AccountWithAdd
         <Title fontSize={2} lineHeight="1rem" fontWeight="400">
           {name}
         </Title>
-        <Caption>{truncateMiddle(account.address, 9)}</Caption>
+        <Caption>{truncateMiddle(account.address, 4)}</Caption>
       </Stack>
     </Stack>
   );

--- a/src/pages/choose-account/components/accounts.tsx
+++ b/src/pages/choose-account/components/accounts.tsx
@@ -61,7 +61,7 @@ export const AccountItem: React.FC<AccountItemProps> = ({ selectedAddress, accou
               {name}
             </Title>
             <Caption fontSize={0} {...getLoadingProps(showLoadingProps)}>
-              {truncateMiddle(account.address)}
+              {truncateMiddle(account.address, 4)}
             </Caption>
           </Stack>
           {isLoading && <Spinner width={4} height={4} {...loadingProps} />}

--- a/src/pages/home/components/user-area.tsx
+++ b/src/pages/home/components/user-area.tsx
@@ -15,7 +15,7 @@ const UserAddress = memo((props: StackProps) => {
   return currentAccount ? (
     <Tooltip placement="right-end" label={hasCopied ? 'Copied!' : 'Copy address'}>
       <Stack isInline {...props}>
-        <Caption>{truncateMiddle(currentAccount.address)}</Caption>
+        <Caption>{truncateMiddle(currentAccount.address, 4)}</Caption>
 
         <Box
           _hover={{ cursor: 'pointer' }}

--- a/src/pages/receive-tokens/receive-tokens.tsx
+++ b/src/pages/receive-tokens/receive-tokens.tsx
@@ -66,7 +66,7 @@ export const PopupReceive: React.FC = () => {
         )}
         <Box>
           <Tooltip interactive placement="bottom" label={address}>
-            <Caption userSelect="none">{truncateMiddle(address, 8)}</Caption>
+            <Caption userSelect="none">{truncateMiddle(address, 4)}</Caption>
           </Tooltip>
         </Box>
       </Stack>

--- a/src/pages/transaction-signing/components/confirm-send-drawer.tsx
+++ b/src/pages/transaction-signing/components/confirm-send-drawer.tsx
@@ -50,9 +50,9 @@ const TransactionDetails: React.FC<
         ticker={ticker || 'STX'}
         title="You will transfer exactly"
         left={
-          currentAccount?.address ? `From ${truncateMiddle(currentAccount?.address)}` : undefined
+          currentAccount?.address ? `From ${truncateMiddle(currentAccount?.address, 4)}` : undefined
         }
-        right={`To ${truncateMiddle(recipient)}`}
+        right={`To ${truncateMiddle(recipient, 4)}`}
       />
     </Flex>
   );

--- a/src/pages/transaction-signing/components/post-conditions/list.tsx
+++ b/src/pages/transaction-signing/components/post-conditions/list.tsx
@@ -27,7 +27,7 @@ function StxPostcondition() {
       left="Stacks Token"
       right={
         pendingTransaction.txType === TransactionTypes.STXTransfer
-          ? `To ${truncateMiddle(pendingTransaction.recipient, 6)}`
+          ? `To ${truncateMiddle(pendingTransaction.recipient, 4)}`
           : undefined
       }
     />


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1056492890).<!-- Sticky Header Marker -->

 Display all addresses with 4 char on both side of the ellipsis.