### PR TITLE
refactor: use `whenChainId` helper

### DIFF
--- a/src/common/transactions/transaction-utils.spec.ts
+++ b/src/common/transactions/transaction-utils.spec.ts
@@ -1,5 +1,6 @@
+import { ChainID } from '@stacks/transactions';
 import { AddressTransactionWithTransfers, Transaction } from '@stacks/stacks-blockchain-api-types';
-import { createTxDateFormatList } from './transaction-utils';
+import { createTxDateFormatList, whenChainId } from './transaction-utils';
 
 function createFakeTx(tx: Partial<Transaction>) {
   return {
@@ -46,5 +47,26 @@ describe(createTxDateFormatList.name, () => {
     const result = createTxDateFormatList([mockTx]);
     expect(result[0].date).toEqual(date.toISOString().split('T')[0]);
     expect(result[0].displayDate).not.toContain(new Date().getFullYear().toString());
+  });
+});
+
+describe(whenChainId.name, () => {
+  const expectedResult = 'should be this value';
+  test('that it returns testnet when given a testnet chain id', () => {
+    expect(
+      whenChainId(ChainID.Testnet)({
+        [ChainID.Testnet]: expectedResult,
+        [ChainID.Mainnet]: 'One plus one equals two.',
+      })
+    ).toEqual(expectedResult);
+  });
+  test('that it returns mainnet when given a mainnet chain id', () => {
+    const expectedResult = 'should be this value';
+    expect(
+      whenChainId(ChainID.Mainnet)({
+        [ChainID.Testnet]: 'The capital city of Mongolia is Ulaanbaatar.',
+        [ChainID.Mainnet]: expectedResult,
+      })
+    ).toEqual(expectedResult);
   });
 });

--- a/src/common/transactions/transaction-utils.ts
+++ b/src/common/transactions/transaction-utils.ts
@@ -13,6 +13,7 @@ import { stacksValue } from '@common/stacks-utils';
 import { BigNumber } from 'bignumber.js';
 import { AssetWithMeta } from '@common/asset-types';
 import { TransactionTypes } from '@stacks/connect';
+import { ChainID } from '@stacks/transactions';
 
 type Tx = MempoolTransaction | Transaction;
 
@@ -166,4 +167,12 @@ export function isTransactionTypeSupported(txType: TransactionTypes) {
     txType === TransactionTypes.ContractCall ||
     txType === TransactionTypes.ContractDeploy
   );
+}
+
+interface WhenChainIdMap<T> {
+  [ChainID.Mainnet]: T;
+  [ChainID.Testnet]: T;
+}
+export function whenChainId(chainId: ChainID) {
+  return <T>(chainIdMap: WhenChainIdMap<T>): T => chainIdMap[chainId];
 }

--- a/src/store/network/networks.ts
+++ b/src/store/network/networks.ts
@@ -7,6 +7,7 @@ import { StacksMainnet, StacksNetwork, StacksTestnet } from '@stacks/network';
 import { ChainID } from '@stacks/transactions';
 import { transactionRequestNetwork } from '@store/transactions/requests';
 import { makeLocalDataKey } from '@common/store-utils';
+import { whenChainId } from '@common/transactions/transaction-utils';
 
 // Our root networks list, users can add to this list and it will persist to localstorage
 export const networksState = atomWithStorage<Networks>(
@@ -43,10 +44,12 @@ export const currentNetworkState = atom(get => get(networksState)[get(currentNet
 // a `StacksNetwork` instance using the current network
 export const currentStacksNetworkState = atom<StacksNetwork>(get => {
   const network = get(currentNetworkState);
-  const stacksNetwork =
-    network.chainId === ChainID.Testnet
-      ? new StacksTestnet({ url: network.url })
-      : new StacksMainnet({ url: network.url });
+
+  const stacksNetwork = whenChainId(network.chainId)({
+    [ChainID.Mainnet]: new StacksMainnet({ url: network.url }),
+    [ChainID.Testnet]: new StacksTestnet({ url: network.url }),
+  });
+
   stacksNetwork.bnsLookupUrl = network.url;
   return stacksNetwork;
 });

--- a/src/store/transactions/index.ts
+++ b/src/store/transactions/index.ts
@@ -11,7 +11,7 @@ import { serializePayload } from '@stacks/transactions/dist/payload';
 
 import { validateStacksAddress } from '@common/stacks-utils';
 
-import { stacksTransactionToHex } from '@common/transactions/transaction-utils';
+import { stacksTransactionToHex, whenChainId } from '@common/transactions/transaction-utils';
 import { currentNetworkState, currentStacksNetworkState } from '@store/network/networks';
 import { currentAccountNonceState } from '@store/accounts/nonce';
 import { currentAccountState, currentAccountStxAddressState } from '@store/accounts';
@@ -110,11 +110,17 @@ export const estimatedSignedTransactionByteLengthState = atom<number | null>(get
   return serializedTx.byteLength;
 });
 
-export const transactionNetworkVersionState = atom(get =>
-  get(currentNetworkState)?.chainId === ChainID.Mainnet
-    ? TransactionVersion.Mainnet
-    : TransactionVersion.Testnet
-);
+export const transactionNetworkVersionState = atom(get => {
+  const chainId = get(currentNetworkState)?.chainId;
+
+  const defaultChainId = TransactionVersion.Testnet;
+  if (!chainId) return defaultChainId;
+
+  return whenChainId(chainId)({
+    [ChainID.Mainnet]: TransactionVersion.Mainnet,
+    [ChainID.Testnet]: TransactionVersion.Testnet,
+  });
+});
 
 export const transactionBroadcastErrorState = atom<string | null>(null);
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1475801586).<!-- Sticky Header Marker -->

Doing my best to make small PRs as I go, but at some point there'll be a big one. Prepare yourselves.

I used this pattern in desktop wallet for network/wallet type, think it's more readable/robust than a ternary. The issue with code like below is that, assume `network.chainId` somehow becomes `undefined` somehow, or a tertiary ChainId is introduced. Then it will fallback to mainnet, which could be extremely problematic.

```ts
  const stacksNetwork =
    network.chainId === ChainID.Testnet
      ? new StacksTestnet({ url: network.url })
      : new StacksMainnet({ url: network.url });
```


