### PR TITLE
ci: query chrome webstore api version

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -84,7 +84,8 @@ jobs:
           node <<EOF> chrome_version
           var webstore = require('chrome-webstore')
           ;(async () => {
-            var details = await webstore.detail({id: '${{ secrets.CHROME_APP_ID }}'})
+            var webstore_api_version = await webstore.version()
+            var details = await webstore.detail({id: '${{ secrets.CHROME_APP_ID }}', version: webstore_api_version})
             console.log(details.version)
           })()
           EOF


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1186736485).<!-- Sticky Header Marker -->

This PR fixes the notify-release Github Workflow. It was previously failing with `400` HTTP errors when querying the Chrome webstore. This is because the store's API version was recently updated, and the NPM package being used to query the store's API was still using the old unsupported API version.

Explicitly setting the API version to use fixes this issue. Once merged, we can re-enable this workflow for the repo.
Closes https://github.com/hirosystems/devops/issues/787

cc/ @aulneau @kyranjamie @fbwoolf
