### PR TITLE
ci: gh release multi-line body and don't publish on commits to main

### DIFF
--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -34,4 +34,4 @@ jobs:
             ${{ steps.release_info.outputs.release_body }}
           commit: ${{ github.sha }}
           tag: v${{ steps.release_info.outputs.version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Release
         uses: ncipollo/release-action@v1
         with:
-          body: ${{ steps.release_info.outputs.release_body }}
+          body: |
+            ${{ steps.release_info.outputs.release_body }}
           commit: ${{ github.sha }}
           tag: v${{ steps.release_info.outputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -1,8 +1,6 @@
 name: Publish Extensions
 on:
   push:
-    branches:
-      - 'main'
     tags:
       - "v*"
   workflow_dispatch:


### PR DESCRIPTION
Addressing [comment here](https://github.com/hirosystems/devops/issues/740#issuecomment-892660588).

* I think the GH release body wasn't working because the bosy was a multi-line string being fed into a YAML property without a YAML block style indicator (`|`)
* Removes a tirgger for the publish-extensions workflow so it doesn't run on `main` commits, only new tags.
* Publishes should now trigger from this workflow creating new tags. Previously it was configured to use the default set of credentials when pushing the tag which won't trigger new workflows. This new set of creds will trigger a publish.

cc/ @aulneau @kyranjamie @fbwoolf
