### PR TITLE
fix: copy address tooltip

### DIFF
--- a/.changeset/pink-yaks-cry.md
+++ b/.changeset/pink-yaks-cry.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This fixes the placement of the tooltip when copying the user address in the wallet header.

--- a/src/pages/home/components/user-area.tsx
+++ b/src/pages/home/components/user-area.tsx
@@ -13,20 +13,21 @@ const UserAddress = memo((props: StackProps) => {
   const currentAccount = useCurrentAccount();
   const { onCopy, hasCopied } = useClipboard(currentAccount?.address || '');
   return currentAccount ? (
-    <Tooltip placement="right-end" label={hasCopied ? 'Copied!' : 'Copy address'}>
-      <Stack isInline {...props}>
-        <Caption>{truncateMiddle(currentAccount.address, 4)}</Caption>
-
-        <Box
-          _hover={{ cursor: 'pointer' }}
-          onClick={onCopy}
-          size="12px"
-          color={color('text-caption')}
-          data-testid={UserAreaSelectors.AccountCopyAddress}
-          as={FiCopy}
-        />
-      </Stack>
-    </Tooltip>
+    <Stack isInline {...props}>
+      <Caption>{truncateMiddle(currentAccount.address, 4)}</Caption>
+      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy address'}>
+        <Stack>
+          <Box
+            _hover={{ cursor: 'pointer' }}
+            onClick={onCopy}
+            size="12px"
+            color={color('text-caption')}
+            data-testid={UserAreaSelectors.AccountCopyAddress}
+            as={FiCopy}
+          />
+        </Stack>
+      </Tooltip>
+    </Stack>
   ) : null;
 });
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1125200881).<!-- Sticky Header Marker -->

This PR fixes the placement of the tooltip for copying the user address in the header.

Issue #1527

![image](https://user-images.githubusercontent.com/6493321/129257992-a28769fe-4650-4144-8fa1-456f5c5d8853.png)

![image](https://user-images.githubusercontent.com/6493321/129258001-754aa9a0-11d8-440b-9c84-5234ffcaafe9.png)

cc/ @aulneau @kyranjamie @fbwoolf
