### PR TITLE
fix: failing contract call

### DIFF
--- a/src/components/asset-item.tsx
+++ b/src/components/asset-item.tsx
@@ -39,7 +39,7 @@ const AssetCaption: React.FC<{ caption?: string; show?: boolean }> = ({ caption,
     </Flex>
   ) : null;
 
-const SubBalance: React.FC<{ amount: string }> = ({ amount }) =>
+const SubBalance: React.FC<{ amount: string | undefined }> = ({ amount }) =>
   amount ? (
     <Text
       fontVariantNumeric="tabular-nums"
@@ -66,6 +66,7 @@ export const AssetItem = memo(
         caption,
         amount,
         subAmount,
+        isDifferent,
         ...rest
       }: {
         isPressable?: boolean;
@@ -74,13 +75,13 @@ export const AssetItem = memo(
         caption?: string;
         amount: string;
         subAmount?: string;
+        isDifferent?: boolean;
       } & StackProps,
       ref
     ) => {
       const [component, bind] = usePressable(isPressable);
       const formatted = getFormattedAmount(amount.toString());
-      const subAmountFormatted = (subAmount && getFormattedAmount(subAmount)) ?? '';
-      const isDifferent = !!subAmountFormatted && formatted.value !== subAmountFormatted.value;
+
       return (
         <Box
           as={isPressable ? 'button' : 'div'}
@@ -120,9 +121,7 @@ export const AssetItem = memo(
                       {formatted.value}
                     </Text>
                   </Tooltip>
-                  {isDifferent ? (
-                    <SubBalance amount={subAmountFormatted && subAmountFormatted.value} />
-                  ) : null}
+                  {isDifferent ? <SubBalance amount={subAmount} /> : null}
                 </Box>
               </SpaceBetween>
             </Stack>

--- a/src/components/asset-row.tsx
+++ b/src/components/asset-row.tsx
@@ -30,6 +30,7 @@ export const AssetRow = React.forwardRef<HTMLDivElement, AssetRowProps>((props, 
   const correctBalance = availableStxBalance && type === 'stx' ? availableStxBalance : balance;
   const amount = valueFromBalance(correctBalance);
   const subAmount = subBalance && valueFromBalance(subBalance);
+  const isDifferent = subBalance && !correctBalance.isEqualTo(subBalance);
 
   return (
     <AssetItem
@@ -45,6 +46,7 @@ export const AssetRow = React.forwardRef<HTMLDivElement, AssetRowProps>((props, 
       caption={symbol}
       amount={amount}
       subAmount={subAmount}
+      isDifferent={isDifferent}
       {...rest}
     />
   );

--- a/src/store/accounts/index.ts
+++ b/src/store/accounts/index.ts
@@ -213,12 +213,13 @@ export const accountBalancesState = atom(get => {
 export const accountUnanchoredBalancesState = atom(get => {
   const balances = get(currentAccountDataState)?.unanchoredBalances;
   const stxBalance = balances ? balances.stx.balance : '';
+  const lockedStxBalance = balances ? balances.stx.locked : 0;
   return balances
     ? {
         ...balances,
         stx: {
           ...balances.stx,
-          balance: new BigNumber(stxBalance),
+          balance: new BigNumber(stxBalance).minus(lockedStxBalance),
         },
       }
     : undefined;

--- a/src/store/assets/tokens.ts
+++ b/src/store/assets/tokens.ts
@@ -12,7 +12,6 @@ import { assetMetaDataState } from '@store/assets/fungible-tokens';
 import { contractInterfaceState } from '@store/contracts';
 import { isSip10Transfer } from '@common/token-utils';
 import { currentNetworkState } from '@store/networks';
-import { BigNumber } from 'bignumber.js';
 
 const transferDataState = atomFamily<ContractPrincipal, any>(
   ({ contractAddress, contractName }) => {
@@ -149,9 +148,7 @@ export const stxTokenState = atom(get => {
     type: 'stx',
     contractAddress: '',
     balance: balance,
-    subBalance: unanchoredBalances?.stx?.balance
-      ? new BigNumber(unanchoredBalances.stx.balance)
-      : undefined,
+    subBalance: unanchoredBalances?.stx?.balance || undefined,
     subtitle: 'STX',
     name: 'Stacks Token',
   } as AssetWithMeta;

--- a/src/store/contracts.ts
+++ b/src/store/contracts.ts
@@ -35,7 +35,7 @@ export const contractInterfaceResponseState = atomFamilyWithQuery<
     return setLocalData(keyParams, data);
   } catch (e) {
     console.debug('contractInterfaceResponseState error', e);
-    return null;
+    return (() => Promise.resolve(null)) as unknown as null;
   }
 });
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1140610191).<!-- Sticky Header Marker -->

I'm not sure I'm happy calling this a fix, as such—and I haven't tackled type issues—but this seems to trick jotai into not suspending.

Going forward, we should reevaluate the practice of having root async atoms that rely on API requests. 