### PR TITLE
fix: clean hex value for deserializeCV

### DIFF
--- a/.changeset/blue-icons-pump.md
+++ b/.changeset/blue-icons-pump.md
@@ -1,0 +1,5 @@
+---
+'@stacks/wallet-web': patch
+---
+
+This fixes a small bug where if a serialized clarity value is passed to deserializeCV that is prefixed with `0x` it will error out.

--- a/src/common/transactions/transaction-utils.ts
+++ b/src/common/transactions/transaction-utils.ts
@@ -24,6 +24,7 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { displayDate, isoDateToLocalDateSafe, todaysIsoDate } from '@common/date-utils';
 import { getContractName, truncateMiddle } from '@stacks/ui-utils';
+import { hexToBuff } from '@common/utils';
 import { stacksValue } from '@common/stacks-utils';
 import { BigNumber } from 'bignumber.js';
 import { AssetWithMeta } from '@common/asset-types';
@@ -64,7 +65,7 @@ export const generateContractCallTx = ({
     postConditions,
   } = txData;
   const args = functionArgs.map(arg => {
-    return deserializeCV(Buffer.from(arg, 'hex'));
+    return deserializeCV(hexToBuff(arg));
   });
 
   let network = txData.network;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -168,9 +168,19 @@ function isHex(hex: string): boolean {
   return regexp.test(hex);
 }
 
+function cleanHex(hexWithMaybePrefix: string): string {
+  return hexWithMaybePrefix.startsWith('0x')
+    ? hexWithMaybePrefix.replace('0x', '')
+    : hexWithMaybePrefix;
+}
+
+export function hexToBuff(hex: string): Buffer {
+  return Buffer.from(cleanHex(hex), 'hex');
+}
+
 export function hexToHumanReadable(hex: string) {
   if (!isHex(hex)) return hex;
-  const buff = Buffer.from(hex, 'hex');
+  const buff = hexToBuff(hex);
   if (isUtf8(buff)) return buff.toString('utf8');
   return `0x${hex}`;
 }

--- a/src/pages/transaction-signing/components/contract-call-details.spec.tsx
+++ b/src/pages/transaction-signing/components/contract-call-details.spec.tsx
@@ -8,12 +8,13 @@ import { cvToString, deserializeCV } from '@stacks/transactions';
 import { ProviderWithWalletAndRequestToken } from '@tests/state-utils';
 import { HEYSTACK_HEY_TX_REQUEST_DECODED } from '@tests/mocks';
 import { setupHeystackEnv } from '@tests/mocks/heystack';
+import { hexToBuff } from '@common/utils';
 
 const truncatedContractAddress = truncateMiddle(HEYSTACK_HEY_TX_REQUEST_DECODED.contractAddress, 4);
 const truncatedContractId = `${truncatedContractAddress}.${HEYSTACK_HEY_TX_REQUEST_DECODED.contractName}`;
 
 const getStringValueFromHexCv = (hex: string) => {
-  const argCV = deserializeCV(Buffer.from(hex, 'hex'));
+  const argCV = deserializeCV(hexToBuff(hex));
   return cvToString(argCV);
 };
 const message = getStringValueFromHexCv(HEYSTACK_HEY_TX_REQUEST_DECODED.functionArgs[0]);

--- a/src/pages/transaction-signing/components/contract-call-details.tsx
+++ b/src/pages/transaction-signing/components/contract-call-details.tsx
@@ -3,6 +3,7 @@ import React, { memo } from 'react';
 import { useContractFunction } from '@query/contract/contract.hooks';
 import { useExplorerLink } from '@common/hooks/use-explorer-link';
 import { Divider } from '@components/divider';
+import { hexToBuff } from '@common/utils';
 import { Caption, Title } from '@components/typography';
 import { ContractPreview } from '@pages/transaction-signing/components/contract-preview';
 import { Stack, color, StackProps } from '@stacks/ui';
@@ -23,7 +24,7 @@ const FunctionArgumentName = ({ index }: { index: number }) => {
 };
 
 const FunctionArgumentRow: React.FC<ArgumentProps> = ({ arg, index, ...rest }) => {
-  const argCV = deserializeCV(Buffer.from(arg, 'hex'));
+  const argCV = deserializeCV(hexToBuff(arg));
   const strValue = cvToString(argCV);
 
   return (


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1439319539).<!-- Sticky Header Marker -->

Rebased @aulneau fix from fungible-systems:fix/hex-values onto main
See PR https://github.com/blockstack/stacks-wallet-web/pull/1793

cc/ @kyranjamie @fbwoolf 
To be merged after the refactor-week merge.