### PR TITLE
fix: validate send form input precision

### DIFF
--- a/src/common/utils.spec.ts
+++ b/src/common/utils.spec.ts
@@ -1,0 +1,11 @@
+import { countDecimals } from './utils';
+
+describe(countDecimals.name, () => {
+  test('that it returns 0 when given an integer', () => expect(countDecimals(100)).toEqual(0));
+
+  test('that it returns accurate decimal numbers', () => {
+    expect(countDecimals(0.999)).toEqual(3);
+    expect(countDecimals('0.000000000000000000000000000001')).toEqual(30);
+    expect(countDecimals(0.1)).toEqual(1);
+  });
+});

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -344,3 +344,11 @@ export function with0x(value: string): string {
 export function initBigNumber(num: string | number | BigNumber) {
   return BigNumber.isBigNumber(num) ? num : new BigNumber(num);
 }
+
+export function countDecimals(num: string | number | BigNumber) {
+  const LARGE_NUMBER_OF_DECIMALS = 100;
+  BigNumber.config({ DECIMAL_PLACES: LARGE_NUMBER_OF_DECIMALS });
+  const amount = initBigNumber(num);
+  const decimals = amount.toString(10).split('.')[1];
+  return decimals ? decimals.length : 0;
+}

--- a/src/common/validation/validate-memo.ts
+++ b/src/common/validation/validate-memo.ts
@@ -1,0 +1,8 @@
+import { MEMO_MAX_LENGTH_BYTES } from '@stacks/transactions';
+
+const exceedsMaxLengthBytes = (string: string, maxLengthBytes: number): boolean =>
+  string ? Buffer.from(string).length > maxLengthBytes : false;
+
+export function isTxMemoValid(memo: string) {
+  return !exceedsMaxLengthBytes(memo, MEMO_MAX_LENGTH_BYTES);
+}

--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -55,9 +55,7 @@ const DrawerHeader = memo(
           iconSize="20px"
           onClick={onClose}
           color={color('text-caption')}
-          _hover={{
-            color: color('text-title'),
-          }}
+          _hover={{ color: color('text-title') }}
           icon={IconX}
         />
       </Flex>

--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -93,6 +93,8 @@ export const BaseDrawer: React.FC<BaseDrawerProps> = memo(props => {
         transitionDuration="0.4s"
         willChange="transform, opacity"
         width="100%"
+        maxWidth="600px"
+        m="auto auto 0"
         bg="white"
         borderTopLeftRadius="24px"
         borderTopRightRadius="24px"

--- a/src/components/error-label.tsx
+++ b/src/components/error-label.tsx
@@ -5,7 +5,7 @@ import { FiAlertTriangle as IconAlertTriangle } from 'react-icons/fi';
 export const ErrorLabel: React.FC<StackProps> = ({ children, ...rest }) => (
   <Stack spacing="tight" color={color('feedback-error')} isInline alignItems="flex-start" {...rest}>
     <Box
-      size="1.2rem"
+      size="1rem"
       color={color('feedback-error')}
       as={IconAlertTriangle}
       position="relative"

--- a/src/pages/send-tokens/components/amount-field.tsx
+++ b/src/pages/send-tokens/components/amount-field.tsx
@@ -13,17 +13,16 @@ import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 interface AmountFieldProps extends StackProps {
   value: number;
   error?: string;
-  onChange?: any;
 }
 
 // TODO: this should use a new "Field" component (with inline label like in figma)
 export const AmountField = memo((props: AmountFieldProps) => {
-  const { onChange, value, error, ...rest } = props;
+  const { value, error, ...rest } = props;
 
   const assets = useAssets();
   const balances = useFetchBalances();
   const { selectedAsset, placeholder } = useSelectedAsset();
-  const { setFieldValue } = useFormikContext();
+  const { setFieldValue, handleChange } = useFormikContext();
   const { handleOnKeyDown, handleSetSendMax } = useSendAmountFieldActions({
     setFieldValue,
   });
@@ -45,7 +44,7 @@ export const AmountField = memo((props: AmountFieldProps) => {
             autoFocus={assets?.length === 1}
             value={value === 0 ? '' : value}
             onKeyDown={handleOnKeyDown}
-            onChange={onChange}
+            onChange={handleChange}
             autoComplete="off"
             name="amount"
             data-testid={SendFormSelectors.InputAmountField}

--- a/src/pages/send-tokens/components/asset-search/asset-search.tsx
+++ b/src/pages/send-tokens/components/asset-search/asset-search.tsx
@@ -64,7 +64,7 @@ const AssetSearchResults = forwardRef(
                   asset={asset}
                   index={index}
                   key={`${asset.contractAddress || asset.name}__${index}`}
-                  highlighted={highlightedIndex === index}
+                  // highlighted={highlightedIndex === index}
                   {...getItemProps({ item: asset, index })}
                 />
               );

--- a/src/pages/send-tokens/components/memo-field.tsx
+++ b/src/pages/send-tokens/components/memo-field.tsx
@@ -1,14 +1,16 @@
+import React, { memo } from 'react';
+import { useFormikContext } from 'formik';
 import { Input, InputGroup, Stack, StackProps, Text } from '@stacks/ui';
 import { ErrorLabel } from '@components/error-label';
-import React, { memo } from 'react';
 
 interface FieldProps extends StackProps {
   value: string;
-  onChange?: any;
   error?: string;
 }
 // TODO: this should use a new "Field" component (with inline label like in figma)
-export const MemoField = memo(({ value, onChange, error, ...props }: FieldProps) => {
+export const MemoField = memo(({ value, error, ...props }: FieldProps) => {
+  const { handleChange } = useFormikContext();
+
   return (
     <Stack width="100%" {...props}>
       <InputGroup flexDirection="column">
@@ -21,7 +23,7 @@ export const MemoField = memo(({ value, onChange, error, ...props }: FieldProps)
           width="100%"
           name="memo"
           value={value}
-          onChange={onChange}
+          onChange={handleChange}
           placeholder="Enter an message (optional)"
           autoComplete="off"
         />

--- a/src/pages/send-tokens/components/recipient-field.tsx
+++ b/src/pages/send-tokens/components/recipient-field.tsx
@@ -2,14 +2,15 @@ import { Input, InputGroup, Stack, StackProps, Text } from '@stacks/ui';
 import { ErrorLabel } from '@components/error-label';
 import React, { memo } from 'react';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
+import { useFormikContext } from 'formik';
 
 interface RecipientField extends StackProps {
   value: string;
-  onChange?: any;
   error?: string;
 }
 // TODO: this should use a new "Field" component (with inline label like in figma)
-export const RecipientField = memo(({ value, onChange, error, ...rest }: RecipientField) => {
+export const RecipientField = memo(({ value, error, ...rest }: RecipientField) => {
+  const { handleChange } = useFormikContext();
   return (
     <Stack width="100%" {...rest}>
       <InputGroup flexDirection="column">
@@ -29,7 +30,7 @@ export const RecipientField = memo(({ value, onChange, error, ...rest }: Recipie
           width="100%"
           name="recipient"
           value={value}
-          onChange={onChange}
+          onChange={handleChange}
           placeholder="Enter an address"
           autoComplete="off"
           data-testid={SendFormSelectors.InputRecipientField}

--- a/src/pages/send-tokens/components/send-max-button.tsx
+++ b/src/pages/send-tokens/components/send-max-button.tsx
@@ -42,7 +42,7 @@ interface SendMaxWithSuspense extends SendMaxProps {
 }
 export function SendMaxWithSuspense({ showButton, onSetMax, ...props }: SendMaxWithSuspense) {
   return (
-    <Suspense fallback={<SendMaxButton isDisabled />}>
+    <Suspense fallback={<SendMaxButton />}>
       {showButton ? <SendMax onSetMax={fee => onSetMax(fee)} {...props} /> : null}
     </Suspense>
   );

--- a/src/pages/send-tokens/send-tokens.tsx
+++ b/src/pages/send-tokens/send-tokens.tsx
@@ -48,28 +48,20 @@ const SendForm = (props: SendFormProps) => {
   const refreshAllAccountData = useRefreshAllAccountData();
   const assets = useTransferableAssets();
 
-  const { handleSubmit, handleChange, values, setErrors, setValues, errors } =
-    useFormikContext<FormValues>();
-
-  const onChange = useCallback(
-    (e: React.ChangeEvent<any>) => {
-      setErrors({});
-      handleChange(e);
-    },
-    [setErrors, handleChange]
-  );
+  const { handleSubmit, values, setValues, errors, setFieldError } = useFormikContext<FormValues>();
 
   const onSubmit = useCallback(async () => {
     if (values.amount && values.recipient && selectedAsset) {
-      await handleSubmit();
+      handleSubmit();
       await refreshAllAccountData(250);
     }
   }, [refreshAllAccountData, handleSubmit, values, selectedAsset]);
 
-  const onItemClick = useCallback(() => {
+  const onItemSelect = useCallback(() => {
     if (assets.length === 1) return;
     setValues({ ...values, amount: '' });
-  }, [assets, setValues, values]);
+    setFieldError('amount', undefined);
+  }, [assets, setValues, values, setFieldError]);
 
   const hasValues = values.amount && values.recipient !== '';
 
@@ -78,14 +70,12 @@ const SendForm = (props: SendFormProps) => {
       header={<Header title="Send" onClose={() => doChangeScreen(ScreenPaths.POPUP_HOME)} />}
     >
       <Stack spacing="loose" flexDirection="column" flexGrow={1} shouldWrapChildren>
-        <AssetSearch onItemClick={onItemClick} />
+        <AssetSearch onItemClick={onItemSelect} />
         <Suspense fallback={<></>}>
-          <AmountField value={values.amount || 0} onChange={onChange} error={errors.amount} />
+          <AmountField value={values.amount || 0} error={errors.amount} />
         </Suspense>
-        <RecipientField error={errors.recipient} value={values.recipient} onChange={onChange} />
-        {selectedAsset?.hasMemo && (
-          <MemoField value={values.memo} error={errors.memo} onChange={onChange} />
-        )}
+        <RecipientField error={errors.recipient} value={values.recipient} />
+        {selectedAsset?.hasMemo && <MemoField value={values.memo} error={errors.memo} />}
         <Box mt="auto">
           {assetError && (
             <ErrorLabel mb="base">
@@ -93,6 +83,7 @@ const SendForm = (props: SendFormProps) => {
             </ErrorLabel>
           )}
           <Button
+            type="submit"
             borderRadius="12px"
             width="100%"
             onClick={onSubmit}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1119370358).<!-- Sticky Header Marker -->

Adds validation for decimal places

The `useSendFormValidation` hook is getting very unwieldy tbh. We should refactor this to use yup.

I've included the max width for the drawer as well. As jasper says should be a modal, but that can be another job.

https://user-images.githubusercontent.com/1618764/128863188-75683221-8e49-4eff-bd5f-7b786f007a28.mp4

cc/ @aulneau @kyranjamie @fbwoolf
