### PR TITLE
fix: use react-query for mempool calls

### DIFF
--- a/src/common/hooks/account/use-refresh-all-account-data.ts
+++ b/src/common/hooks/account/use-refresh-all-account-data.ts
@@ -1,14 +1,17 @@
 import { useCallback } from 'react';
 import { delay } from '@common/utils';
 import { useRefreshAccountData } from '@store/accounts/account.hooks';
+import { useCurrentAccountMempool } from '@query/mempool/mempool.hooks';
 
 export function useRefreshAllAccountData() {
   const update = useRefreshAccountData();
+  const { refetch } = useCurrentAccountMempool();
   return useCallback(
     async (ms?: number) => {
       if (typeof ms === 'number') await delay(ms);
       update(null);
+      void refetch();
     },
-    [update]
+    [update, refetch]
   );
 }

--- a/src/features/activity-list/account-activity.tsx
+++ b/src/features/activity-list/account-activity.tsx
@@ -6,11 +6,11 @@ import { LocalTxList } from '@features/local-transaction-activity/local-tx-list'
 
 import { NoAccountActivity } from './components/no-account-activity';
 import { useAccountTransactionsWithTransfers } from '@common/hooks/account/use-account-transactions-with-transfers.hooks';
-import { useCurrentAccountMempoolTransactionsState } from '@store/accounts/account.hooks';
+import { useCurrentAccountFilteredMempoolTransactionsState } from '@query/mempool/mempool.hooks';
 
 export const ActivityList = () => {
   const transactions = useAccountTransactionsWithTransfers();
-  const pendingTransactions = useCurrentAccountMempoolTransactionsState();
+  const pendingTransactions = useCurrentAccountFilteredMempoolTransactionsState();
 
   const txids = useCurrentAccountLocalTxids();
   const allTransactions = [...pendingTransactions, ...transactions];

--- a/src/features/fee-nonce-drawers/speed-up-transaction-drawer.tsx
+++ b/src/features/fee-nonce-drawers/speed-up-transaction-drawer.tsx
@@ -8,16 +8,14 @@ import {
   useRawTxIdState,
 } from '@store/transactions/raw.hooks';
 import { TxItem } from '@components/popup/tx-item';
-import {
-  useAccountSingleTransaction,
-  useCurrentAccountAvailableStxBalance,
-} from '@store/accounts/account.hooks';
+import { useCurrentAccountAvailableStxBalance } from '@store/accounts/account.hooks';
 import * as yup from 'yup';
 import { Formik, FormikProps } from 'formik';
 import { microStxToStx } from '@stacks/ui-utils';
 import BigNumber from 'bignumber.js';
 import { toast } from 'react-hot-toast';
 
+import { useTransactionById } from '@query/transactions/transactions-by-id.query';
 import { LOADING_KEYS, useLoading } from '@common/hooks/use-loading';
 import { FeeField } from '@features/fee-nonce-drawers/components/fee-field';
 import { StacksTransaction } from '@stacks/transactions';
@@ -26,10 +24,10 @@ import { useFeeRate, useReplaceByFeeSubmitCallBack } from '@store/transactions/f
 import { useRefreshAllAccountData } from '@common/hooks/account/use-refresh-all-account-data';
 import { useFeeSchema } from './use-fee-schema';
 
-const useSelectedTx = () => {
+function useSelectedTx() {
   const [rawTxId] = useRawTxIdState();
-  return useAccountSingleTransaction(rawTxId || undefined);
-};
+  return useTransactionById(rawTxId || '').data;
+}
 
 const Messaging = () => {
   return (

--- a/src/pages/transaction-signing/hooks/use-submit-stx-transaction.ts
+++ b/src/pages/transaction-signing/hooks/use-submit-stx-transaction.ts
@@ -13,12 +13,10 @@ import { ScreenPaths } from '@common/types';
 import { useHomeTabs } from '@common/hooks/use-home-tabs';
 import { useRefreshAllAccountData } from '@common/hooks/account/use-refresh-all-account-data';
 import { useCurrentStacksNetworkState } from '@store/network/networks.hooks';
-import {
-  useCurrentAccountTxIdsState,
-  useSetLocalTxsCallback,
-} from '@store/accounts/account-activity.hooks';
+import { useSetLocalTxsCallback } from '@store/accounts/account-activity.hooks';
 import { todaysIsoDate } from '@common/date-utils';
 import { logger } from '@common/logger';
+import { useCurrentAccountTxIds } from '@query/transactions/transaction.hooks';
 
 function getErrorMessage(
   reason: TxBroadcastResultRejected['reason'] | 'ConflictingNonceInMempool'
@@ -53,7 +51,7 @@ export function useSubmitTransactionCallback({
   const stacksNetwork = useCurrentStacksNetworkState();
   const { setActiveTabActivity } = useHomeTabs();
   const setLocalTxs = useSetLocalTxsCallback();
-  const externalTxid = useCurrentAccountTxIdsState();
+  const externalTxid = useCurrentAccountTxIds();
 
   return useCallback<(tx: StacksTransaction) => Promise<void>>(
     async transaction => {

--- a/src/query/mempool/mempool.hooks.ts
+++ b/src/query/mempool/mempool.hooks.ts
@@ -1,0 +1,49 @@
+import { logger } from '@common/logger';
+import { useTransactionsById } from '@query/transactions/transactions-by-id.query';
+import { MempoolTransaction } from '@stacks/stacks-blockchain-api-types';
+import { useCurrentAccountStxAddressState } from '@store/accounts/account.hooks';
+import { useAccountMempool } from './mempool.query';
+
+const droppedCache = new Map();
+
+function useAccountUnanchoredMempoolTransactions(address: string) {
+  const { data: accountMempoolTxs } = useAccountMempool(address);
+  const mempoolTxs = (accountMempoolTxs ? accountMempoolTxs.results : []) as MempoolTransaction[];
+  const results = mempoolTxs.filter(
+    tx => tx.tx_status === 'pending' && !droppedCache.has(tx.tx_id)
+  );
+  const txs = useTransactionsById(results.map(tx => tx.tx_id));
+  return txs
+    .map(tx => tx.data)
+    .filter(tx => {
+      if (typeof tx === 'undefined') return false;
+      if (droppedCache.has(tx.tx_id)) return false;
+      if (tx.tx_status !== 'pending') {
+        // because stale txs persist in the mempool endpoint
+        // we should cache dropped txids to prevent unneeded fetches
+        droppedCache.set(tx.tx_id, true);
+        return false;
+      }
+      return true;
+    });
+}
+
+export function useCurrentAccountFilteredMempoolTransactionsState() {
+  const address = useCurrentAccountStxAddressState();
+  if (!address)
+    logger.error(
+      `Attempting to fetch from mempool with no address in ${useCurrentAccountFilteredMempoolTransactionsState.name}`
+    );
+  return useAccountUnanchoredMempoolTransactions(address ?? '').filter(
+    tx => !!tx
+  ) as MempoolTransaction[];
+}
+
+export function useCurrentAccountMempool() {
+  const address = useCurrentAccountStxAddressState();
+  if (!address)
+    logger.error(
+      `Attempting to fetch from mempool with no address in ${useCurrentAccountFilteredMempoolTransactionsState.name}`
+    );
+  return useAccountMempool(address ?? '');
+}

--- a/src/query/mempool/mempool.query.ts
+++ b/src/query/mempool/mempool.query.ts
@@ -1,0 +1,22 @@
+import { useQuery } from 'react-query';
+
+import { useSetMempoolTransactions } from '@store/accounts/account.hooks';
+import { useApi } from '@store/common/api-clients.hooks';
+import type { MempoolTransaction } from '@stacks/stacks-blockchain-api-types';
+
+export function useAccountMempool(address: string) {
+  const api = useApi();
+  const setMempoolTxs = useSetMempoolTransactions();
+
+  function accountMempoolFetcher() {
+    return api.transactionsApi.getAddressMempoolTransactions({ address, limit: 50 });
+  }
+
+  return useQuery({
+    queryKey: ['account-mempool', address],
+    queryFn: accountMempoolFetcher,
+    onSuccess(resp) {
+      setMempoolTxs(resp.results as MempoolTransaction[]);
+    },
+  });
+}

--- a/src/query/transactions/transaction.hooks.ts
+++ b/src/query/transactions/transaction.hooks.ts
@@ -1,0 +1,8 @@
+import { useCurrentAccountFilteredMempoolTransactionsState } from '@query/mempool/mempool.hooks';
+import { useAccountConfirmedTransactions } from '@store/accounts/account.hooks';
+
+export function useCurrentAccountTxIds() {
+  const confirmedTxs = useAccountConfirmedTransactions();
+  const mempoolTxs = useCurrentAccountFilteredMempoolTransactionsState();
+  return [...new Set([...confirmedTxs, ...mempoolTxs].map(tx => tx.tx_id))];
+}

--- a/src/query/transactions/transactions-by-id.query.ts
+++ b/src/query/transactions/transactions-by-id.query.ts
@@ -1,0 +1,35 @@
+import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types/generated';
+import { useApi } from '@store/common/api-clients.hooks';
+import { useQueries, useQuery } from 'react-query';
+
+export function useTransactionsById(txids: string[]) {
+  const api = useApi();
+
+  function transactionByIdFetcher(txId: string) {
+    return api.transactionsApi.getTransactionById({ txId }) as unknown as MempoolTransaction;
+  }
+
+  return useQueries(
+    txids.map(txid => {
+      return {
+        queryKey: ['transaction-by-id', txid],
+        queryFn: () => transactionByIdFetcher(txid),
+      };
+    })
+  );
+}
+
+export function useTransactionById(txid: string) {
+  const api = useApi();
+
+  function transactionByIdFetcher(txId: string) {
+    return api.transactionsApi.getTransactionById({ txId }) as unknown as
+      | Transaction
+      | MempoolTransaction;
+  }
+
+  return useQuery({
+    queryKey: ['transaction-by-id', txid],
+    queryFn: () => transactionByIdFetcher(txid),
+  });
+}

--- a/src/store/accounts/account-activity.ts
+++ b/src/store/accounts/account-activity.ts
@@ -1,6 +1,5 @@
 import { atom } from 'jotai';
 import { currentNetworkState } from '@store/network/networks';
-import { deserializeTransaction, StacksTransaction } from '@stacks/transactions';
 import { atomFamily, atomWithStorage } from 'jotai/utils';
 import {
   currentAccountStxAddressState,
@@ -9,10 +8,7 @@ import {
 import { makeLocalDataKey } from '@common/store-utils';
 import deepEqual from 'fast-deep-equal';
 import { safelyFormatHexTxid } from '@common/utils/safe-handle-txid';
-
-export const currentAccountExternalTxIdsState = atom(get => [
-  ...new Set([...get(currentAccountTransactionsState).map(tx => tx.tx_id)]),
-]);
+import { deserializeTransaction, StacksTransaction } from '@stacks/transactions';
 
 type LocalTx = Record<
   string,
@@ -26,6 +22,14 @@ const currentAccountLocallySubmittedTxsRootState = atomFamily<[string, string], 
     atomWithStorage<LocalTx>(makeLocalDataKey([_address, _network, 'LOCAL_TXS']), {}),
   deepEqual
 );
+
+/**
+ * @deprecated
+ * Use `useCurrentAccountTxIds`
+ */
+const currentAccountExternalTxIdsState = atom(get => [
+  ...new Set([...get(currentAccountTransactionsState).map(tx => tx.tx_id)]),
+]);
 
 export const currentAccountLocallySubmittedTxsState = atom<LocalTx, LocalTx>(
   get => {
@@ -44,7 +48,7 @@ export const currentAccountLocallySubmittedTxsState = atom<LocalTx, LocalTx>(
   }
 );
 
-export const currentAccountLocallySubmittedTxIdsState = atom(get => {
+const currentAccountLocallySubmittedTxIdsState = atom(get => {
   const txs = get(currentAccountLocallySubmittedTxsState);
   const externalTxids = get(currentAccountExternalTxIdsState);
   return txs
@@ -55,7 +59,8 @@ export const currentAccountLocallySubmittedTxIdsState = atom(get => {
     : [];
 });
 
-export const currentAccountLocallySubmittedStacksTransactionsState = atom(get => {
+/** @deprecated */
+const currentAccountLocallySubmittedStacksTransactionsState = atom(get => {
   const localTxs = get(currentAccountLocallySubmittedTxsState);
   const txids = get(currentAccountLocallySubmittedTxIdsState);
   const result: any = {};
@@ -74,6 +79,7 @@ export const currentAccountLocallySubmittedStacksTransactionsState = atom(get =>
   >;
 });
 
+/** @deprecated */
 export const currentAccountLocallySubmittedLatestNonceState = atom(get => {
   const txids = get(currentAccountLocallySubmittedTxIdsState);
   const latestTxId = txids[0];

--- a/src/store/accounts/account.hooks.ts
+++ b/src/store/accounts/account.hooks.ts
@@ -6,12 +6,12 @@ import {
   accountsWithAddressState,
   currentAccountAvailableStxBalanceState,
   currentAccountBalancesUnanchoredState,
+  currentAccountConfirmedTransactionsState,
   currentAccountIndexState,
   currentAccountInfoState,
   currentAccountMempoolTransactionsState,
   currentAccountState,
   currentAccountStxAddressState,
-  currentAccountTransactionsState,
   hasSwitchedAccountsState,
   refreshAccountDataState,
   transactionAccountIndexState,
@@ -25,22 +25,16 @@ export function useCurrentAccountAvailableStxBalance() {
   return useAtomValue(currentAccountAvailableStxBalanceState);
 }
 
-function useAccountActivity() {
-  return useAtomValue(currentAccountTransactionsState);
+export function useAccountConfirmedTransactions() {
+  return useAtomValue(currentAccountConfirmedTransactionsState);
 }
 
-export function useAccountSingleTransaction(txid?: string) {
-  const txs = useAccountActivity();
-  if (!txid) return;
-  return txs.find(tx => tx.tx_id === txid);
+export function useSetMempoolTransactions() {
+  return useUpdateAtom(currentAccountMempoolTransactionsState);
 }
 
 export function useCurrentAccountBalancesUnanchoredState() {
   return useAtomValue(currentAccountBalancesUnanchoredState);
-}
-
-export function useCurrentAccountMempoolTransactionsState() {
-  return useAtomValue(currentAccountMempoolTransactionsState);
 }
 
 export function useAccounts() {

--- a/src/store/accounts/index.ts
+++ b/src/store/accounts/index.ts
@@ -15,7 +15,6 @@ import {
   accountBalancesUnanchoredBigNumberState,
   accountBalancesUnanchoredClient,
   accountInfoUnanchoredClient,
-  accountMempoolTransactionsUnanchoredClient,
   accountTransactionsUnanchoredClient,
 } from '@store/accounts/api';
 import { AccountWithAddress } from './account.models';
@@ -153,21 +152,13 @@ export const currentAccountConfirmedTransactionsState = atom<Transaction[]>(get 
   return transactionsWithTransfers.map(atx => atx.tx);
 });
 
-export const currentAccountMempoolTransactionsState = atom<MempoolTransaction[]>(get => {
-  const principal = get(currentAccountStxAddressState);
-  const networkUrl = get(currentNetworkState).url;
-  if (!principal) return [];
-  const mempool = get(
-    accountMempoolTransactionsUnanchoredClient({
-      principal,
-      limit: DEFAULT_LIST_LIMIT,
-      networkUrl,
-    })
-  );
-  return mempool?.pages[0].results || [];
-});
+/**
+ * @deprecated
+ * Populated by mempool `useQuery`
+ */
+export const currentAccountMempoolTransactionsState = atom<MempoolTransaction[]>([]);
 
-// combo of pending and confirmed transactions for the current address
+/** @deprecated */
 export const currentAccountTransactionsState = atom<(MempoolTransaction | Transaction)[]>(get => {
   const transactions = get(currentAccountConfirmedTransactionsState);
   const pending = get(currentAccountMempoolTransactionsState);
@@ -185,16 +176,6 @@ export const refreshAccountDataState = atom(null, (get, set) => {
   const principal = get(currentAccountStxAddressState);
   const networkUrl = get(currentNetworkState).url;
   if (!principal) return;
-  set(
-    accountMempoolTransactionsUnanchoredClient({
-      principal,
-      limit: DEFAULT_LIST_LIMIT,
-      networkUrl,
-    }),
-    {
-      type: 'refetch',
-    }
-  );
   set(accountTransactionsUnanchoredClient({ principal, limit: DEFAULT_LIST_LIMIT, networkUrl }), {
     type: 'refetch',
   });
@@ -211,4 +192,3 @@ currentAccountState.debugLabel = 'currentAccountState';
 currentAccountStxAddressState.debugLabel = 'currentAccountStxAddressState';
 currentAccountPrivateKeyState.debugLabel = 'currentAccountPrivateKeyState';
 currentAccountBalancesUnanchoredState.debugLabel = 'currentAccountBalancesState';
-currentAccountTransactionsState.debugLabel = 'currentAccountTransactionsState';

--- a/src/store/accounts/nonce.ts
+++ b/src/store/accounts/nonce.ts
@@ -3,10 +3,10 @@ import { atomFamily, atomWithStorage } from 'jotai/utils';
 import deepEqual from 'fast-deep-equal';
 
 import {
-  currentAccountStxAddressState,
-  currentAccountInfoState,
   currentAccountConfirmedTransactionsState,
+  currentAccountInfoState,
   currentAccountMempoolTransactionsState,
+  currentAccountStxAddressState,
 } from '@store/accounts';
 import { currentNetworkState } from '@store/network/networks';
 import { makeLocalDataKey } from '@common/store-utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6659,9 +6659,9 @@ cssstyle@^2.3.0:
     cssom "~0.3.6"
 
 csstype@^3.0.2:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
-  integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -15794,9 +15794,9 @@ webpack-sources@^2.2.0:
     source-map "^0.6.1"
 
 webpack-sources@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.1.tgz#251a7d9720d75ada1469ca07dbb62f3641a05b6d"
-  integrity sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.2.tgz#d88e3741833efec57c4c789b6010db9977545260"
+  integrity sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==
 
 webpack@*, webpack@^5, webpack@^5.1.0, webpack@^5.38.1:
   version "5.64.0"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1462746096).<!-- Sticky Header Marker -->

Closes #1938

Per bug reported in splat channel, we need to better handle failed requests for mempool, as after retries are made, the wallet breaks atm.

This is a good chance to refactor the mempool logic out state mgmt, into react query. `useQueries` makes it super easy to get loading states per request etc. Currently this info is inaccessible to UI as its not exposed by the async atom.

In attempting this, I tried to get rid of the base atom completely, but _so many_ atoms derive from it, including nonce calculation I didn't want to touch.

Would be great to get QA on this before merging if possible:

QA requirements:
- Checking any code that touches the mempool
  - This includes nonce calculation, and sending transaction flows
  - That the wallet updates correctly during these flows
