### PR TITLE
fix: custom fee state after fallback

### DIFF
--- a/src/pages/sign-transaction/sign-transaction.tsx
+++ b/src/pages/sign-transaction/sign-transaction.tsx
@@ -3,6 +3,7 @@ import { Formik } from 'formik';
 import * as yup from 'yup';
 import { Stack } from '@stacks/ui';
 
+import { stxToMicroStx } from '@common/stacks-utils';
 import { useFeeSchema } from '@common/validation/use-fee-schema';
 import { LoadingKeys, useLoading } from '@common/hooks/use-loading';
 import { useNextTxNonce } from '@common/hooks/account/use-next-tx-nonce';
@@ -39,23 +40,27 @@ function SignTransactionBase(): JSX.Element | null {
   const [, setFeeRate] = useFeeRateState();
   const schema = useFeeSchema();
 
-  const onSubmit = useCallback(async () => {
-    setIsLoading();
-    await handleBroadcastTransaction();
-    setIsIdle();
-    setFeeEstimations([]);
-    setFee(null);
-    setFeeRate(null);
-    return () => setBroadcastError(null);
-  }, [
-    handleBroadcastTransaction,
-    setBroadcastError,
-    setFee,
-    setFeeEstimations,
-    setFeeRate,
-    setIsIdle,
-    setIsLoading,
-  ]);
+  const onSubmit = useCallback(
+    async values => {
+      setFee(stxToMicroStx(values.txFee).toNumber());
+      setIsLoading();
+      await handleBroadcastTransaction();
+      setIsIdle();
+      setFeeEstimations([]);
+      setFee(null);
+      setFeeRate(null);
+      return () => setBroadcastError(null);
+    },
+    [
+      handleBroadcastTransaction,
+      setBroadcastError,
+      setFee,
+      setFeeEstimations,
+      setFeeRate,
+      setIsIdle,
+      setIsLoading,
+    ]
+  );
 
   if (!transactionRequest) return null;
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1477387797).<!-- Sticky Header Marker -->

This should fix making sure the fee state is set before submitting the tx when falling back to the custom input.

cc/ @kyranjamie @beguene
