### PR TITLE
test: upload traces, remove '.only'

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: set-dirs
         working-directory: ./tests/integration
-        run: echo "::set-output name=dir::$(ls -d */ | jq -R -s -c 'split("\n")[:-1]')"
+        run: echo "::set-output name=dir::$( ls -d */ | xargs -0 | sed 's/\///' | jq -R -s -c 'split("\n")[:-2]')"
 
   test-integration:
     runs-on: ubuntu-latest
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
+
+      - run: echo ${{ fromJson(needs.directories.outputs.dir) }}
+      - run: echo ${{ matrix.dir }}
 
       - uses: actions/cache@v2
         name: Cache node_modules
@@ -39,37 +42,18 @@ jobs:
         id: cache-playwright-browsers
         with:
           path: '~/.cache/ms-playwright'
-          key: playwright-browser
-
-      - uses: actions/cache@v1
-        name: Cache Jest cache
-        id: cache-jest-cache
-        with:
-          path: '.jest-cache'
-          key: ${{ runner.os }}--jest-integration
+          key: ${{ runner.os }}-playwright-browser
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-
-      - run: npx playwright install
+          node-version: 16.x
 
       - name: Install packages
         uses: ./.github/actions/provision
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
-      - name: Install browser binaries
-        uses: nick-invision/retry@v2
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        with:
-          timeout_seconds: 600
-          max_attempts: 3
-          retry_on: error
-          command: node node_modules/playwright/install.js
-
-      - name: Install playwright deps
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: yarn playwright install-deps chromium
+      - name: Install Playwright dependencies
+        run: npx playwright install
 
       - name: Build assets
         run: yarn build:test
@@ -79,14 +63,17 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Run tests
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 6
-          max_attempts: 3
-          command: xvfb-run --auto-servernum -- yarn jest --config=./jest.integration.config.js --runInBand --testPathPattern=./tests/integration/${{ matrix.dir }}* --detectOpenHandles
+        run: |
+          xvfb-run --auto-servernum -- \
+            yarn jest \
+              --config=./jest.integration.config.js \
+              --detectOpenHandles \
+              --forceExit \
+              --testPathPattern=./tests/integration/${{ matrix.dir }}/*
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload traces
+        uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test-screenshots-${{ steps.date.outputs.date }}
-          path: tests/screenshots
+          name: traces-${{ matrix.dir }}-${{ steps.date.outputs.date }}
+          path: '**/**.trace.zip'

--- a/tests/integration/transactions/transactions.spec.ts
+++ b/tests/integration/transactions/transactions.spec.ts
@@ -1,4 +1,4 @@
-import { BrowserDriver, createTestSelector, setupBrowser } from '../utils';
+import { BrowserDriver, createTestSelector, getCurrentTestName, setupBrowser } from '../utils';
 import { WalletPage } from '@tests/page-objects/wallet.page';
 import { DemoPage } from '@tests/page-objects/demo.page';
 import { RouteUrls } from '@routes/route-urls';
@@ -19,6 +19,7 @@ describe(`Transaction signing`, () => {
 
   beforeEach(async () => {
     browser = await setupBrowser();
+    await browser.context.tracing.start({ screenshots: true, snapshots: true });
     wallet = await WalletPage.init(browser, RouteUrls.Installed);
     demo = browser.demo;
     await wallet.clickAllowAnalytics();
@@ -26,8 +27,13 @@ describe(`Transaction signing`, () => {
 
   afterEach(async () => {
     try {
+      await browser.context.tracing.stop({
+        path: `trace-${getCurrentTestName()}.trace.zip`,
+      });
       await browser.context.close();
-    } catch (error) {}
+    } catch (error) {
+      console.log(error);
+    }
   });
 
   describe('New created wallet scenarios', () => {
@@ -66,7 +72,7 @@ describe(`Transaction signing`, () => {
     });
   });
 
-  describe.only('App initiated STX transfer', () => {
+  describe('App initiated STX transfer', () => {
     let txSigningPage: TransactionSigningPage;
 
     function interceptTransactionBroadcast(page: Page): Promise<Buffer> {

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -15,6 +15,10 @@ export function createTestSelector<T extends string>(name: T): `[data-testid="${
   return `[data-testid="${name}"]`;
 }
 
+export function getCurrentTestName() {
+  return expect.getState().currentTestName.replaceAll(' ', '-');
+}
+
 export function randomString(len: number) {
   const charSet = 'abcdefghijklmnopqrstuvwxyz0123456789';
   let randomString = '';


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1536082257).<!-- Sticky Header Marker -->

[Playwright now has tracing support.](https://playwright.dev/docs/api/class-tracing) This PR enables traces for the tx signing tests, and uploads them to CI.

To test, download the zip files from the integration test action, and upload them to the [playwright trace viewer](https://trace.playwright.dev/).

Also removes the mistaken `describe.only`.