### PR TITLE
fix: too high font weight for activity list

### DIFF
--- a/.changeset/shaggy-windows-think.md
+++ b/.changeset/shaggy-windows-think.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Fix font-weight issue in activity list.

--- a/src/components/popup/tx-item.tsx
+++ b/src/components/popup/tx-item.tsx
@@ -126,8 +126,12 @@ export const TxItem: React.FC<TxItemProps & BoxProps> = ({ transaction, ...rest 
         <TxItemIcon transaction={transaction} />
         <Stack flexGrow={1} spacing="base-tight">
           <SpaceBetween>
-            <Title as="h3">{getTxTitle(transaction as any)}</Title>
-            <Title as="h3">{getTxValue(transaction, isOriginator)}</Title>
+            <Title as="h3" fontWeight="normal">
+              {getTxTitle(transaction as any)}
+            </Title>
+            <Title as="h3" fontWeight="normal">
+              {getTxValue(transaction, isOriginator)}
+            </Title>
           </SpaceBetween>
           <Stack isInline>
             <Status transaction={transaction} />


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1093051341).<!-- Sticky Header Marker -->

Fix too big font-weight for activity list

Before
<img width="551" alt="font-weight-activity" src="https://user-images.githubusercontent.com/1501454/127826844-a0397654-bc5e-4870-93c9-9cd80264a89d.png">

After

<img width="458" alt="font-weight-activity-2" src="https://user-images.githubusercontent.com/1501454/127827727-92445671-e416-40d7-b209-5ac66e46ef7b.png">

