### PR TITLE
refactor: move core actions to their own folder

### DIFF
--- a/src/common/actions/finalize-auth-response.ts
+++ b/src/common/actions/finalize-auth-response.ts
@@ -1,0 +1,51 @@
+import { DecodedAuthRequest } from '@common/dev/types';
+import {
+  AuthenticationResponseMessage,
+  ExternalMethods,
+  MESSAGE_SOURCE,
+} from '@common/message-types';
+import { deleteTabForRequest, getTab, StorageKey } from '@common/storage';
+import { isValidUrl } from '@common/validation/validate-url';
+
+interface FinalizeAuthParams {
+  decodedAuthRequest: DecodedAuthRequest;
+  authResponse: string;
+  authRequest: string;
+}
+/**
+ * Call this function at the end of onboarding.
+ *
+ * We fetch the ID of the tab that originated this request from a data store.
+ * Then, we send a message back to that tab, which is handled by the content script
+ * of the extension.
+ *
+ */
+export const finalizeAuthResponse = ({
+  decodedAuthRequest,
+  authRequest,
+  authResponse,
+}: FinalizeAuthParams) => {
+  const dangerousUri = decodedAuthRequest.redirect_uri;
+  if (!isValidUrl(dangerousUri)) {
+    throw new Error('Cannot proceed with malicious url');
+  }
+  try {
+    const tabId = getTab(StorageKey.authenticationRequests, authRequest);
+    const responseMessage: AuthenticationResponseMessage = {
+      source: MESSAGE_SOURCE,
+      payload: {
+        authenticationRequest: authRequest,
+        authenticationResponse: authResponse,
+      },
+      method: ExternalMethods.authenticationResponse,
+    };
+    chrome.tabs.sendMessage(tabId, responseMessage);
+    deleteTabForRequest(StorageKey.authenticationRequests, authRequest);
+    window.close();
+  } catch (error) {
+    console.debug('Failed to get Tab ID for authentication request:', authRequest);
+    throw new Error(
+      'Your transaction was broadcasted, but we lost communication with the app you started with.'
+    );
+  }
+};

--- a/src/common/actions/finalize-tx-signature.ts
+++ b/src/common/actions/finalize-tx-signature.ts
@@ -1,0 +1,31 @@
+import {
+  ExternalMethods,
+  MESSAGE_SOURCE,
+  TransactionResponseMessage,
+  TxResult,
+} from '@common/message-types';
+import { deleteTabForRequest, getTab, StorageKey } from '@common/storage';
+
+export const finalizeTxSignature = (requestPayload: string, data: TxResult | string) => {
+  try {
+    const tabId = getTab(StorageKey.transactionRequests, requestPayload);
+    const responseMessage: TransactionResponseMessage = {
+      source: MESSAGE_SOURCE,
+      method: ExternalMethods.transactionResponse,
+      payload: {
+        transactionRequest: requestPayload,
+        transactionResponse: data,
+      },
+    };
+    chrome.tabs.sendMessage(tabId, responseMessage);
+    deleteTabForRequest(StorageKey.transactionRequests, requestPayload);
+    // If this is a string, then the transaction has been canceled
+    // and the user has closed the window
+    if (typeof data !== 'string') window.close();
+  } catch (error) {
+    console.debug('Failed to get Tab ID for transaction request:', requestPayload);
+    throw new Error(
+      'Your transaction was broadcasted, but we lost communication with the app you started with.'
+    );
+  }
+};

--- a/src/common/hooks/use-wallet.ts
+++ b/src/common/hooks/use-wallet.ts
@@ -4,7 +4,6 @@ import { getAccountDisplayName } from '@stacks/wallet-sdk';
 import { useVaultMessenger } from '@common/hooks/use-vault-messenger';
 
 import { useOnboardingState } from './auth/use-onboarding-state';
-import { finalizeAuthResponse } from '@common/utils';
 
 import { bytesToText } from '@common/store-utils';
 import {
@@ -27,6 +26,7 @@ import {
   useCurrentNetworkState,
   useNetworkState,
 } from '@store/network/networks.hooks';
+import { finalizeAuthResponse } from '@common/actions/finalize-auth-response';
 
 export function useWallet() {
   const hasRehydratedVault = useHasRehydratedVault();

--- a/src/store/transactions/requests.hooks.ts
+++ b/src/store/transactions/requests.hooks.ts
@@ -6,10 +6,10 @@ import {
   transactionRequestCustomFeeState,
   transactionRequestCustomFeeRateState,
 } from '@store/transactions/requests';
-import { finalizeTxSignature } from '@common/utils';
 import { requestTokenState } from '@store/transactions/requests';
 import { transactionBroadcastErrorState } from '@store/transactions';
 import { useCallback } from 'react';
+import { finalizeTxSignature } from '@common/actions/finalize-tx-signature';
 
 export function useOrigin() {
   return useAtomValue(requestTokenOriginState);

--- a/src/store/transactions/transaction.hooks.ts
+++ b/src/store/transactions/transaction.hooks.ts
@@ -40,7 +40,6 @@ import { postConditionsState } from './post-conditions';
 import { useWallet } from '@common/hooks/use-wallet';
 import { requestTokenState } from './requests';
 import { handleBroadcastTransaction } from '@common/transactions/transactions';
-import { finalizeTxSignature } from '@common/utils';
 import { makeFungibleTokenTransferState } from './fungible-token-transfer';
 import { selectedAssetStore } from '@store/assets/asset-search';
 import { updateTransactionFee } from '@store/transactions/utils';
@@ -51,6 +50,7 @@ import {
 } from '@store/transactions/local-transactions';
 import { currentAccountLocallySubmittedTxsState } from '@store/accounts/account-activity';
 import { todaysIsoDate } from '@common/date-utils';
+import { finalizeTxSignature } from '@common/actions/finalize-tx-signature';
 
 export function usePendingTransaction() {
   return useAtomValue(pendingTransactionState);

--- a/src/store/wallet/wallet.hooks.ts
+++ b/src/store/wallet/wallet.hooks.ts
@@ -4,7 +4,6 @@ import type { VaultActions } from '@background/vault-types';
 import { gaiaUrl } from '@common/constants';
 import { useOnboardingState } from '@common/hooks/auth/use-onboarding-state';
 import { textToBytes } from '@common/store-utils';
-import { finalizeAuthResponse } from '@common/utils';
 import {
   createWalletGaiaConfig,
   getOrCreateWalletConfig,
@@ -24,6 +23,7 @@ import {
   secretKeyState,
   walletState,
 } from './wallet';
+import { finalizeAuthResponse } from '@common/actions/finalize-auth-response';
 
 export function useHasRehydratedVault() {
   return useAtomValue(hasRehydratedVaultStore);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1329378434).<!-- Sticky Header Marker -->

Small reactor, and open for discussion.

This PR moves two functions `finalizeAuthResponse` and `finalizeTxSignature` to their own folder under `src/actions`. Not sure if this is the best name, but they're deserving of its own folder.

**Motivation**

These functions represent perhaps the two most core actions the entire extension has: 
1) authenticating with an app
2) returning a broadcast tx

So I'm not sure what they were doing in a completely undescriptive hidden part of the codebase `src/common/utils.ts`.

This is a small step towards having deliberate places where we invoke **any** `chrome.*` APIs.