### PR TITLE
refactor: estimations default state and max button

### DIFF
--- a/src/features/fee-row/components/fee-estimate-item.tsx
+++ b/src/features/fee-row/components/fee-estimate-item.tsx
@@ -4,26 +4,25 @@ import { color, Stack } from '@stacks/ui';
 
 import { Caption } from '@components/typography';
 
-const LABELS = ['Low', 'Standard', 'High', 'Custom'];
-
 interface FeeEstimateItemProps {
   hasFeeEstimations?: boolean | null;
   index: number;
+  isSelectActive?: boolean | null;
+  label: string;
   onClick?: (index: number) => void | undefined;
   selected?: number;
-  visible?: boolean;
 }
 
 export function FeeEstimateItem(props: FeeEstimateItemProps) {
-  const { hasFeeEstimations, index, onClick, visible } = props;
+  const { hasFeeEstimations, index, isSelectActive, label, onClick } = props;
 
   return (
     <Stack
       alignItems="center"
-      border={visible ? 'none' : '1px solid #EFEFF2'}
-      borderRadius={visible ? '0px' : '10px'}
+      border={isSelectActive ? 'none' : '1px solid #EFEFF2'}
+      borderRadius={isSelectActive ? '0px' : '10px'}
       bg={color('bg')}
-      _hover={{ bg: visible ? color('bg-alt') : 'none', borderRadius: '8px' }}
+      _hover={{ bg: isSelectActive ? color('bg-alt') : 'none', borderRadius: '8px' }}
       height="32px"
       isInline
       minWidth="100px"
@@ -32,9 +31,11 @@ export function FeeEstimateItem(props: FeeEstimateItemProps) {
       onClick={() => onClick?.(index)}
     >
       <Stack alignItems="center" isInline flexGrow={1}>
-        <Caption ml="2px">{LABELS[index]}</Caption>
+        <Caption ml="2px">{label}</Caption>
       </Stack>
-      <Stack textAlign="right">{visible || !hasFeeEstimations ? <></> : <FiChevronDown />}</Stack>
+      <Stack textAlign="right">
+        {isSelectActive || !hasFeeEstimations ? <></> : <FiChevronDown />}
+      </Stack>
     </Stack>
   );
 }

--- a/src/features/fee-row/components/fee-estimate-select.tsx
+++ b/src/features/fee-row/components/fee-estimate-select.tsx
@@ -1,26 +1,36 @@
-import React, { Dispatch, SetStateAction, useRef } from 'react';
+import React, { Dispatch, SetStateAction, useMemo, useRef } from 'react';
 import { color, Fade, Stack } from '@stacks/ui';
 
 import { useOnClickOutside } from '@common/hooks/use-onclickoutside';
-import { Estimations, FeeEstimation } from '@models/fees-types';
+import { FeeEstimation } from '@models/fees-types';
 
 import { FeeEstimateItem } from './fee-estimate-item';
 
 interface FeeEstimateSelectProps {
-  items: FeeEstimation[];
+  isOpen: boolean;
+  feeEstimations: FeeEstimation[];
   onClick: (index: number) => void;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
-  visible: boolean;
 }
 
 export function FeeEstimateSelect(props: FeeEstimateSelectProps) {
-  const { items, onClick, setIsOpen, visible } = props;
+  const { feeEstimations, isOpen, onClick, setIsOpen } = props;
   const ref = useRef<HTMLDivElement | null>(null);
 
   useOnClickOutside(ref, () => setIsOpen(false));
 
+  const feeEstimationsListItems = useMemo(() => {
+    return [
+      { label: '' },
+      { label: 'Low', ...feeEstimations[0] },
+      { label: 'Standard', ...feeEstimations[1] },
+      { label: 'High', ...feeEstimations[2] },
+      { label: 'Custom' },
+    ];
+  }, [feeEstimations]);
+
   return (
-    <Fade in={visible}>
+    <Fade in={isOpen}>
       {styles => (
         <Stack
           bg={color('bg')}
@@ -34,13 +44,18 @@ export function FeeEstimateSelect(props: FeeEstimateSelectProps) {
           position="absolute"
           ref={ref}
           style={styles}
-          top="-32px"
+          top="-64px"
           zIndex={9999}
         >
-          {items.map((item, index) => (
-            <FeeEstimateItem index={index} key={item.fee} onClick={onClick} visible />
+          {feeEstimationsListItems.map((item, index) => (
+            <FeeEstimateItem
+              index={index}
+              isSelectActive={isOpen}
+              key={item.label}
+              label={item.label}
+              onClick={onClick}
+            />
           ))}
-          <FeeEstimateItem index={Estimations.Custom} onClick={onClick} visible />
         </Stack>
       )}
     </Fade>

--- a/src/features/fee-row/components/transaction-fee.tsx
+++ b/src/features/fee-row/components/transaction-fee.tsx
@@ -5,20 +5,18 @@ import { stacksValue } from '@common/stacks-utils';
 import { useTxForSettingsState } from '@store/transactions/transaction.hooks';
 import { useFeeState } from '@store/transactions/fees.hooks';
 
-export function TransactionFee(): JSX.Element | null {
+export function TransactionFee(): JSX.Element {
   /** @deprecated */
   const [transaction] = useTxForSettingsState();
   const [fee] = useFeeState();
   const isSponsored = transaction?.auth?.authType === AuthType.Sponsored;
-
-  if (!fee) return null;
 
   return (
     <>
       {isSponsored
         ? '🎉 sponsored'
         : stacksValue({
-            value: fee,
+            value: fee || 0,
             fixedDecimals: true,
           })}
     </>

--- a/src/models/fees-types.ts
+++ b/src/models/fees-types.ts
@@ -1,6 +1,7 @@
 export enum Estimations {
+  Default,
   Low,
-  Middle,
+  Standard,
   High,
   Custom,
 }

--- a/src/pages/send-tokens/components/amount-field.tsx
+++ b/src/pages/send-tokens/components/amount-field.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
-import { Box, Input, InputGroup, Stack, StackProps, Text } from '@stacks/ui';
 import { useFormikContext } from 'formik';
+import { Box, Input, InputGroup, Stack, StackProps, Text } from '@stacks/ui';
 
 import { useAssets } from '@store/assets/asset.hooks';
 import { useSelectedAsset } from '@common/hooks/use-selected-asset';
@@ -33,8 +33,9 @@ function AmountFieldBase(props: AmountFieldProps) {
   });
   const [fee] = useFeeState();
 
+  const isStx = selectedAsset?.type === 'stx';
+
   const handleSetSendMaxTracked = (fee: number | null) => {
-    if (!fee) return;
     void analytics.track('select_maximum_amount_for_send');
     return handleSetSendMax(fee);
   };
@@ -61,9 +62,9 @@ function AmountFieldBase(props: AmountFieldProps) {
             name="amount"
             data-testid={SendFormSelectors.InputAmountField}
           />
-          {balances && selectedAsset ? (
-            <SendMaxButton isLoadingFee={!fee} onClick={() => handleSetSendMaxTracked(fee)} />
-          ) : null}
+          {balances &&
+            selectedAsset &&
+            (isStx && !fee ? null : <SendMaxButton onClick={() => handleSetSendMaxTracked(fee)} />)}
         </Box>
       </InputGroup>
       {error && (

--- a/src/pages/send-tokens/components/send-form-inner.tsx
+++ b/src/pages/send-tokens/components/send-form-inner.tsx
@@ -3,7 +3,6 @@ import { useFormikContext } from 'formik';
 import { Box, Text, Button, Stack } from '@stacks/ui';
 
 import { useNextTxNonce } from '@common/hooks/account/use-next-tx-nonce';
-import { microStxToStx } from '@common/stacks-utils';
 import { TransactionFormValues } from '@common/types';
 import { ErrorLabel } from '@components/error-label';
 import { FeeRow } from '@features/fee-row/fee-row';
@@ -27,7 +26,6 @@ import {
 } from '@store/transactions/transaction.hooks';
 import { useFeeEstimationsQuery } from '@query/fees/fees.hooks';
 import { ShowEditNonceAction } from '@pages/sign-transaction/components/show-edit-nonce';
-import { Estimations } from '@models/fees-types';
 
 import { SendFormMemoWarning } from './memo-warning';
 
@@ -52,17 +50,14 @@ export function SendFormInner(props: SendFormProps) {
   const { selectedAsset } = useSelectedAsset();
   const assets = useTransferableAssets();
 
-  const { handleSubmit, values, setValues, errors, setFieldError, setFieldValue } =
+  const { handleSubmit, values, setValues, errors, setFieldError } =
     useFormikContext<TransactionFormValues>();
 
   useEffect(() => {
     if (!fee && feeEstimationsResp && feeEstimationsResp.estimations) {
       setFeeEstimations(feeEstimationsResp.estimations);
-      setFee(feeEstimationsResp.estimations[Estimations.Middle].fee);
-      setFeeRate(feeEstimationsResp.estimations[Estimations.Middle].fee_rate);
-      setFieldValue('txFee', microStxToStx(feeEstimationsResp.estimations[Estimations.Middle].fee));
     }
-  }, [fee, feeEstimationsResp, setFee, setFeeEstimations, setFeeRate, setFieldValue]);
+  }, [fee, feeEstimationsResp, setFeeEstimations]);
 
   useEffect(() => {
     return () => {

--- a/src/pages/send-tokens/components/send-max-button.tsx
+++ b/src/pages/send-tokens/components/send-max-button.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Box, ButtonProps, color } from '@stacks/ui';
-import { toast } from 'react-hot-toast';
+
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
-function SendMaxButtonAction(props: ButtonProps) {
+export function SendMaxButton(props: ButtonProps) {
   return (
     <Box
       as="button"
@@ -23,20 +23,5 @@ function SendMaxButtonAction(props: ButtonProps) {
     >
       Max
     </Box>
-  );
-}
-
-interface SendMaxProps {
-  isLoadingFee: boolean | undefined;
-  onClick: () => void;
-}
-
-export function SendMaxButton(props: SendMaxProps): JSX.Element | null {
-  const { isLoadingFee, onClick } = props;
-
-  return !isLoadingFee ? (
-    <SendMaxButtonAction onClick={onClick} />
-  ) : (
-    <SendMaxButtonAction onClick={() => toast.error('Unable to calculate max spend')} />
   );
 }

--- a/src/pages/send-tokens/hooks/use-send-form.ts
+++ b/src/pages/send-tokens/hooks/use-send-form.ts
@@ -17,13 +17,10 @@ export function useSendAmountFieldActions({
   const handleSetSendMax = useCallback(
     (fee: number | null) => {
       if (!selectedAsset || !balance) return;
-      if (isStx) {
-        if (fee) {
-          const stx = microStxToStx(availableStxBalance || 0).minus(microStxToStx(fee));
-          if (stx.isLessThanOrEqualTo(0)) return;
-          return setFieldValue('amount', stx.toNumber());
-        }
-        return setFieldValue('amount', removeCommas(balance));
+      if (isStx && fee) {
+        const stx = microStxToStx(availableStxBalance || 0).minus(microStxToStx(fee));
+        if (stx.isLessThanOrEqualTo(0)) return;
+        return setFieldValue('amount', stx.toNumber());
       } else {
         if (balance) setFieldValue('amount', removeCommas(balance));
       }

--- a/src/pages/sign-transaction/components/fee-and-submit-form.tsx
+++ b/src/pages/sign-transaction/components/fee-and-submit-form.tsx
@@ -1,10 +1,7 @@
 import React, { useEffect } from 'react';
-import { useFormikContext } from 'formik';
 
-import { microStxToStx } from '@common/stacks-utils';
 import { LoadingRectangle } from '@components/loading-rectangle';
 import { FeeRow } from '@features/fee-row/fee-row';
-import { Estimations } from '@models/fees-types';
 import { MinimalErrorMessage } from '@pages/sign-transaction/components/minimal-error-message';
 import { SubmitAction } from '@pages/sign-transaction/components/submit-action';
 import { useFeeEstimationsQuery } from '@query/fees/fees.hooks';
@@ -12,14 +9,9 @@ import {
   useEstimatedSignedTransactionByteLengthState,
   useSerializedSignedTransactionPayloadState,
 } from '@store/transactions/transaction.hooks';
-import {
-  useFeeEstimationsState,
-  useFeeRateState,
-  useFeeState,
-} from '@store/transactions/fees.hooks';
+import { useFeeEstimationsState, useFeeState } from '@store/transactions/fees.hooks';
 
 export function FeeAndSubmitForm(): JSX.Element | null {
-  const { setFieldValue } = useFormikContext();
   const serializedSignedTransactionPayloadState = useSerializedSignedTransactionPayloadState();
   const estimatedSignedTxByteLength = useEstimatedSignedTransactionByteLengthState();
   const { data: feeEstimationsResp, isError } = useFeeEstimationsQuery(
@@ -27,17 +19,13 @@ export function FeeAndSubmitForm(): JSX.Element | null {
     estimatedSignedTxByteLength
   );
   const [, setFeeEstimations] = useFeeEstimationsState();
-  const [fee, setFee] = useFeeState();
-  const [, setFeeRate] = useFeeRateState();
+  const [fee] = useFeeState();
 
   useEffect(() => {
     if (!fee && feeEstimationsResp && feeEstimationsResp.estimations) {
       setFeeEstimations(feeEstimationsResp.estimations);
-      setFee(feeEstimationsResp.estimations[Estimations.Middle].fee);
-      setFeeRate(feeEstimationsResp.estimations[Estimations.Middle].fee_rate);
-      setFieldValue('txFee', microStxToStx(feeEstimationsResp.estimations[Estimations.Middle].fee));
     }
-  }, [fee, feeEstimationsResp, setFee, setFeeEstimations, setFeeRate, setFieldValue]);
+  }, [fee, feeEstimationsResp, setFeeEstimations]);
 
   return (
     <>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1474404654).<!-- Sticky Header Marker -->

This PR changes the fee estimation to default to an empty state so the user has to select a fee before `Preview` becomes active. In addition, bc of it's relationship to the `Max` button, I am hiding the button for STX transactions until the user selects a fee. For a non STX transaction, the button will always be present bc it will just load their full balance for them.

cc/ @markmhx @eugeniadigon for feedback on this change...

![Screen Shot 2021-11-17 at 4 08 17 PM](https://user-images.githubusercontent.com/6493321/142293334-d8200e43-9473-4eb6-be66-7e8b0a66e239.png)

![Screen Shot 2021-11-17 at 4 19 04 PM](https://user-images.githubusercontent.com/6493321/142293348-5d5dcf21-d996-421d-a336-3263bb345220.png)

![Screen Shot 2021-11-17 at 4 30 59 PM](https://user-images.githubusercontent.com/6493321/142293359-4e6a55ba-c508-4992-a377-05072415b3a2.png)

cc/ @kyranjamie @beguene
