### PR TITLE
Fix commit linting

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,6 +1,6 @@
 name: Commit lint
 
-on: [ pull_request ]
+on: [pull_request]
 
 jobs:
   pre_run:
@@ -22,4 +22,4 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: wagoid/commitlint-github-action@v1
+      - uses: wagoid/commitlint-github-action@v4


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1209229138).<!-- Sticky Header Marker -->

Prevent _un_ conventional commits 