### PR TITLE
fix: sign out not working on unlocked state mode

### DIFF
--- a/.changeset/afraid-rocks-draw.md
+++ b/.changeset/afraid-rocks-draw.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This adds the sign out drawer to the lock screen so users can sign out.

--- a/src/components/unlock.tsx
+++ b/src/components/unlock.tsx
@@ -5,6 +5,7 @@ import { PopupContainer } from './popup/container';
 import { buildEnterKeyEvent } from './link';
 import { ErrorLabel } from './error-label';
 import { Header } from '@components/header';
+import { Outlet } from 'react-router-dom';
 
 export const Unlock: React.FC = () => {
   const { doUnlockWallet } = useWallet();
@@ -24,45 +25,48 @@ export const Unlock: React.FC = () => {
   }, [doUnlockWallet, password]);
 
   return (
-    <PopupContainer header={<Header />} requestType="auth">
-      <Box width="100%" mt="loose">
-        <Text textStyle="body.large" display="block">
-          Enter your password you used on this device to unlock your wallet.
-        </Text>
-      </Box>
-      <Box mt="loose" width="100%">
-        <Input
-          placeholder="Enter your password."
-          width="100%"
-          autoFocus
-          type="password"
-          value={password}
-          isDisabled={loading}
-          data-testid="set-password"
-          onChange={(e: React.FormEvent<HTMLInputElement>) => setPassword(e.currentTarget.value)}
-          onKeyUp={buildEnterKeyEvent(submit)}
-        />
-      </Box>
-      {error && (
-        <Box>
-          <ErrorLabel>
-            <Text textStyle="caption">{error}</Text>
-          </ErrorLabel>
+    <>
+      <PopupContainer header={<Header />} requestType="auth">
+        <Box width="100%" mt="loose">
+          <Text textStyle="body.large" display="block">
+            Enter your password you used on this device to unlock your wallet.
+          </Text>
         </Box>
-      )}
-      <Box flexGrow={1} />
-      <Box>
-        <Button
-          width="100%"
-          isLoading={loading}
-          isDisabled={loading}
-          onClick={submit}
-          data-testid="set-password-done"
-          borderRadius="10px"
-        >
-          Unlock
-        </Button>
-      </Box>
-    </PopupContainer>
+        <Box mt="loose" width="100%">
+          <Input
+            placeholder="Enter your password."
+            width="100%"
+            autoFocus
+            type="password"
+            value={password}
+            isDisabled={loading}
+            data-testid="set-password"
+            onChange={(e: React.FormEvent<HTMLInputElement>) => setPassword(e.currentTarget.value)}
+            onKeyUp={buildEnterKeyEvent(submit)}
+          />
+        </Box>
+        {error && (
+          <Box>
+            <ErrorLabel>
+              <Text textStyle="caption">{error}</Text>
+            </ErrorLabel>
+          </Box>
+        )}
+        <Box flexGrow={1} />
+        <Box>
+          <Button
+            width="100%"
+            isLoading={loading}
+            isDisabled={loading}
+            onClick={submit}
+            data-testid="set-password-done"
+            borderRadius="10px"
+          >
+            Unlock
+          </Button>
+        </Box>
+      </PopupContainer>
+      <Outlet />
+    </>
   );
 };


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1267092656).<!-- Sticky Header Marker -->

Closes #1740 

Sign out drawer now appears on lock screen. Issue was that the sign out drawer is a child route, and only home page had an `<Outlet />`. The locked page needed one too.

![image](https://user-images.githubusercontent.com/1618764/134543532-c70acf46-b431-4d85-be77-4faf3a7be163.png)

cc @whoabuddy

@Eshwari007 @timstackblock Would you be able to QA this today? 