### PR TITLE
fix: don't warn of no writekey in dev by default

### DIFF
--- a/src/common/segment-init.ts
+++ b/src/common/segment-init.ts
@@ -14,7 +14,8 @@ export function initSegment() {
   }
   if (IS_TEST_ENV) return;
   if (!writeKey) {
-    logger.info('segment init aborted: No WRITE_KEY setup.');
+    if (process.env.WALLET_ENVIRONMENT === 'production')
+      logger.error('segment init aborted: No WRITE_KEY setup.');
     return;
   }
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1526502896).<!-- Sticky Header Marker -->

Added a check so that there's no an always present error at development-time.

Also, merging this will be a test of the _merge to beta_ set up, 🤞🏼 