### PR TITLE
ci: publish from 'beta'

### DIFF
--- a/.github/workflows/create-version.yml
+++ b/.github/workflows/create-version.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - dev
+      - beta
     tags-ignore:
       - '**'
     paths-ignore:

--- a/.github/workflows/publish-dev-extension.yml
+++ b/.github/workflows/publish-dev-extension.yml
@@ -1,8 +1,8 @@
-name: Publish Dev Extensions
+name: Publish Beta Extensions
 on:
   push:
     tags:
-      - 'v*dev*'
+      - 'v*beta*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -2,7 +2,7 @@ name: Publish Extensions
 on:
   push:
     tags-ignore:
-      - 'v*dev*'
+      - 'v*beta*'
   workflow_dispatch:
 
 env:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "release": {
     "branches": [
       {
-        "name": "dev",
+        "name": "beta",
         "prerelease": true
       },
       "main"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1516464449).<!-- Sticky Header Marker -->

Not 100% how well this will work, but it's our dev build so let's just try it.

https://github.com/hirosystems/stacks-wallet-web/pull/2004 mirrors `dev` on `beta`, now semantic release will run against that. This should reduce the conflicts between `dev` and `main`.