### PR TITLE
feat: add diagnostics with user permissions

### DIFF
--- a/.changeset/twenty-tools-yell.md
+++ b/.changeset/twenty-tools-yell.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': minor
+---
+
+Add a new state that asks users for permission to record application diagnostics

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,6 +1,9 @@
 name: Build beta extensions
 on: [pull_request, workflow_dispatch]
 
+env:
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
 jobs:
   pre_run:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -5,6 +5,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+env:
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
 jobs:
   pre_run:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@reach/utils": "0.15.3",
     "@reach/visually-hidden": "0.15.2",
     "@rehooks/document-title": "1.0.2",
+    "@sentry/react": "6.12.0",
+    "@sentry/tracing": "6.12.0",
     "@stacks/auth": "2.0.0-beta.1",
     "@stacks/blockchain-api-client": "0.65.0",
     "@stacks/common": "2.0.0-beta.0",

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -60,7 +60,7 @@ const devManifest = {
 const prodManifest = {
   name: 'Hiro Wallet',
   content_security_policy:
-    "script-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
+    "default-src 'none'; connect-src *; style-src 'unsafe-inline'; script-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
   icons: {
     128: 'assets/connect-logo/Stacks128w.png',
     256: 'assets/connect-logo/Stacks256w.png',

--- a/src/common/hooks/use-diagnostic-permission-prompt.ts
+++ b/src/common/hooks/use-diagnostic-permission-prompt.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+import { ScreenPaths } from '@common/types';
+import { IS_TEST_ENV } from '@common/constants';
+import { userHasAllowedDiagnosticsKey } from '@store/onboarding/onboarding.hooks';
+
+import { useChangeScreen } from './use-change-screen';
+
+export function usePromptUserToSetDiagnosticPermissions() {
+  const changeScreen = useChangeScreen();
+
+  useEffect(() => {
+    if (IS_TEST_ENV) return;
+    const persistedUserDiagnosticDecision = localStorage.getItem(userHasAllowedDiagnosticsKey);
+    if (persistedUserDiagnosticDecision === null) changeScreen(ScreenPaths.REQUEST_DIAGNOSTICS);
+  }, [changeScreen]);
+}

--- a/src/common/sentry-init.ts
+++ b/src/common/sentry-init.ts
@@ -1,0 +1,21 @@
+import * as Sentry from '@sentry/react';
+import { Integrations } from '@sentry/tracing';
+
+import { userHasAllowedDiagnosticsKey } from '@store/onboarding/onboarding.hooks';
+
+function checkUserHasGrantedPermission() {
+  return localStorage.getItem(userHasAllowedDiagnosticsKey) === 'true';
+}
+
+export function initSentry() {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    integrations: [new Integrations.BrowserTracing()],
+    tracesSampleRate: 1.0,
+    enabled: checkUserHasGrantedPermission(),
+    beforeSend(event) {
+      if (!checkUserHasGrantedPermission()) return null;
+      return event;
+    },
+  });
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -40,6 +40,7 @@ export enum ScreenPaths {
   POPUP_SEND = '/send',
   POPUP_RECEIVE = '/receive',
   ADD_NETWORK = '/add-network',
+  REQUEST_DIAGNOSTICS = '/request-diagnostics',
   EDIT_POST_CONDITIONS = '/transaction/post-conditions',
   TRANSACTION_POPUP = '/transaction',
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './app';
+
 import { persistAndRenderApp } from '@common/persistence';
+import { initSentry } from '@common/sentry-init';
+
+initSentry();
 
 function renderApp() {
   ReactDOM.render(<App />, document.getElementById('actions-root'));

--- a/src/pages/allow-diagnostics/allow-diagnostics-layout.tsx
+++ b/src/pages/allow-diagnostics/allow-diagnostics-layout.tsx
@@ -1,0 +1,65 @@
+import React, { FC } from 'react';
+
+import { Body } from '@components/typography';
+import { Box, Button, Flex, color, Stack } from '@stacks/ui';
+import { BaseDrawer } from '@components/drawer';
+import { FiCheck } from 'react-icons/fi';
+
+interface ReasonToAllowDiagnosticsProps {
+  text: string;
+}
+const ReasonToAllowDiagnostics: FC<ReasonToAllowDiagnosticsProps> = ({ text }) => {
+  return (
+    <Flex color={color('text-caption')} textStyle="body.small">
+      <Box mr="tight" mt="3px">
+        <FiCheck />
+      </Box>
+      <Box>{text}</Box>
+    </Flex>
+  );
+};
+
+interface AllowDiagnosticsLayoutProps {
+  onUserAllowDiagnostics(): void;
+  onUserDenyDiagnosticsPermissions(): void;
+}
+export const AllowDiagnosticsLayout: FC<AllowDiagnosticsLayoutProps> = props => {
+  const { onUserAllowDiagnostics, onUserDenyDiagnosticsPermissions } = props;
+
+  const title = 'Help us improve';
+
+  return (
+    <BaseDrawer title={title} isShowing onClose={() => onUserDenyDiagnosticsPermissions()}>
+      <Box mx="loose" mb="extra-loose">
+        <Body>
+          Hiro would like to gather anonymous data to help improve the experience of using Stacks
+          apps and the wallet.
+        </Body>
+        <Stack mt="loose" spacing="base-tight">
+          <ReasonToAllowDiagnostics text="Send anonymous data about page views and clicks" />
+          <ReasonToAllowDiagnostics text="We'll never collect personal data such as your Stacks address, keys, balances, or IP address" />
+          <ReasonToAllowDiagnostics text="We'll never share or sell any user data" />
+        </Stack>
+        <Flex mt="loose" fontSize="14px">
+          <Button
+            type="button"
+            mode="primary"
+            onClick={() => onUserAllowDiagnostics()}
+            mr="base-tight"
+          >
+            Yes, I'll help
+          </Button>
+          <Button
+            type="button"
+            mode="tertiary"
+            ml="base"
+            variant="link"
+            onClick={() => onUserDenyDiagnosticsPermissions()}
+          >
+            No thanks
+          </Button>
+        </Flex>
+      </Box>
+    </BaseDrawer>
+  );
+};

--- a/src/pages/allow-diagnostics/allow-diagnostics.tsx
+++ b/src/pages/allow-diagnostics/allow-diagnostics.tsx
@@ -1,0 +1,29 @@
+import React, { useCallback } from 'react';
+
+import { ScreenPaths } from '@common/types';
+import { useChangeScreen } from '@common/hooks/use-change-screen';
+import { useHasAllowedDiagnostics } from '@store/onboarding/onboarding.hooks';
+
+import { AllowDiagnosticsLayout } from './allow-diagnostics-layout';
+import { initSentry } from '@common/sentry-init';
+
+export const AllowDiagnosticsDrawer = () => {
+  const changeScreen = useChangeScreen();
+  const [, setHasAllowedDiagnostics] = useHasAllowedDiagnostics();
+
+  const goHomeAndSetDiagnosticsPermissionTo = useCallback(
+    (areDiagnosticsAllowed: boolean) => {
+      changeScreen(ScreenPaths.HOME);
+      setHasAllowedDiagnostics(areDiagnosticsAllowed);
+      if (areDiagnosticsAllowed) initSentry();
+    },
+    [changeScreen, setHasAllowedDiagnostics]
+  );
+
+  return (
+    <AllowDiagnosticsLayout
+      onUserDenyDiagnosticsPermissions={() => goHomeAndSetDiagnosticsPermissionTo(false)}
+      onUserAllowDiagnostics={() => goHomeAndSetDiagnosticsPermissionTo(true)}
+    />
+  );
+};

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -8,7 +8,11 @@ import { UserAccount } from '@pages/home/components/user-area';
 import { HomeActions } from '@pages/home/components/actions';
 import { HiroMessages } from '@features/hiro-messages/hiro-messages';
 
+import { usePromptUserToSetDiagnosticPermissions } from '@common/hooks/use-diagnostic-permission-prompt';
+
 export const PopupHome = () => {
+  usePromptUserToSetDiagnosticPermissions();
+
   return (
     <>
       <PopupContainer

--- a/src/pages/sign-out-confirm/sign-out-confirm-layout.tsx
+++ b/src/pages/sign-out-confirm/sign-out-confirm-layout.tsx
@@ -10,7 +10,6 @@ interface SignOutConfirmLayoutProps {
   onUserDeleteWallet(): void;
   onUserSafelyReturnToHomepage(): void;
 }
-
 export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
   const { onUserDeleteWallet, onUserSafelyReturnToHomepage } = props;
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -27,6 +27,7 @@ import { Unlock } from '@pages/unlock';
 import { PopupHome } from '@pages/home/home';
 import { useUpdateLastSeenStore } from '@store/wallet/wallet.hooks';
 import { SignOutConfirmDrawer } from '@pages/sign-out-confirm/sign-out-confirm';
+import { AllowDiagnosticsDrawer } from '@pages/allow-diagnostics/allow-diagnostics';
 
 interface RouteProps {
   path: ScreenPaths;
@@ -90,6 +91,7 @@ export const Routes: React.FC = () => {
     <RoutesDom>
       <Route path={ScreenPaths.HOME} element={getHomeComponent()}>
         <Route path={ScreenPaths.SIGN_OUT_CONFIRM} element={<SignOutConfirmDrawer />} />
+        <Route path={ScreenPaths.REQUEST_DIAGNOSTICS} element={<AllowDiagnosticsDrawer />} />
       </Route>
       {/* Installation */}
       <Route path={ScreenPaths.SIGN_IN_INSTALLED} element={<InstalledSignIn />} />

--- a/src/store/onboarding/onboarding.hooks.ts
+++ b/src/store/onboarding/onboarding.hooks.ts
@@ -3,6 +3,7 @@ import { useAtomValue, useUpdateAtom } from 'jotai/utils';
 import {
   authRequestState,
   currentScreenState,
+  hasAllowedDiagnosticsState,
   magicRecoveryCodePasswordState,
   magicRecoveryCodeState,
   onboardingPathState,
@@ -10,8 +11,11 @@ import {
   secretKeyState,
   seedInputErrorState,
   seedInputState,
+  userHasAllowedDiagnosticsKey,
   usernameState,
 } from './onboarding';
+
+export { userHasAllowedDiagnosticsKey };
 
 export function useAuthRequest() {
   return useAtomValue(authRequestState);
@@ -63,4 +67,8 @@ export function useUsernameState() {
 
 export function useOnboardingPathState() {
   return useAtomValue(onboardingPathState);
+}
+
+export function useHasAllowedDiagnostics() {
+  return useAtom(hasAllowedDiagnosticsState);
 }

--- a/src/store/onboarding/onboarding.ts
+++ b/src/store/onboarding/onboarding.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
-import { atomWithDefault } from 'jotai/utils';
+import { atomWithDefault, atomWithStorage } from 'jotai/utils';
 
 import { ScreenPaths } from '@common/types';
 import { DecodedAuthRequest } from '@common/dev/types';
@@ -42,6 +42,10 @@ export const authRequestState = atom<AuthRequestState>({
   appIcon: undefined,
   appURL: undefined,
 });
+
+export const userHasAllowedDiagnosticsKey = 'stacks-wallet-has-allowed-diagnostics';
+
+export const hasAllowedDiagnosticsState = atomWithStorage(userHasAllowedDiagnosticsKey, false);
 
 magicRecoveryCodePasswordState.debugLabel = 'magicRecoveryCodePasswordState';
 seedInputState.debugLabel = 'seedInputState';

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -205,6 +205,11 @@ const config = {
       'process.env.USERNAMES_ENABLED': JSON.stringify(process.env.USERNAMES_ENABLED || 'false'),
       'process.env.TEST_ENV': JSON.stringify(TEST_ENV ? 'true' : 'false'),
     }),
+
+    new webpack.EnvironmentPlugin({
+      SENTRY_DSN: process.env.SENTRY_DSN ?? '',
+    }),
+
     new webpack.ProvidePlugin({
       process: 'process/browser.js',
       Buffer: ['buffer', 'Buffer'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2840,6 +2840,81 @@
   resolved "https://registry.yarnpkg.com/@schemastore/web-manifest/-/web-manifest-0.0.5.tgz#97f0b1f14d095189c5672309e4975760278461b2"
   integrity sha512-3SF3OwzJ+PIqYDVW0MXoUAyypyx7N5RlYj2zek36qVuDUgoiI65q0ietwuxyVtbTRYJyP64KBGKvKqHzbIxdfA==
 
+"@sentry/browser@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.12.0.tgz#970cd68fa117a1e1336fdb373e3b1fa76cd63e2d"
+  integrity sha512-wsJi1NLOmfwtPNYxEC50dpDcVY7sdYckzwfqz1/zHrede1mtxpqSw+7iP4bHADOJXuF+ObYYTHND0v38GSXznQ==
+  dependencies:
+    "@sentry/core" "6.12.0"
+    "@sentry/types" "6.12.0"
+    "@sentry/utils" "6.12.0"
+    tslib "^1.9.3"
+
+"@sentry/core@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.12.0.tgz#bc7c5f0785b6a392d9ad47bd9b1fae3f5389996c"
+  integrity sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==
+  dependencies:
+    "@sentry/hub" "6.12.0"
+    "@sentry/minimal" "6.12.0"
+    "@sentry/types" "6.12.0"
+    "@sentry/utils" "6.12.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.12.0.tgz#29e323ab6a95e178fb14fffb684aa0e09707197f"
+  integrity sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==
+  dependencies:
+    "@sentry/types" "6.12.0"
+    "@sentry/utils" "6.12.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.12.0.tgz#cbe20e95056cedb9709d7d5b2119ef95206a9f8c"
+  integrity sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==
+  dependencies:
+    "@sentry/hub" "6.12.0"
+    "@sentry/types" "6.12.0"
+    tslib "^1.9.3"
+
+"@sentry/react@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.12.0.tgz#8ae2680d226fafb0da0f3d8366bb285004ba6c2e"
+  integrity sha512-E8Nw9PPzP/EyMy64ksr9xcyYYlBmUA5ROnkPQp7o5wF0xf5/J+nMS1tQdyPnLQe2KUgHlN4kVs2HHft1m7mSYQ==
+  dependencies:
+    "@sentry/browser" "6.12.0"
+    "@sentry/minimal" "6.12.0"
+    "@sentry/types" "6.12.0"
+    "@sentry/utils" "6.12.0"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.12.0.tgz#a05c8985ee7fed7310b029b147d8f9f14f2a2e67"
+  integrity sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==
+  dependencies:
+    "@sentry/hub" "6.12.0"
+    "@sentry/minimal" "6.12.0"
+    "@sentry/types" "6.12.0"
+    "@sentry/utils" "6.12.0"
+    tslib "^1.9.3"
+
+"@sentry/types@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.12.0.tgz#b7395688a79403c6df8d8bb8d81deb8222519853"
+  integrity sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA==
+
+"@sentry/utils@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.12.0.tgz#3de261e8d11bdfdc7add64a3065d43517802e975"
+  integrity sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==
+  dependencies:
+    "@sentry/types" "6.12.0"
+    tslib "^1.9.3"
+
 "@sideway/address@^4.1.0":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
@@ -9352,7 +9427,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -15346,7 +15421,7 @@ tsconfig-paths@^3.11.0, tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1328889867).<!-- Sticky Header Marker -->

Closes #1634

- [x] Disable Sentry based on diagnostic permission state
- [x] Take existing users to drawer when they haven't made a decision. This is done when they visit the home screen and never comes up again when they've made a choice.
- [ ] Settings state where they can later go and change their decision. What do we do here? Add a checkbox item to settings dropdown? 🤔 @jasperjansz 

![image](https://user-images.githubusercontent.com/1618764/134153993-da3e941e-9401-4c12-93a8-7bbbf52b37bd.png)

Screen recording, complete with music backing track

https://user-images.githubusercontent.com/1618764/134348688-20e9866a-bc95-4f05-853a-182c3ff728d5.mov



