### PR TITLE
chore: move fee warning label

### DIFF
--- a/src/pages/transaction-signing/components/actions.tsx
+++ b/src/pages/transaction-signing/components/actions.tsx
@@ -13,7 +13,7 @@ import { TransactionsSelectors } from '@tests/integration/transactions.selectors
 import { useTransactionError } from '../hooks/use-transaction-error';
 import {
   useTransactionBroadcastError,
-  useTransactionRequestCustomFee,
+  useTransactionRequest,
 } from '@store/transactions/requests.hooks';
 import { useTransactionBroadcast } from '@store/transactions/transaction.hooks';
 import {
@@ -21,6 +21,7 @@ import {
   ShowTxSettingsPlaceholder,
 } from '@features/fee-nonce-drawers/components/show-tx-settings-action';
 import { HighFeeWarningLabel } from './app-set-fee-warning';
+import { useTransactionFee } from '../hooks/use-transaction-fee';
 
 const MinimalErrorMessageSuspense = memo((props: StackProps) => {
   const error = useTransactionError();
@@ -120,13 +121,22 @@ const SubmitAction = (props: ButtonProps) => {
 };
 
 const FeeRowItemSuspense = () => {
-  const customFee = useTransactionRequestCustomFee();
+  let showWarning = false;
+  const fee = useTransactionFee();
+  const transactionRequest = useTransactionRequest();
+  const appName = transactionRequest?.appDetails?.name;
+  const customFee = transactionRequest?.fee;
+
+  if (!!customFee && fee.amount) {
+    showWarning = customFee > fee.amount * 4;
+  }
+
   return (
     <SpaceBetween>
       <Caption>
         <Flex>
           Fees
-          {!!customFee && <HighFeeWarningLabel uStxFee={1000} appName="StacksPunks" />}
+          {showWarning && <HighFeeWarningLabel appName={appName} />}
         </Flex>
       </Caption>
       <Caption>

--- a/src/pages/transaction-signing/components/actions.tsx
+++ b/src/pages/transaction-signing/components/actions.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback } from 'react';
-import { Box, Button, ButtonProps, color, Stack, StackProps } from '@stacks/ui';
+import { Box, Button, ButtonProps, color, Flex, Stack, StackProps } from '@stacks/ui';
 import { LOADING_KEYS, useLoading } from '@common/hooks/use-loading';
 import { SpaceBetween } from '@components/space-between';
 import { Caption } from '@components/typography';
@@ -11,12 +11,16 @@ import { TransactionErrorReason } from './transaction-error';
 import { LoadingRectangle } from '@components/loading-rectangle';
 import { TransactionsSelectors } from '@tests/integration/transactions.selectors';
 import { useTransactionError } from '../hooks/use-transaction-error';
-import { useTransactionBroadcastError } from '@store/transactions/requests.hooks';
+import {
+  useTransactionBroadcastError,
+  useTransactionRequestCustomFee,
+} from '@store/transactions/requests.hooks';
 import { useTransactionBroadcast } from '@store/transactions/transaction.hooks';
 import {
   ShowTxSettingsAction,
   ShowTxSettingsPlaceholder,
 } from '@features/fee-nonce-drawers/components/show-tx-settings-action';
+import { HighFeeWarningLabel } from './app-set-fee-warning';
 
 const MinimalErrorMessageSuspense = memo((props: StackProps) => {
   const error = useTransactionError();
@@ -116,15 +120,22 @@ const SubmitAction = (props: ButtonProps) => {
 };
 
 const FeeRowItemSuspense = () => {
+  const customFee = useTransactionRequestCustomFee();
   return (
     <SpaceBetween>
-      <Caption>Fees</Caption>
+      <Caption>
+        <Flex>
+          Fees
+          {!!customFee && <HighFeeWarningLabel uStxFee={1000} appName="StacksPunks" />}
+        </Flex>
+      </Caption>
       <Caption>
         <FeeComponent />
       </Caption>
     </SpaceBetween>
   );
 };
+
 const FeeRowItemFallback = () => {
   return (
     <SpaceBetween>

--- a/src/pages/transaction-signing/components/app-set-fee-warning.tsx
+++ b/src/pages/transaction-signing/components/app-set-fee-warning.tsx
@@ -1,20 +1,34 @@
 import React, { FC } from 'react';
-import { Flex, Text, Box, color } from '@stacks/ui';
 import { FiInfo } from 'react-icons/fi';
-
+import { Flex, Text, Box, color, Stack } from '@stacks/ui';
+import { Tooltip } from '@components/tooltip';
 interface HighFeeWarningLabelProps {
-  uStxFee?: number | string;
-  appName: string;
+  appName: string | undefined;
 }
+
 export const HighFeeWarningLabel: FC<HighFeeWarningLabelProps> = ({ appName }) => {
-  return (
-    <Box display="inline">
-      <Flex flexDirection="row">
-        <Text color={color('feedback-alert')} ml="tight">
-          Increased by {appName}
-        </Text>
-        <FiInfo color={color('feedback-alert')} />
-      </Flex>
-    </Box>
-  );
+  const warningLabel = `${appName} suggests a higher fee to speed up your transaction. You can edit the fee in the
+        settings below.`;
+
+  return appName ? (
+    <>
+      <Box display="inline">
+        <Flex flexDirection="row" alignItems="center">
+          <Text color={color('feedback-alert')} ml="tight" mr="extra-tight">
+            Increased by {appName}
+          </Text>
+          <Tooltip placement="bottom" label={warningLabel}>
+            <Stack>
+              <Box
+                _hover={{ cursor: 'pointer' }}
+                size="14px"
+                color={color('feedback-alert')}
+                as={FiInfo}
+              />
+            </Stack>
+          </Tooltip>
+        </Flex>
+      </Box>
+    </>
+  ) : null;
 };

--- a/src/pages/transaction-signing/components/app-set-fee-warning.tsx
+++ b/src/pages/transaction-signing/components/app-set-fee-warning.tsx
@@ -1,30 +1,19 @@
 import React, { FC } from 'react';
-import { Flex, Box, color, Text } from '@stacks/ui';
+import { Flex, Text, Box, color } from '@stacks/ui';
 import { FiInfo } from 'react-icons/fi';
-import { microStxToStx } from '@stacks/ui-utils';
 
-interface AppSetFeeWarningProps {
-  uStxFee: number | string;
+interface HighFeeWarningLabelProps {
+  uStxFee?: number | string;
+  appName: string;
 }
-export const AppSetFeeWarning: FC<AppSetFeeWarningProps> = ({ uStxFee }) => {
+export const HighFeeWarningLabel: FC<HighFeeWarningLabelProps> = ({ appName }) => {
   return (
-    <Box background={color('bg-alt')} py="base" px="base-loose" borderRadius="10px">
-      <Flex>
-        <Box mr="base-tight" mt="2px">
-          <FiInfo color={color('accent')} />
-        </Box>
-        <Box>
-          <Text textStyle="body.small.medium">App has set fee of {microStxToStx(uStxFee)} STX</Text>
-          <Text
-            textStyle="body.small"
-            color={color('text-caption')}
-            lineHeight="22px"
-            mt="extra-tight"
-          >
-            Stacks app developers can set a fee to be used when broadcasting this transaction. This
-            is sometimes needed when calling a particularly expensive contract.
-          </Text>
-        </Box>
+    <Box display="inline">
+      <Flex flexDirection="row">
+        <Text color={color('feedback-alert')} ml="tight">
+          Increased by {appName}
+        </Text>
+        <FiInfo color={color('feedback-alert')} />
       </Flex>
     </Box>
   );

--- a/src/pages/transaction-signing/transaction-signing.tsx
+++ b/src/pages/transaction-signing/transaction-signing.tsx
@@ -3,7 +3,6 @@ import { Stack } from '@stacks/ui';
 
 import {
   useTransactionRequest,
-  useTransactionRequestCustomFee,
   useUpdateTransactionBroadcastError,
 } from '@store/transactions/requests.hooks';
 import { PopupHeader } from '@pages/transaction-signing/components/popup-header';
@@ -16,12 +15,10 @@ import { PostConditions } from '@pages/transaction-signing/components/post-condi
 import { StxTransferDetails } from '@pages/transaction-signing/components/stx-transfer-details';
 import { PostConditionModeWarning } from '@pages/transaction-signing/components/post-condition-mode-warning';
 import { TransactionError } from './components/transaction-error';
-import { AppSetFeeWarning } from './components/app-set-fee-warning';
 
 export const TransactionPage = memo(() => {
   const transactionRequest = useTransactionRequest();
   const setBroadcastError = useUpdateTransactionBroadcastError();
-  const customFee = useTransactionRequestCustomFee();
   if (!transactionRequest) return null;
 
   useEffect(() => {
@@ -38,7 +35,6 @@ export const TransactionPage = memo(() => {
         {transactionRequest.txType === 'contract_call' && <ContractCallDetails />}
         {transactionRequest.txType === 'token_transfer' && <StxTransferDetails />}
         {transactionRequest.txType === 'smart_contract' && <ContractDeployDetails />}
-        {!!customFee && <AppSetFeeWarning uStxFee={customFee} />}
         <TransactionsActions />
       </Stack>
     </PopupContainer>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1187593194).<!-- Sticky Header Marker -->

Changes the warning label towards @jasperjansz's designs. This PR isn't incomplete, but making anyway as I'm not sure how much further I get while at Bristol Airport. 

@fbwoolf perhaps this is one you can help with. Foremost, we need to add any conditional logic to decide when we do/don't show this warning label. I'd do this before starting on the tooltip.

Afaik, we don't have a warning label in the app yet. This is a lower priority task imo, but I'd recommend using the same one as in the desktop wallet, one of the more popular react tooltip libraries.

Sorry again for my unavailability today @blockstack/ux-team, I'd tried to schedule my travel so it wouldn't get in the way of work, but it was an absolute palava try to get a covid test result needed to travel.