### PR TITLE
fix: add max values for fee estimations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stacks/wallet-web",
   "description": "The Hiro Wallet is browser extension for interacting with Stacks apps.",
   "private": true,
-  "version": "2.21.1",
+  "version": "2.21.4",
   "author": "Hiro Systems PBC",
   "scripts": {
     "dev": "node webpack/dev-server.js",

--- a/src/common/transactions/transaction-utils.ts
+++ b/src/common/transactions/transaction-utils.ts
@@ -49,6 +49,32 @@ function txHasTime(tx: Tx) {
   );
 }
 
+const maxValueForLowFeeEstimation = 5000000;
+const maxValueForMiddleFeeEstimation = 15000000;
+const maxValueForHighFeeEstimation = 25000000;
+
+export function getFeeEstimationsWithMaxValues(feeEstimations: FeeEstimation[]) {
+  const feeEstimationsWithMaxValues = [];
+
+  if (new BigNumber(feeEstimations[0].fee).isGreaterThan(maxValueForLowFeeEstimation)) {
+    feeEstimationsWithMaxValues.push({ fee: maxValueForLowFeeEstimation, fee_rate: 0 });
+  } else {
+    feeEstimationsWithMaxValues.push(feeEstimations[0]);
+  }
+  if (new BigNumber(feeEstimations[1].fee).isGreaterThan(maxValueForMiddleFeeEstimation)) {
+    feeEstimationsWithMaxValues.push({ fee: maxValueForMiddleFeeEstimation, fee_rate: 0 });
+  } else {
+    feeEstimationsWithMaxValues.push(feeEstimations[1]);
+  }
+  if (new BigNumber(feeEstimations[2].fee).isGreaterThan(maxValueForHighFeeEstimation)) {
+    feeEstimationsWithMaxValues.push({ fee: maxValueForHighFeeEstimation, fee_rate: 0 });
+  } else {
+    feeEstimationsWithMaxValues.push(feeEstimations[2]);
+  }
+
+  return feeEstimationsWithMaxValues;
+}
+
 function calculateFeeFromFeeRate(txBytes: number, feeRate: number) {
   return new BigNumber(txBytes).multipliedBy(feeRate);
 }

--- a/src/pages/send-tokens/components/send-form-inner.tsx
+++ b/src/pages/send-tokens/components/send-form-inner.tsx
@@ -8,16 +8,15 @@ import { LoadingKeys, useLoading } from '@common/hooks/use-loading';
 import { useNextTxNonce } from '@common/hooks/account/use-next-tx-nonce';
 import { useSelectedAsset } from '@common/hooks/use-selected-asset';
 import { isEmpty } from '@common/utils';
-import { stacksValue } from '@common/stacks-utils';
 import {
   getDefaultSimulatedFeeEstimations,
+  getFeeEstimationsWithMaxValues,
   isTxSponsored,
   TransactionFormValues,
 } from '@common/transactions/transaction-utils';
 import { ErrorLabel } from '@components/error-label';
 import { ShowEditNonceAction } from '@components/show-edit-nonce';
 import { FeeRow } from '@components/fee-row/fee-row';
-import { Estimations } from '@models/fees-types';
 import { AssetSearch } from '@pages/send-tokens/components/asset-search/asset-search';
 import { AmountField } from '@pages/send-tokens/components/amount-field';
 import { useTransferableAssets } from '@store/assets/asset.hooks';
@@ -67,15 +66,10 @@ export function SendFormInner(props: SendFormProps) {
         setFeeEstimations(getDefaultSimulatedFeeEstimations(estimatedTxByteLength));
       }
       if (feeEstimationsResp.estimations && feeEstimationsResp.estimations.length) {
-        setFeeEstimations(feeEstimationsResp.estimations);
-        setFieldValue(
-          'fee',
-          stacksValue({
-            fixedDecimals: true,
-            value: feeEstimationsResp.estimations[Estimations.Middle].fee,
-            withTicker: false,
-          })
+        const feeEstimationsWithMaxValues = getFeeEstimationsWithMaxValues(
+          feeEstimationsResp.estimations
         );
+        setFeeEstimations(feeEstimationsWithMaxValues);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/sign-transaction/components/fee-form.tsx
+++ b/src/pages/sign-transaction/components/fee-form.tsx
@@ -1,15 +1,14 @@
 import React, { useEffect } from 'react';
 import { useFormikContext } from 'formik';
 
-import { stacksValue } from '@common/stacks-utils';
 import { LoadingRectangle } from '@components/loading-rectangle';
 import {
   getDefaultSimulatedFeeEstimations,
+  getFeeEstimationsWithMaxValues,
   isTxSponsored,
   TransactionFormValues,
 } from '@common/transactions/transaction-utils';
 import { FeeRow } from '@components/fee-row/fee-row';
-import { Estimations } from '@models/fees-types';
 import { MinimalErrorMessage } from '@pages/sign-transaction/components/minimal-error-message';
 import { useFeeEstimationsQuery } from '@query/fees/fees.hooks';
 import {
@@ -42,15 +41,10 @@ export function FeeForm(): JSX.Element | null {
         setFeeEstimations(getDefaultSimulatedFeeEstimations(estimatedSignedTxByteLength));
       }
       if (feeEstimationsResp.estimations && feeEstimationsResp.estimations.length) {
-        setFeeEstimations(feeEstimationsResp.estimations);
-        setFieldValue(
-          'fee',
-          stacksValue({
-            fixedDecimals: true,
-            value: feeEstimationsResp.estimations[Estimations.Middle].fee,
-            withTicker: false,
-          })
+        const feeEstimationsWithMaxValues = getFeeEstimationsWithMaxValues(
+          feeEstimationsResp.estimations
         );
+        setFeeEstimations(feeEstimationsWithMaxValues);
       }
     }
   }, [estimatedSignedTxByteLength, feeEstimationsResp, isError, setFeeEstimations, setFieldValue]);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1508886373).<!-- Sticky Header Marker -->

This PR adds max values for fee estimations:

```
if (high > 25) high = 25;
if (standard > 15) standard = 15;
if (low > 5) low = 5;
```

cc/ @kyranjamie @markmhx 