### PR TITLE
fix: the label of the select token dropdown

### DIFF
--- a/.changeset/large-masks-join.md
+++ b/.changeset/large-masks-join.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Change wording of the select asset dropdown.

--- a/src/pages/send-tokens/components/asset-search/selected-asset.tsx
+++ b/src/pages/send-tokens/components/asset-search/selected-asset.tsx
@@ -90,7 +90,7 @@ export const SelectedAsset: React.FC<{ hideArrow?: boolean } & StackProps> = mem
       <Stack spacing="base-loose" flexDirection="column" {...rest}>
         <Stack spacing="tight">
           <Text display="block" fontSize={1} fontWeight="500" mb="tight">
-            Token
+            Choose an asset
           </Text>
           <SelectedAssetItem hideArrow={hideArrow} />
         </Stack>


### PR DESCRIPTION
> Try out this version of the Stacks Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1067549846).<!-- Sticky Header Marker -->

Keep the select dropdown consistent between toggled and not toggled

closes #996


