### PR TITLE
chore: rename key to avoid cache collisions

### DIFF
--- a/.changeset/tidy-crews-float.md
+++ b/.changeset/tidy-crews-float.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This update adds the global variable VERSION to all cache keys for any data that is persisted in local storage. This makes it so when the wallet updates, there isn't any leaking between versions and avoids using possibily outdated/stale data.

--- a/src/common/persistence.ts
+++ b/src/common/persistence.ts
@@ -18,6 +18,7 @@ export async function persistAndRenderApp(renderApp: () => void) {
     await persistQueryClient({
       queryClient,
       persistor: localStoragePersistor,
+      buster: VERSION,
     });
   renderApp();
 }

--- a/src/common/store-utils.ts
+++ b/src/common/store-utils.ts
@@ -19,7 +19,7 @@ export function bytesToHex(uint8a: Uint8Array): string {
 }
 
 export function makeLocalDataKey(params: QueryKey): string {
-  return hash(hashQueryKey(params));
+  return hash(hashQueryKey([params, VERSION]));
 }
 
 export function getLocalData<Data>(params: string[]) {

--- a/src/store/assets/fungible-tokens.ts
+++ b/src/store/assets/fungible-tokens.ts
@@ -9,9 +9,7 @@ import { apiClientState } from '@store/common/api-clients';
 import { FungibleTokenMetadata } from '@stacks/blockchain-api-client';
 
 enum FungibleTokensQueryKeys {
-  SIP_10_COMPLIANT = 'SIP_10_COMPLIANT',
-  META_DATA_METHODS = 'META_DATA_METHODS',
-  ASSET_META_DATA = 'ASSET_META_DATA',
+  FUNGIBLE_TOKEN_META_DATA = 'FUNGIBLE_TOKEN_META_DATA',
 }
 
 type ContractWithNetwork = Readonly<ContractPrincipal & { networkUrl: string }>;
@@ -47,7 +45,7 @@ export const assetMetaDataState = atomFamily<ContractWithNetwork, FtMeta | null>
         network.url,
         contractAddress,
         contractName,
-        FungibleTokensQueryKeys.ASSET_META_DATA,
+        FungibleTokensQueryKeys.FUNGIBLE_TOKEN_META_DATA,
       ];
       const localData = getLocalData<FtMeta | { error: string }>(keyParams);
       if (localData) {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1234009248).<!-- Sticky Header Marker -->

This makes a small change so that fungible token meta data will not use the same cache key as it did in older versions, as the shape of persisted data has changed.

cc/ @aulneau @kyranjamie @fbwoolf
