### PR TITLE
refactor(validation): break up validation logic, use yup

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -352,3 +352,11 @@ export function countDecimals(num: string | number | BigNumber) {
   const decimals = amount.toString(10).split('.')[1];
   return decimals ? decimals.length : 0;
 }
+
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number';
+}
+
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}

--- a/src/common/validation/currency-schema.ts
+++ b/src/common/validation/currency-schema.ts
@@ -1,0 +1,20 @@
+import { STX_DECIMALS } from '@common/constants';
+import { countDecimals, isNumber } from '@common/utils';
+import * as yup from 'yup';
+
+export function curencyAmountSchema() {
+  return yup.number().positive('Amount must be positive').typeError('Currency be a number');
+}
+
+export function stxAmountSchema(errorMsg: string) {
+  return curencyAmountSchema()
+    .required('Enter an amount of STX')
+    .typeError('Amount of STX must be a number')
+    .test({
+      message: errorMsg,
+      test(value: unknown) {
+        if (!isNumber(value)) return false;
+        return countDecimals(value) <= STX_DECIMALS;
+      },
+    });
+}

--- a/src/common/validation/stx-address-schema.ts
+++ b/src/common/validation/stx-address-schema.ts
@@ -1,0 +1,25 @@
+import * as yup from 'yup';
+import { validateAddressChain, validateStacksAddress } from '@common/stacks-utils';
+import { isString } from '@common/utils';
+import { Network } from '@common/constants';
+
+export function stxAddressNetworkValidatorFactory(currentNetwork: Network) {
+  return (value: unknown) => {
+    if (!isString(value)) return false;
+    return validateAddressChain(value, currentNetwork);
+  };
+}
+
+export function stxNotCurrentAddressValidatorFactory(currentAddress: string) {
+  return (value: unknown) => value !== currentAddress;
+}
+
+export function stxAddressSchema(errorMsg: string) {
+  return yup.string().test({
+    message: errorMsg,
+    test(value: unknown) {
+      if (!isString(value)) return false;
+      return validateStacksAddress(value);
+    },
+  });
+}

--- a/src/common/validation/validate-memo.ts
+++ b/src/common/validation/validate-memo.ts
@@ -1,8 +1,20 @@
+import * as yup from 'yup';
 import { MEMO_MAX_LENGTH_BYTES } from '@stacks/transactions';
+import { isString } from '@common/utils';
 
 const exceedsMaxLengthBytes = (string: string, maxLengthBytes: number): boolean =>
   string ? Buffer.from(string).length > maxLengthBytes : false;
 
-export function isTxMemoValid(memo: string) {
+function isTxMemoValid(memo: string) {
   return !exceedsMaxLengthBytes(memo, MEMO_MAX_LENGTH_BYTES);
+}
+
+export function transactionMemoSchema(errorMsg: string) {
+  return yup.string().test({
+    message: errorMsg,
+    test(value: unknown) {
+      if (!isString(value)) return true;
+      return isTxMemoValid(value);
+    },
+  });
 }

--- a/src/pages/send-tokens/hooks/use-send-form-validation.ts
+++ b/src/pages/send-tokens/hooks/use-send-form-validation.ts
@@ -1,17 +1,20 @@
-import { FormikErrors } from 'formik';
+import * as yup from 'yup';
 import BigNumber from 'bignumber.js';
 import { useWallet } from '@common/hooks/use-wallet';
 import { useSelectedAsset } from '@common/hooks/use-selected-asset';
-import { microStxToStx, validateAddressChain, validateStacksAddress } from '@common/stacks-utils';
-import { FormValues } from '@pages/send-tokens/send-tokens';
-import { STX_TRANSFER_TX_SIZE_BYTES } from '@common/constants';
+import { microStxToStx } from '@common/stacks-utils';
+import { STX_DECIMALS, STX_TRANSFER_TX_SIZE_BYTES } from '@common/constants';
 import { useCurrentAccountAvailableStxBalance } from '@common/hooks/use-available-stx-balance';
-import { countDecimals } from '@common/utils';
-import { isTxMemoValid } from '@common/validation/validate-memo';
-
-interface UseSendFormValidationArgs {
-  setAssetError: (error: string) => void;
-}
+import { countDecimals, initBigNumber, isNumber } from '@common/utils';
+import { transactionMemoSchema } from '@common/validation/validate-memo';
+import { stxToMicroStx } from '@stacks/ui-utils';
+import { stxAmountSchema } from '@common/validation/currency-schema';
+import {
+  stxAddressNetworkValidatorFactory,
+  stxAddressSchema,
+  stxNotCurrentAddressValidatorFactory,
+} from '@common/validation/stx-address-schema';
+import { useCallback, useMemo } from 'react';
 
 export enum SendFormErrorMessages {
   IncorrectAddressMode = 'The address is for the incorrect Stacks network',
@@ -31,80 +34,107 @@ function formatPrecisionError(symbol: string, decimals: number) {
   return error.replace('{token}', symbol).replace('{decimals}', String(decimals));
 }
 
+function formatInsufficientBalanceError(availableBalance?: BigNumber | string, symbol?: string) {
+  if (!availableBalance || !symbol) return;
+  const amount = initBigNumber(availableBalance);
+  return `${SendFormErrorMessages.InsufficientBalance} ${
+    amount.lt(0) ? '0' : microStxToStx(amount).toString()
+  } ${symbol}`;
+}
+
+interface UseSendFormValidationArgs {
+  setAssetError(error: string): void;
+}
 export const useSendFormValidation = ({ setAssetError }: UseSendFormValidationArgs) => {
   const { currentNetwork, currentAccountStxAddress } = useWallet();
   const availableStxBalance = useCurrentAccountAvailableStxBalance();
   const { selectedAsset, balance } = useSelectedAsset();
   const isSendingStx = selectedAsset?.type === 'stx';
-  const selectedAssetHasDecimals =
-    isSendingStx ||
-    (typeof selectedAsset?.meta?.decimals === 'number' && selectedAsset?.meta.decimals !== 0);
 
-  return async ({
-    recipient,
-    amount,
-    memo,
-  }: {
-    recipient: string;
-    amount: string | number;
-    memo: string;
-  }) => {
-    const errors: FormikErrors<FormValues> = {};
-    if (!validateStacksAddress(recipient)) {
-      errors.recipient = SendFormErrorMessages.InvalidAddress;
-    } else if (!validateAddressChain(recipient, currentNetwork)) {
-      errors.recipient = SendFormErrorMessages.IncorrectAddressMode;
-    } else if (recipient === currentAccountStxAddress) {
-      errors.recipient = SendFormErrorMessages.SameAddress;
-    }
-    if (amount === '') {
-      errors.amount = SendFormErrorMessages.AmountRequired;
-    } else if (amount <= 0) {
-      errors.amount = SendFormErrorMessages.MustNotBeZero;
-    }
-    if (selectedAsset) {
-      const valueHasDecimals = typeof amount === 'string' && amount.includes('.');
-      const parsedAmount = new BigNumber(amount);
+  // `selectedAsset` is in an atom's state, not the form, but we want to
+  // validate it at the same time, to call `setAssetError`. This is a dummy
+  // schema that we use to call this function at the same time as the rest
+  // of the form is validated
+  const selectedAssetSchema = useCallback(
+    () =>
+      yup.mixed().test(() => {
+        if (!selectedAsset) setAssetError(SendFormErrorMessages.MustSelectAsset);
+        return !!selectedAsset;
+      }),
+    [selectedAsset, setAssetError]
+  );
 
-      if (!selectedAssetHasDecimals && valueHasDecimals) {
-        errors.amount = SendFormErrorMessages.DoesNotSupportDecimals;
-      }
-      const assetBalance = balance && new BigNumber(balance);
-      const assetAmountToTransfer = new BigNumber(amount);
+  const stxAmountFormSchema = useCallback(
+    () =>
+      stxAmountSchema(formatPrecisionError('STX', STX_DECIMALS)).test({
+        message: formatInsufficientBalanceError(availableStxBalance, 'STX'),
+        test(value: unknown) {
+          if (!availableStxBalance || !isNumber(value)) return false;
+          const availableBalanceLessFee = availableStxBalance.minus(STX_TRANSFER_TX_SIZE_BYTES);
+          return availableBalanceLessFee.isGreaterThanOrEqualTo(stxToMicroStx(value));
+        },
+      }),
+    [availableStxBalance]
+  );
 
-      if (isSendingStx && availableStxBalance) {
-        if (countDecimals(parsedAmount) > 6) {
-          errors.amount = formatPrecisionError('STX', 6);
-        }
+  const fungibleTokenSchema = useCallback(
+    () =>
+      yup
+        .number()
+        .test((value: unknown, context) => {
+          if (!isNumber(value) || !selectedAsset || !selectedAsset.meta) return false;
+          if (!selectedAsset.meta.decimals && countDecimals(value) > 0)
+            return context.createError({
+              message: SendFormErrorMessages.DoesNotSupportDecimals,
+            });
+          if (countDecimals(value) > selectedAsset.meta.decimals) {
+            const { symbol, decimals } = selectedAsset.meta;
+            return context.createError({ message: formatPrecisionError(symbol, decimals) });
+          }
+          return true;
+        })
+        .test({
+          message: formatInsufficientBalanceError(balance, selectedAsset?.meta?.symbol),
+          test(value: unknown) {
+            if (!isNumber(value) || !balance) return false;
+            return new BigNumber(value).isLessThanOrEqualTo(balance);
+          },
+        }),
+    [balance, selectedAsset]
+  );
 
-        const currentBalance = microStxToStx(availableStxBalance);
-        const availableBalance = currentBalance.minus(microStxToStx(STX_TRANSFER_TX_SIZE_BYTES));
-        if (availableBalance.lt(assetAmountToTransfer)) {
-          errors.amount = `${SendFormErrorMessages.InsufficientBalance} ${
-            availableBalance.lt(0) ? '0' : availableBalance.toString()
-          } STX`;
-        }
-      } else {
-        if (
-          selectedAsset.type === 'ft' &&
-          selectedAsset.meta?.decimals &&
-          countDecimals(parsedAmount) > selectedAsset.meta.decimals
-        ) {
-          errors.amount = formatPrecisionError(
-            selectedAsset.meta.symbol,
-            selectedAsset.meta.decimals
-          );
-        }
-        if (assetBalance && assetBalance.lt(assetAmountToTransfer)) {
-          errors.amount = `${SendFormErrorMessages.InsufficientBalance} ${selectedAsset.balance} ${selectedAsset.meta?.symbol}`;
-        }
-      }
-    } else {
-      setAssetError(SendFormErrorMessages.MustSelectAsset);
-    }
-    if (!isTxMemoValid(memo)) {
-      errors.memo = SendFormErrorMessages.MemoExceedsLimit;
-    }
-    return errors;
-  };
+  const amountSchema = useCallback(
+    () =>
+      yup
+        .number()
+        .required()
+        .positive(SendFormErrorMessages.MustNotBeZero)
+        .concat(isSendingStx ? stxAmountFormSchema() : fungibleTokenSchema()),
+    [fungibleTokenSchema, isSendingStx, stxAmountFormSchema]
+  );
+
+  const recipientSchema = useCallback(
+    () =>
+      stxAddressSchema(SendFormErrorMessages.InvalidAddress)
+        .test({
+          message: SendFormErrorMessages.IncorrectAddressMode,
+          test: stxAddressNetworkValidatorFactory(currentNetwork),
+        })
+        .test({
+          message: SendFormErrorMessages.SameAddress,
+          test: stxNotCurrentAddressValidatorFactory(currentAccountStxAddress || ''),
+        }),
+    [currentAccountStxAddress, currentNetwork]
+  );
+
+  return useMemo(
+    () =>
+      yup.object({
+        selectedAsset: selectedAssetSchema(),
+        recipient: recipientSchema(),
+        amount: amountSchema(),
+        memo: transactionMemoSchema(SendFormErrorMessages.MemoExceedsLimit),
+      }),
+    [amountSchema, recipientSchema, selectedAssetSchema]
+  );
 };

--- a/src/pages/send-tokens/send-tokens.spec.tsx
+++ b/src/pages/send-tokens/send-tokens.spec.tsx
@@ -57,7 +57,7 @@ describe('Send form tests', () => {
     const recipientField: HTMLElement = getByTestId(SendFormSelectors.InputRecipientField);
     const previewBtn: HTMLElement = getByTestId(SendFormSelectors.BtnPreviewSendTx);
 
-    userEvent.paste(amountField, '999999999');
+    userEvent.paste(amountField, '999');
     userEvent.paste(recipientField, 'ST1P72Z3704VMT3DMHPP2CB8TGQWGDBHD3RD69GE2');
     userEvent.click(previewBtn);
     await findByText(SendFormErrorMessages.InsufficientBalance, { exact: false });

--- a/src/pages/send-tokens/send-tokens.tsx
+++ b/src/pages/send-tokens/send-tokens.tsx
@@ -102,7 +102,7 @@ export const SendTokensForm: React.FC = memo(() => {
   const [isShowing, setShowing] = useState(false);
   const [assetError, setAssetError] = useState<string | undefined>();
   const { selectedAsset } = useSelectedAsset();
-  const onValidate = useSendFormValidation({ setAssetError });
+  const sendFormSchema = useSendFormValidation({ setAssetError });
 
   return (
     <Formik
@@ -116,7 +116,7 @@ export const SendTokensForm: React.FC = memo(() => {
       validateOnChange={false}
       validateOnBlur={false}
       validateOnMount={false}
-      validate={onValidate}
+      validationSchema={sendFormSchema}
     >
       {form => (
         <>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1127666929).<!-- Sticky Header Marker -->

The previous approach to validating the send form was to use a single validator function. As logic has been added, its grown to be a large, multi-purpose validate-everything method, which was difficult to read, and extend with new validation requirements.

As in the desktop wallet, this refactor uses `yup` to declaratively describe a schema for each field of the form. Reusable domain validation logic has been moved to shared folders, and the `useSendFormValidation` hook composes these to create the entire form's validation schema. @aulneau's tests helped the refactor 👍🏼 

I'd encourage us to use `yup` for all validation going forward. `Formik` has first class support for this type of validation, and imo it makes it easy to divide and share validation logic between forms/inputs.

No rush to merge this PR, we can wait until after microblocks, and go through a full QA cycle.

--------------

Side note: Doing this refactor, I'm wondering whether the `useSelectedAsset` atom is a good idea. All user inputs are form values, except the selected asset, which is shared via this atom. This makes the validation a bit trickier, as values are both between the form (ephemeral state) and the state (persisted state).

I gather the reason for this is because the value is used elsewhere, such as the transaction signing hook. But, I'd have thought that when initiating a transaction, we'd call some sort of `initTokenTransfer({})` method **once**, that describes all parameters, and from which point the values are immutable. You can either scrap the transaction request, or confirm and send it; but not modify it.

As we use an atom (that can update at any time), doesn't this pose the risk that, once a transaction has been initiated, some erroneous code in the background could change the selected asset, and in turn update the state of the transaction? Wouldn't it be better to have the state update in the same way it does _until_ you preview the transaction at which point the values cannot be changed?

Curious to hear everyone's thoughts.

