### PR TITLE
refactor: add high fee confirmation

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,6 +2,8 @@ import { ChainID } from '@stacks/transactions';
 
 export const gaiaUrl = 'https://hub.blockstack.org';
 
+export const HIGH_FEE_AMOUNT_STX = 5;
+
 export const HUMAN_REACTION_DEBOUNCE_TIME = 250;
 
 export const STX_TRANSFER_TX_SIZE_BYTES = 180;

--- a/src/common/hooks/use-drawers.ts
+++ b/src/common/hooks/use-drawers.ts
@@ -1,6 +1,7 @@
 import {
   useAccountDrawerStep,
   useShowAccountsStore,
+  useShowHighFeeConfirmationState,
   useShowNetworksStore,
   useShowSettingsStore,
   useShowSignOut,
@@ -11,6 +12,7 @@ import {
 export function useDrawers() {
   const [accountStep, setAccountStep] = useAccountDrawerStep();
   const [showAccounts, setShowAccounts] = useShowAccountsStore();
+  const [showHighFeeConfirmation, setShowHighFeeConfirmation] = useShowHighFeeConfirmationState();
   const [showNetworks, setShowNetworks] = useShowNetworksStore();
   const [showSettings, setShowSettings] = useShowSettingsStore();
   const [showEditNonce, setShowEditNonce] = useShowEditNonceState();
@@ -22,6 +24,8 @@ export function useDrawers() {
     setAccountStep,
     showAccounts,
     setShowAccounts,
+    showHighFeeConfirmation,
+    setShowHighFeeConfirmation,
     showNetworks,
     setShowNetworks,
     showSettings,

--- a/src/common/hooks/use-loading.ts
+++ b/src/common/hooks/use-loading.ts
@@ -1,11 +1,11 @@
 import { useLoadingState } from '@store/ui/ui.hooks';
 
 export enum LoadingKeys {
-  SUBMIT_TRANSACTION = 'loading/SUBMIT_TRANSACTION',
+  CONFIRM_DRAWER = 'loading/CONFIRM_DRAWER',
   EDIT_NONCE_DRAWER = 'loading/EDIT_NONCE_DRAWER',
   INCREASE_FEE_DRAWER = 'loading/INCREASE_FEE_DRAWER',
   SEND_TOKENS_FORM = 'loading/SEND_TOKENS_FORM',
-  CONFIRM_DRAWER = 'loading/CONFIRM_DRAWER',
+  SUBMIT_TRANSACTION = 'loading/SUBMIT_TRANSACTION',
 }
 
 export function useLoading(key: string) {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -278,3 +278,7 @@ export function isNumber(value: unknown): value is number {
 export function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
+
+export function isEmpty(value: Object) {
+  return Object.keys(value).length === 0;
+}

--- a/src/components/drawer/controlled.tsx
+++ b/src/components/drawer/controlled.tsx
@@ -6,7 +6,7 @@ interface ControlledDrawerProps {
   /** An optional callback that is fired _after_ visibility has been turned off. */
   onClose: () => void;
   isShowing: boolean;
-  title: string;
+  title: string | JSX.Element;
 }
 
 /**

--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -1,12 +1,14 @@
 import React, { useRef, useCallback, memo } from 'react';
 import { Flex, useEventListener, IconButton, color, transition } from '@stacks/ui';
 import { FiX as IconX } from 'react-icons/fi';
+
 import { useOnClickOutside } from '@common/hooks/use-onclickoutside';
+import { isString } from '@common/utils';
 import { Title } from '@components/typography';
 
 export interface BaseDrawerProps {
   isShowing: boolean;
-  title?: string;
+  title?: string | JSX.Element;
   pauseOnClickOutside?: boolean;
   onClose: () => void;
 }
@@ -38,10 +40,12 @@ const DrawerHeader = ({
 }) => {
   return (
     <Flex pb="base" justifyContent="space-between" alignItems="center" pt="extra-loose" px="loose">
-      {title && (
+      {title && isString(title) ? (
         <Title fontSize="20px" lineHeight="28px">
           {title}
         </Title>
+      ) : (
+        title
       )}
       <IconButton
         transform="translateX(8px)"

--- a/src/features/fee-row/fee-row.tsx
+++ b/src/features/fee-row/fee-row.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
 import { useFormikContext } from 'formik';
-import { Box, color, Flex, Stack, Text } from '@stacks/ui';
+import { Box, color, Stack, Text } from '@stacks/ui';
 
 import { SendFormErrorMessages } from '@common/error-messages';
 import { stacksValue } from '@common/stacks-utils';
@@ -102,57 +102,66 @@ export function FeeRow(props: FeeRowProps): JSX.Element {
   }, [errors.txFee]);
 
   return (
-    <Stack spacing="base">
-      <SpaceBetween position="relative">
-        <Stack alignItems="center" isInline>
-          <Caption>
-            <Flex>Fees</Flex>
-          </Caption>
-          <Stack _hover={{ cursor: 'pointer' }}>
-            <FeeEstimateItem
-              hasFeeEstimations={!feeEstimationsQueryError}
-              index={selected}
-              onClick={!feeEstimationsQueryError ? () => setIsOpen(true) : undefined}
-            />
-            <FeeEstimateSelect
-              items={feeEstimations}
-              onClick={handleSelectedItem}
-              setIsOpen={setIsOpen}
-              visible={isOpen}
-            />
-          </Stack>
-          <Tooltip label={FEES_INFO} placement="bottom">
-            <Stack>
-              <Box
-                _hover={{ cursor: 'pointer' }}
-                as={FiInfo}
-                color={color('text-caption')}
-                onClick={() => openInNewTab(URL)}
-                size="14px"
+    <>
+      <Stack spacing="base">
+        <SpaceBetween position="relative">
+          <Stack alignItems="center" isInline>
+            <Caption>Fees</Caption>
+            <Stack _hover={{ cursor: 'pointer' }}>
+              <FeeEstimateItem
+                hasFeeEstimations={!feeEstimationsQueryError}
+                index={selected}
+                onClick={!feeEstimationsQueryError ? () => setIsOpen(true) : undefined}
+              />
+              <FeeEstimateSelect
+                items={feeEstimations}
+                onClick={handleSelectedItem}
+                setIsOpen={setIsOpen}
+                visible={isOpen}
               />
             </Stack>
-          </Tooltip>
-        </Stack>
-        {isCustom ? (
-          <CustomFeeField setFieldWarning={setFieldWarning} />
-        ) : !fee ? (
-          <LoadingRectangle width="50px" height="10px" />
-        ) : (
-          <Suspense fallback={<>0.00</>}>
-            <Caption>
-              <TransactionFee />
-            </Caption>
-          </Suspense>
+            <Tooltip label={FEES_INFO} placement="bottom">
+              <Stack>
+                <Box
+                  _hover={{ cursor: 'pointer' }}
+                  as={FiInfo}
+                  color={color('text-caption')}
+                  onClick={() => openInNewTab(URL)}
+                  size="14px"
+                />
+              </Stack>
+            </Tooltip>
+          </Stack>
+          {isCustom ? (
+            <CustomFeeField setFieldWarning={setFieldWarning} />
+          ) : !fee ? (
+            <LoadingRectangle width="50px" height="10px" />
+          ) : (
+            <Suspense
+              fallback={
+                <>
+                  {stacksValue({
+                    value: 0,
+                    fixedDecimals: true,
+                  })}
+                </>
+              }
+            >
+              <Caption>
+                <TransactionFee />
+              </Caption>
+            </Suspense>
+          )}
+        </SpaceBetween>
+        {errors.txFee && (
+          <ErrorLabel data-testid={SendFormSelectors.InputCustomFeeFieldErrorLabel}>
+            <Text lineHeight="18px" textStyle="caption">
+              {fieldError}
+            </Text>
+          </ErrorLabel>
         )}
-      </SpaceBetween>
-      {errors.txFee && (
-        <ErrorLabel data-testid={SendFormSelectors.InputCustomFeeFieldErrorLabel}>
-          <Text lineHeight="18px" textStyle="caption">
-            {fieldError}
-          </Text>
-        </ErrorLabel>
-      )}
-      {!errors.txFee && fieldWarning && <WarningLabel>{fieldWarning}</WarningLabel>}
-    </Stack>
+        {!errors.txFee && fieldWarning && <WarningLabel>{fieldWarning}</WarningLabel>}
+      </Stack>
+    </>
   );
 }

--- a/src/features/high-fee-drawer/components/high-fee-confirmation.tsx
+++ b/src/features/high-fee-drawer/components/high-fee-confirmation.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useFormikContext } from 'formik';
+import { Button, Stack } from '@stacks/ui';
+
+import { useDrawers } from '@common/hooks/use-drawers';
+import { TransactionFormValues } from '@common/types';
+import { openInNewTab } from '@common/utils/open-in-new-tab';
+import { Link } from '@components/link';
+import { Caption, Title } from '@components/typography';
+
+const URL = 'https://hiro.so/questions/fee-estimates';
+
+export function HighFeeConfirmation(): JSX.Element | null {
+  const { handleSubmit, values } = useFormikContext<TransactionFormValues>();
+  const { showHighFeeConfirmation, setShowHighFeeConfirmation } = useDrawers();
+
+  return (
+    <Stack px="loose" spacing="loose" pb="extra-loose">
+      <Title fontSize="20px" fontWeight={400} lineHeight="28px">
+        Are you sure you want to pay {values.txFee} STX in fees for this transaction?
+      </Title>
+      <Caption>
+        This action cannot be undone and the fees won't be returned, even if the transaction fails.{' '}
+        <Link fontSize="14px" onClick={() => openInNewTab(URL)}>
+          Learn more
+        </Link>
+      </Caption>
+      <Stack isInline mt="loose">
+        <Button
+          borderRadius="10px"
+          mode="tertiary"
+          onClick={() => setShowHighFeeConfirmation(!showHighFeeConfirmation)}
+          width="50%"
+        >
+          Edit fee
+        </Button>
+        <Button
+          borderRadius="10px"
+          onClick={() => {
+            setShowHighFeeConfirmation(!showHighFeeConfirmation);
+            handleSubmit();
+          }}
+          width="50%"
+        >
+          Yes, I'm sure
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/features/high-fee-drawer/high-fee-drawer.tsx
+++ b/src/features/high-fee-drawer/high-fee-drawer.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import { FiAlertTriangle } from 'react-icons/fi';
+import { Box, color } from '@stacks/ui';
+
+import { useDrawers } from '@common/hooks/use-drawers';
+import { ControlledDrawer } from '@components/drawer/controlled';
+
+import { HighFeeConfirmation } from './components/high-fee-confirmation';
+
+export function HighFeeDrawer(): JSX.Element {
+  const { showHighFeeConfirmation, setShowHighFeeConfirmation } = useDrawers();
+
+  useEffect(() => {
+    return () => {
+      if (showHighFeeConfirmation) setShowHighFeeConfirmation(false);
+    };
+  }, [showHighFeeConfirmation, setShowHighFeeConfirmation]);
+
+  return (
+    <ControlledDrawer
+      title={<Box as={FiAlertTriangle} color={color('feedback-error')} size="36px" />}
+      isShowing={!!showHighFeeConfirmation}
+      onClose={() => setShowHighFeeConfirmation(false)}
+    >
+      {showHighFeeConfirmation && <HighFeeConfirmation />}
+    </ControlledDrawer>
+  );
+}

--- a/src/pages/send-tokens/send-tokens-form.tsx
+++ b/src/pages/send-tokens/send-tokens-form.tsx
@@ -9,6 +9,7 @@ import { ScreenPaths, TransactionFormValues } from '@common/types';
 import { PopupContainer } from '@components/popup/container';
 import { Header } from '@components/header';
 import { useChangeScreen } from '@common/hooks/use-change-screen';
+import { HighFeeDrawer } from '@features/high-fee-drawer/high-fee-drawer';
 import { useSendFormValidation } from '@pages/send-tokens/hooks/use-send-form-validation';
 import { useLocalTransactionInputsState } from '@store/transactions/transaction.hooks';
 import { useFeeState } from '@store/transactions/fees.hooks';
@@ -27,13 +28,13 @@ const initialValues: TransactionFormValues = {
 
 function SendTokensFormBase() {
   const { setIsIdle, setIsLoading } = useLoading(LoadingKeys.SEND_TOKENS_FORM);
+  const { showEditNonce, showHighFeeConfirmation } = useDrawers();
   const [isShowing, setShowing] = useState(false);
   const [assetError, setAssetError] = useState<string | undefined>(undefined);
   const { selectedAsset } = useSelectedAsset();
   const sendFormSchema = useSendFormValidation({ setAssetError });
   const [, setTxData] = useLocalTransactionInputsState();
   const [beginShow, setBeginShow] = useState(false);
-  const { showEditNonce } = useDrawers();
   const resetNonceCallback = useResetNonceCallback();
   const [, setFee] = useFeeState();
   const doChangeScreen = useChangeScreen();
@@ -80,7 +81,7 @@ function SendTokensFormBase() {
       >
         {formik => (
           <>
-            {beginShow && (
+            {!showHighFeeConfirmation && beginShow && (
               <Suspense fallback={<></>}>
                 <ShowDelay setShowing={setShowing} beginShow={beginShow} isShowing={isShowing} />
               </Suspense>
@@ -94,6 +95,7 @@ function SendTokensFormBase() {
             <Suspense fallback={<></>}>
               <SendFormInner assetError={assetError} />
             </Suspense>
+            <HighFeeDrawer />
           </>
         )}
       </Formik>

--- a/src/pages/sign-transaction/components/submit-action.tsx
+++ b/src/pages/sign-transaction/components/submit-action.tsx
@@ -2,7 +2,11 @@ import React, { Suspense } from 'react';
 import { useFormikContext } from 'formik';
 import { Button, ButtonProps } from '@stacks/ui';
 
+import { HIGH_FEE_AMOUNT_STX } from '@common/constants';
+import { useDrawers } from '@common/hooks/use-drawers';
 import { LoadingKeys, useLoading } from '@common/hooks/use-loading';
+import { TransactionFormValues } from '@common/types';
+import { isEmpty } from '@common/utils';
 import { ShowEditNonceAction, ShowEditNoncePlaceholder } from '@components/show-edit-nonce';
 import { useTransactionError } from '@pages/sign-transaction/hooks/use-transaction-error';
 import { TransactionsSelectors } from '@tests/integration/transactions.selectors';
@@ -16,16 +20,24 @@ function BaseConfirmButton(props: ButtonProps): JSX.Element {
 }
 
 function SubmitActionSuspense(): JSX.Element {
-  const { handleSubmit } = useFormikContext();
-  const error = useTransactionError();
+  const { handleSubmit, values, validateForm } = useFormikContext<TransactionFormValues>();
+  const { showHighFeeConfirmation, setShowHighFeeConfirmation } = useDrawers();
   const { isLoading } = useLoading(LoadingKeys.SUBMIT_TRANSACTION);
+  const error = useTransactionError();
 
   const isDisabled = !!error;
 
   return (
     <BaseConfirmButton
       data-testid={TransactionsSelectors.BtnConfirmTransaction}
-      onClick={handleSubmit}
+      onClick={async () => {
+        // We need to check for errors here before we show the high fee confirmation
+        const formErrors = await validateForm();
+        if (isEmpty(formErrors) && values.txFee > HIGH_FEE_AMOUNT_STX) {
+          return setShowHighFeeConfirmation(!showHighFeeConfirmation);
+        }
+        handleSubmit();
+      }}
       isLoading={isLoading}
       isDisabled={isDisabled}
     >

--- a/src/pages/sign-transaction/sign-transaction.tsx
+++ b/src/pages/sign-transaction/sign-transaction.tsx
@@ -3,11 +3,12 @@ import { Formik } from 'formik';
 import * as yup from 'yup';
 import { Stack } from '@stacks/ui';
 
-import { stxToMicroStx } from '@common/stacks-utils';
 import { useFeeSchema } from '@common/validation/use-fee-schema';
 import { LoadingKeys, useLoading } from '@common/hooks/use-loading';
 import { useNextTxNonce } from '@common/hooks/account/use-next-tx-nonce';
+import { stxToMicroStx } from '@common/stacks-utils';
 import { PopupContainer } from '@components/popup/container';
+import { HighFeeDrawer } from '@features/high-fee-drawer/high-fee-drawer';
 import { PopupHeader } from '@pages/sign-transaction/components/popup-header';
 import { PageTop } from '@pages/sign-transaction/components/page-top';
 import { ContractCallDetails } from '@pages/sign-transaction/components/contract-call-details/contract-call-details';
@@ -90,6 +91,7 @@ function SignTransactionBase(): JSX.Element | null {
               <>
                 <FeeForm />
                 <SubmitAction />
+                <HighFeeDrawer />
               </>
             )}
           </Formik>

--- a/src/store/transactions/fees.ts
+++ b/src/store/transactions/fees.ts
@@ -3,5 +3,7 @@ import { atom } from 'jotai';
 import { FeeEstimation } from '@models/fees-types';
 
 export const feeEstimationsState = atom<FeeEstimation[]>([]);
+
 export const feeState = atom<number | null>(null);
+
 export const feeRateState = atom<number | null>(null);

--- a/src/store/ui/ui.hooks.ts
+++ b/src/store/ui/ui.hooks.ts
@@ -7,6 +7,7 @@ import {
   errorStackTraceState,
   loadingState,
   showAccountsStore,
+  showHighFeeConfirmationState,
   showNetworksStore,
   showSettingsStore,
   tabState,
@@ -21,6 +22,10 @@ export function useAccountDrawerStep() {
 
 export function useUpdateAccountDrawerStep() {
   return useUpdateAtom(accountDrawerStep);
+}
+
+export function useShowHighFeeConfirmationState() {
+  return useAtom(showHighFeeConfirmationState);
 }
 
 export function useShowAccountsStore() {

--- a/src/store/ui/ui.ts
+++ b/src/store/ui/ui.ts
@@ -22,6 +22,8 @@ export const accountDrawerStep = atom<AccountStep>(AccountStep.Switch);
 // TODO: refactor into atom family
 export const showAccountsStore = atom(false);
 
+export const showHighFeeConfirmationState = atom(false);
+
 export const showNetworksStore = atom(false);
 
 export const showSettingsStore = atom(false);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1492474763).<!-- Sticky Header Marker -->

This PR adds a high fee warning/confirmation step before a user can broadcast a transaction. Currently, we are setting the warning to trigger at greater than 5 STX.

*Note: Designs show flat buttons with no shadow, but that would need to be updated across the app.

![Screen Shot 2021-11-18 at 4 42 39 PM](https://user-images.githubusercontent.com/6493321/142509790-c4b76978-a344-40d3-811d-f3980207c119.png)

![Screen Shot 2021-11-18 at 4 35 19 PM](https://user-images.githubusercontent.com/6493321/142509780-a64a4d6b-9458-4316-97ef-bed9752cd73a.png)


cc/ @kyranjamie @beguene
