### PR TITLE
refactor: rename queued to submitted

### DIFF
--- a/src/features/local-transaction-activity/local-tx-item.tsx
+++ b/src/features/local-transaction-activity/local-tx-item.tsx
@@ -96,7 +96,7 @@ export const LocalTxItem: React.FC<{ transaction: StacksTransaction; txid: strin
         isInline
         position="relative"
         zIndex={2}
-        onClick={() => handleOpenTxLink(txid, `&queued=true`)}
+        onClick={() => handleOpenTxLink(txid, `&submitted=true`)}
       >
         <StacksTransactionItemIcon transaction={transaction} />
         <SpaceBetween flexGrow={1}>
@@ -113,7 +113,7 @@ export const LocalTxItem: React.FC<{ transaction: StacksTransaction; txid: strin
                 }
               >
                 <Caption variant="c2" color={color('text-caption')}>
-                  Queued
+                  Submitted
                 </Caption>
               </Tooltip>
             </Stack>

--- a/src/features/local-transaction-activity/local-tx-list.tsx
+++ b/src/features/local-transaction-activity/local-tx-list.tsx
@@ -23,7 +23,7 @@ export const LocalTxList = ({ txids }: { txids: string[] }) => {
     <Stack pb="extra-loose" spacing="extra-loose">
       <Box>
         <Text textStyle="body.small" color={color('text-caption')}>
-          Queued
+          Submitted
         </Text>
         <Stack mt="base-loose" spacing="loose">
           {txids.map(txid => (


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1307946051).<!-- Sticky Header Marker -->

_Queued_ would imply the transaction hasn't been submitted yet.

