### PR TITLE
fix: correct balance

### DIFF
--- a/.changeset/stale-carrots-kiss.md
+++ b/.changeset/stale-carrots-kiss.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This fixes an error in the wallet by initializing the merged asset balance as a BigNumber.

--- a/src/store/assets/tokens.spec.ts
+++ b/src/store/assets/tokens.spec.ts
@@ -105,9 +105,11 @@ describe(mergeAssetBalances.name, () => {
         expect(tokenMerged.subBalance).toEqual(tokenUnanchored.balance);
       } else if (token && !tokenUnanchored) {
         expect(tokenMerged.balance).toEqual(token.balance);
-        expect(tokenMerged.subBalance).toEqual('0');
+        expect(tokenMerged.subBalance.toFixed()).toEqual(new BigNumber(0).toFixed());
+        expect(BigNumber.isBigNumber(tokenMerged.subBalance)).toBeTruthy();
       } else if (!token && tokenUnanchored) {
-        expect(tokenMerged.balance).toEqual('0');
+        expect(tokenMerged.balance.toFixed()).toEqual(new BigNumber(0).toFixed());
+        expect(BigNumber.isBigNumber(tokenMerged.balance)).toBeTruthy();
         // If there is a token in the unanchored balance it should be present in the merge as subBalance
         expect(tokenMerged.subBalance).toEqual(tokenUnanchored.balance);
       }

--- a/src/store/assets/tokens.ts
+++ b/src/store/assets/tokens.ts
@@ -1,6 +1,7 @@
 import { atom } from 'jotai';
 import deepEqual from 'fast-deep-equal';
 import { atomFamily, waitForAll } from 'jotai/utils';
+import BigNumber from 'bignumber.js';
 import {
   currentAccountAvailableStxBalanceState,
   accountUnanchoredBalancesState,
@@ -83,12 +84,16 @@ export const mergeAssetBalances = (
   // Merge both balances (unanchored and anchored)
   assets.forEach(
     asset =>
-      asset.type === assetType && assetMap.set(asset.subtitle, { ...asset, ...{ subBalance: '0' } })
+      asset.type === assetType &&
+      assetMap.set(asset.subtitle, { ...asset, ...{ subBalance: new BigNumber(0) } })
   );
   unanchoredAssets.forEach(asset => {
     if (asset.type !== assetType) return;
     if (!assetMap.has(asset.subtitle)) {
-      assetMap.set(asset.subtitle, { ...asset, ...{ subBalance: asset.balance, balance: '0' } });
+      assetMap.set(asset.subtitle, {
+        ...asset,
+        ...{ subBalance: asset.balance, balance: new BigNumber(0) },
+      });
     } else {
       assetMap.get(asset.subtitle).subBalance = asset?.balance;
     }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1151582757).<!-- Sticky Header Marker -->

This PR fixes an error being reported when loading balances by initializing the merged balance as a BigNumber.

Issue #1596, #1597 

cc/ @aulneau @kyranjamie @fbwoolf
