### PR TITLE
refactor: remove use of do syntax

### DIFF
--- a/src/common/hooks/account/use-switch-account.ts
+++ b/src/common/hooks/account/use-switch-account.ts
@@ -10,7 +10,7 @@ import {
 const TIMEOUT = 350;
 
 export const useSwitchAccount = (callback?: () => void) => {
-  const { doSwitchAccount } = useWallet();
+  const { switchAccount } = useWallet();
   const currentAccount = useCurrentAccount();
   const txIndex = useTransactionAccountIndex();
   const transactionVersion = useTransactionNetworkVersion();
@@ -19,14 +19,14 @@ export const useSwitchAccount = (callback?: () => void) => {
   const handleSwitchAccount = useCallback(
     async index => {
       if (typeof txIndex === 'number') setHasSwitched(true);
-      await doSwitchAccount(index);
+      await switchAccount(index);
       if (callback) {
         window.setTimeout(() => {
           callback();
         }, TIMEOUT);
       }
     },
-    [txIndex, setHasSwitched, doSwitchAccount, callback]
+    [txIndex, setHasSwitched, switchAccount, callback]
   );
 
   const getIsActive = useCallback(

--- a/src/common/hooks/auth/use-sign-in.ts
+++ b/src/common/hooks/auth/use-sign-in.ts
@@ -21,8 +21,8 @@ export function useSignIn() {
   const [error, setError] = useSeedInputErrorState();
 
   const { isLoading, setIsLoading, setIsIdle } = useLoading('useSignIn');
-  const doChangeScreen = useChangeScreen();
-  const { doStoreSeed } = useWallet();
+  const changeScreen = useChangeScreen();
+  const { storeSeed } = useWallet();
   const analytics = useAnalytics();
 
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -54,7 +54,7 @@ export function useSignIn() {
         const result = validateAndCleanRecoveryInput(parsedKeyInput);
         if (result.isValid) {
           setMagicRecoveryCode(parsedKeyInput);
-          doChangeScreen(RouteUrls.RecoveryCode);
+          changeScreen(RouteUrls.RecoveryCode);
           return;
         } else {
           // single word and not a valid recovery key
@@ -63,9 +63,9 @@ export function useSignIn() {
       }
 
       try {
-        await doStoreSeed({ secretKey: parsedKeyInput });
+        await storeSeed({ secretKey: parsedKeyInput });
         void analytics.track('submit_valid_secret_key');
-        doChangeScreen(RouteUrls.SetPassword);
+        changeScreen(RouteUrls.SetPassword);
         setIsIdle();
       } catch (error) {
         handleSetError();
@@ -76,8 +76,8 @@ export function useSignIn() {
       seed,
       handleSetError,
       setMagicRecoveryCode,
-      doChangeScreen,
-      doStoreSeed,
+      changeScreen,
+      storeSeed,
       analytics,
       setIsIdle,
     ]
@@ -127,7 +127,7 @@ export function useSignIn() {
     [handleSubmit]
   );
 
-  const onBack = useCallback(() => doChangeScreen(RouteUrls.Home), [doChangeScreen]);
+  const onBack = useCallback(() => changeScreen(RouteUrls.Home), [changeScreen]);
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {

--- a/src/common/hooks/use-submit-stx-transaction.ts
+++ b/src/common/hooks/use-submit-stx-transaction.ts
@@ -47,8 +47,8 @@ export function useSubmitTransactionCallback({
   loadingKey,
 }: UseSubmitTransactionCallbackArgs) {
   const refreshAccountData = useRefreshAllAccountData();
-  const doChangeScreen = useChangeScreen();
-  const { doSetLatestNonce } = useWallet();
+  const changeScreen = useChangeScreen();
+  const { setLatestNonce } = useWallet();
   const { setIsLoading, setIsIdle } = useLoading(loadingKey);
   const stacksNetwork = useCurrentStacksNetworkState();
   const { setActiveTabActivity } = useHomeTabs();
@@ -75,13 +75,13 @@ export function useSubmitTransactionCallback({
               txid,
             });
           }
-          if (nonce) await doSetLatestNonce(nonce);
+          if (nonce) await setLatestNonce(nonce);
           toast.success('Transaction submitted!');
           void analytics.track('broadcast_transaction');
-          doChangeScreen(RouteUrls.Home);
+          changeScreen(RouteUrls.Home);
           onClose();
           setIsIdle();
-          doChangeScreen(RouteUrls.Home);
+          changeScreen(RouteUrls.Home);
           // switch active tab to activity
           setActiveTabActivity();
           await refreshAccountData(250); // delay to give the api time to receive the tx
@@ -100,9 +100,9 @@ export function useSubmitTransactionCallback({
       onClose,
       setIsIdle,
       externalTxid,
-      doSetLatestNonce,
+      setLatestNonce,
       analytics,
-      doChangeScreen,
+      changeScreen,
       setActiveTabActivity,
       refreshAccountData,
       setLocalTxs,

--- a/src/common/hooks/use-vault-messenger.ts
+++ b/src/common/hooks/use-vault-messenger.ts
@@ -10,7 +10,7 @@ export function useVaultMessenger() {
   const innerMessageWrapper = useInnerMessageWrapper();
   const analytics = useAnalytics();
 
-  const doSetPassword = useCallback(
+  const setPassword = useCallback(
     (payload: string) => {
       const message: SetPassword = {
         method: InternalMethods.setPassword,
@@ -21,7 +21,7 @@ export function useVaultMessenger() {
     [innerMessageWrapper]
   );
 
-  const doStoreSeed = useCallback(
+  const storeSeed = useCallback(
     (payload: { secretKey: string; password?: string }) => {
       const message: StoreSeed = {
         method: InternalMethods.storeSeed,
@@ -32,7 +32,7 @@ export function useVaultMessenger() {
     [innerMessageWrapper]
   );
 
-  const doUnlockWallet = useCallback(
+  const unlockWallet = useCallback(
     payload => {
       const message: UnlockWallet = {
         method: InternalMethods.unlockWallet,
@@ -43,7 +43,7 @@ export function useVaultMessenger() {
     [innerMessageWrapper]
   );
 
-  const doSwitchAccount = useCallback(
+  const switchAccount = useCallback(
     payload => {
       const message: SwitchAccount = {
         method: InternalMethods.switchAccount,
@@ -56,32 +56,32 @@ export function useVaultMessenger() {
 
   const getWallet = () =>
     innerMessageWrapper({ method: InternalMethods.getWallet, payload: undefined });
-  const doMakeWallet = () =>
+  const makeWallet = () =>
     innerMessageWrapper({ method: InternalMethods.makeWallet, payload: undefined });
-  const doCreateNewAccount = () =>
+  const createNewAccount = () =>
     innerMessageWrapper({
       method: InternalMethods.createNewAccount,
       payload: undefined,
     });
   const handleSignOut = () =>
     innerMessageWrapper({ method: InternalMethods.signOut, payload: undefined });
-  const doSignOut = async () => {
+  const signOut = async () => {
     await handleSignOut();
     void analytics.track('sign_out');
     clearSessionLocalData();
   };
-  const doLockWallet = () =>
+  const lockWallet = () =>
     innerMessageWrapper({ method: InternalMethods.lockWallet, payload: undefined });
 
   return {
     getWallet,
-    doMakeWallet,
-    doCreateNewAccount,
-    doSignOut,
-    doLockWallet,
-    doSetPassword,
-    doStoreSeed,
-    doUnlockWallet,
-    doSwitchAccount,
+    makeWallet,
+    createNewAccount,
+    signOut,
+    lockWallet,
+    setPassword,
+    storeSeed,
+    unlockWallet,
+    switchAccount,
   };
 }

--- a/src/common/hooks/use-wallet.ts
+++ b/src/common/hooks/use-wallet.ts
@@ -51,9 +51,9 @@ export function useWallet() {
 
   const isSignedIn = !!wallet;
 
-  const doSetLatestNonce = useSetLatestNonceCallback();
+  const setLatestNonce = useSetLatestNonceCallback();
 
-  const handleCancelAuthentication = useCallback(() => {
+  const cancelAuthentication = useCallback(() => {
     if (!decodedAuthRequest || !authRequest) {
       return;
     }
@@ -61,7 +61,7 @@ export function useWallet() {
     finalizeAuthResponse({ decodedAuthRequest, authRequest, authResponse });
   }, [decodedAuthRequest, authRequest]);
 
-  const doFinishSignIn = useFinishSignInCallback();
+  const finishSignIn = useFinishSignInCallback();
 
   return {
     hasRehydratedVault,
@@ -73,16 +73,15 @@ export function useWallet() {
     currentAccountStxAddress,
     currentAccountDisplayName,
     transactionVersion,
-
     networks,
     currentNetwork,
     currentNetworkKey,
     encryptedSecretKey,
     hasSetPassword,
-    doFinishSignIn,
-    doSetLatestNonce,
+    finishSignIn,
+    setLatestNonce,
     setWallet,
-    handleCancelAuthentication,
+    cancelAuthentication,
     ...vaultMessenger,
   };
 }

--- a/src/components/drawer/accounts/create-account.tsx
+++ b/src/components/drawer/accounts/create-account.tsx
@@ -12,7 +12,7 @@ interface CreateAccountProps {
 const TIMEOUT = 3000;
 
 export const CreateAccount: React.FC<CreateAccountProps> = ({ close }) => {
-  const { doCreateNewAccount } = useWallet();
+  const { createNewAccount } = useWallet();
   const [isSetting, setSetting] = useState(false);
   const [hasFired, setHasFired] = useState(false);
   const analytics = useAnalytics();
@@ -20,12 +20,12 @@ export const CreateAccount: React.FC<CreateAccountProps> = ({ close }) => {
   const createAccount = useCallback(async () => {
     if (!isSetting) {
       setSetting(true);
-      await doCreateNewAccount();
+      await createNewAccount();
       void analytics.track('create_new_account');
       setSetting(false);
       window.setTimeout(() => close(), TIMEOUT);
     }
-  }, [isSetting, doCreateNewAccount, analytics, close]);
+  }, [isSetting, createNewAccount, analytics, close]);
 
   useEffect(() => {
     if (!hasFired) {

--- a/src/components/navigate.tsx
+++ b/src/components/navigate.tsx
@@ -9,12 +9,12 @@ interface NavigateProps {
 }
 
 export const Navigate: React.FC<NavigateProps> = ({ to, screenPath }) => {
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
   const navigate = useNavigate();
   useEffect(() => {
     navigate(to);
-    doChangeScreen(screenPath, false);
-  }, [screenPath, doChangeScreen, to, navigate]);
+    changeScreen(screenPath, false);
+  }, [screenPath, changeScreen, to, navigate]);
 
   return null;
 };

--- a/src/components/popup/container.tsx
+++ b/src/components/popup/container.tsx
@@ -19,7 +19,7 @@ const UnmountEffectSuspense = ({
   const pendingTx = usePendingTransaction();
   const { authRequest } = useAuthRequest();
   const handleCancelTransaction = useOnCancel();
-  const { handleCancelAuthentication } = useWallet();
+  const { cancelAuthentication } = useWallet();
 
   /*
    * When the popup is closed, this checks the requestType and forces
@@ -29,9 +29,9 @@ const UnmountEffectSuspense = ({
     if (requestType === 'transaction' || !!pendingTx) {
       await handleCancelTransaction();
     } else if (requestType === 'auth' || !!authRequest) {
-      handleCancelAuthentication();
+      cancelAuthentication();
     }
-  }, [requestType, handleCancelAuthentication, authRequest, pendingTx, handleCancelTransaction]);
+  }, [requestType, cancelAuthentication, authRequest, pendingTx, handleCancelTransaction]);
 
   useEffect(() => {
     window.addEventListener('beforeunload', handleUnmount);

--- a/src/features/network-drawer/networks-drawer.tsx
+++ b/src/features/network-drawer/networks-drawer.tsx
@@ -11,14 +11,14 @@ import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 export const NetworksDrawer: React.FC = () => {
   const { setShowNetworks } = useDrawers();
   const [isShowing] = useShowNetworksStore();
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
   const analytics = useAnalytics();
 
   const handleAddNetworkClick = useCallback(() => {
     void analytics.track('add_network');
     setShowNetworks(false);
-    doChangeScreen(RouteUrls.AddNetwork);
-  }, [analytics, setShowNetworks, doChangeScreen]);
+    changeScreen(RouteUrls.AddNetwork);
+  }, [analytics, setShowNetworks, changeScreen]);
 
   return (
     <ControlledDrawer

--- a/src/features/settings-dropdown/settings-popover.tsx
+++ b/src/features/settings-dropdown/settings-popover.tsx
@@ -55,14 +55,8 @@ const MenuItem: React.FC<BoxProps> = memo(props => {
 
 export const SettingsPopover: React.FC = () => {
   const ref = React.useRef<HTMLDivElement | null>(null);
-  const {
-    currentAccount,
-    doLockWallet,
-    wallet,
-    currentNetworkKey,
-    isSignedIn,
-    encryptedSecretKey,
-  } = useWallet();
+  const { currentAccount, lockWallet, wallet, currentNetworkKey, isSignedIn, encryptedSecretKey } =
+    useWallet();
   const {
     setShowNetworks,
     setShowAccounts,
@@ -159,7 +153,7 @@ export const SettingsPopover: React.FC = () => {
                 <MenuItem
                   onClick={wrappedCloseCallback(() => {
                     void analytics.track('lock_session');
-                    void doLockWallet();
+                    void lockWallet();
                     changeScreen(RouteUrls.PopupHome);
                   })}
                   data-testid="settings-lock"

--- a/src/pages/add-network/add-network.tsx
+++ b/src/pages/add-network/add-network.tsx
@@ -14,13 +14,13 @@ import { useUpdateCurrentNetworkKey, useUpdateNetworkState } from '@store/networ
 export const AddNetwork: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
   const setNetworks = useUpdateNetworkState();
   const setNetworkKey = useUpdateCurrentNetworkKey();
 
   return (
     <PopupContainer
-      header={<Header title="Add a network" onClose={() => doChangeScreen(RouteUrls.PopupHome)} />}
+      header={<Header title="Add a network" onClose={() => changeScreen(RouteUrls.PopupHome)} />}
     >
       <Box mt="base">
         <Text fontSize={2}>
@@ -58,7 +58,7 @@ export const AddNetwork: React.FC = () => {
                 };
               });
               setNetworkKey(key);
-              doChangeScreen(RouteUrls.PopupHome);
+              changeScreen(RouteUrls.PopupHome);
               return;
             }
             setError('Unable to determine chainID from node.');

--- a/src/pages/choose-account/choose-account.tsx
+++ b/src/pages/choose-account/choose-account.tsx
@@ -15,11 +15,11 @@ interface ChooseAccountProps {
 
 export const ChooseAccount: React.FC<ChooseAccountProps> = memo(() => {
   const { name: appName } = useAppDetails();
-  const { wallet, handleCancelAuthentication } = useWallet();
+  const { wallet, cancelAuthentication } = useWallet();
 
   const handleUnmount = useCallback(async () => {
-    handleCancelAuthentication();
-  }, [handleCancelAuthentication]);
+    cancelAuthentication();
+  }, [cancelAuthentication]);
 
   useEffect(() => {
     window.addEventListener('beforeunload', handleUnmount);

--- a/src/pages/choose-account/components/accounts.tsx
+++ b/src/pages/choose-account/components/accounts.tsx
@@ -54,15 +54,15 @@ const AccountTitle = ({ account, ...rest }: { account: AccountWithAddress } & Bo
 const AccountItem: React.FC<AccountItemProps> = ({ selectedAddress, account, ...rest }) => {
   const [component, bind] = usePressable(true);
   const { isLoading, setIsLoading } = useLoading(`CHOOSE_ACCOUNT__${account.address}`);
-  const { doFinishSignIn } = useWallet();
+  const { finishSignIn } = useWallet();
   const { decodedAuthRequest } = useOnboardingState();
   const name = useAccountDisplayName(account);
   const availableStxBalance = useAccountAvailableStxBalance(account.address);
   const showLoadingProps = !!selectedAddress || !decodedAuthRequest;
   const handleOnClick = useCallback(async () => {
     setIsLoading();
-    await doFinishSignIn(account.index);
-  }, [setIsLoading, doFinishSignIn, account]);
+    await finishSignIn(account.index);
+  }, [setIsLoading, finishSignIn, account]);
 
   const accountSlug = slugify(`Account ${account?.index + 1}`);
 

--- a/src/pages/install/index.tsx
+++ b/src/pages/install/index.tsx
@@ -12,20 +12,20 @@ import { InitialPageSelectors } from '@tests/integration/initial-page.selectors'
 import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 
 const Actions: React.FC<StackProps> = props => {
-  const { doMakeWallet } = useWallet();
+  const { makeWallet } = useWallet();
   const { decodedAuthRequest } = useOnboardingState();
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
   const analytics = useAnalytics();
 
   const [isCreatingWallet, setIsCreatingWallet] = useState(false);
   const register = useCallback(async () => {
     setIsCreatingWallet(true);
-    await doMakeWallet();
+    await makeWallet();
     void analytics.track('generate_new_secret_key');
     if (decodedAuthRequest) {
-      doChangeScreen(RouteUrls.SetPassword);
+      changeScreen(RouteUrls.SetPassword);
     }
-  }, [doMakeWallet, analytics, decodedAuthRequest, doChangeScreen]);
+  }, [makeWallet, analytics, decodedAuthRequest, changeScreen]);
 
   return (
     <Stack justifyContent="center" spacing="loose" textAlign="center" {...props}>
@@ -38,7 +38,7 @@ const Actions: React.FC<StackProps> = props => {
         I'm new to Stacks
       </Button>
       <Link
-        onClick={() => doChangeScreen(RouteUrls.SignInInstalled)}
+        onClick={() => changeScreen(RouteUrls.SignInInstalled)}
         data-testid={InitialPageSelectors.SignIn}
       >
         Sign in with Secret Key

--- a/src/pages/install/magic-recovery-code.tsx
+++ b/src/pages/install/magic-recovery-code.tsx
@@ -9,7 +9,8 @@ import { useMountEffect } from '@common/hooks/use-mount-effect';
 import { Header } from '@components/header';
 
 const Form: React.FC<StackProps> = memo(props => {
-  const { onBack, onSubmit, onChange, password, error, isLoading } = useMagicRecoveryCode();
+  const { onBack, onSubmit, onChange, magicRecoveryCodePassword, error, isLoading } =
+    useMagicRecoveryCode();
 
   // weird fix for preventing the input from using a value of the last input
   // i think this is related to the routing and should be resolved with
@@ -29,7 +30,7 @@ const Form: React.FC<StackProps> = memo(props => {
             spellCheck={false}
             width="100%"
             onChange={onChange}
-            value={password}
+            value={magicRecoveryCodePassword}
           />
         )}
         {error && (

--- a/src/pages/receive-tokens/receive-tokens.tsx
+++ b/src/pages/receive-tokens/receive-tokens.tsx
@@ -15,7 +15,7 @@ import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 
 export const PopupReceive: React.FC = () => {
   const { currentAccount, currentAccountStxAddress } = useWallet();
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
   const address = currentAccountStxAddress || '';
   const analytics = useAnalytics();
   const { onCopy, hasCopied } = useClipboard(address);
@@ -26,7 +26,7 @@ export const PopupReceive: React.FC = () => {
 
   return (
     <PopupContainer
-      header={<ReceiveTokensHeader onClose={() => doChangeScreen(RouteUrls.PopupHome)} />}
+      header={<ReceiveTokensHeader onClose={() => changeScreen(RouteUrls.PopupHome)} />}
     >
       <Toast show={hasCopied} />
       <Box mt="extra-loose" textAlign="center" mx="auto">

--- a/src/pages/send-tokens/send-tokens-form.tsx
+++ b/src/pages/send-tokens/send-tokens-form.tsx
@@ -18,7 +18,7 @@ import { ShowDelay } from './components/show-delay';
 import { useResetNonceCallback } from './hooks/use-reset-nonce-callback';
 
 function SendTokensFormBase() {
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
   const { setIsIdle, setIsLoading } = useLoading(LoadingKeys.SEND_TOKENS_FORM);
   const { showEditNonce, showHighFeeConfirmation } = useDrawers();
   const [isShowing, setShowing] = useState(false);
@@ -39,7 +39,7 @@ function SendTokensFormBase() {
 
   return (
     <PopupContainer
-      header={<Header title="Send" onClose={() => doChangeScreen(RouteUrls.PopupHome)} />}
+      header={<Header title="Send" onClose={() => changeScreen(RouteUrls.PopupHome)} />}
     >
       <Formik
         initialValues={{

--- a/src/pages/set-password.tsx
+++ b/src/pages/set-password.tsx
@@ -29,8 +29,8 @@ export const SetPasswordPage: React.FC<SetPasswordProps> = ({
 }) => {
   const [loading, setLoading] = useState(false);
   const [strengthResult, setStrengthResult] = useState(blankPasswordValidation);
-  const { doSetPassword, wallet, doFinishSignIn } = useWallet();
-  const doChangeScreen = useChangeScreen();
+  const { setPassword, wallet, finishSignIn } = useWallet();
+  const changeScreen = useChangeScreen();
   const { decodedAuthRequest } = useOnboardingState();
   const analytics = useAnalytics();
   useEffect(() => {
@@ -41,30 +41,22 @@ export const SetPasswordPage: React.FC<SetPasswordProps> = ({
     async (password: string) => {
       if (!wallet) throw 'Please log in before setting a password.';
       setLoading(true);
-      await doSetPassword(password);
+      await setPassword(password);
       if (accountGate) return;
       if (decodedAuthRequest) {
         const { accounts } = wallet;
         if (accounts && (accounts.length > 1 || accounts[0].username)) {
-          doChangeScreen(RouteUrls.ChooseAccount);
+          changeScreen(RouteUrls.ChooseAccount);
         } else if (!USERNAMES_ENABLED) {
-          await doFinishSignIn(0);
+          await finishSignIn(0);
         } else {
-          doChangeScreen(RouteUrls.Username);
+          changeScreen(RouteUrls.Username);
         }
       } else if (redirect) {
-        doChangeScreen(RouteUrls.Installed);
+        changeScreen(RouteUrls.Installed);
       }
     },
-    [
-      doSetPassword,
-      doChangeScreen,
-      redirect,
-      decodedAuthRequest,
-      wallet,
-      doFinishSignIn,
-      accountGate,
-    ]
+    [setPassword, changeScreen, redirect, decodedAuthRequest, wallet, finishSignIn, accountGate]
   );
 
   const handleSubmit = useCallback(

--- a/src/pages/sign-out-confirm/sign-out-confirm.tsx
+++ b/src/pages/sign-out-confirm/sign-out-confirm.tsx
@@ -7,14 +7,14 @@ import React from 'react';
 import { SignOutConfirmLayout } from './sign-out-confirm-layout';
 
 export const SignOutConfirmDrawer = () => {
-  const { doSignOut } = useWallet();
+  const { signOut } = useWallet();
   const changeScreen = useChangeScreen();
   const { setShowSignOut } = useDrawers();
 
   return (
     <SignOutConfirmLayout
       onUserDeleteWallet={async () => {
-        await doSignOut();
+        await signOut();
         setShowSignOut(false);
         changeScreen(RouteUrls.Installed);
       }}

--- a/src/pages/signed-out/signed-out-view.tsx
+++ b/src/pages/signed-out/signed-out-view.tsx
@@ -9,7 +9,7 @@ import { useChangeScreen } from '@common/hooks/use-change-screen';
 import { Header } from '@components/header';
 
 export const SignedOut = memo(() => {
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
   return (
     <PopupContainer header={<Header hideActions />}>
       <Box width="100%" mt="extra-loose" textAlign="center">
@@ -19,7 +19,7 @@ export const SignedOut = memo(() => {
         <Button
           my="extra-loose"
           onClick={() => {
-            doChangeScreen(RouteUrls.Installed);
+            changeScreen(RouteUrls.Installed);
           }}
         >
           Get started

--- a/src/pages/unlock.tsx
+++ b/src/pages/unlock.tsx
@@ -9,7 +9,7 @@ import { SignOutConfirmDrawer } from '@pages/sign-out-confirm/sign-out-confirm';
 import { useDrawers } from '@common/hooks/use-drawers';
 
 export const Unlock: React.FC = () => {
-  const { doUnlockWallet } = useWallet();
+  const { unlockWallet } = useWallet();
   const [loading, setLoading] = useState(false);
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -19,12 +19,12 @@ export const Unlock: React.FC = () => {
     setLoading(true);
     setError('');
     try {
-      await doUnlockWallet(password);
+      await unlockWallet(password);
     } catch (error) {
       setError('The password you entered is invalid.');
     }
     setLoading(false);
-  }, [doUnlockWallet, password]);
+  }, [unlockWallet, password]);
 
   return (
     <>

--- a/src/pages/username.tsx
+++ b/src/pages/username.tsx
@@ -9,7 +9,7 @@ import { Header } from '@components/header';
 import { logger } from '@common/logger';
 
 export const Username: React.FC = () => {
-  const { wallet, currentAccount, setWallet, doFinishSignIn } = useWallet();
+  const { wallet, currentAccount, setWallet, finishSignIn } = useWallet();
   const { decodedAuthRequest } = useOnboardingState();
   const [username, setUsername] = useState('');
   const [loading, setLoading] = useState(false);
@@ -30,7 +30,7 @@ export const Username: React.FC = () => {
       // });
       setWallet(wallet);
       if (decodedAuthRequest) {
-        await doFinishSignIn(0);
+        await finishSignIn(0);
       }
     } catch (error) {
       logger.error(error);

--- a/src/routes/app-routes.tsx
+++ b/src/routes/app-routes.tsx
@@ -36,7 +36,7 @@ export function AppRoutes(): JSX.Element {
   const { search, pathname } = useLocation();
   const setLastSeen = useUpdateLastSeenStore();
 
-  const doChangeScreen = useChangeScreen();
+  const changeScreen = useChangeScreen();
   const analytics = useAnalytics();
   useSaveAuthRequest();
 
@@ -120,10 +120,7 @@ export function AppRoutes(): JSX.Element {
         path={RouteUrls.SettingsKey}
         element={
           <AccountGate>
-            <SaveYourKeyView
-              onClose={() => doChangeScreen(RouteUrls.Home)}
-              title="Your Secret Key"
-            />
+            <SaveYourKeyView onClose={() => changeScreen(RouteUrls.Home)} title="Your Secret Key" />
           </AccountGate>
         }
       />

--- a/src/store/transactions/transaction.hooks.ts
+++ b/src/store/transactions/transaction.hooks.ts
@@ -69,7 +69,7 @@ export function useEstimatedTransactionByteLengthState() {
 }
 
 export function useTransactionBroadcast() {
-  const { doSetLatestNonce } = useWallet();
+  const { setLatestNonce } = useWallet();
   return useAtomCallback(
     useCallback(
       async (get, set) => {
@@ -97,7 +97,7 @@ export function useTransactionBroadcast() {
             attachment,
             networkUrl: network.url,
           });
-          typeof nonce !== 'undefined' && (await doSetLatestNonce(nonce));
+          typeof nonce !== 'undefined' && (await setLatestNonce(nonce));
           finalizeTxSignature(requestToken, result);
           if (result.txId) {
             set(currentAccountLocallySubmittedTxsState, {
@@ -112,7 +112,7 @@ export function useTransactionBroadcast() {
           if (error instanceof Error) set(transactionBroadcastErrorState, error.message);
         }
       },
-      [doSetLatestNonce]
+      [setLatestNonce]
     )
   );
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1522821290).<!-- Sticky Header Marker -->

This PR is step 2 in the routing refactor. It removes our use of the `do` syntax across the app (except for methods imported from @stacks/connect). We have talked about making this change for awhile, so hopefully this is helpful. I wanted to tackle it with needing to use what had typically been implemented as `doChangeScreen`.

cc/ @kyranjamie @beguene
