### PR TITLE
fix(csp): external images broken

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -68,7 +68,7 @@ const name = PREVIEW_RELEASE ? 'Hiro Wallet Preview' : 'Hiro Wallet';
 const prodManifest = {
   name,
   content_security_policy:
-    "default-src 'none'; connect-src *; style-src 'unsafe-inline'; script-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
+    "default-src 'none'; connect-src *; style-src 'unsafe-inline'; img-src 'self' https:; script-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
   icons: generateImageAssetUrlsWithSuffix(PREVIEW_RELEASE ? '-preview' : ''),
   browser_action: {
     default_icon: `assets/connect-logo/Stacks128w${PREVIEW_RELEASE ? '-preview' : ''}.png`,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/ux/actions/runs/1399310558).<!-- Sticky Header Marker -->

Reported by @agraebe, images aren't working in the extension owing to v. strict CSP rules.

This allows all images coming from extension src, or any HTTPS resource.

**Before**
![image](https://user-images.githubusercontent.com/1618764/139450129-e1bf1f95-6489-4550-9b20-0fb2ce7d871d.png)

**After**
![image](https://user-images.githubusercontent.com/1618764/139450320-4a994b6f-46cc-468b-8f13-623133e0a9f4.png)
