### PR TITLE
fix: remove post conditions in allow mode

### DIFF
--- a/.changeset/sharp-mails-fly.md
+++ b/.changeset/sharp-mails-fly.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This fixes the test-app post conditions that were causing contract call failures.

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -128,6 +128,13 @@ export const Debugger = () => {
       standardPrincipalCV('ST1X6M947Z7E58CNE0H8YJVJTVKS9VW0PHEG3NHN3'),
       trueCV(),
     ];
+    const postConditions = [
+      makeStandardSTXPostCondition(
+        address || '',
+        FungibleConditionCode.LessEqual,
+        new BN('100', 10)
+      )
+    ]
     await doContractCall({
       fee: customFee,
       network,
@@ -137,23 +144,7 @@ export const Debugger = () => {
       functionArgs: args,
       attachment: 'This is an attachment',
       postConditionMode: mode,
-      postConditions: [
-        makeStandardSTXPostCondition(
-          address || '',
-          FungibleConditionCode.LessEqual,
-          new BN('100', 10)
-        ),
-        makeStandardFungiblePostCondition(
-          'ST1X6M947Z7E58CNE0H8YJVJTVKS9VW0PHEG3NHN3',
-          FungibleConditionCode.Equal,
-          new BN(1234),
-          createAssetInfo(
-            'ST1X6M947Z7E58CNE0H8YJVJTVKS9VW0PHEG3NHN3',
-            'connect-token',
-            'connect-token'
-          )
-        ),
-      ],
+      postConditions,
       onFinish: data => {
         console.log('finished faker!', data);
         console.log(data.stacksTransaction.auth.spendingCondition?.nonce.toNumber());


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1311415178).<!-- Sticky Header Marker -->

The issue is that those postconditions are never satisfied, so the tx fails. If you remove the post-conditions, this works fine.

See here https://explorer.stacks.co/txid/0xdc4bf6a353e2ef46daaa88bd1cada6901f8cc1d0c6ea7a328e796aadec455099?chain=testnet
I changed the post-conditions to something simpler in the debugger page so it's satisfied.