### PR TITLE
fix: relocate learn more text

### DIFF
--- a/.changeset/violet-pigs-decide.md
+++ b/.changeset/violet-pigs-decide.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This relocates the 'Learn more' text link in the advanced settings drawer.

--- a/src/features/fee-nonce-drawers/transaction-settings-drawer.tsx
+++ b/src/features/fee-nonce-drawers/transaction-settings-drawer.tsx
@@ -47,6 +47,7 @@ const Messaging = () => {
   const url = 'https://www.hiro.so/questions/transactions-advanced-settings';
 
   const openInNewTab = (url: string) => {
+    if (!isValidUrl(url)) return;
     const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
     if (newWindow) newWindow.opener = null;
   };
@@ -56,7 +57,7 @@ const Messaging = () => {
       <Caption>
         Apply a higher fee to help your transaction confirm quickly, especially when the network is
         congested by other transactions.{' '}
-        <Link fontSize="14px" onClick={() => isValidUrl(url) && openInNewTab(url)}>
+        <Link fontSize="14px" onClick={() => openInNewTab(url)}>
           Learn more.
         </Link>
       </Caption>

--- a/src/features/fee-nonce-drawers/transaction-settings-drawer.tsx
+++ b/src/features/fee-nonce-drawers/transaction-settings-drawer.tsx
@@ -55,11 +55,11 @@ const Messaging = () => {
     <>
       <Caption>
         Apply a higher fee to help your transaction confirm quickly, especially when the network is
-        congested by other transactions.
+        congested by other transactions.{' '}
+        <Link fontSize="14px" onClick={() => isValidUrl(url) && openInNewTab(url)}>
+          Learn more.
+        </Link>
       </Caption>
-      <Link fontSize="14px" onClick={() => isValidUrl(url) && openInNewTab(url)}>
-        Learn more...
-      </Link>
     </>
   );
 };


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1194671974).<!-- Sticky Header Marker -->

This PR relocates the newly added 'Learn more' text link in the advanced settings drawer.
@markmhx @jasperjansz 

full-page:
![Screen Shot 2021-09-02 at 8 27 20 AM](https://user-images.githubusercontent.com/6493321/131853614-e2d1a061-fe0a-4b3c-9773-be16f50f5bc5.png)

popup:
![Screen Shot 2021-09-02 at 8 29 04 AM](https://user-images.githubusercontent.com/6493321/131853647-e840c30a-b68c-4407-ac87-53f4821c9237.png)

cc/ @aulneau @kyranjamie @fbwoolf
