### PR TITLE
fix: filtering local transactions

### DIFF
--- a/.changeset/tough-moles-reflect.md
+++ b/.changeset/tough-moles-reflect.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This fixes filtering local transactions using the safely formatted hex txid.

--- a/src/common/utils/safe-handle-txid.ts
+++ b/src/common/utils/safe-handle-txid.ts
@@ -1,0 +1,5 @@
+export function safelyFormatHexTxid(id: string) {
+  const prefix = '0x';
+  if (id.startsWith(prefix)) return id;
+  return prefix + id;
+}

--- a/src/pages/transaction-signing/hooks/use-submit-stx-transaction.ts
+++ b/src/pages/transaction-signing/hooks/use-submit-stx-transaction.ts
@@ -100,6 +100,7 @@ export function useSubmitTransactionCallback({
       setIsIdle,
       stacksNetwork,
       setActiveTabActivity,
+      externalTxid,
     ]
   );
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1308868092).<!-- Sticky Header Marker -->

This PR fixes a bug with saving local transactions where the filter wasn't matching up correctly bc the `0x` was missing in one of the id strings.

Issues #1769 and #1770

## Testing:
- On testnet send some tokens
- If it shows up in pending right away, refresh the full-page view
- Make sure it doesn't show up in `Queued` after refresh
- If it shows up in `Queued` first, make sure it properly clears once it moves into pending state
- Also try deploying a contract from the test-app, make sure the `Queued` behavior works
- Verify there are no duplicate transactions

cc/ @kyranjamie @beguene 
