### PR TITLE
fix: send max toast

### DIFF
--- a/src/pages/send-tokens/components/amount-field.tsx
+++ b/src/pages/send-tokens/components/amount-field.tsx
@@ -34,7 +34,6 @@ function AmountFieldBase(props: AmountFieldProps) {
   const [fee] = useFeeState();
 
   const handleSetSendMaxTracked = (fee: number | null) => {
-    if (!fee) return;
     void analytics.track('select_maximum_amount_for_send');
     return handleSetSendMax(fee);
   };
@@ -62,7 +61,11 @@ function AmountFieldBase(props: AmountFieldProps) {
             data-testid={SendFormSelectors.InputAmountField}
           />
           {balances && selectedAsset ? (
-            <SendMaxButton isLoadingFee={!fee} onClick={() => handleSetSendMaxTracked(fee)} />
+            <SendMaxButton
+              isLoadingFee={!fee}
+              onClick={() => handleSetSendMaxTracked(fee)}
+              selectedAsset={selectedAsset}
+            />
           ) : null}
         </Box>
       </InputGroup>

--- a/src/pages/send-tokens/components/send-max-button.tsx
+++ b/src/pages/send-tokens/components/send-max-button.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { Box, ButtonProps, color } from '@stacks/ui';
 import { toast } from 'react-hot-toast';
+import { Box, ButtonProps, color } from '@stacks/ui';
+
+import { AssetWithMeta } from '@common/asset-types';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
 function SendMaxButtonAction(props: ButtonProps) {
@@ -29,14 +31,16 @@ function SendMaxButtonAction(props: ButtonProps) {
 interface SendMaxProps {
   isLoadingFee: boolean | undefined;
   onClick: () => void;
+  selectedAsset: AssetWithMeta | undefined;
 }
 
 export function SendMaxButton(props: SendMaxProps): JSX.Element | null {
-  const { isLoadingFee, onClick } = props;
+  const { isLoadingFee, onClick, selectedAsset } = props;
+  const isStx = selectedAsset?.type === 'stx';
 
-  return !isLoadingFee ? (
-    <SendMaxButtonAction onClick={onClick} />
+  return isLoadingFee && isStx ? (
+    <SendMaxButtonAction onClick={() => toast.error('Unable to calculate max. Try Again.')} />
   ) : (
-    <SendMaxButtonAction onClick={() => toast.error('Unable to calculate max spend')} />
+    <SendMaxButtonAction onClick={onClick} />
   );
 }

--- a/src/pages/send-tokens/hooks/use-send-form.ts
+++ b/src/pages/send-tokens/hooks/use-send-form.ts
@@ -17,13 +17,10 @@ export function useSendAmountFieldActions({
   const handleSetSendMax = useCallback(
     (fee: number | null) => {
       if (!selectedAsset || !balance) return;
-      if (isStx) {
-        if (fee) {
-          const stx = microStxToStx(availableStxBalance || 0).minus(microStxToStx(fee));
-          if (stx.isLessThanOrEqualTo(0)) return;
-          return setFieldValue('amount', stx.toNumber());
-        }
-        return setFieldValue('amount', removeCommas(balance));
+      if (isStx && fee) {
+        const stx = microStxToStx(availableStxBalance || 0).minus(microStxToStx(fee));
+        if (stx.isLessThanOrEqualTo(0)) return;
+        return setFieldValue('amount', stx.toNumber());
       } else {
         if (balance) setFieldValue('amount', removeCommas(balance));
       }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1481462189).<!-- Sticky Header Marker -->

This PR fixes the send max toast so it is only activated if the selected asset is STX and if there is no fee present yet to calculate the max available.

@markmhx @eugeniadigon thoughts on type here? Kyran proposed this version.

![Screen Shot 2021-11-18 at 7 11 20 PM](https://user-images.githubusercontent.com/6493321/142526947-8517122b-2b22-458f-9203-592187948f53.png)

cc/ @kyranjamie @beguene 
