### PR TITLE
fix: allow zero balance accounts to sign sponsored transactions

### DIFF
--- a/.changeset/tricky-numbers-breathe.md
+++ b/.changeset/tricky-numbers-breathe.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This change allows a wallet with zero STX balance to sign a sponsored transaction.

--- a/src/pages/transaction-signing/hooks/use-transaction-error.ts
+++ b/src/pages/transaction-signing/hooks/use-transaction-error.ts
@@ -49,7 +49,7 @@ export function useTransactionError() {
         if (transferAmount.gte(availableStxBalance))
           return TransactionErrorReason.StxTransferInsufficientFunds;
       }
-      if (zeroBalance) return TransactionErrorReason.FeeInsufficientFunds;
+      if (zeroBalance && !fee.isSponsored) return TransactionErrorReason.FeeInsufficientFunds;
       if (fee && !fee.isSponsored && fee.amount) {
         const feeAmount = new BigNumber(fee.amount);
         if (feeAmount.gte(availableStxBalance)) return TransactionErrorReason.FeeInsufficientFunds;


### PR DESCRIPTION
## Purpose
This change modifies the logic to throw an insufficient funds error state when attempting to sign a sponsored transaction. A zero balance alone does not constitute an error if the transaction is sponsored.

### Before
<img width="400" alt="Screen Shot 2021-09-22 at 10 54 14 PM" src="https://user-images.githubusercontent.com/2329654/134460286-bfe901db-b087-4e33-9c61-1fe358dfcefc.png">


### After

<img width="400" alt="Screen Shot 2021-09-22 at 10 42 22 PM" src="https://user-images.githubusercontent.com/2329654/134460117-9e0296c0-c576-4410-a2b5-478d954f4d8a.png">

## Reason for Fix
Our team is attempting to onboard users to the Stacks ecosystem and obtaining STX is small hurdle that we don't want our new users to deal with. Our solution is to sponsor the transactions for an NFT collection we are using for educational purposes. As such, many of our new users will begin with fresh wallets and a zero balance.

Ideally, we'd love to have this merged quickly as we're presenting the project early next week, but obviously we want the PR to go through the proper channels.

We are excited to get involved with Stacks and we look forward to contributing more significantly in the near future.

Thanks for the hard work!

cc/ @aulneau @kyranjamie @fbwoolf
