### PR TITLE
ci(release): create Github Release for stable channel

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -9,7 +9,7 @@ env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
 jobs:
-  pre_run:
+  pre-run:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
@@ -17,12 +17,66 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+  build-extension:
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.extract_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/provision
+
+      - name: Extract version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.1.1
+
+      - name: Build project
+        env:
+          IS_PUBLISHING: true
+        run: yarn build
+
+      - uses: actions/upload-artifact@v2
+        name: Upload build artifact
+        with:
+          name: hiro-wallet
+          path: dist
+
+  create-github-release:
+    name: Create Github release
+    runs-on: ubuntu-latest
+    needs:
+      - build-extension
+    steps:
+      - name: Download extension build
+        uses: actions/download-artifact@v2
+        with:
+          path: .
+
+      - name: Download release-notes.txt from create-version workflow
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: create-version.yml
+          name: release-notes
+
+      - run: ls -R
+
+      - name: Zip release build
+        run: zip -r hiro-wallet.v${{ needs.build-extension.outputs.new_version }}.zip hiro-wallet/
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: false
+          tag_name: v${{ needs.build-extension.outputs.new_version }}
+          body_path: release-notes.txt
+          files: hiro-wallet.v${{ needs.build-extension.outputs.new_version }}.zip
+
   publish_chrome_extension:
     name: Publish Chrome extension
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
-      - pre_run
+      - pre-run
+      - create-github-release
     outputs:
       publish_status: ${{ steps.publish-chrome.outputs.publish_status }}
     steps:
@@ -70,7 +124,8 @@ jobs:
       MINIFY_PRODUCTION_BUILD: true
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
-      - pre_run
+      - pre-run
+      - create-github-release
     outputs:
       publish_status: ${{ steps.publish-firefox.outputs.publish_status }}
     steps:


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1445191085).<!-- Sticky Header Marker -->

- Creates a Github release also for the stable release channel