### PR TITLE
fix: fee estimations default and send max decimals

### DIFF
--- a/src/features/fee-row/components/custom-fee-field.tsx
+++ b/src/features/fee-row/components/custom-fee-field.tsx
@@ -33,7 +33,7 @@ export function CustomFeeField(props: CustomFeeFieldProps) {
   );
 
   return (
-    <Stack width="100%" position="relative" {...rest}>
+    <Stack position="relative" {...rest}>
       <InputGroup
         alignSelf="flex-end"
         flexDirection="column"

--- a/src/features/fee-row/components/fee-estimate-item.tsx
+++ b/src/features/fee-row/components/fee-estimate-item.tsx
@@ -2,20 +2,20 @@ import React from 'react';
 import { FiChevronDown } from 'react-icons/fi';
 import { color, Stack } from '@stacks/ui';
 
+import { SpaceBetween } from '@components/space-between';
 import { Caption } from '@components/typography';
 
 const LABELS = ['Low', 'Standard', 'High', 'Custom'];
 
 interface FeeEstimateItemProps {
-  hasFeeEstimations?: boolean | null;
   index: number;
-  onClick?: (index: number) => void | undefined;
+  onClick: (index: number) => void;
   selected?: number;
   visible?: boolean;
 }
 
 export function FeeEstimateItem(props: FeeEstimateItemProps) {
-  const { hasFeeEstimations, index, onClick, visible } = props;
+  const { index, onClick, visible } = props;
 
   return (
     <Stack
@@ -29,12 +29,12 @@ export function FeeEstimateItem(props: FeeEstimateItemProps) {
       minWidth="100px"
       p="tight"
       mb="0px !important"
-      onClick={() => onClick?.(index)}
+      onClick={() => onClick(index)}
     >
-      <Stack alignItems="center" isInline flexGrow={1}>
+      <SpaceBetween flexGrow={1}>
         <Caption ml="2px">{LABELS[index]}</Caption>
-      </Stack>
-      <Stack textAlign="right">{visible || !hasFeeEstimations ? <></> : <FiChevronDown />}</Stack>
+        {visible ? <></> : <FiChevronDown />}
+      </SpaceBetween>
     </Stack>
   );
 }

--- a/src/features/fee-row/fee-row.tsx
+++ b/src/features/fee-row/fee-row.tsx
@@ -77,20 +77,18 @@ export function FeeRow(props: FeeRowProps): JSX.Element {
     <Stack spacing="base">
       <SpaceBetween position="relative">
         <Stack alignItems="center" isInline>
-          <Caption>Fees</Caption>
-          <Stack _hover={{ cursor: 'pointer' }}>
-            <FeeEstimateItem
-              hasFeeEstimations={!feeEstimationsError}
-              index={selected}
-              onClick={!feeEstimationsError ? () => setIsOpen(true) : undefined}
-            />
-            <FeeEstimateSelect
-              items={feeEstimations}
-              onClick={handleSelectedItem}
-              setIsOpen={setIsOpen}
-              visible={isOpen}
-            />
-          </Stack>
+          {!feeEstimationsError ? <Caption>Fees</Caption> : <Caption>Enter a custom fee</Caption>}
+          {!feeEstimationsError ? (
+            <Stack _hover={{ cursor: 'pointer' }}>
+              <FeeEstimateItem index={selected} onClick={() => setIsOpen(true)} />
+              <FeeEstimateSelect
+                items={feeEstimations}
+                onClick={handleSelectedItem}
+                setIsOpen={setIsOpen}
+                visible={isOpen}
+              />
+            </Stack>
+          ) : null}
           <Tooltip label={feesInfo} placement="bottom">
             <Stack>
               <Box

--- a/src/pages/send-tokens/hooks/use-send-form.ts
+++ b/src/pages/send-tokens/hooks/use-send-form.ts
@@ -6,6 +6,7 @@ import { microStxToStx } from '@common/stacks-utils';
 import { removeCommas } from '@common/token-utils';
 import { TransactionFormValues } from '@common/transactions/transaction-utils';
 import { useCurrentAccountAvailableStxBalance } from '@store/accounts/account.hooks';
+import { STX_DECIMALS } from '@common/constants';
 
 export function useSendAmountFieldActions({
   setFieldValue,
@@ -20,7 +21,7 @@ export function useSendAmountFieldActions({
       if (isStx && fee) {
         const stx = microStxToStx(availableStxBalance || 0).minus(microStxToStx(fee));
         if (stx.isLessThanOrEqualTo(0)) return;
-        return setFieldValue('amount', stx.toNumber());
+        return setFieldValue('amount', stx.toNumber().toFixed(STX_DECIMALS));
       } else {
         if (balance) setFieldValue('amount', removeCommas(balance));
       }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1496162062).<!-- Sticky Header Marker -->

This PR changes the 'failed' 400 fee estimations query to display `Enter a custom fee` as a default label with the custom input. It also fixes the send max button to be only 6 decimals for STX.

cc @Eshwari007 @timstackblock 

![image](https://user-images.githubusercontent.com/6493321/143083173-6c742054-6d47-4c2a-b6d0-ec6d1cc51880.png)

![Screen Shot 2021-11-23 at 12 30 41 PM](https://user-images.githubusercontent.com/6493321/143083238-c62db8bc-5358-4c1a-a9b2-06172af54b6d.png)

cc/ @kyranjamie @beguene
