### PR TITLE
refactor: compose fee form on upper component

### DIFF
--- a/src/pages/sign-transaction/components/fee-form.tsx
+++ b/src/pages/sign-transaction/components/fee-form.tsx
@@ -6,7 +6,6 @@ import { LoadingRectangle } from '@components/loading-rectangle';
 import { FeeRow } from '@features/fee-row/fee-row';
 import { Estimations } from '@models/fees-types';
 import { MinimalErrorMessage } from '@pages/sign-transaction/components/minimal-error-message';
-import { SubmitAction } from '@pages/sign-transaction/components/submit-action';
 import { useFeeEstimationsQuery } from '@query/fees/fees.hooks';
 import {
   useEstimatedSignedTransactionByteLengthState,
@@ -18,7 +17,7 @@ import {
   useFeeState,
 } from '@store/transactions/fees.hooks';
 
-export function FeeAndSubmitForm(): JSX.Element | null {
+export function FeeForm(): JSX.Element | null {
   const { setFieldValue } = useFormikContext();
   const serializedSignedTransactionPayloadState = useSerializedSignedTransactionPayloadState();
   const estimatedSignedTxByteLength = useEstimatedSignedTransactionByteLengthState();
@@ -47,7 +46,6 @@ export function FeeAndSubmitForm(): JSX.Element | null {
         <LoadingRectangle height="32px" width="100%" />
       )}
       <MinimalErrorMessage />
-      <SubmitAction />
     </>
   );
 }

--- a/src/pages/sign-transaction/components/submit-action.tsx
+++ b/src/pages/sign-transaction/components/submit-action.tsx
@@ -10,6 +10,14 @@ import {
 import { useTransactionError } from '@pages/sign-transaction/hooks/use-transaction-error';
 import { TransactionsSelectors } from '@tests/integration/transactions.selectors';
 
+function BaseConfirmButton(props: ButtonProps): JSX.Element {
+  return (
+    <Button borderRadius="10px" py="base" type="submit" width="100%" {...props}>
+      Confirm
+    </Button>
+  );
+}
+
 function SubmitActionSuspense(): JSX.Element {
   const { handleSubmit } = useFormikContext();
   const error = useTransactionError();
@@ -26,14 +34,6 @@ function SubmitActionSuspense(): JSX.Element {
     >
       Confirm
     </BaseConfirmButton>
-  );
-}
-
-function BaseConfirmButton(props: ButtonProps): JSX.Element {
-  return (
-    <Button borderRadius="10px" py="base" type="submit" width="100%" {...props}>
-      Confirm
-    </Button>
   );
 }
 

--- a/src/pages/sign-transaction/sign-transaction.tsx
+++ b/src/pages/sign-transaction/sign-transaction.tsx
@@ -26,7 +26,8 @@ import {
   useFeeState,
 } from '@store/transactions/fees.hooks';
 
-import { FeeAndSubmitForm } from './components/fee-and-submit-form';
+import { FeeForm } from './components/fee-form';
+import { SubmitAction } from './components/submit-action';
 
 function SignTransactionBase(): JSX.Element | null {
   useNextTxNonce();
@@ -37,7 +38,7 @@ function SignTransactionBase(): JSX.Element | null {
   const [, setFeeEstimations] = useFeeEstimationsState();
   const [, setFee] = useFeeState();
   const [, setFeeRate] = useFeeRateState();
-  const schema = useFeeSchema();
+  const feeSchema = useFeeSchema();
 
   const onSubmit = useCallback(async () => {
     setIsLoading();
@@ -77,10 +78,15 @@ function SignTransactionBase(): JSX.Element | null {
             validateOnBlur={false}
             validateOnMount={false}
             validationSchema={yup.object({
-              txFee: schema(),
+              txFee: feeSchema(),
             })}
           >
-            {() => <FeeAndSubmitForm />}
+            {() => (
+              <>
+                <FeeForm />
+                <SubmitAction />
+              </>
+            )}
           </Formik>
         </Suspense>
       </Stack>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1477235423).<!-- Sticky Header Marker -->

Tiny small refactor. If a component name has "and" in it, then it's often a sign it's doing too much. 

Here, we can place them next to each other on the upper component. There's merit in choosing to have it a a single component, but then ideally that should be composed of the individual components, fee input, submit etc