### PR TITLE
feat: use webworker to keep main thread free

### DIFF
--- a/.changeset/new-emus-train.md
+++ b/.changeset/new-emus-train.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': minor
+---
+
+Makes use of a WebWorker to prevent main thread from lagging during unlock operation

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -60,7 +60,7 @@ const devManifest = {
 const prodManifest = {
   name: 'Hiro Wallet',
   content_security_policy:
-    "script-src 'self' 'wasm-eval'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
+    "script-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
   icons: {
     128: 'assets/connect-logo/Stacks128w.png',
     256: 'assets/connect-logo/Stacks256w.png',

--- a/src/background/crypto/generate-encryption-key.ts
+++ b/src/background/crypto/generate-encryption-key.ts
@@ -1,17 +1,15 @@
-import argon2, { ArgonType } from 'argon2-browser';
+const worker = new Worker('./decryption-worker.js');
 
 interface GenerateEncryptionKeyArgs {
   password: string;
   salt: string;
 }
 export async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyArgs) {
-  const argonHash = await argon2.hash({
-    pass: password,
-    salt,
-    hashLen: 48,
-    time: 44,
-    mem: 1024 * 32,
-    type: ArgonType.Argon2id,
+  return new Promise(resolve => {
+    worker.postMessage({ password, salt });
+    worker.addEventListener('message', e => {
+      console.log('bg', e);
+      resolve(e.data);
+    });
   });
-  return argonHash.hashHex;
 }

--- a/src/background/crypto/generate-encryption-key.ts
+++ b/src/background/crypto/generate-encryption-key.ts
@@ -1,15 +1,17 @@
-const worker = new Worker('./decryption-worker.js');
+import { createWorker, WorkerScript } from '../../workers';
 
 interface GenerateEncryptionKeyArgs {
   password: string;
   salt: string;
 }
-export async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyArgs) {
+export async function generateEncryptionKey(args: GenerateEncryptionKeyArgs): Promise<string> {
+  const worker = createWorker(WorkerScript.DecryptionWorker);
+
   return new Promise(resolve => {
-    worker.postMessage({ password, salt });
-    worker.addEventListener('message', e => {
-      console.log('bg', e);
+    worker.addEventListener('message', (e: MessageEvent<string>) => {
+      worker.terminate();
       resolve(e.data);
     });
+    worker.postMessage(args);
   });
 }

--- a/src/components/unlock.tsx
+++ b/src/components/unlock.tsx
@@ -37,6 +37,7 @@ export const Unlock: React.FC = () => {
           autoFocus
           type="password"
           value={password}
+          isDisabled={loading}
           data-testid="set-password"
           onChange={(e: React.FormEvent<HTMLInputElement>) => setPassword(e.currentTarget.value)}
           onKeyUp={buildEnterKeyEvent(submit)}

--- a/src/workers/decryption-worker.ts
+++ b/src/workers/decryption-worker.ts
@@ -1,0 +1,27 @@
+import argon2, { ArgonType } from 'argon2-browser';
+
+interface GenerateEncryptionKeyArgs {
+  password: string;
+  salt: string;
+}
+export async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyArgs) {
+  const argonHash = await argon2.hash({
+    pass: password,
+    salt,
+    hashLen: 48,
+    time: 44,
+    mem: 1024 * 32,
+    type: ArgonType.Argon2id,
+  });
+  return argonHash.hashHex;
+}
+
+self.addEventListener(
+  'message',
+  async function (e) {
+    const hex = await generateEncryptionKey(e.data);
+    self.postMessage(hex);
+    console.log('worker', hex);
+  },
+  false
+);

--- a/src/workers/decryption-worker.ts
+++ b/src/workers/decryption-worker.ts
@@ -1,5 +1,7 @@
 import argon2, { ArgonType } from 'argon2-browser';
 
+const context = self as unknown as Worker;
+
 interface GenerateEncryptionKeyArgs {
   password: string;
   salt: string;
@@ -16,12 +18,9 @@ export async function generateEncryptionKey({ password, salt }: GenerateEncrypti
   return argonHash.hashHex;
 }
 
-self.addEventListener(
-  'message',
-  async function (e) {
-    const hex = await generateEncryptionKey(e.data);
-    self.postMessage(hex);
-    console.log('worker', hex);
-  },
-  false
-);
+async function stretchKeyPostMessageHandler(e: MessageEvent<GenerateEncryptionKeyArgs>) {
+  const hex = await generateEncryptionKey(e.data);
+  context.postMessage(hex);
+}
+
+context.addEventListener('message', stretchKeyPostMessageHandler, false);

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -1,0 +1,7 @@
+export enum WorkerScript {
+  DecryptionWorker = 'decryption-worker.js',
+}
+
+export function createWorker(scriptName: WorkerScript) {
+  return new Worker(scriptName);
+}

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -77,6 +77,7 @@ const config = {
     inpage: path.join(SRC_ROOT_PATH, 'inpage', 'inpage.ts'),
     'content-script': path.join(SRC_ROOT_PATH, 'content-scripts', 'content-script.ts'),
     index: path.join(SRC_ROOT_PATH, 'index.tsx'),
+    'decryption-worker': path.join(SRC_ROOT_PATH, 'workers/decryption-worker.ts'),
   },
   output: {
     path: DIST_ROOT_PATH,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1242048650).<!-- Sticky Header Marker -->

In both wallets we use [Argon2](https://github.com/P-H-C/phc-winner-argon2) to stretch the user's password, deriving the encryption key. By design, it's hugely resource intensive, to make brute force attacks as infeasible as possible.

The downside to this is the the wallet can seem unresponsive as the thread is busy deriving the key. This is noticeable in that the animation lags, and everything else becomes temporarily inaccessible. In the video below, I've added buttons with hover colours and a text input that demonstrates this. I'm frantically clicking the input to no avail. Only at the end does it become accessible before navigating to the homepage.

https://user-images.githubusercontent.com/1618764/133125583-70e2e9e5-ab0e-42f4-abcb-19833ad57ae4.mp4

In this example, the function has been modified so that the msg is sent to a WebWorker, which does the key stretching on a different thread, and returns a `postMessage` with the same response.

https://user-images.githubusercontent.com/1618764/133125590-b3e504af-b1f7-4c3a-b539-50c47547d02a.mp4

