### PR TITLE
fix: mega api client state

### DIFF
--- a/.changeset/wicked-insects-type.md
+++ b/.changeset/wicked-insects-type.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This update refactors the way we implement the helper library `@stacks/blockchain-api-client`.

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -74,3 +74,5 @@ export enum QueryRefreshRates {
   MEDIUM = 10_000,
   FAST = 3_500,
 }
+
+export const MICROBLOCKS_ENABLED = false;

--- a/src/store/accounts/index.ts
+++ b/src/store/accounts/index.ts
@@ -12,8 +12,8 @@ import { currentNetworkState } from '@store/networks';
 import { walletState } from '@store/wallet';
 import { transactionNetworkVersionState } from '@store/transactions';
 import { atomFamilyWithQuery } from '@store/query';
-import { accountsApiClientState } from '@store/common/api-clients';
 import { QueryRefreshRates } from '@common/constants';
+import { apiClientState } from '@store/common/api-clients';
 
 enum AccountQueryKeys {
   ALL_ACCOUNT_DATA = 'ALL_ACCOUNT_DATA',
@@ -144,8 +144,8 @@ export const accountInfoResponseState = atomFamilyWithQuery<
 >(
   AccountQueryKeys.ACCOUNT_INFO_STATE,
   async function accountInfoResponseQueryFn(get, [principal]) {
-    const client = get(accountsApiClientState);
-    const data = await client.getAccountInfo({
+    const { accountsApi } = get(apiClientState);
+    const data = await accountsApi.getAccountInfo({
       principal,
       proof: 0,
     });

--- a/src/store/common/api-clients.ts
+++ b/src/store/common/api-clients.ts
@@ -1,41 +1,84 @@
 import { atom } from 'jotai';
 import { currentNetworkState } from '@store/networks';
+import { fetcher as fetchApi } from '@common/api/wrapped-fetch';
+
 import {
   Configuration,
   AccountsApi,
   SmartContractsApi,
   InfoApi,
+  TransactionsApi,
   BlocksApi,
+  FaucetsApi,
+  BnsApi,
+  BurnchainApi,
   FeesApi,
+  SearchApi,
+  RosettaApi,
+  // MicroblocksApi,
 } from '@stacks/blockchain-api-client';
-import { fetcher } from '@common/api/wrapped-fetch';
 
-export const apiClientConfiguration = atom<Configuration>(get => {
+import type { Middleware, RequestContext } from '@stacks/blockchain-api-client';
+import { MICROBLOCKS_ENABLED } from '@common/constants';
+
+/**
+ * Our mega api clients function. This is a combo of all clients that the blockchain-api-client package offers.
+ * @param config - the `@stacks/blockchain-api-client` configuration object
+ */
+export function apiClients(config: Configuration) {
+  const smartContractsApi = new SmartContractsApi(config);
+  const accountsApi = new AccountsApi(config);
+  const infoApi = new InfoApi(config);
+  const transactionsApi = new TransactionsApi(config);
+  // const microblocksApi = new MicroblocksApi(config);
+  const blocksApi = new BlocksApi(config);
+  const faucetsApi = new FaucetsApi(config);
+  const bnsApi = new BnsApi(config);
+  const burnchainApi = new BurnchainApi(config);
+  const feesApi = new FeesApi(config);
+  const searchApi = new SearchApi(config);
+  const rosettaApi = new RosettaApi(config);
+
+  return {
+    smartContractsApi,
+    accountsApi,
+    infoApi,
+    transactionsApi,
+    // microblocksApi,
+    blocksApi,
+    faucetsApi,
+    bnsApi,
+    burnchainApi,
+    feesApi,
+    searchApi,
+    rosettaApi,
+  };
+}
+
+// this is used to enable automatic passing of `unanchored=true` to all requests
+const unanchoredMiddleware: Middleware = {
+  pre: (context: RequestContext) => {
+    const url = new URL(context.url);
+    if (!url.toString().includes('/v2')) url.searchParams.set('unanchored', 'true');
+    return Promise.resolve({
+      init: context.init,
+      url: url.toString(),
+    });
+  },
+};
+
+function createConfig(basePath: string) {
+  const middleware: Middleware[] = [];
+  if (MICROBLOCKS_ENABLED) middleware.push(unanchoredMiddleware);
+  return new Configuration({
+    basePath,
+    fetchApi,
+    middleware,
+  });
+}
+
+export const apiClientState = atom(get => {
   const network = get(currentNetworkState);
-  return new Configuration({ basePath: network.url, fetchApi: fetcher });
-});
-
-export const smartContractClientState = atom<SmartContractsApi>(get => {
-  const config = get(apiClientConfiguration);
-  return new SmartContractsApi(config);
-});
-
-export const accountsApiClientState = atom<AccountsApi>(get => {
-  const config = get(apiClientConfiguration);
-  return new AccountsApi(config);
-});
-
-export const infoApiClientState = atom<InfoApi>(get => {
-  const config = get(apiClientConfiguration);
-  return new InfoApi(config);
-});
-
-export const blocksApiClientState = atom<BlocksApi>(get => {
-  const config = get(apiClientConfiguration);
-  return new BlocksApi(config);
-});
-
-export const feesApiClientState = atom<FeesApi>(get => {
-  const config = get(apiClientConfiguration);
-  return new FeesApi(config);
+  const config = createConfig(network.url);
+  return apiClients(config);
 });

--- a/src/store/common/api-request.ts
+++ b/src/store/common/api-request.ts
@@ -1,6 +1,7 @@
 import { atom } from 'jotai';
-import { feesApiClientState } from '@store/common/api-clients';
+import { apiClientState } from '@store/common/api-clients';
 
 export const feeRateState = atom(async get => {
-  return get(feesApiClientState).getFeeTransfer() as unknown as Promise<number>;
+  const { feesApi } = get(apiClientState);
+  return feesApi.getFeeTransfer() as unknown as Promise<number>;
 });

--- a/src/store/contracts.ts
+++ b/src/store/contracts.ts
@@ -1,6 +1,6 @@
 import { atomFamilyWithQuery } from '@store/query';
 import { ContractPrincipal } from '@common/asset-types';
-import { smartContractClientState } from '@store/common/api-clients';
+import { apiClientState } from '@store/common/api-clients';
 import { atomFamily } from 'jotai/utils';
 import { atom } from 'jotai';
 import { currentNetworkState } from '@store/networks';
@@ -18,10 +18,10 @@ export const contractInterfaceResponseState = atomFamilyWithQuery<
   ContractPrincipal,
   ContractInterface | null
 >(ContractQueryKeys.ContractInterface, async (get, { contractAddress, contractName }) => {
-  const client = get(smartContractClientState);
+  const { smartContractsApi } = get(apiClientState);
   const network = get(currentNetworkState);
   try {
-    const data = (await client.getContractInterface({
+    const data = (await smartContractsApi.getContractInterface({
       contractAddress,
       contractName,
     })) as ContractInterface;
@@ -63,9 +63,9 @@ export const contractSourceResponseState = atomFamilyWithQuery<
   ContractPrincipal,
   ContractSourceResponse
 >(ContractQueryKeys.ContractSource, async (get, { contractAddress, contractName }) => {
-  const client = get(smartContractClientState);
+  const { smartContractsApi } = get(apiClientState);
   const network = get(currentNetworkState);
-  const data = await client.getContractSource({
+  const data = await smartContractsApi.getContractSource({
     contractAddress,
     contractName,
   });

--- a/src/store/networks.ts
+++ b/src/store/networks.ts
@@ -5,8 +5,8 @@ import { StacksMainnet, StacksNetwork, StacksTestnet } from '@stacks/network';
 import { transactionRequestNetwork } from '@store/transactions/requests';
 import { fetchWithTimeout, findMatchingNetworkKey } from '@common/utils';
 import { defaultNetworks, Networks, QueryRefreshRates } from '@common/constants';
-import { blocksApiClientState, infoApiClientState } from '@store/common/api-clients';
 import { atomFamilyWithQuery } from '@store/query';
+import { apiClientState } from '@store/common/api-clients';
 
 // Our root networks list, users can add to this list and it will persist to localstorage
 export const networksState = atomWithStorage<Networks>('networks', defaultNetworks);
@@ -50,12 +50,12 @@ export const currentStacksNetworkState = atom<StacksNetwork>(get => {
 
 // external data, the most recent block height of the selected network
 export const latestBlockHeightState = atom(async get => {
-  const client = get(blocksApiClientState);
-  return (await client.getBlockList({}))?.results?.[0]?.height;
+  const { blocksApi } = get(apiClientState);
+  return (await blocksApi.getBlockList({}))?.results?.[0]?.height;
 });
 
 // external data, `v2/info` endpoint of the selected network
-export const networkInfoState = atom(get => get(infoApiClientState).getCoreApiInfo());
+export const networkInfoState = atom(get => get(apiClientState).infoApi.getCoreApiInfo());
 
 export const networkOnlineStatusState = atomFamilyWithQuery<string, boolean>(
   'NETWORK_ONLINE',


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1094544914).<!-- Sticky Header Marker -->

This brings over the api clients atom that is used in the explorer, which combines all api clients from the `@stacks/blockchain-api-client` package. This also is a more robust fix for https://github.com/blockstack/stacks-wallet-web/pull/1430#issuecomment-891217157

cc/ @aulneau @kyranjamie @fbwoolf
