### PR TITLE
fix: replace by fee cache bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "react-dom": "17.0.2",
     "react-hot-toast": "2.0.0",
     "react-icons": "4.2.0",
-    "react-query": "3.32.1",
+    "react-query": "3.33.4",
     "react-router-dom": "6.0.0-beta.0",
     "ts-debounce": "3.0.0",
     "use-events": "1.4.2",

--- a/src/features/increase-fee-drawer/components/increase-fee-form.tsx
+++ b/src/features/increase-fee-drawer/components/increase-fee-form.tsx
@@ -25,6 +25,7 @@ import { useCurrentAccountAvailableStxBalance } from '@store/accounts/account.ho
 import { IncreaseFeeActions } from './increase-fee-actions';
 import { IncreaseFeeField } from './increase-fee-field';
 import { useSelectedTx } from '../hooks/use-selected-tx';
+import { useRemoveLocalSubmittedTxById } from '@store/accounts/account-activity.hooks';
 
 export function IncreaseFeeForm(): JSX.Element | null {
   const refreshAccountData = useRefreshAllAccountData();
@@ -36,8 +37,9 @@ export function IncreaseFeeForm(): JSX.Element | null {
   const byteSize = useRawTxByteLengthState();
   const [, setTxId] = useRawTxIdState();
   const schema = useFeeSchema();
-  const handleSubmit = useReplaceByFeeSubmitCallBack();
+  const replaceByFee = useReplaceByFeeSubmitCallBack();
   const stxBalance = useCurrentAccountAvailableStxBalance();
+  const removeLocallySubmittedTx = useRemoveLocalSubmittedTxById();
 
   useEffect(() => {
     // Set fee on mount
@@ -61,9 +63,12 @@ export function IncreaseFeeForm(): JSX.Element | null {
       const feeRate = newFeeRate.toNumber();
       setFeeRate(feeRate);
       setFee(stxToMicroStx(values.txFee).toNumber());
-      await handleSubmit(values);
+      await replaceByFee(values);
+      if (tx?.tx_id) {
+        removeLocallySubmittedTx(tx.tx_id);
+      }
     },
-    [byteSize, handleSubmit, refreshAccountData, setFeeRate, setFee]
+    [byteSize, refreshAccountData, setFeeRate, setFee, tx, replaceByFee, removeLocallySubmittedTx]
   );
 
   if (!tx || !rawTx) return null;

--- a/src/features/local-transaction-activity/local-tx-list.tsx
+++ b/src/features/local-transaction-activity/local-tx-list.tsx
@@ -9,11 +9,7 @@ import { Box, color, Stack, Text } from '@stacks/ui';
 const LocalTxListItem = ({ txid }: { txid: string }) => {
   const localTx = useCurrentAccountLocalStacksTransaction(txid);
   const cleanup = useCleanupLocalTxsCallback();
-  useEffect(() => {
-    return () => {
-      cleanup();
-    };
-  }, [cleanup]);
+  useEffect(() => () => cleanup(), [cleanup]);
   if (localTx) return <LocalTxItem txid={txid} transaction={localTx.transaction} />;
   return <>Loading...</>;
 };

--- a/src/store/accounts/account-activity.hooks.ts
+++ b/src/store/accounts/account-activity.hooks.ts
@@ -2,6 +2,7 @@ import { useAtomCallback, useAtomValue, useUpdateAtom } from 'jotai/utils';
 import {
   cleanupLocalTxs,
   currentAccountLocallySubmittedTxsState,
+  removeLocalSubmittedTxById,
 } from '@store/accounts/account-activity';
 import { deserializeTransaction, StacksTransaction } from '@stacks/transactions';
 
@@ -66,4 +67,8 @@ export function useCurrentAccountLocalStacksTransaction(tx_id: string) {
 
 export function useCleanupLocalTxsCallback() {
   return useUpdateAtom(cleanupLocalTxs);
+}
+
+export function useRemoveLocalSubmittedTxById() {
+  return useUpdateAtom(removeLocalSubmittedTxById);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13808,10 +13808,10 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-query@3.32.1:
-  version "3.32.1"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.32.1.tgz#829a87d039ece85660d8911ac59b1c92d1879064"
-  integrity sha512-7UN8BYBaZb911iJUyJ/T+CjlBGBf5W8rcm3jRQ5wW4f+mt/onvRxJlB0U2r2fsT204poJt6VO0jPlm5dwu3PrQ==
+react-query@3.33.4:
+  version "3.33.4"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.33.4.tgz#486d81d04824e314bc46e587e272c522013a5ec8"
+  integrity sha512-mNPnVjJfMQpflX7kU2JW6AR3Z++Xh0OMHs452WQf4uYNm21LU0zo+VjRGQtv0fih4gYfCGB7QJckRM27ywHnpA==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1494761658).<!-- Sticky Header Marker -->

This issue's rather confused me, to be honest. It isn't clear how my refactor would've broken it, nor how it ever worked in the first place lol.

There's code to "clean up" the cache, called from the `<LocalTxIdListItem />` component. 

https://github.com/hirosystems/stacks-wallet-web/blob/99a619bdd471bdd8b4e94c1cd5011520c883ce0c/src/store/accounts/account-activity.ts#L93

But this works implicitly based on whether there's a duplicate id, which there isn't in the case of replace by fee, the id changes.

This PR adds the behaviour where, on successful replace by fee of a given tx, the previous txid is removed from the cache.