### PR TITLE
fix(csp): chrome 96 regression breaks argon2

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -67,8 +67,10 @@ const name = PREVIEW_RELEASE ? 'Hiro Wallet Preview' : 'Hiro Wallet';
 
 const prodManifest = {
   name,
+  // CSP loosened to allow `wasm-eval` per
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1268576
   content_security_policy:
-    "default-src 'none'; connect-src *; style-src 'unsafe-inline'; img-src 'self' https:; script-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
+    "default-src 'none'; connect-src *; style-src 'unsafe-inline'; img-src 'self' https:; script-src 'self' 'wasm-eval'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';",
   icons: generateImageAssetUrlsWithSuffix(PREVIEW_RELEASE ? '-preview' : ''),
   browser_action: {
     default_icon: `assets/connect-logo/Stacks128w${PREVIEW_RELEASE ? '-preview' : ''}.png`,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1443428892).<!-- Sticky Header Marker -->

Chromium v96 introduces a regression where WebWorkers are evaluated against the CSP incorrectly https://bugs.chromium.org/p/chromium/issues/detail?id=1268576. If released currently, all wallets will break.

```
Error [RuntimeError]: abort(CompileError: WebAssembly.instantiate(): Wasm code generation disallowed by embedder). Build with -s ASSERTIONS=1 for more info.
  at abort (chrome-extension://eecnpiikplhmnkkfjdnlmhjfhalcnohl/decryption-worker.js:18:7620)
    at chrome-extension://eecnpiikplhmnkkfjdnlmhjfhalcnohl/decryption-worker.js:18:9491
```

Can reproduce this installing the Chrome Beta release channel.

We can reintroduce the `'wasm-eval'` rule to prevent this from happening, without any significant security concerns (we had this directive on previously, before the Worker was added).

Discovered via Playwright issue, and timely flagging by @markmhx