### PR TITLE
fix: Use api to get possible nonce

### DIFF
--- a/.changeset/fast-items-retire.md
+++ b/.changeset/fast-items-retire.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Use the api to get possible nonce and fallback to default nonce calculation if the api is not available.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 import { ThemeProvider, ColorModeProvider } from '@stacks/ui';
+import { QueryClientProvider } from 'react-query';
+import { jotaiWrappedReactQueryQueryClient as queryClient } from '@store/common/common.hooks';
 import { Toaster } from 'react-hot-toast';
 
 import { theme } from '@common/theme';
@@ -23,22 +25,24 @@ export const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyles />
-      <ColorModeProvider defaultMode="light">
-        <>
-          <Router>
-            <AppErrorBoundary>
-              <VaultLoader />
-              <Routes />
-              <AccountsDrawer />
-              <NetworksDrawer />
-              <TransactionSettingsDrawer />
-              <SpeedUpTransactionDrawer />
-              <SettingsPopover />
-            </AppErrorBoundary>
-            <Toaster position="bottom-center" toastOptions={{ style: { fontSize: '14px' } }} />
-          </Router>
-        </>
-      </ColorModeProvider>
+      <QueryClientProvider client={queryClient}>
+        <ColorModeProvider defaultMode="light">
+          <>
+            <Router>
+              <AppErrorBoundary>
+                <VaultLoader />
+                <Routes />
+                <AccountsDrawer />
+                <NetworksDrawer />
+                <TransactionSettingsDrawer />
+                <SpeedUpTransactionDrawer />
+                <SettingsPopover />
+              </AppErrorBoundary>
+              <Toaster position="bottom-center" toastOptions={{ style: { fontSize: '14px' } }} />
+            </Router>
+          </>
+        </ColorModeProvider>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 };

--- a/src/common/hooks/account/use-api-nonce.spec.ts
+++ b/src/common/hooks/account/use-api-nonce.spec.ts
@@ -1,0 +1,82 @@
+import { correctNextNonce } from '@common/hooks/account/use-next-tx-nonce';
+import { AddressNonces } from '@stacks/blockchain-api-client/lib/generated';
+
+describe(correctNextNonce.name, () => {
+  test('normal behavior', () => {
+    const response1: AddressNonces = {
+      last_executed_tx_nonce: 53,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 54,
+      detected_missing_nonces: [],
+    };
+    expect(correctNextNonce(response1)).toEqual(54);
+  });
+
+  test('with a missing nonce', () => {
+    const response1: AddressNonces = {
+      last_executed_tx_nonce: 48,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 54,
+      detected_missing_nonces: [49],
+    };
+    expect(correctNextNonce(response1)).toEqual(49);
+  });
+
+  test('possible_next_nonce is less than missing nonce', () => {
+    const response1: AddressNonces = {
+      last_executed_tx_nonce: 48,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 24,
+      detected_missing_nonces: [49],
+    };
+    expect(correctNextNonce(response1)).toEqual(49);
+  });
+
+  test('invalid state: last_executed_tx_nonce is more or equal than missing nonce', () => {
+    const response1: AddressNonces = {
+      last_executed_tx_nonce: 49,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 50,
+      detected_missing_nonces: [49],
+    };
+    expect(correctNextNonce(response1)).toEqual(50); // fallback to possible_next_nonce
+  });
+
+  test('Initial state', () => {
+    const response1: AddressNonces = {
+      last_executed_tx_nonce: null,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 0,
+      detected_missing_nonces: [],
+    };
+    expect(correctNextNonce(response1)).toEqual(0); // fallback to possible_next_nonce
+  });
+
+  test('With last_mempool_tx_nonce', () => {
+    const response1: AddressNonces = {
+      last_executed_tx_nonce: 70,
+      last_mempool_tx_nonce: 72,
+      possible_next_nonce: 73,
+      detected_missing_nonces: [71],
+    };
+    expect(correctNextNonce(response1)).toEqual(71);
+  });
+
+  test('With many missing nonce and handling order', () => {
+    const response1: AddressNonces = {
+      detected_missing_nonces: [73, 71],
+      last_executed_tx_nonce: 70,
+      last_mempool_tx_nonce: 74,
+      possible_next_nonce: 75,
+    };
+    expect(correctNextNonce(response1)).toEqual(71);
+
+    const response2: AddressNonces = {
+      detected_missing_nonces: [71, 73],
+      last_executed_tx_nonce: 70,
+      last_mempool_tx_nonce: 74,
+      possible_next_nonce: 75,
+    };
+    expect(correctNextNonce(response2)).toEqual(71);
+  });
+});

--- a/src/common/hooks/account/use-get-account-nonce.ts
+++ b/src/common/hooks/account/use-get-account-nonce.ts
@@ -1,0 +1,19 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import { useCurrentAccountStxAddressState } from '@store/accounts/account.hooks';
+import { useCurrentNetworkState } from '@store/network/networks.hooks';
+import { useAccountsApi } from '@store/common/api-clients.hooks';
+
+export function useGetAccountNonce(reactQueryOptions: UseQueryOptions = {}) {
+  const principal = useCurrentAccountStxAddressState();
+  const network = useCurrentNetworkState();
+  const { accountsApi } = useAccountsApi();
+  const fetchNonce = () => {
+    if (!principal) return;
+    return accountsApi.getAccountNonces({ principal });
+  };
+
+  return useQuery(['accountNonce', principal, network], fetchNonce, {
+    enabled: !!principal,
+    ...reactQueryOptions,
+  });
+}

--- a/src/common/hooks/account/use-next-tx-nonce.ts
+++ b/src/common/hooks/account/use-next-tx-nonce.ts
@@ -1,0 +1,28 @@
+import { AddressNonces } from '@stacks/blockchain-api-client/lib/generated';
+import { useGetAccountNonce } from '@common/hooks/account/use-get-account-nonce';
+import { UseQueryOptions } from 'react-query';
+import { useLastApiNonceState } from '@store/accounts/nonce.hooks';
+
+export function correctNextNonce(apiNonce: AddressNonces): number | undefined {
+  if (!apiNonce) return;
+
+  const missingNonces = apiNonce.detected_missing_nonces;
+  if (
+    missingNonces &&
+    missingNonces.length > 0 &&
+    missingNonces[0] > (apiNonce.last_executed_tx_nonce || 0)
+  ) {
+    return missingNonces.sort()[0];
+  }
+  return apiNonce.possible_next_nonce;
+}
+
+export function useNextTxNonce() {
+  const [nonce, setLastApiNonce] = useLastApiNonceState();
+  const onSuccess = (data: AddressNonces) => {
+    const nextNonce = data && correctNextNonce(data);
+    if (typeof nextNonce === 'number') setLastApiNonce(nextNonce);
+  };
+  useGetAccountNonce({ onSuccess } as UseQueryOptions);
+  return nonce;
+}

--- a/src/pages/send-tokens/send-tokens.tsx
+++ b/src/pages/send-tokens/send-tokens.tsx
@@ -34,6 +34,7 @@ import {
   useFeeRateUseCustom,
 } from '@store/transactions/fees.hooks';
 import { useCustomNonce } from '@store/transactions/nonce.hooks';
+import { useNextTxNonce } from '@common/hooks/account/use-next-tx-nonce';
 
 type Amount = number | '';
 
@@ -63,6 +64,7 @@ const SendForm = (props: SendFormProps) => {
   const { selectedAsset } = useSelectedAsset();
   const refreshAllAccountData = useRefreshAllAccountData();
   const assets = useTransferableAssets();
+  useNextTxNonce();
 
   const { handleSubmit, values, setValues, errors, setFieldError } = useFormikContext<FormValues>();
 

--- a/src/pages/transaction-signing/transaction-signing.tsx
+++ b/src/pages/transaction-signing/transaction-signing.tsx
@@ -15,16 +15,18 @@ import { PostConditions } from '@pages/transaction-signing/components/post-condi
 import { StxTransferDetails } from '@pages/transaction-signing/components/stx-transfer-details';
 import { PostConditionModeWarning } from '@pages/transaction-signing/components/post-condition-mode-warning';
 import { TransactionError } from './components/transaction-error';
+import { useNextTxNonce } from '@common/hooks/account/use-next-tx-nonce';
 
 export const TransactionPage = memo(() => {
+  useNextTxNonce();
   const transactionRequest = useTransactionRequest();
   const setBroadcastError = useUpdateTransactionBroadcastError();
-  if (!transactionRequest) return null;
 
   useEffect(() => {
     return () => setBroadcastError(null);
   }, [setBroadcastError]);
 
+  if (!transactionRequest) return null;
   return (
     <PopupContainer header={<PopupHeader />}>
       <Stack spacing="loose">

--- a/src/store/accounts/nonce.hooks.ts
+++ b/src/store/accounts/nonce.hooks.ts
@@ -1,0 +1,6 @@
+import { lastApiNonceState } from '@store/accounts/nonce';
+import { useAtom } from 'jotai';
+
+export function useLastApiNonceState() {
+  return useAtom(lastApiNonceState);
+}

--- a/src/store/accounts/nonce.ts
+++ b/src/store/accounts/nonce.ts
@@ -23,12 +23,18 @@ export const currentAccountLocalNonceState = atom(get => {
   return get(localNonceState([address, network.url]));
 });
 
+export const lastApiNonceState = atom<number | undefined>(undefined);
+
 export const currentAccountNonceState = atom(get => {
   const address = get(currentAccountStxAddressState);
   const account = get(currentAccountInfoState);
   const confirmedTransactions = get(currentAccountConfirmedTransactionsState);
   const pendingTransactions = get(currentAccountMempoolTransactionsState);
   const lastLocalNonce = get(currentAccountLocalNonceState);
+
+  const apiNonce = get(lastApiNonceState);
+  // We try to use the api nonce first since it will be the most accurate value
+  if (typeof apiNonce === 'number') return apiNonce;
 
   // most recent confirmed transactions sent by current address
   const lastConfirmedTx = confirmedTransactions?.filter(tx => tx.sender_address === address)?.[0];

--- a/src/store/common/api-clients.hooks.ts
+++ b/src/store/common/api-clients.hooks.ts
@@ -1,0 +1,6 @@
+import { useAtomValue } from 'jotai/utils';
+import { apiClientState } from '@store/common/api-clients';
+
+export function useAccountsApi() {
+  return useAtomValue(apiClientState);
+}

--- a/tests/integration/balance/balance.spec.ts
+++ b/tests/integration/balance/balance.spec.ts
@@ -1,19 +1,14 @@
-import {
-  BrowserDriver,
-  createTestSelector,
-  selectTestNet,
-  setupBrowser
-} from '../utils';
-import {WalletPage} from '../../page-objects/wallet.page';
-import {ScreenPaths} from '@common/types';
-import {BalanceSelectors} from "@tests/integration/balance.selectors";
-import {SECRET_KEY_2} from "@tests/mocks";
+import { BrowserDriver, createTestSelector, selectTestNet, setupBrowser } from '../utils';
+import { WalletPage } from '../../page-objects/wallet.page';
+import { ScreenPaths } from '@common/types';
+import { BalanceSelectors } from '@tests/integration/balance.selectors';
+import { SECRET_KEY_2 } from '@tests/mocks';
 
 jest.setTimeout(50_000);
 jest.retryTimes(process.env.CI ? 2 : 0);
 
 const getAmount = (stxAmount: string) => {
-  return stxAmount? parseFloat(stxAmount.replace(/,/g, '')): 0;
+  return stxAmount ? parseFloat(stxAmount.replace(/,/g, '')) : 0;
 };
 
 describe(`Wallet Balance integration tests`, () => {

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -6,8 +6,8 @@ import { tmpdir } from 'os';
 import { promisify } from 'util';
 import { setupMocks } from '../mocks';
 import { DemoPage } from '../page-objects/demo.page';
-import {WalletPage} from "@tests/page-objects/wallet.page";
-import {SettingsSelectors} from "@tests/integration/settings.selectors";
+import { WalletPage } from '@tests/page-objects/wallet.page';
+import { SettingsSelectors } from '@tests/integration/settings.selectors';
 
 const makeTmpDir = promisify(mkdtemp);
 

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -150,4 +150,5 @@ export const TEST_ACCOUNTS_WITH_ADDRESS = [
     address: 'SP23C2PBK6PVQEW2M17JSB6S2K0VZ611PPJ0D20NH',
   },
 ];
-export const SECRET_KEY_2 = 'derive plug aerobic cook until crucial school fine cushion panda ready crew photo typical nuclear ride steel indicate cupboard potato ignore bamboo script galaxy';
+export const SECRET_KEY_2 =
+  'derive plug aerobic cook until crucial school fine cushion panda ready crew photo typical nuclear ride steel indicate cupboard potato ignore bamboo script galaxy';

--- a/tests/page-objects/wallet.page.ts
+++ b/tests/page-objects/wallet.page.ts
@@ -5,7 +5,7 @@ import {
   wait,
   BrowserDriver,
   randomString,
-  timeDifference
+  timeDifference,
 } from '../integration/utils';
 import { USERNAMES_ENABLED } from '@common/constants';
 import { WalletPageSelectors } from './wallet.selectors';
@@ -154,14 +154,23 @@ export class WalletPage {
     let startTime = new Date();
     await this.enterSecretKey(secretKey);
     await this.waitForSetPassword();
-    console.log(`Page load time for 12 or 24 word Secret Key: ${timeDifference(startTime, new Date())} seconds`);
+    console.log(
+      `Page load time for 12 or 24 word Secret Key: ${timeDifference(
+        startTime,
+        new Date()
+      )} seconds`
+    );
     const password = randomString(15);
     startTime = new Date();
     await this.enterPassword(password);
     await this.waitForMainHomePage();
-    console.log(`Page load time for sign in with password: ${timeDifference(startTime, new Date())} seconds`);
+    console.log(
+      `Page load time for sign in with password: ${timeDifference(startTime, new Date())} seconds`
+    );
     startTime = new Date();
     await this.waitForHomePage();
-    console.log(`Page load time for mainnet account: ${timeDifference(startTime, new Date())} seconds`);
+    console.log(
+      `Page load time for mainnet account: ${timeDifference(startTime, new Date())} seconds`
+    );
   }
 }

--- a/tests/state-utils.tsx
+++ b/tests/state-utils.tsx
@@ -9,6 +9,8 @@ import Mock = jest.Mock;
 import { selectedAssetIdState } from '@store/assets/asset-search';
 import { currentAccountIndexState } from '@store/accounts';
 import { currentNetworkKeyState } from '@store/network/networks';
+import { QueryClientProvider } from 'react-query';
+import { queryClient } from 'jotai-query-toolkit';
 
 export const ProviderWithWalletAndRequestToken: React.FC = ({ children }) => (
   <Router>
@@ -29,20 +31,22 @@ export const ProviderWithWalletAndRequestToken: React.FC = ({ children }) => (
 
 export const ProviderWitHeySelectedAsset: React.FC = ({ children }) => (
   <Router>
-    <Provider
-      initialValues={[
-        [walletState, TEST_WALLET] as const,
-        [currentNetworkKeyState, 'regtest'] as const,
-        [currentAccountIndexState, 1] as const,
-        [hasRehydratedVaultStore, true] as const,
-        [
-          selectedAssetIdState,
-          'ST21FTC82CCKE0YH9SK5SJ1D4XEMRA069FKV0VJ8N.hey-token::hey-token',
-        ] as const,
-      ]}
-    >
-      {children}
-    </Provider>
+    <QueryClientProvider client={queryClient}>
+      <Provider
+        initialValues={[
+          [walletState, TEST_WALLET] as const,
+          [currentNetworkKeyState, 'regtest'] as const,
+          [currentAccountIndexState, 1] as const,
+          [hasRehydratedVaultStore, true] as const,
+          [
+            selectedAssetIdState,
+            'ST21FTC82CCKE0YH9SK5SJ1D4XEMRA069FKV0VJ8N.hey-token::hey-token',
+          ] as const,
+        ]}
+      >
+        {children}
+      </Provider>
+    </QueryClientProvider>
   </Router>
 );
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1217197742).<!-- Sticky Header Marker -->

fallback to default nonce calculation if the api is not available.
This should solve most of our nonce issues.

Note that I added the QueryClientProvider in the app.tsx for react-query.

cc/ @aulneau @kyranjamie @fbwoolf

Test cases:

Case A (normal case):
1. Send a transaction (example nonce = 10)
2. Send another transaction, go to settings, edit nonce

Expected: the nonce displayed should be 11

Case B:
1. Send a transaction (example nonce = 10)
2. Send another transaction with nonce = 12 (use settings -> edit nonce) : this tx will always be pending
3. Try sending another transaction: Go to send form, settings, edit nonce: The displayed nonce should be 11 (missing nonce)
4. Click send: After some time the tx with nonce = 12 and the one with nonce = 11 will all be confirmed.