### PR TITLE
fix: remove activeTab permission

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -6,7 +6,7 @@ const manifest = {
   author: 'Hiro PBC',
   description:
     'Hiro Wallet. Use the Stacks blockchain to access privacy-friendly apps, and keep data in your control.',
-  permissions: ['activeTab', 'contextMenus'],
+  permissions: ['contextMenus'],
   manifest_version: 2,
   background: {
     scripts: ['background.js'],


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1191666399).<!-- Sticky Header Marker -->

This removes the unused `activeTab` permission. I tested a few things out and nothing seems broken. I'm not sure why we had this originally. 

cc/ @aulneau @kyranjamie @fbwoolf
