### PR TITLE
chore: remove error overlay

### DIFF
--- a/webpack/dev-server.js
+++ b/webpack/dev-server.js
@@ -31,16 +31,7 @@ Object.keys(config.entry).forEach(entryName => {
 
 config.plugins = [
   new webpack.HotModuleReplacementPlugin(),
-  new ReactRefreshWebpackPlugin({
-    overlay: {
-      entry: '@pmmmwh/react-refresh-webpack-plugin/client/ErrorOverlayEntry',
-      module: '@pmmmwh/react-refresh-webpack-plugin/overlay',
-      sockIntegration: 'wds',
-      sockProtocol: 'ws',
-      sockHost: 'localhost',
-      sockPort: 8080,
-    },
-  }),
+  new ReactRefreshWebpackPlugin({ overlay: false }),
 ].concat(config.plugins || []);
 
 const compiler = webpack(config);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1166838914).<!-- Sticky Header Marker -->

Any objections to this change?

This removes the overlay that pops up when there's a runtime error in the wallet. I find this _sooooo_ annoying, as if I switch from editor to browser when there's an error, it breaks whatever webpage you're on.