### PR TITLE
feat: fetch stx market data

### DIFF
--- a/src/common/utils/calculate-averages.ts
+++ b/src/common/utils/calculate-averages.ts
@@ -1,0 +1,6 @@
+import BigNumber from 'bignumber.js';
+
+export function calculateMeanAverage(prices: BigNumber[]) {
+  const sum = prices.reduce((acc, price) => acc.plus(price), new BigNumber(0));
+  return sum.dividedBy(prices.length).toString();
+}

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -12,7 +12,11 @@ import { ActivityList } from '@features/activity-list/account-activity';
 import { BalancesList } from '@features/balances-list/balances-list';
 import { HomeTabs } from './components/home-tabs';
 
+import { useStxMarketPrice } from '@query/market-data/market-data.hooks';
+
 export const Home = () => {
+  const y = useStxMarketPrice();
+  console.log(y);
   return (
     <>
       <PopupContainer

--- a/src/query/market-data/market-data.hooks.ts
+++ b/src/query/market-data/market-data.hooks.ts
@@ -1,0 +1,41 @@
+import BigNumber from 'bignumber.js';
+
+import { calculateMeanAverage } from '@common/utils/calculate-averages';
+import {
+  selectBinanceStxPrice,
+  useBinanceStxMarketDataQuery,
+} from './vendors/binance-market-data.query';
+import {
+  selectCoincapStxPrice,
+  useCoincapStxMarketDataQuery,
+} from './vendors/coincap-market-data.query';
+import {
+  selectCoingeckoStxPrice,
+  useCoinGeckoStxMarketDataQuery,
+} from './vendors/coingecko-market-data.query';
+
+interface MarketDataVendorWithPriceSelector {
+  result: any;
+  selector(v: unknown): string | number;
+}
+function pullPriceDataFromAvailableResponses(responses: MarketDataVendorWithPriceSelector[]) {
+  return responses
+    .filter(({ result }) => !!result)
+    .map(({ result, selector: priceSelector }) => priceSelector(result))
+    .map(val => new BigNumber(val));
+}
+
+export function useStxMarketPrice() {
+  const { data: coingecko } = useCoinGeckoStxMarketDataQuery();
+  const { data: coincap } = useCoincapStxMarketDataQuery();
+  const { data: binance } = useBinanceStxMarketDataQuery();
+
+  const stxPriceData = pullPriceDataFromAvailableResponses([
+    { result: coingecko, selector: selectCoingeckoStxPrice },
+    { result: coincap, selector: selectCoincapStxPrice },
+    { result: binance, selector: selectBinanceStxPrice },
+  ]);
+
+  const meanStxPrice = calculateMeanAverage(stxPriceData).toString();
+  return { symbol: 'USD', value: meanStxPrice };
+}

--- a/src/query/market-data/market-data.query.ts
+++ b/src/query/market-data/market-data.query.ts
@@ -1,0 +1,22 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+
+const marketDataQueryOptions: UseQueryOptions = {
+  staleTime: 1000 * 120,
+  refetchOnMount: false,
+  refetchInterval: false,
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+  refetchIntervalInBackground: false,
+} as const;
+
+export function useMarketDataQueryFactory({ url, queryKey }: { url: string; queryKey: string }) {
+  async function marketDataFetcher() {
+    return fetch(url).then(r => r.json());
+  }
+
+  return useQuery({
+    queryKey: [queryKey],
+    queryFn: () => marketDataFetcher(),
+    ...marketDataQueryOptions,
+  });
+}

--- a/src/query/market-data/vendors/binance-market-data.query.ts
+++ b/src/query/market-data/vendors/binance-market-data.query.ts
@@ -1,0 +1,11 @@
+import { useMarketDataQueryFactory } from '../market-data.query';
+
+export function selectBinanceStxPrice(resp: any) {
+  return resp?.price;
+}
+export function useBinanceStxMarketDataQuery() {
+  return useMarketDataQueryFactory({
+    url: 'https://api1.binance.com/api/v3/ticker/price?symbol=STXUSDT',
+    queryKey: 'binance-stx-market-data',
+  });
+}

--- a/src/query/market-data/vendors/coincap-market-data.query.ts
+++ b/src/query/market-data/vendors/coincap-market-data.query.ts
@@ -1,0 +1,11 @@
+import { useMarketDataQueryFactory } from '../market-data.query';
+
+export function selectCoincapStxPrice(resp: any) {
+  return resp?.data?.priceUsd;
+}
+export function useCoincapStxMarketDataQuery() {
+  return useMarketDataQueryFactory({
+    url: 'https://api.coincap.io/v2/assets/stacks',
+    queryKey: 'coincap-stx-market-data',
+  });
+}

--- a/src/query/market-data/vendors/coingecko-market-data.query.ts
+++ b/src/query/market-data/vendors/coingecko-market-data.query.ts
@@ -1,0 +1,11 @@
+import { useMarketDataQueryFactory } from '../market-data.query';
+
+export function selectCoingeckoStxPrice(resp: any) {
+  return resp?.blockstack?.usd;
+}
+export function useCoinGeckoStxMarketDataQuery() {
+  return useMarketDataQueryFactory({
+    url: 'https://api.coingecko.com/api/v3/simple/price?ids=blockstack&vs_currencies=usd',
+    queryKey: 'coin-gecko-market-data',
+  });
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1517383234).<!-- Sticky Header Marker -->

Had a quick look how we can add fiat values to the wallet.

This PR pulls data from the APIs of:
- [CoinGecko](https://www.coingecko.com/en/api)
- [Coincap](http://api.coincap.io/)
- [Binance](https://binance-docs.github.io/apidocs/spot/en/)

and calculates the mean average of which ever are availables. (Not so much to aggregate the price client-side, than to facilitate redundancy of either of the resources).

cc/ @markmhx @andresgalante @eugeniadigon Please share thoughts on how/when/if we can incorporate this