### PR TITLE
refactor: use absolute fee values in store, remove multiples state

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -144,6 +144,7 @@ jobs:
           path: '.jest-cache'
           key: ${{ runner.os }}--jest
 
+      # https://github.com/nodejs/node/issues/40030
       - uses: actions/setup-node@v2
         with:
           node-version: 14

--- a/src/common/error-messages.ts
+++ b/src/common/error-messages.ts
@@ -9,4 +9,5 @@ export enum SendFormErrorMessages {
   MustSelectAsset = 'You must select a valid token to transfer',
   TooMuchPrecision = '{token} can only have {decimals} decimals',
   MemoExceedsLimit = 'Memo must be less than 34-bytes',
+  AdjustedFeeExceedsBalance = 'AdjustedFeeExceedsBalance',
 }

--- a/src/common/transactions/transactions.ts
+++ b/src/common/transactions/transactions.ts
@@ -85,7 +85,7 @@ export type ContractDeployOptions = Pick<
   'txType' | 'contractName' | 'codeBody' | 'postConditions' | 'postConditionMode' | 'network'
 >;
 
-interface GenerateSignedTransactionOptions {
+export interface GenerateSignedTransactionOptions {
   txData: ContractCallOptions | TokenTransferOptions | ContractDeployOptions;
   senderKey: string;
   nonce?: number;

--- a/src/features/fee-nonce-drawers/speed-up-transaction-drawer.tsx
+++ b/src/features/fee-nonce-drawers/speed-up-transaction-drawer.tsx
@@ -14,23 +14,17 @@ import {
 } from '@store/accounts/account.hooks';
 import * as yup from 'yup';
 import { Formik, FormikProps } from 'formik';
-import { LOADING_KEYS, useLoading } from '@common/hooks/use-loading';
+import { microStxToStx } from '@stacks/ui-utils';
+import BigNumber from 'bignumber.js';
+import { toast } from 'react-hot-toast';
 
+import { LOADING_KEYS, useLoading } from '@common/hooks/use-loading';
 import { FeeField } from '@features/fee-nonce-drawers/components/fee-field';
 import { StacksTransaction } from '@stacks/transactions';
 import { stacksValue, stxToMicroStx } from '@common/stacks-utils';
-import {
-  useFeeRate,
-  useFeeRateMultiplier,
-  useFeeRateMultiplierCustom,
-  useFeeRateUseCustom,
-  useReplaceByFeeSubmitCallBack,
-} from '@store/transactions/fees.hooks';
-import BigNumber from 'bignumber.js';
-import { toast } from 'react-hot-toast';
+import { useFeeRate, useReplaceByFeeSubmitCallBack } from '@store/transactions/fees.hooks';
 import { useRefreshAllAccountData } from '@common/hooks/account/use-refresh-all-account-data';
 import { useFeeSchema } from './use-fee-schema';
-import { microStxToStx } from '@stacks/ui-utils';
 
 const useSelectedTx = () => {
   const [rawTxId] = useRawTxIdState();
@@ -96,9 +90,7 @@ const getFeeNonceFromStacksTransaction = (tx?: StacksTransaction) => ({
 
 const FeeForm = () => {
   const refreshAccountData = useRefreshAllAccountData();
-  const [multiplier] = useFeeRateMultiplier();
-  const [multiplierCustom] = useFeeRateMultiplierCustom();
-  const [, setUseCustom] = useFeeRateUseCustom();
+
   const [, setFeeRate] = useFeeRate();
   const tx = useSelectedTx();
   const rawTx = useRawStacksTransactionState();
@@ -111,9 +103,6 @@ const FeeForm = () => {
 
   const onSubmit = useCallback(
     async values => {
-      if (multiplierCustom !== multiplier) {
-        setUseCustom(true);
-      }
       if (!byteSize) return;
       // TODO: we should do some double checks that nothing changed before submitting
       await refreshAccountData();
@@ -122,15 +111,7 @@ const FeeForm = () => {
       setFeeRate(feeRate);
       await handleSubmit(values);
     },
-    [
-      byteSize,
-      handleSubmit,
-      multiplier,
-      multiplierCustom,
-      refreshAccountData,
-      setFeeRate,
-      setUseCustom,
-    ]
+    [byteSize, handleSubmit, refreshAccountData, setFeeRate]
   );
 
   useEffect(() => {

--- a/src/features/fee-nonce-drawers/use-fee-schema.ts
+++ b/src/features/fee-nonce-drawers/use-fee-schema.ts
@@ -6,6 +6,7 @@ import { STX_DECIMALS } from '@common/constants';
 import { isNumber } from '@common/utils';
 import BigNumber from 'bignumber.js';
 import { stxToMicroStx } from '@stacks/ui-utils';
+import { SendFormErrorMessages } from '@common/error-messages';
 
 /**
  * @param amountToSend stx amount in µSTX
@@ -31,8 +32,7 @@ export const useFeeSchema = (amountToSend?: number) => {
           const amountWithFee = new BigNumber(amountToSend).plus(fee);
           if (amountWithFee.isGreaterThan(availableStxBalance)) {
             return context.createError({
-              message:
-                'The fee added now exceeds your current STX balance. Consider lowering the amount being sent.',
+              message: SendFormErrorMessages.AdjustedFeeExceedsBalance,
             });
           }
           return true;

--- a/src/pages/send-tokens/components/send-max-button.tsx
+++ b/src/pages/send-tokens/components/send-max-button.tsx
@@ -1,7 +1,7 @@
 import React, { FC, Suspense } from 'react';
 import { Box, color, ButtonProps } from '@stacks/ui';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
-import { useCurrentFeeRate } from '@store/transactions/fees.hooks';
+import { useFeeRate } from '@store/transactions/fees.hooks';
 
 const SendMaxButton: FC<ButtonProps> = props => (
   <Box
@@ -27,7 +27,7 @@ interface SendMaxProps extends ButtonProps {
   onSetMax(fee: number): void;
 }
 function SendMax({ onSetMax, ...props }: SendMaxProps) {
-  const [feeRate] = useCurrentFeeRate();
+  const [feeRate] = useFeeRate();
   return (
     <SendMaxButton
       onClick={() => onSetMax(feeRate)}

--- a/src/pages/send-tokens/send-tokens.tsx
+++ b/src/pages/send-tokens/send-tokens.tsx
@@ -12,14 +12,14 @@ import { AssetSearch } from '@pages/send-tokens/components/asset-search/asset-se
 import { Header } from '@components/header';
 import { useSelectedAsset } from '@common/hooks/use-selected-asset';
 
-import { useSendFormValidation } from '@pages/send-tokens/hooks/use-send-form-validation';
 import { AmountField } from '@pages/send-tokens/components/amount-field';
+import { useTransferableAssets } from '@store/assets/asset.hooks';
 import { RecipientField } from '@pages/send-tokens/components/recipient-field';
 import { MemoField } from '@pages/send-tokens/components/memo-field';
-import { useTransferableAssets } from '@store/assets/asset.hooks';
+
+import { useSendFormValidation } from '@pages/send-tokens/hooks/use-send-form-validation';
 import { ConfirmSendDrawer } from '@pages/transaction-signing/components/confirm-send-drawer';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
-import { SendFormMemoWarning } from './components/memo-warning';
 import {
   useLocalTransactionInputsState,
   useTxForSettingsState,
@@ -27,13 +27,10 @@ import {
 import { LOADING_KEYS, useLoading } from '@common/hooks/use-loading';
 import { useDrawers } from '@common/hooks/use-drawers';
 import { useLocalStxTransactionAmount } from '@store/transactions/local-transactions.hooks';
-import {
-  useFeeRate,
-  useFeeRateMultiplierCustom,
-  useFeeRateUseCustom,
-} from '@store/transactions/fees.hooks';
-import { useCustomNonce } from '@store/transactions/nonce.hooks';
 import { useNextTxNonce } from '@common/hooks/account/use-next-tx-nonce';
+import { useCustomAbsoluteFee } from '@store/transactions/fees.hooks';
+import { SendFormMemoWarning } from './components/memo-warning';
+import { useCustomNonce } from '@store/transactions/nonce.hooks';
 
 type Amount = number | '';
 
@@ -147,18 +144,15 @@ const ShowDelay = ({
 
 const useResetFeesCallback = () => {
   const { showTxSettings, setShowTxSettings } = useDrawers();
-  const [, setFeeRateUseCustom] = useFeeRateUseCustom();
-  const [, setFeeRateMultiplierCustom] = useFeeRateMultiplierCustom();
+
   const { isLoading, setIsIdle } = useLoading(LOADING_KEYS.TX_FEE_NONCE_DRAWER);
-  const [, setFeeRate] = useFeeRate();
   const [, setCustomNonce] = useCustomNonce();
+  const [, setAbsoluteCustomFee] = useCustomAbsoluteFee();
 
   return () => {
     if (showTxSettings) setShowTxSettings(false);
-    setFeeRateUseCustom(false);
-    setFeeRateMultiplierCustom(undefined);
-    setFeeRate(undefined);
     setCustomNonce(undefined);
+    setAbsoluteCustomFee(null);
     if (isLoading) setIsIdle();
   };
 };

--- a/src/store/transactions/fees.hooks.ts
+++ b/src/store/transactions/fees.hooks.ts
@@ -1,17 +1,14 @@
+import { useCallback } from 'react';
 import { useAtomCallback, useAtomValue } from 'jotai/utils';
 import {
-  currentFeeRateState,
   currentFeeState,
-  feeRateState,
-  feeRateMultiplierState,
-  feeRateMultiplierCustomState,
-  feeRateUseCustom,
   currentDefaultFeeState,
+  feeRateState,
+  customAbsoluteTxFee,
 } from '@store/transactions/fees';
 import { useAtom } from 'jotai';
 import { useRawTxIdState } from '@store/transactions/raw.hooks';
 import { useSubmitTransactionCallback } from '@pages/transaction-signing/hooks/use-submit-stx-transaction';
-import { useCallback } from 'react';
 import { rawSignedStacksTransactionState } from '@store/transactions/raw';
 import { LOADING_KEYS } from '@common/hooks/use-loading';
 
@@ -23,38 +20,22 @@ export function useCurrentDefaultFee() {
   return useAtomValue(currentDefaultFeeState);
 }
 
-export function useFeeRateMultiplier() {
-  return useAtom(feeRateMultiplierState);
-}
-
-export function useFeeRateMultiplierCustom() {
-  return useAtom(feeRateMultiplierCustomState);
-}
-
-export function useFeeRateUseCustom() {
-  return useAtom(feeRateUseCustom);
+export function useCustomAbsoluteFee() {
+  return useAtom(customAbsoluteTxFee);
 }
 
 export function useFeeRate() {
   return useAtom(feeRateState);
 }
 
-export function useCurrentFeeRate() {
-  return useAtom(currentFeeRateState);
-}
-
 export const useReplaceByFeeSubmitCallBack = () => {
-  const [, setMultiplier] = useFeeRateMultiplierCustom();
-  const [, setUseCustom] = useFeeRateUseCustom();
-  const [, setFeeRate] = useFeeRate();
   const [, setTxId] = useRawTxIdState();
+  const [, setCustomAbsoluteFee] = useCustomAbsoluteFee();
 
   const submitTransaction = useSubmitTransactionCallback({
     onClose: () => {
       setTxId(null);
-      setUseCustom(false);
-      setMultiplier(undefined);
-      setFeeRate(undefined);
+      setCustomAbsoluteFee(null);
     },
     loadingKey: LOADING_KEYS.INCREASE_FEE_DRAWER,
     replaceByFee: true,

--- a/src/store/transactions/fees.ts
+++ b/src/store/transactions/fees.ts
@@ -1,31 +1,11 @@
 import { atom } from 'jotai';
-import { DEFAULT_FEE_RATE, DEFAULT_FEE_RATE_MULTIPLIER } from '@store/common/constants';
+import { DEFAULT_FEE_RATE } from '@store/common/constants';
 import { txForSettingsState } from '@store/transactions/index';
-import { transactionRequestCustomFeeRateState } from '@store/transactions/requests';
 import { getUpdatedTransactionFee } from '@store/transactions/utils';
 
-export const feeRateMultiplierCustomState = atom<number | undefined>(undefined);
-export const feeRateUseCustom = atom<boolean>(false);
-export const feeRateMultiplierState = atom<number, number | undefined>(
-  get => {
-    const useCustom = get(feeRateUseCustom);
-    if (!useCustom) return DEFAULT_FEE_RATE_MULTIPLIER;
-    return get(feeRateMultiplierCustomState) || DEFAULT_FEE_RATE_MULTIPLIER;
-  },
-  (_get, set, update) => {
-    set(feeRateMultiplierCustomState, update);
-  }
-);
+export const feeRateState = atom(DEFAULT_FEE_RATE);
 
-export const feeRateCustomState = atom<number | undefined>(undefined);
-export const feeRateState = atom<number, number | undefined>(
-  get => {
-    return get(feeRateCustomState) || get(transactionRequestCustomFeeRateState) || DEFAULT_FEE_RATE;
-  },
-  (_get, set, update) => set(feeRateCustomState, update)
-);
-
-export const currentFeeRateState = atom(get => get(feeRateState) * get(feeRateMultiplierState));
+export const customAbsoluteTxFee = atom<number | null>(null);
 
 export const currentFeeState = atom(get => {
   const transaction = get(txForSettingsState);

--- a/src/store/transactions/raw.ts
+++ b/src/store/transactions/raw.ts
@@ -7,7 +7,8 @@ import {
 } from '@stacks/transactions';
 import { currentAccountPrivateKeyState } from '@store/accounts';
 import { updateTransactionFee } from '@store/transactions/utils';
-import { currentFeeRateState } from '@store/transactions/fees';
+import { customAbsoluteTxFee, feeRateState } from '@store/transactions/fees';
+import BN from 'bn.js';
 
 export const rawTxIdState = atom<string | null>(null);
 
@@ -42,8 +43,12 @@ export const rawSignedStacksTransactionState = atom(get => {
   const transaction = get(rawStacksTransactionState);
   const privateKey = get(currentAccountPrivateKeyState);
   if (!transaction || !privateKey) return;
-  const feeRate = get(currentFeeRateState);
+  const feeRate = get(feeRateState);
+  const absoluteCustomFee = get(customAbsoluteTxFee);
   const updatedTx = updateTransactionFee(transaction, feeRate);
+  if (absoluteCustomFee) {
+    updatedTx.setFee(new BN(absoluteCustomFee));
+  }
   const signer = new TransactionSigner(updatedTx);
   signer.signOrigin(createStacksPrivateKey(privateKey));
   return transaction;

--- a/src/store/transactions/utils.ts
+++ b/src/store/transactions/utils.ts
@@ -33,6 +33,15 @@ export function getPayloadFromToken(requestToken: string) {
   return payload;
 }
 
+export function getTxByteLength(tx: StacksTransaction) {
+  return new BigNumber(tx.serialize().byteLength);
+}
+
+export function calculateDefaultFee(tx: StacksTransaction, feeRate: number) {
+  const txBytes = new BigNumber(tx.serialize().byteLength);
+  return txBytes.multipliedBy(feeRate);
+}
+
 export function getUpdatedTransactionFee(tx: StacksTransaction, _feeRate: number) {
   const txBytes = new BigNumber(tx.serialize().byteLength);
   const feeRate = new BigNumber(_feeRate);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1221538543).<!-- Sticky Header Marker -->

- Removes concept of multiplier from store, it's better that it doesn't have a concept of this, as that we do the multiplication on the component level and only persist the absolute value
- An error is shown when setting the fee above your balance
 
<img src="https://user-images.githubusercontent.com/1618764/132500563-955d13f0-6fbf-42ac-b2cb-c0e2067519e4.png" width="450" />

This approach doesn't factor in the send max functionality, rather prohibits the fee ever exceeding your balance. Some feature to improve/allow the user to update this would be nice, but I'm inclined to leave this out for now on the grounds of simplicity. It's going to be a very common occurrence that someone wants to send their entire balance & increase the fee greatly. Ideas welcome though.