### PR TITLE
ci: mirror 'dev' --> 'beta'

### DIFF
--- a/.github/workflows/mirror-dev.yml
+++ b/.github/workflows/mirror-dev.yml
@@ -1,0 +1,13 @@
+name: Mirror dev to beta
+
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zofrex/mirror-branch@v1
+        with:
+          target-branch: beta


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1515203122).<!-- Sticky Header Marker -->

CI job to mirror `dev` to `beta`.

Hoping to do dev releases from `beta`, so that `dev` remains void of release commits. See commentary here https://softwareengineering.stackexchange.com/questions/377374/using-gitflow-and-semantic-versioning-how-to-avoid-version-number-conflicts-whe