### PR TITLE
fix: nonce calc

### DIFF
--- a/.changeset/smart-apricots-enjoy.md
+++ b/.changeset/smart-apricots-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This fixes a rare bug where if an address has received more transactions than we fetch for, it would assume it was a fresh account and return the incorrect nonce.

--- a/src/store/accounts/index.ts
+++ b/src/store/accounts/index.ts
@@ -19,7 +19,7 @@ import {
 } from '@store/accounts/api';
 import deepEqual from 'fast-deep-equal';
 
-const DEFAULT_LIST_LIMIT = 30;
+const DEFAULT_LIST_LIMIT = 50;
 
 /**
  * --------------------------------------

--- a/src/store/accounts/nonce.ts
+++ b/src/store/accounts/nonce.ts
@@ -46,7 +46,7 @@ export const currentAccountNonceState = atom(get => {
   // they have any pending or confirmed transactions
   const hasTransactions = !!latestPendingTx || !!lastConfirmedTx;
 
-  if (!hasTransactions || !account || (!hasTransactions && account.nonce === 0)) return 0;
+  if (!account) return 0;
 
   // if the oldest pending tx is more than 1 above the account nonce, it's likely there was
   // a race condition such that the client didn't have the most up to date pending tx
@@ -55,7 +55,8 @@ export const currentAccountNonceState = atom(get => {
     oldestPendingTx && lastConfirmedTx ? oldestPendingTx.nonce > lastConfirmedTx.nonce + 1 : false;
 
   // if they do have a miss match, let's use the account nonce
-  if (hasNonceMismatch) return account.nonce;
+  // or if we don't have any prior transactions, use the info api nonce
+  if (hasNonceMismatch || !hasTransactions) return account.nonce;
 
   // otherwise, without micro-blocks, the account nonce will likely be out of date compared
   // and not be incremented based on pending transactions

--- a/yarn.lock
+++ b/yarn.lock
@@ -10652,7 +10652,7 @@ jotai-query-toolkit@0.1.7:
     fast-deep-equal "3.1.3"
     proxy-memoize "^0.3.5"
 
-jotai@1.3.0, "jotai@https://pkg.csb.dev/pmndrs/jotai/commit/c6868435/jotai":
+jotai@1.3.0:
   version "1.3.0"
   resolved "https://pkg.csb.dev/pmndrs/jotai/commit/c6868435/jotai#35037ac388b8b69835c984a5299fec774200be60"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10654,7 +10654,8 @@ jotai-query-toolkit@0.1.7:
 
 jotai@1.3.0:
   version "1.3.0"
-  resolved "https://pkg.csb.dev/pmndrs/jotai/commit/c6868435/jotai#35037ac388b8b69835c984a5299fec774200be60"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.3.0.tgz#dfeb67928304272215e9a99f100bfc36aa84c922"
+  integrity sha512-Qw0MUsx+y5ljGcLwppZp1Q9YuyEC4jutqWdR4A8Yvb9fvRYnXXy55WxXIESxHjQ+rWgnvx4eEL/xzUz5O4PfVQ==
 
 joycon@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1164174381).<!-- Sticky Header Marker -->

This likely won't matter once we ship https://github.com/blockstack/stacks-wallet-web/pull/1530, but I found my account in a place where it was able to repro a bug I hadn't been able to before. The bug was this:

We fetch the last 30 transactions in both mempool and confirmed, and if the account doesn't have one where the sender_address is the accounts address, the logic was written such that it would always return 0.

This fixes it, so rather than returning 0, we just return the `account.nonce`

cc/ @aulneau @kyranjamie @fbwoolf
