### PR TITLE
fix: bug with scroll snap behaviour, closes #1757

### DIFF
--- a/.changeset/clean-trains-obey.md
+++ b/.changeset/clean-trains-obey.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+Fixes bug where it auto-scrolls up

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -45,7 +45,6 @@ export const Header: React.FC<HeaderProps> = memo(props => {
       alignItems={hideActions ? 'center' : 'flex-start'}
       justifyContent="space-between"
       position="relative"
-      scrollSnapAlign="start"
       {...rest}
     >
       {!title ? (

--- a/src/components/popup/container.tsx
+++ b/src/components/popup/container.tsx
@@ -62,7 +62,6 @@ export const PopupContainer: React.FC<PopupHomeProps> = ({ children, header, req
         maxHeight="100vh"
         position="relative"
         overflow="auto"
-        scrollSnapType="y proximity"
       >
         {header || null}
         <Flex

--- a/src/features/hiro-messages/hiro-messages.tsx
+++ b/src/features/hiro-messages/hiro-messages.tsx
@@ -9,7 +9,7 @@ export const HiroMessages = (props: FlexProps) => {
   if (!messages || !messages.global || !messages.global[0]) return null;
 
   return (
-    <Box pt="tight" scrollSnapAlign="start" scrollPadding="20%">
+    <Box pt="tight">
       <Flex background="#F7F8FD" borderRadius="8px" p="base" {...props}>
         <HiroMessageItem {...messages.global[0]} />
       </Flex>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1289841822).<!-- Sticky Header Marker -->

Silly scroll snap bug, huge problem as it prevents scroll on send form in modal view. See @Eshwari007 video in issue for demo