### PR TITLE
fix: button border radius to be consistently 10px

### DIFF
--- a/.changeset/angry-moles-impress.md
+++ b/.changeset/angry-moles-impress.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Fix button border-radius to be consistent. Set it to 10px.

--- a/src/components/drawer/accounts/create-account.tsx
+++ b/src/components/drawer/accounts/create-account.tsx
@@ -40,6 +40,7 @@ export const CreateAccount: React.FC<CreateAccountProps> = ({ close }) => {
             width="100%"
             onClick={close}
             isLoading={isSetting}
+            borderRadius="10px"
             isDisabled={isSetting}
             data-testid={isSetting ? undefined : SettingsSelectors.BtnCreateAccountDone}
           >

--- a/src/components/popup/token-assets.tsx
+++ b/src/components/popup/token-assets.tsx
@@ -46,7 +46,7 @@ function NoAssets(props: StackProps) {
         bg="#EEF2FB"
         _hover={{ bg: '#E5EBFA' }}
         color={color('brand')}
-        borderRadius="12px"
+        borderRadius="10px"
         onClick={onCopy}
         data-testid={UserAreaSelectors.AccountBalancesCopyAddress}
       >

--- a/src/components/unlock.tsx
+++ b/src/components/unlock.tsx
@@ -57,6 +57,7 @@ export const Unlock: React.FC = () => {
           isDisabled={loading}
           onClick={submit}
           data-testid="set-password-done"
+          borderRadius="10px"
         >
           Unlock
         </Button>

--- a/src/features/network-drawer/networks-drawer.tsx
+++ b/src/features/network-drawer/networks-drawer.tsx
@@ -94,7 +94,9 @@ export const NetworksDrawer: React.FC = memo(() => {
     <ControlledDrawer title="Select Network" state={showNetworksStore}>
       <NetworkList />
       <Box pb="loose" width="100%" px="loose" mt="base">
-        <Button onClick={handleAddNetworkClick}>Add a network</Button>
+        <Button borderRadius="10px" onClick={handleAddNetworkClick}>
+          Add a network
+        </Button>
       </Box>
     </ControlledDrawer>
   );

--- a/src/features/settings-dropdown/settings-popover.tsx
+++ b/src/features/settings-dropdown/settings-popover.tsx
@@ -18,7 +18,7 @@ const MenuWrapper = forwardRefWithAs((props, ref) => (
     position="absolute"
     top="60px"
     right="extra-loose"
-    borderRadius="8px"
+    borderRadius="10px"
     width="296px"
     boxShadow="0px 8px 16px rgba(27, 39, 51, 0.08);"
     zIndex={2000}

--- a/src/pages/home/components/actions.tsx
+++ b/src/pages/home/components/actions.tsx
@@ -35,7 +35,7 @@ const TxButton: React.FC<TxButtonProps> = memo(({ kind, path, ...rest }) => {
         position="relative"
         ref={ref}
         onClick={handleClick}
-        borderRadius="12px"
+        borderRadius="10px"
         {...rest}
       >
         <Box

--- a/src/pages/install/index.tsx
+++ b/src/pages/install/index.tsx
@@ -30,6 +30,7 @@ const Actions: React.FC<StackProps> = props => {
         onClick={register}
         isLoading={isCreatingWallet}
         data-testid={InitialPageSelectors.SignUp}
+        borderRadius="10px"
       >
         I'm new to Stacks
       </Button>

--- a/src/pages/install/sign-in.tsx
+++ b/src/pages/install/sign-in.tsx
@@ -58,6 +58,7 @@ export const InstalledSignIn: React.FC = () => {
             isDisabled={isLoading}
             data-testid="sign-in-key-continue"
             type="submit"
+            borderRadius="10px"
           >
             Continue
           </Button>

--- a/src/pages/receive-tokens/receive-tokens.tsx
+++ b/src/pages/receive-tokens/receive-tokens.tsx
@@ -71,7 +71,7 @@ export const PopupReceive: React.FC = () => {
         </Box>
       </Stack>
       <Box mt="auto">
-        <Button width="100%" onClick={onCopy}>
+        <Button width="100%" onClick={onCopy} borderRadius="10px">
           Copy your address
         </Button>
       </Box>

--- a/src/pages/save-your-secret-key/save-your-key-view.tsx
+++ b/src/pages/save-your-secret-key/save-your-key-view.tsx
@@ -46,12 +46,18 @@ export const SecretKeyActions: React.FC<{ handleNext?: () => void } & StackProps
         borderColor={color('border')}
         color={color(hasCopied ? 'text-caption' : 'brand')}
         mode="tertiary"
+        borderRadius="10px"
         onClick={hasCopied ? undefined : onCopy}
       >
         {hasCopied ? 'Copied!' : 'Copy to clipboard'}
       </Button>
       {handleNext && (
-        <Button width="100%" onClick={handleNext} data-testid="confirm-saved-key">
+        <Button
+          width="100%"
+          onClick={handleNext}
+          data-testid="confirm-saved-key"
+          borderRadius="10px"
+        >
           I've saved it
         </Button>
       )}

--- a/src/pages/set-password.tsx
+++ b/src/pages/set-password.tsx
@@ -130,6 +130,7 @@ export const SetPasswordPage: React.FC<SetPasswordProps> = ({
                   isLoading={loading || formik.isSubmitting}
                   isDisabled={loading}
                   data-testid="set-password-done"
+                  borderRadius="10px"
                 >
                   Done
                 </Button>

--- a/src/pages/transaction-signing/components/actions.tsx
+++ b/src/pages/transaction-signing/components/actions.tsx
@@ -64,7 +64,7 @@ export const MinimalErrorMessage = memo((props: StackProps) => {
 });
 
 const BaseConfirmButton = (props: ButtonProps) => (
-  <Button borderRadius="12px" py="base" width="100%" {...props}>
+  <Button borderRadius="10px" py="base" width="100%" {...props}>
     Confirm
   </Button>
 );


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1059977101).<!-- Sticky Header Marker -->

make all the buttons consistent with their border-radius.
Fixes https://github.com/blockstack/stacks-wallet-web/issues/1262