### PR TITLE
refactor: update stx token icon

### DIFF
--- a/.changeset/fuzzy-weeks-refuse.md
+++ b/.changeset/fuzzy-weeks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This updates the STX token icon in all places to match current designs.

--- a/src/components/icons/stx-icon.tsx
+++ b/src/components/icons/stx-icon.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Svg, BoxProps } from '@stacks/ui';
 
 export const StxIcon: React.FC<BoxProps> = props => (
-  <Svg width="12" height="12" viewBox="0 0 12 12" fill="none" {...props}>
+  <Svg height="39" width="39" fill="none" viewBox="0 0 39 39" {...props}>
     <path
-      d="M8.34257 8.14106L10.8917 12H8.98741L5.99496 7.46599L3.00252 12H1.10831L3.65743 8.15113H0V6.69018H12V8.14106H8.34257Z"
+      d="M22.4282 22.8547L25.6146 28H23.2343L19.4937 21.9547L15.7531 28H13.3854L16.5718 22.8682H12V20.9202H27V22.8547H22.4282Z"
       fill="white"
     />
     <path
-      d="M12 3.80856V5.26952V5.2796H0V3.80856H3.5869L1.06801 0H2.97229L5.99496 4.59446L9.02771 0H10.932L8.4131 3.80856H12Z"
+      d="M27 17.0781V19.026V19.0395H12V17.0781H16.4836L13.335 12H15.7154L19.4937 18.1259L23.2846 12H25.665L22.5164 17.0781H27Z"
       fill="white"
     />
   </Svg>

--- a/src/components/stx-avatar.tsx
+++ b/src/components/stx-avatar.tsx
@@ -4,8 +4,8 @@ import { BoxProps, Circle, color, DynamicColorCircle } from '@stacks/ui';
 
 export const StxAvatar: React.FC<BoxProps> = props => {
   return (
-    <Circle backgroundColor={color('invert')} {...props}>
-      <StxIcon size="12px" />
+    <Circle backgroundColor={color('accent')} {...props}>
+      <StxIcon />
     </Circle>
   );
 };

--- a/src/components/tx-icon.tsx
+++ b/src/components/tx-icon.tsx
@@ -7,10 +7,11 @@ import {
   FiAlertOctagon as IconMoodSad,
   FiPlus as IconPlus,
 } from 'react-icons/fi';
-import { Box, BoxProps, Circle, color, DynamicColorCircle, StxNexus } from '@stacks/ui';
+import { Box, BoxProps, Circle, color, DynamicColorCircle } from '@stacks/ui';
 import FunctionIcon from 'mdi-react/FunctionIcon';
 import type { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
 import { useWallet } from '@common/hooks/use-wallet';
+import { StxIcon } from './icons/stx-icon';
 
 type Tx = MempoolTransaction | Transaction;
 
@@ -78,8 +79,8 @@ const ItemIconWrapper: React.FC<
     transaction: Tx;
   } & BoxProps
 > = ({ icon: Icon, transaction, ...rest }) => (
-  <Circle position="relative" size="36px" bg={color('invert')} color={color('bg')} {...rest}>
-    <Box size="20px" as={Icon} />
+  <Circle position="relative" size="36px" bg={color('accent')} color={color('bg')} {...rest}>
+    <Box as={Icon} />
     <TypeIcon transaction={transaction} />
   </Circle>
 );
@@ -113,7 +114,7 @@ export const TxItemIcon: React.FC<{ transaction: Tx }> = ({ transaction, ...rest
         </DynamicColorCircle>
       );
     case 'token_transfer':
-      return <ItemIconWrapper icon={StxNexus} transaction={transaction} {...rest} />;
+      return <ItemIconWrapper icon={StxIcon} transaction={transaction} {...rest} />;
     case 'poison_microblock':
       return <ItemIconWrapper icon={IconMoodSad} transaction={transaction} {...rest} />;
     default:


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1128706771).<!-- Sticky Header Marker -->

This PR updates the STX token icon to be current with designs.

Issue #1568

![image](https://user-images.githubusercontent.com/6493321/129402526-6a7e3900-e9ec-41b5-9418-25346a7658f1.png)

![image](https://user-images.githubusercontent.com/6493321/129405786-53339013-9d4b-49d6-9cd6-5b2432ff6a50.png)

cc/ @aulneau @kyranjamie @fbwoolf
