### PR TITLE
chore: use branch name as version for feature PRs

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -4,6 +4,7 @@ on: [pull_request, workflow_dispatch]
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
+  WALLET_ENVIRONMENT: feature
 
 jobs:
   pre_run:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 env:
   CI: true
+  WALLET_ENVIRONMENT: testing
 
 jobs:
   directories:

--- a/.github/workflows/publish-dev-extension.yml
+++ b/.github/workflows/publish-dev-extension.yml
@@ -9,6 +9,7 @@ env:
   # To use another sentry DSN
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   PREVIEW_RELEASE: true
+  WALLET_ENVIRONMENT: preview
 
 jobs:
   build-extension:

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -8,6 +8,7 @@ on:
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
+  WALLET_ENVIRONMENT: production
 
 jobs:
   pre-run:

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { Box, BoxProps, color, Flex, FlexProps, IconButton, Stack } from '@stacks/ui';
 import { FiMoreHorizontal as IconDots, FiArrowLeft as IconArrowLeft } from 'react-icons/fi';
 
@@ -37,7 +37,21 @@ interface HeaderProps extends FlexProps {
 }
 export const Header: React.FC<HeaderProps> = memo(props => {
   const { onClose, title, hideActions, ...rest } = props;
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
+
+  const version = useMemo(() => {
+    switch (process.env.WALLET_ENVIRONMENT) {
+      case 'production':
+      case 'preview':
+        return `v${VERSION}`;
+      case 'feature':
+        return BRANCH;
+      case 'development':
+        return 'dev';
+      default:
+        return null;
+    }
+  }, []);
 
   return (
     <Flex
@@ -49,16 +63,17 @@ export const Header: React.FC<HeaderProps> = memo(props => {
     >
       {!title ? (
         <Stack alignItems="center" pt="7px" isInline>
-          <StacksWalletLogo onClick={() => doChangeScreen(ScreenPaths.HOME)} />
-          {VERSION ? (
+          <StacksWalletLogo onClick={() => changeScreen(ScreenPaths.HOME)} />
+          {version ? (
             <Caption
               pt="extra-tight"
+              mt="2px"
               color="#8D929A"
               variant="c3"
               marginRight="10px"
               fontFamily="mono"
             >
-              v{VERSION}
+              {version}
             </Caption>
           ) : null}
         </Stack>

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -27,14 +27,14 @@ const GITHUB_SHA = process.env.GITHUB_SHA;
 /**
  * For non main branch builds, we add a random number after the patch version.
  */
-const getVersion = ref => {
+const getVersionWithRandomSuffix = ref => {
   if (ref === MAIN_BRANCH || !ref || IS_PUBLISHING) return _version;
   return `${_version}.${Math.floor(Math.floor(Math.random() * 1000))}`;
 };
 
 const BRANCH = GITHUB_REF;
 const COMMIT_SHA = GITHUB_SHA;
-const VERSION = getVersion(BRANCH);
+const VERSION = getVersionWithRandomSuffix(BRANCH);
 
 // to measure speed :~)
 const smp = new SpeedMeasurePlugin({
@@ -203,6 +203,7 @@ const config = {
     new webpack.EnvironmentPlugin({
       SENTRY_DSN: process.env.SENTRY_DSN ?? '',
       SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY ?? '',
+      WALLET_ENVIRONMENT: process.env.WALLET_ENVIRONMENT ?? 'development',
     }),
 
     new webpack.ProvidePlugin({


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1499439172).<!-- Sticky Header Marker -->

Add branch name to feature PRs, not current dev version.

@beguene hopefully this can work nicely with your environment stuff in your branch. Atm we have a bit of a mess of different environment variables. We can't really reuse `NODE_ENV`, what if we want to run in production locally etc?

This PR introduces a `WALLET_ENVIRONMENT` env var which we could use consistently, rather than a mix of `PREVIEW: true/false`, `IS_PUBLISHING` etc