### PR TITLE
Feat/rbf send max fix

### DIFF
--- a/src/components/popup/tx-item.tsx
+++ b/src/components/popup/tx-item.tsx
@@ -57,7 +57,7 @@ const getTxCaption = (transaction: Tx) => {
     case 'token_transfer':
     case 'coinbase':
     case 'poison_microblock':
-      return truncateMiddle(transaction.tx_id);
+      return truncateMiddle(transaction.tx_id, 4);
     default:
       return null;
   }
@@ -158,19 +158,12 @@ export const TxItem: React.FC<TxItemProps & BoxProps> = ({ transaction, ...rest 
       <Stack alignItems="center" spacing="base-loose" isInline position="relative" zIndex={2}>
         <TxItemIcon transaction={transaction} />
         <SpaceBetween flexGrow={1}>
-          <Stack onClick={() => handleOpenTxLink(transaction.tx_id)}>
+          <Stack spacing="base-tight" onClick={() => handleOpenTxLink(transaction.tx_id)}>
             <Title as="h3" fontWeight="normal">
               {getTxTitle(transaction as any)}
             </Title>
             <Stack isInline flexWrap="wrap">
               <Status transaction={transaction} />
-              {transaction.tx_type === 'token_transfer' ? (
-                isOriginator ? (
-                  <Caption variant="c2">Sent</Caption>
-                ) : (
-                  <Caption variant="c2">Received</Caption>
-                )
-              ) : null}
               <Caption variant="c2">{getTxCaption(transaction)}</Caption>
             </Stack>
           </Stack>

--- a/src/features/fee-nonce-drawers/transaction-settings-drawer.tsx
+++ b/src/features/fee-nonce-drawers/transaction-settings-drawer.tsx
@@ -20,6 +20,7 @@ import { useLoading } from '@common/hooks/use-loading';
 import BigNumber from 'bignumber.js';
 import { useFeeSchema } from '@features/fee-nonce-drawers/use-fee-schema';
 import { ErrorLabel } from '@components/error-label';
+import { useLocalStxTransactionAmount } from '@store/transactions/local-transactions.hooks';
 
 const Messaging = () => {
   return (
@@ -103,7 +104,8 @@ const SettingsForm = () => {
   const [isEnabled, setIsEnabled] = useState(false);
   const { setIsLoading, setIsIdle } = useLoading('settings-form');
   const [values, setValues] = useState({ fee: 0, nonce: 0 });
-  const feeSchema = useFeeSchema();
+  const [amount] = useLocalStxTransactionAmount();
+  const feeSchema = useFeeSchema(amount || undefined);
 
   return (
     <Formik
@@ -178,11 +180,17 @@ const SettingsForm = () => {
 
 export const TransactionSettingsDrawer: React.FC = () => {
   const { showTxSettings, setShowTxSettings } = useDrawers();
+  const [, setFeeRateUseCustom] = useFeeRateUseCustom();
+  const [, setFeeRateMultiplierCustom] = useFeeRateMultiplierCustom();
   return (
     <ControlledDrawer
       title="Advanced settings"
       isShowing={showTxSettings}
-      onClose={() => setShowTxSettings(false)}
+      onClose={() => {
+        setShowTxSettings(false);
+        setFeeRateUseCustom(false);
+        setFeeRateMultiplierCustom(undefined);
+      }}
     >
       <Stack px="loose" spacing="loose" pb="extra-loose">
         <Messaging />

--- a/src/pages/send-tokens/components/amount-field.tsx
+++ b/src/pages/send-tokens/components/amount-field.tsx
@@ -52,7 +52,7 @@ export const AmountField = memo((props: AmountFieldProps) => {
           {balances && selectedAsset ? (
             <SendMaxWithSuspense
               showButton={Boolean(balances && selectedAsset)}
-              onSetMax={fee => handleSetSendMax(fee)}
+              onSetMax={feeRate => handleSetSendMax(feeRate)}
             />
           ) : null}
         </Box>

--- a/src/pages/send-tokens/components/send-max-button.tsx
+++ b/src/pages/send-tokens/components/send-max-button.tsx
@@ -1,7 +1,7 @@
 import React, { FC, Suspense } from 'react';
 import { Box, color, ButtonProps } from '@stacks/ui';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
-import { useCurrentFee } from '@store/transactions/fees.hooks';
+import { useCurrentFeeRate } from '@store/transactions/fees.hooks';
 
 const SendMaxButton: FC<ButtonProps> = props => (
   <Box
@@ -27,10 +27,10 @@ interface SendMaxProps extends ButtonProps {
   onSetMax(fee: number): void;
 }
 function SendMax({ onSetMax, ...props }: SendMaxProps) {
-  const fee = useCurrentFee();
+  const [feeRate] = useCurrentFeeRate();
   return (
     <SendMaxButton
-      onClick={() => onSetMax(fee)}
+      onClick={() => onSetMax(feeRate)}
       data-testid={SendFormSelectors.BtnSendMaxBalance}
       {...props}
     />
@@ -43,7 +43,7 @@ interface SendMaxWithSuspense extends SendMaxProps {
 export function SendMaxWithSuspense({ showButton, onSetMax, ...props }: SendMaxWithSuspense) {
   return (
     <Suspense fallback={<SendMaxButton />}>
-      {showButton ? <SendMax onSetMax={fee => onSetMax(fee)} {...props} /> : null}
+      {showButton ? <SendMax onSetMax={onSetMax} {...props} /> : null}
     </Suspense>
   );
 }

--- a/src/pages/send-tokens/hooks/use-send-form.ts
+++ b/src/pages/send-tokens/hooks/use-send-form.ts
@@ -18,11 +18,11 @@ export function useSendAmountFieldActions({
   const isStx = selectedAsset?.type === 'stx';
 
   const handleSetSendMax = useCallback(
-    (fee: number) => {
+    (feeRate: number) => {
       if (!selectedAsset || !balance) return;
       if (isStx) {
         const txFee = microStxToStx(
-          new BigNumber(fee ?? 1).multipliedBy(STX_TRANSFER_TX_SIZE_BYTES).toString()
+          new BigNumber(feeRate ?? 1).multipliedBy(STX_TRANSFER_TX_SIZE_BYTES).toString()
         );
         const stx = microStxToStx(availableStxBalance || 0).minus(txFee);
         if (stx.isLessThanOrEqualTo(0)) return;

--- a/src/store/transactions/local-transactions.hooks.ts
+++ b/src/store/transactions/local-transactions.hooks.ts
@@ -1,0 +1,6 @@
+import { useAtom } from 'jotai';
+import { localStxTransactionAmountState } from '@store/transactions/local-transactions';
+
+export function useLocalStxTransactionAmount() {
+  return useAtom(localStxTransactionAmountState);
+}

--- a/src/store/transactions/local-transactions.ts
+++ b/src/store/transactions/local-transactions.ts
@@ -152,9 +152,15 @@ export const ftTokenTransferTransactionState = atom(get => {
   });
 });
 
-export const localTransactionState = atom(get => {
+export const localStxTransactionAmountState = atom<null | number>(null);
+
+export const localTransactionIsStxTransferState = atom(get => {
   const selectedAsset = get(selectedAssetStore);
-  return selectedAsset?.type === 'stx'
+  return selectedAsset?.type === 'stx';
+});
+
+export const localTransactionState = atom(get => {
+  return get(localTransactionIsStxTransferState)
     ? get(tokenTransferTransaction)
     : get(ftTokenTransferTransactionState);
 });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1188106495).<!-- Sticky Header Marker -->

Some fixes around sending max. The story here is still not ideal -- not sure what to do when the user hits "send max" for a token transfer, and then increases the fee. Do we want to update their send amount to reflect the fee increase? Currently it will just error and prevent a fee increase.

cc/ @aulneau @kyranjamie @fbwoolf
