### PR TITLE
fix: the weight of all Open Sauce titles

### DIFF
--- a/.changeset/rich-cheetahs-talk.md
+++ b/.changeset/rich-cheetahs-talk.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Make all our Open Sauce titles consistent with their font-weight. Set it to medium

--- a/src/components/typography.tsx
+++ b/src/components/typography.tsx
@@ -104,6 +104,7 @@ export const Title = forwardRefWithAs<BoxProps, Headings>((props, ref) => (
     fontFeatureSettings={`'ss01' on`}
     letterSpacing="-0.01em"
     fontFamily="'Open Sauce One'"
+    fontWeight="500"
     color={color('text-title')}
     ref={ref}
     display="block"


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1059871816).<!-- Sticky Header Marker -->

Make the font weight of Open Sauce titles consistent

Fixes https://github.com/blockstack/stacks-wallet-web/issues/1261