### PR TITLE
refactor: more readable balance fns with HOF

### DIFF
--- a/src/common/api/accounts.ts
+++ b/src/common/api/accounts.ts
@@ -7,19 +7,17 @@ import type {
 import { fetchPendingTxs } from '@common/api/transactions';
 import { fetchFromBlockchainApi } from '@common/api/fetch';
 
-export const fetchBalances =
-  (apiServer: string) =>
-  (principal: string): Promise<AddressBalanceResponse> => {
-    const path = `/address/${principal}/balances`;
-    return fetchFromBlockchainApi(apiServer)(path, {}, false);
-  };
+function fetchBalanceFactory({ isUnanchored }: { isUnanchored: boolean }) {
+  return (apiServer: string) =>
+    (principal: string): Promise<AddressBalanceResponse> => {
+      const path = `/address/${principal}/balances`;
+      return fetchFromBlockchainApi(apiServer)(path, {}, isUnanchored);
+    };
+}
 
-export const fetchUnanchoredBalances =
-  (apiServer: string) =>
-  (principal: string): Promise<AddressBalanceResponse> => {
-    const path = `/address/${principal}/balances`;
-    return fetchFromBlockchainApi(apiServer)(path, {}, true);
-  };
+export const fetchBalances = fetchBalanceFactory({ isUnanchored: false });
+
+export const fetchUnanchoredBalances = fetchBalanceFactory({ isUnanchored: true });
 
 export const fetchTransactions =
   (apiServer: string) =>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1140251415).<!-- Sticky Header Marker -->

Tiny refactor, but like @fbwoolf, I was also pretty blind to the difference of the two functions.

Using a higher order function with a clear, labeled argument, we remove duplication and I think this makes the difference between both fns immediately obvious and more readable. 