### PR TITLE
Regression test looks for extension crash described in the related issue #1698

### DIFF
--- a/src/pages/transaction-signing/components/event-card.tsx
+++ b/src/pages/transaction-signing/components/event-card.tsx
@@ -4,6 +4,7 @@ import { SpaceBetween } from '@components/space-between';
 import { FiMoreHorizontal as IconDots } from 'react-icons/fi';
 import { Caption } from '@components/typography';
 import { AssetItem } from '@pages/transaction-signing/components/asset-item';
+import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
 export const TransactionEventCard: React.FC<any> = ({
   title,
@@ -21,7 +22,7 @@ export const TransactionEventCard: React.FC<any> = ({
       <Stack spacing="base-loose" p="base-loose">
         <SpaceBetween position="relative">
           <Text fontWeight={500} fontSize={2}>
-            {title}
+            <span data-testid={SendFormSelectors.TransferMessage}>{title}</span>
           </Text>
           {actions && <IconButton size="24px" icon={IconDots} position="absolute" right={0} />}
         </SpaceBetween>

--- a/tests/integration/send-tokens/send-tokens.spec.ts
+++ b/tests/integration/send-tokens/send-tokens.spec.ts
@@ -3,6 +3,7 @@ import { ScreenPaths } from '@common/types';
 import { SendPage } from '../../page-objects/send-form.page';
 import { WalletPage } from '../../page-objects/wallet.page';
 import { BrowserDriver, setupBrowser } from '../utils';
+import { SECRET_KEY_2 } from '@tests/mocks';
 
 jest.setTimeout(30_000);
 jest.retryTimes(process.env.CI ? 2 : 0);
@@ -54,6 +55,15 @@ describe(`Send tokens flow`, () => {
       expect(errorMsg).toBeFalsy();
     });
 
+    it('validates that the address used is from different network', async () => {
+      await sendForm.inputToAmountField('0.000001');
+      await sendForm.inputToAddressField('STRE7HABZGQ204G3VQAKMDMVBBD8A8CYKET9M0T');
+      await sendForm.clickPreviewTxBtn();
+      const errorMsgElement = await sendForm.page.$$(sendForm.getSelector('$stxAddressFieldError'));
+      const errorMessage = await errorMsgElement[0].innerText();
+      expect(errorMessage).toContain('The address is for the incorrect Stacks network');
+    });
+
     it('validates against a negative amount of tokens', async () => {
       await sendForm.inputToAmountField('-9999');
       await sendForm.inputToAddressField('ess-pee');
@@ -61,5 +71,68 @@ describe(`Send tokens flow`, () => {
       const errorMsg = await sendForm.page.isVisible(sendForm.getSelector('$amountFieldError'));
       expect(errorMsg).toBeTruthy();
     });
+
+    it('validates that token amount has more than 6 decimal places', async () => {
+      await sendForm.inputToAmountField('0.0000001');
+      await sendForm.inputToAddressField('SP15DFMYE5JDDKRMAZSC6947TCERK36JM4KD5VKZD');
+      await sendForm.clickPreviewTxBtn();
+      const errorMsgElement = await sendForm.page.$$(sendForm.getSelector('$amountFieldError'));
+      const errorMessage = await errorMsgElement[0].innerText();
+      expect(errorMessage).toEqual('STX can only have 6 decimals');
+    });
+
+    it('validates that token amount is greater than the available balance', async () => {
+      await sendForm.inputToAmountField('999999999');
+      await sendForm.inputToAddressField('SP15DFMYE5JDDKRMAZSC6947TCERK36JM4KD5VKZD');
+      await sendForm.clickPreviewTxBtn();
+      const errorMsgElement = await sendForm.page.$$(sendForm.getSelector('$amountFieldError'));
+      const errorMessage = await errorMsgElement[0].innerText();
+      expect(errorMessage).toContain('Insufficient balance');
+    });
+  });
+});
+
+describe('Preview for sending token', () => {
+  let browser: BrowserDriver;
+  let walletPage: WalletPage;
+  let sendForm: SendPage;
+
+  beforeEach(async () => {
+    browser = await setupBrowser();
+    walletPage = await WalletPage.init(browser, ScreenPaths.INSTALLED);
+    await walletPage.signIn(SECRET_KEY_2);
+    await walletPage.waitForHomePage();
+    await walletPage.goToSendForm();
+    sendForm = new SendPage(walletPage.page);
+  }, 30_000);
+
+  afterEach(async () => {
+    try {
+      await browser.context.close();
+    } catch (error) {}
+  });
+
+  it('should show the preview', async () => {
+    await sendForm.inputToAmountField('0.000001');
+    await sendForm.inputToAddressField('SP15DFMYE5JDDKRMAZSC6947TCERK36JM4KD5VKZD');
+    await sendForm.clickPreviewTxBtn();
+    await sendForm.waitForPreview('$transferMessage');
+    const previewPopup = await sendForm.page.isVisible(sendForm.getSelector('$transferMessage'));
+    expect(previewPopup).toBeTruthy();
+  });
+
+  it('should show the preview when there is a validation error on token amount and later it is resolved', async () => {
+    await sendForm.fillToAmountField('0.0000001');
+    await sendForm.inputToAddressField('SP15DFMYE5JDDKRMAZSC6947TCERK36JM4KD5VKZD');
+    await sendForm.clickPreviewTxBtn();
+    const errorMsgElement = await sendForm.page.$$(sendForm.getSelector('$amountFieldError'));
+    const errorMessage = await errorMsgElement[0].innerText();
+    expect(errorMessage).toEqual('STX can only have 6 decimals');
+
+    await sendForm.fillToAmountField('0.000001');
+    await sendForm.clickPreviewTxBtn();
+    await sendForm.waitForPreview('$transferMessage');
+    const previewPopup = await sendForm.page.isVisible(sendForm.getSelector('$transferMessage'));
+    expect(previewPopup).toBeTruthy();
   });
 });

--- a/tests/page-objects/send-form.page.ts
+++ b/tests/page-objects/send-form.page.ts
@@ -9,6 +9,7 @@ const selectors = {
   $stxAddressField: createTestSelector(SendFormSelectors.InputRecipientField),
   $stxAddressFieldError: createTestSelector(SendFormSelectors.InputRecipientFieldErrorLabel),
   $previewBtn: createTestSelector(SendFormSelectors.BtnPreviewSendTx),
+  $transferMessage: createTestSelector(SendFormSelectors.TransferMessage),
 };
 
 export class SendPage {
@@ -41,8 +42,17 @@ export class SendPage {
     await field?.type(input);
   }
 
+  async fillToAmountField(input: string) {
+    const field = await this.page.$(this.selectors.$amountField);
+    await field?.fill(input);
+  }
+
   async inputToAddressField(input: string) {
     const field = await this.page.$(this.selectors.$stxAddressField);
     await field?.type(input);
+  }
+
+  async waitForPreview(selector: keyof typeof selectors) {
+    await this.page.waitForSelector(this.selectors[selector]);
   }
 }

--- a/tests/page-objects/send-form.selectors.ts
+++ b/tests/page-objects/send-form.selectors.ts
@@ -8,4 +8,5 @@ export enum SendFormSelectors {
   InputRecipientFieldErrorLabel = 'input-recipient-field-error-label',
 
   BtnPreviewSendTx = 'btn-preview-send-tx',
+  TransferMessage = 'transfer-message',
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1279083466).<!-- Sticky Header Marker -->

<!--
PR reminders:
  - Link issues to PR
  - Update UserX board
  - Use checkmarks for progress
  - Link PRs in other issues

Tips for good PR etiquette https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/
-->
I made all the revision mentioned for PR 1719 here.

This is a regression test to look for web wallet crashes that are caused by entering more than 7 decimal places. The test attempts to reproduce the P1 bug we found in issue #1698 as well as additional test that test edge cases related to that functionality.

@UXteam
cc/ @aulneau @kyranjamie @fbwoolf @beguene @markmhx @Eshwari007 @andresgalante
