### PR TITLE
fix: balances not displaying when api returns 404

### DIFF
--- a/src/store/assets/tokens.ts
+++ b/src/store/assets/tokens.ts
@@ -99,9 +99,13 @@ export const mergeAssetBalances = (
 
 const calculateBalanceByType = atomFamily((assetType: string) =>
   atom(get => {
-    const assets: AssetWithMeta[] = get(assetsState);
-    const unanchoredAssets: AssetWithMeta[] = get(assetsUnanchoredState);
-    return mergeAssetBalances(assets, unanchoredAssets, assetType);
+    try {
+      const assets: AssetWithMeta[] = get(assetsState);
+      const unanchoredAssets: AssetWithMeta[] = get(assetsUnanchoredState);
+      return mergeAssetBalances(assets, unanchoredAssets, assetType);
+    } catch (e) {
+      return undefined;
+    }
   })
 );
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1139150415).<!-- Sticky Header Marker -->

When the api returns 404 for endpoints like https://stacks-node-api.testnet.stacks.co/v2/contracts/interface/XXX
the balance is not showing, only the loader appears.
This issue exists also in 762dedd2a * @ v2.12.3. and in production.
