### PR TITLE
refactor: remove mode from network badge

### DIFF
--- a/.changeset/tall-ads-deny.md
+++ b/.changeset/tall-ads-deny.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This updates the network badge by removing 'mode' from the label. It now reads 'Testnet'.

--- a/src/components/network-mode-badge.tsx
+++ b/src/components/network-mode-badge.tsx
@@ -27,7 +27,7 @@ export const NetworkModeBadge: React.FC<FlexProps> = memo(props => {
       {...props}
     >
       <Text fontSize="11px" fontWeight="500">
-        Testnet mode
+        Testnet
       </Text>
     </Flex>
   ) : null;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1121256420).<!-- Sticky Header Marker -->

This updates the network badge to `Testnet` instead of `Testnet mode`.

Issue #1510 

![image](https://user-images.githubusercontent.com/6493321/129085920-2e2c9093-f124-4860-8a36-94d1aabc595e.png)

![image](https://user-images.githubusercontent.com/6493321/129085949-1c9052cf-9df5-4d86-a854-f59556b2ee2e.png)

cc/ @aulneau @kyranjamie @fbwoolf
