### PR TITLE
feat: Add token transfer amount in activity

### DIFF
--- a/.changeset/clever-yaks-flash.md
+++ b/.changeset/clever-yaks-flash.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': minor
+---
+
+Show token transfer amount in activity list

--- a/src/common/stacks-utils.ts
+++ b/src/common/stacks-utils.ts
@@ -39,9 +39,15 @@ export const ftDecimals = (value: number | string | BigNumber, decimals: number)
     .toNumber()
     .toLocaleString('en-US', { maximumFractionDigits: decimals });
 };
+
 export const ftUnshiftDecimals = (value: number | string | BigNumber, decimals: number) => {
   const amount = initBigNumber(value);
   return amount.shiftedBy(decimals).toString(10);
+};
+
+export const amountToDecimals = (value: number | string | BigNumber, decimals: number = 2) => {
+  const amount = initBigNumber(value);
+  return amount.toNumber().toLocaleString('en-US', { maximumFractionDigits: decimals });
 };
 
 export const stxToMicroStx = (stx: number | string | BigNumber) => {

--- a/src/common/transactions/transaction-utils.ts
+++ b/src/common/transactions/transaction-utils.ts
@@ -15,6 +15,17 @@ import {
   ContractDeployOptions,
   TokenTransferOptions,
 } from '@common/transactions/transactions';
+import {
+  CoinbaseTransaction,
+  ContractCallTransaction,
+  TransactionEventFungibleAsset,
+  TransactionEventStxAsset,
+} from '@stacks/stacks-blockchain-api-types';
+import BigNumber from 'bignumber.js';
+import { assetById } from '@store/assets/asset.hooks';
+import { Tx } from '@common/api/transactions';
+import { stacksValue } from '@common/stacks-utils';
+import { getContractName, truncateMiddle } from '@stacks/ui-utils';
 
 export const generateContractCallTx = ({
   txData,
@@ -119,3 +130,89 @@ export const generateSTXTransferTx = ({
 
 export const stacksTransactionToHex = (transaction: StacksTransaction) =>
   `0x${transaction.serialize().toString('hex')}`;
+
+export const isContractFtTokenTransfer = (tx: Tx) => {
+  return tx.tx_type === 'contract_call' && tx.contract_call.function_name === 'transfer' 
+  && tx.contract_call.function_args?.[0]?.name === 'amount';
+};
+
+// calculate the real amount of the token based on the decimal number
+// specified in the corresponding token smart contract
+export const tokenRealAmount = (tx: ContractCallTransaction) => {
+  if (!tx.contract_call?.function_args) return;
+  const val = tx.contract_call.function_args[0].repr.replace('u', '');
+  const x = new BigNumber(val);
+  if (!x.isFinite()) return;
+  // Get the decimal number for this token
+  const asset = assetById(tx.contract_call.contract_id);
+  if (!asset || !asset.meta) return;
+  const y = new BigNumber(asset.meta.decimals);
+  // Exponentiation is unsafe here based on SIP-10 and clarity uint 128bits
+  // https://github.com/stacksgov/sips/blob/main/sips/sip-010/sip-010-fungible-token-standard.md
+  const decimalDivisor = new BigNumber(10).pow(y)
+  if (!decimalDivisor.isFinite()) return;
+  return x.dividedBy(decimalDivisor);
+};
+
+export const getAmountFromTokenTransfer = (tx: ContractCallTransaction) => {
+  if (!isContractFtTokenTransfer(tx)) return;
+  return tokenRealAmount(tx);
+};
+
+export const getAssetTransfer = (tx: Tx): TransactionEventFungibleAsset | null => {
+  if (tx.tx_type !== 'contract_call') return null;
+  if (tx.tx_status !== 'success') return null;
+  const transfer = tx.events.find(event => event.event_type === 'fungible_token_asset');
+  if (transfer?.event_type !== 'fungible_token_asset') return null;
+  return transfer;
+};
+
+export const getTxValue = (tx: Tx, isOriginator: boolean): number | string | null => {
+  if (tx.tx_type === 'token_transfer') {
+    return `${isOriginator ? '-' : ''}${stacksValue({
+      value: tx.token_transfer.amount,
+      withTicker: false,
+    })}`;
+  }
+
+  if (isContractFtTokenTransfer(tx)) {
+    const contractFtTokenAmount = getAmountFromTokenTransfer(tx as ContractCallTransaction) 
+    if (!contractFtTokenAmount) return null;
+    return `${isOriginator ? '-' : ''}${contractFtTokenAmount}`;
+  }
+
+  const transfer = getAssetTransfer(tx);
+  if (transfer?.asset?.amount) return new BigNumber(transfer.asset.amount).toFormat();
+  return null;
+};
+
+export const getTxCaption = (transaction: Tx) => {
+  if (!transaction) return null;
+  switch (transaction.tx_type) {
+    case 'smart_contract':
+      return truncateMiddle(transaction.smart_contract.contract_id, 4);
+    case 'contract_call':
+      return transaction.contract_call.contract_id.split('.')[1];
+    case 'token_transfer':
+    case 'coinbase':
+    case 'poison_microblock':
+      return truncateMiddle(transaction.tx_id, 4);
+    default:
+      return null;
+  }
+};
+
+export const getTxTitle = (tx: Tx) => {
+  switch (tx.tx_type) {
+    case 'token_transfer':
+      return 'Stacks Token';
+    case 'contract_call':
+      return tx.contract_call.function_name;
+    case 'smart_contract':
+      return getContractName(tx.smart_contract.contract_id);
+    case 'coinbase':
+      return `Coinbase ${(tx as CoinbaseTransaction).block_height}`;
+    case 'poison_microblock':
+      return 'Poison Microblock';
+  }
+};

--- a/src/components/popup/tx-item.tsx
+++ b/src/components/popup/tx-item.tsx
@@ -13,7 +13,8 @@ import { useCurrentAccount } from '@store/accounts/account.hooks';
 import { usePressable } from '@components/item-hover';
 import { useRawTxIdState } from '@store/transactions/raw.hooks';
 import { FiFastForward } from 'react-icons/all';
-import { getTxCaption, getTxTitle, getTxValue } from '@common/transactions/transaction-utils';
+import { getTxCaption, getTxTitle } from '@common/transactions/transaction-utils';
+import { useTxValue } from '@store/transactions/transaction.hooks';
 
 type Tx = MempoolTransaction | Transaction;
 
@@ -88,16 +89,13 @@ export const TxItem: React.FC<TxItemProps & BoxProps> = ({ transaction, ...rest 
   const [component, bind, { isHovered }] = usePressable(true);
   const { handleOpenTxLink } = useExplorerLink();
   const currentAccount = useCurrentAccount();
+  const value = useTxValue(transaction, currentAccount);
 
-  if (!transaction) {
-    return null;
-  }
+  if (!transaction) return null;
 
   const isOriginator = transaction.sender_address === currentAccount?.address;
 
   const isPending = isPendingTx(transaction as MempoolTransaction);
-
-  const value = getTxValue(transaction, isOriginator);
 
   return (
     <Box position="relative" cursor="pointer" {...bind} {...rest}>

--- a/src/store/assets/asset.hooks.ts
+++ b/src/store/assets/asset.hooks.ts
@@ -57,8 +57,9 @@ export function useUpdateSearchInput() {
   return useUpdateAtom(searchInputStore);
 }
 
-export function assetById(contractId: string) {
+export function useAssetByContractId(contractId: string) {
   const assets = useAtomValue(assetsAnchoredState);
+  if (!contractId) return;
   const [contractAddress, contractName] = contractId.split('.');
   return assets.find(
     asset =>

--- a/src/store/assets/asset.hooks.ts
+++ b/src/store/assets/asset.hooks.ts
@@ -56,3 +56,14 @@ export function useSearchInput() {
 export function useUpdateSearchInput() {
   return useUpdateAtom(searchInputStore);
 }
+
+export function assetById(contractId: string) {
+  const assets = useAtomValue(assetsAnchoredState);
+  const [contractAddress, contractName] = contractId.split('.');
+  return assets.find(
+    asset =>
+      asset.type === 'ft' &&
+      asset.contractAddress === contractAddress &&
+      asset.contractName === contractName
+  );
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1278105031).<!-- Sticky Header Marker -->

* Added the amount of fungible token transfer (ex: stella the cat, miami coin etc..) in the activity tab
* Extracted some logic from the TxItem

Fixes issue https://github.com/blockstack/stacks-wallet-web/issues/1432 and
https://github.com/blockstack/stacks-wallet-web/issues/1460

<img width="601" alt="token-transfer" src="https://user-images.githubusercontent.com/1501454/134500727-19162475-7d67-4686-8c6e-e66d368f199c.png">


