### PR TITLE
fix: localhost not being supported

### DIFF
--- a/.changeset/tough-tables-sit.md
+++ b/.changeset/tough-tables-sit.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Fixes bug where users are unable to set the extension to the localhost url, owing to stacks.js changes

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@stacks/connect-react": "11.0.0",
     "@stacks/connect-ui": "5.1.5",
     "@stacks/encryption": "2.0.0-beta.0",
-    "@stacks/network": "2.0.0-beta.0",
+    "@stacks/network": "2.0.1",
     "@stacks/rpc-client": "1.0.3",
     "@stacks/transactions": "2.0.0-beta.1",
     "@stacks/ui": "7.10.0",

--- a/src/pages/transaction-signing/components/transaction-page-top.tsx
+++ b/src/pages/transaction-signing/components/transaction-page-top.tsx
@@ -5,7 +5,12 @@ import { useTransactionPageTitle } from '@pages/transaction-signing/hooks/use-tr
 import { Stack } from '@stacks/ui';
 import { Caption, Title } from '@components/typography';
 import { useCurrentNetwork } from '@common/hooks/use-current-network';
-import { getUrlHostname } from '@common/utils';
+import { getUrlHostname, getUrlPort } from '@common/utils';
+
+function addPortSuffix(url: string) {
+  const port = getUrlPort(url);
+  return port ? `:${port}` : '';
+}
 
 export const TransactionPageTop = memo(() => {
   const transactionRequest = useTransactionRequest();
@@ -15,7 +20,9 @@ export const TransactionPageTop = memo(() => {
   if (!transactionRequest) return null;
   const appName = transactionRequest?.appDetails?.name;
   const originAddition = origin ? ` (${getUrlHostname(origin)})` : '';
-  const testnetAddition = network.isTestnet ? ` using ${getUrlHostname(network.url)}` : '';
+  const testnetAddition = network.isTestnet
+    ? ` using ${getUrlHostname(network.url)}${addPortSuffix(network.url)}`
+    : '';
   const caption = appName ? `Requested by "${appName}"${originAddition}${testnetAddition}` : null;
 
   return (

--- a/src/pages/transaction-signing/hooks/use-asset-transfer.ts
+++ b/src/pages/transaction-signing/hooks/use-asset-transfer.ts
@@ -112,7 +112,7 @@ export function useMakeAssetTransfer() {
         anchorMode: AnchorMode.Any,
       };
 
-      return makeContractCall(txOptions);
+      return makeContractCall(txOptions as any);
     }, [])
   );
 }

--- a/src/pages/transaction-signing/hooks/use-make-stx-transfer.ts
+++ b/src/pages/transaction-signing/hooks/use-make-stx-transfer.ts
@@ -38,7 +38,7 @@ export function useMakeStxTransfer() {
         amount: new BN(stxToMicroStx(amount).toString(), 10),
         memo,
         senderKey: account.stxPrivateKey,
-        network,
+        network: network as any,
         nonce: new BN(nonce.toString(), 10),
         anchorMode: AnchorMode.Any,
       });

--- a/src/pages/transaction-signing/hooks/use-submit-stx-transaction.ts
+++ b/src/pages/transaction-signing/hooks/use-submit-stx-transaction.ts
@@ -51,7 +51,7 @@ export function useHandleSubmitTransaction({
     if (transaction) {
       const nonce = transaction.auth.spendingCondition?.nonce.toNumber();
       try {
-        const response = await broadcastTransaction(transaction, stacksNetwork);
+        const response = await broadcastTransaction(transaction, stacksNetwork as any);
         if (typeof response !== 'string') {
           toast.error(getErrorMessage(response.reason));
         } else {

--- a/src/store/networks.ts
+++ b/src/store/networks.ts
@@ -24,7 +24,7 @@ export const currentNetworkKeyState = atom<string, string>(
     // if txNetwork, default to this always, users cannot currently change networks when signing a transaction
     // @see https://github.com/blockstack/stacks-wallet-web/issues/1281
     if (txNetwork) {
-      const newKey = findMatchingNetworkKey(txNetwork, networks);
+      const newKey = findMatchingNetworkKey(txNetwork as any, networks);
       if (newKey) return newKey;
     }
     // otherwise default to the locally saved network key state
@@ -42,8 +42,9 @@ export const currentNetworkState = atom(get => get(networksState)[get(currentNet
 export const currentStacksNetworkState = atom<StacksNetwork>(get => {
   const network = get(currentNetworkState);
   const stacksNetwork =
-    network.chainId === ChainID.Testnet ? new StacksTestnet() : new StacksMainnet();
-  stacksNetwork.coreApiUrl = network.url;
+    network.chainId === ChainID.Testnet
+      ? new StacksTestnet({ url: network.url })
+      : new StacksMainnet({ url: network.url });
   stacksNetwork.bnsLookupUrl = network.url;
   return stacksNetwork;
 });

--- a/src/store/transactions/index.ts
+++ b/src/store/transactions/index.ts
@@ -39,7 +39,7 @@ export const signedStacksTransactionState = atom(get => {
   return generateSignedTransaction({
     senderKey: account.stxPrivateKey,
     nonce,
-    txData,
+    txData: txData as any,
   });
 });
 

--- a/test-app/src/common/utils.ts
+++ b/test-app/src/common/utils.ts
@@ -5,12 +5,18 @@ import { StacksTestnet } from '@stacks/network';
 
 dayjs.extend(relativeTime);
 
-let coreApiUrl = 'https://stacks-node-api.testnet.stacks.co';
+const testnetUrl = 'https://stacks-node-api.testnet.stacks.co';
+const regtestUrl = 'https://stacks-node-api.regtest.stacks.co';
+const localhostUrl = 'http://localhost:3999';
 
 export const getRPCClient = () => {
-  return new RPCClient(coreApiUrl);
+  return new RPCClient(testnetUrl);
 };
 
 export const toRelativeTime = (ts: number): string => dayjs().to(ts);
 
-export const stacksNetwork = new StacksTestnet({ url: coreApiUrl });
+export const stacksTestnetNetwork = new StacksTestnet({ url: testnetUrl });
+
+export const stacksLocalhostNetwork = new StacksTestnet({ url: localhostUrl });
+
+export const stacksRegtestNetwork = new StacksTestnet({ url: regtestUrl });

--- a/test-app/src/common/utils.ts
+++ b/test-app/src/common/utils.ts
@@ -13,5 +13,4 @@ export const getRPCClient = () => {
 
 export const toRelativeTime = (ts: number): string => dayjs().to(ts);
 
-export const stacksNetwork = new StacksTestnet();
-stacksNetwork.coreApiUrl = coreApiUrl;
+export const stacksNetwork = new StacksTestnet({ url: coreApiUrl });

--- a/test-app/src/components/counter-actions.tsx
+++ b/test-app/src/components/counter-actions.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, ButtonGroup, Box, Text } from '@stacks/ui';
 import { AppContext } from '@common/context';
-import { getRPCClient, stacksNetwork as network } from '@common/utils';
+import { getRPCClient, stacksTestnetNetwork as network } from '@common/utils';
 import { deserializeCV, IntCV } from '@blockstack/stacks-transactions';
 import { useConnect } from '@stacks/connect-react';
 import { ExplorerLink } from '@components/explorer-link';

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 import { Box, Text, Button, ButtonGroup } from '@stacks/ui';
-import { stacksNetwork as network } from '@common/utils';
+import {
+  stacksRegtestNetwork,
+  stacksTestnetNetwork as network,
+  stacksTestnetNetwork,
+  stacksLocalhostNetwork,
+} from '@common/utils';
 import { demoTokenContract } from '@common/contracts';
 import { useSTXAddress } from '@common/use-stx-address';
 import { useConnect } from '@stacks/connect-react';
@@ -27,6 +32,7 @@ import {
 import { TransactionsSelectors } from '@tests/integration/transactions.selectors';
 import { ExplorerLink } from './explorer-link';
 import BN from 'bn.js';
+import { StacksTestnet } from '@stacks/network';
 
 export const Debugger = () => {
   const { doContractCall, doSTXTransfer, doContractDeploy } = useConnect();
@@ -100,7 +106,7 @@ export const Debugger = () => {
     });
   };
 
-  const callFaker = async () => {
+  const callFaker = async (network: StacksTestnet) => {
     clearState();
     const args = [
       uintCV(1234),
@@ -316,8 +322,26 @@ export const Debugger = () => {
 
       <Box>
         <ButtonGroup spacing={4} my="base">
-          <Button data-testid={TransactionsSelectors.BtnContractCall} mt={3} onClick={callFaker}>
-            Contract call
+          <Button
+            data-testid={TransactionsSelectors.BtnContractCall}
+            mt={3}
+            onClick={() => callFaker(stacksTestnetNetwork)}
+          >
+            Contract call (Testnet)
+          </Button>
+          <Button
+            data-testid={TransactionsSelectors.BtnContractCall}
+            mt={3}
+            onClick={() => callFaker(stacksRegtestNetwork)}
+          >
+            Contract call (Regtest)
+          </Button>
+          <Button
+            data-testid={TransactionsSelectors.BtnContractCall}
+            mt={3}
+            onClick={() => callFaker(stacksLocalhostNetwork)}
+          >
+            Contract call (Localhost)
           </Button>
           <Button mt={3} onClick={() => stxTransfer('102')}>
             STX transfer

--- a/test-app/src/components/status.tsx
+++ b/test-app/src/components/status.tsx
@@ -10,7 +10,7 @@ import {
   ClarityType,
   bufferCV,
 } from '@blockstack/stacks-transactions';
-import { getRPCClient, stacksNetwork as network } from '@common/utils';
+import { getRPCClient, stacksTestnetNetwork as network } from '@common/utils';
 import type { ContractCallTransaction } from '@stacks/stacks-blockchain-api-types';
 import { TxCard } from '@components/tx-card';
 import { useSTXAddress } from '@common/use-stx-address';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,6 +2742,16 @@
   dependencies:
     cross-fetch "^3.0.6"
 
+"@stacks/common@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stacks/common/-/common-2.0.1.tgz#fd1a241b721ee6dc06db82855a5714af09e15f2f"
+  integrity sha512-PXU3Niimk7WK6Q2uetPZmwGhCXIc1u8RBZWvHKYe4dZxdDgT0QLX+eNAui591lsPWOH4ZkhpgSyWtJrtM9hU8g==
+  dependencies:
+    "@types/node" "^14.14.43"
+    bn.js "^5.2.0"
+    buffer "^6.0.3"
+    cross-fetch "^3.1.4"
+
 "@stacks/connect-react@11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@stacks/connect-react/-/connect-react-11.0.0.tgz#9cc112481f031bbd8c02520f13e948aa206c987f"
@@ -2808,12 +2818,12 @@
     ripemd160-min "^0.0.6"
     sha.js "^2.4.11"
 
-"@stacks/network@2.0.0-beta.0", "@stacks/network@^2.0.0-beta.0":
-  version "2.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@stacks/network/-/network-2.0.0-beta.0.tgz#1facdc42ef76ba57448cebf28e022385758e675a"
-  integrity sha512-ZhpHjnmgdHvy28oaUGK66IKMepopFiyhlJ6L3jbe6RJLHJFpupB5Kho6pa+Z4zXg2MsgZuHqBX6CyPaHfw9E4A==
+"@stacks/network@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stacks/network/-/network-2.0.1.tgz#b48cf3c50793e7aff5a1fbe5ee6ed4bf86da7db5"
+  integrity sha512-eA4AHrhFcIXIurW54HxzIoR6cYqe7hg/eS6aebtgyOUBaMc5w+RwR2iqZwG4M5aO4/Bwe3xdReINUUXJgMFK3g==
   dependencies:
-    "@stacks/common" "^2.0.0-beta.0"
+    "@stacks/common" "^2.0.1"
 
 "@stacks/network@^1.2.2":
   version "1.2.2"
@@ -2821,6 +2831,13 @@
   integrity sha512-xcWwuRrLJn9qqi3PEBcP2UPZHQztTZd31C0aVlzYHttNMir/sY9SrUqSnw45z2Jo4O9pIYYPIiPRtdV91Ho3fw==
   dependencies:
     "@stacks/common" "^1.2.2"
+
+"@stacks/network@^2.0.0-beta.0":
+  version "2.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@stacks/network/-/network-2.0.0-beta.0.tgz#1facdc42ef76ba57448cebf28e022385758e675a"
+  integrity sha512-ZhpHjnmgdHvy28oaUGK66IKMepopFiyhlJ6L3jbe6RJLHJFpupB5Kho6pa+Z4zXg2MsgZuHqBX6CyPaHfw9E4A==
+  dependencies:
+    "@stacks/common" "^2.0.0-beta.0"
 
 "@stacks/prettier-config@0.0.8":
   version "0.0.8"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1158817555).<!-- Sticky Header Marker -->

Closes #1590

This should fix #1590, allowing users to request that the transaction signing points to local testnet.

One oversight of the changes in https://github.com/blockstack/stacks.js/pull/1044 was where `coreApiUrl` was made a getter method of the `StacksNetwork` class. This wouldn't be an issue if the object wasn't serialised/deserialised, which it is.
Thus, the private field, `_coreApiUrl` was serialised, not `coreApiUrl`.

This change adds a helper method that looks for both properties, which allows the url matcher to work properly.

cc/ @grahamulator @pseudozach