### PR TITLE
test: use `--runInBand` setting for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -84,7 +84,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Serve and run tests
-        run: xvfb-run --auto-servernum -- yarn jest --config=./jest.integration.config.js --testPathPattern=./tests/integration/${{ matrix.dir }}* --detectOpenHandles
+        run: xvfb-run --auto-servernum -- yarn jest --config=./jest.integration.config.js --runInBand --testPathPattern=./tests/integration/${{ matrix.dir }}* --detectOpenHandles
 
       - uses: actions/upload-artifact@v2
         if: always()

--- a/tests/integration/settings/create-switch-account.spec.ts
+++ b/tests/integration/settings/create-switch-account.spec.ts
@@ -5,9 +5,11 @@ import { SettingsSelectors } from '@tests/integration/settings.selectors';
 import { delay } from '@common/utils';
 
 jest.setTimeout(40_000);
+
 jest.retryTimes(process.env.CI ? 2 : 0);
+
 describe(`Create and switch account`, () => {
-  const COUNT = 3;
+  const numOfAccountsToTest = 3;
   let browser: BrowserDriver;
   let wallet: WalletPage;
 
@@ -44,9 +46,9 @@ describe(`Create and switch account`, () => {
     expect(displayName2).toEqual('Account 1');
   });
 
-  it(`should be able to create ${COUNT} new accounts then switch between them`, async () => {
+  it(`should be able to create ${numOfAccountsToTest} new accounts then switch between them`, async () => {
     await wallet.signUp();
-    for (let i = 0; i < COUNT - 1; i++) {
+    for (let i = 0; i < numOfAccountsToTest - 1; i++) {
       await wallet.clickSettingsButton();
       await delay(100);
       await wallet.page.waitForSelector(wallet.$createAccountButton);
@@ -56,16 +58,16 @@ describe(`Create and switch account`, () => {
       await wallet.page.click(wallet.$createAccountDone);
     }
 
-    for (let i = 0; i < COUNT; i++) {
+    for (let i = 0; i < numOfAccountsToTest; i++) {
       await wallet.clickSettingsButton();
       await wallet.page.click(createTestSelector(SettingsSelectors.SwitchAccount));
       await wallet.page.click(createTestSelector(`switch-account-item-${i}`));
       await wallet.page.waitForSelector(
-        createTestSelector(`account-checked-${(i - 1 + COUNT) % COUNT}`),
+        createTestSelector(`account-checked-${i - 1 + numOfAccountsToTest}`),
         { state: 'hidden' }
       );
       await delay(100);
-      let displayName = await wallet.page.textContent(
+      const displayName = await wallet.page.textContent(
         createTestSelector('home-current-display-name')
       );
       expect(displayName).toEqual(`Account ${i + 1}`);

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -51,6 +51,7 @@ export async function setupBrowser(verbose?: boolean) {
   const context = (await chromium.launchPersistentContext(tmpDir, {
     args: launchArgs,
     headless: false,
+    slowMo: 100,
   })) as ChromiumBrowserContext;
 
   await context.grantPermissions(['clipboard-read']);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1435129087).<!-- Sticky Header Marker -->

Not sure if this will help much, but we're putting tests in runInBand mode, and slowing them down with the `sloMo` option. This shouldn't make much of an impact to the overall runtime.