### PR TITLE
fix: remove a fullstop from the password placeholder

### DIFF
--- a/src/pages/unlock.tsx
+++ b/src/pages/unlock.tsx
@@ -44,7 +44,7 @@ export const Unlock: React.FC = () => {
         </Box>
         <Box mt="loose" width="100%">
           <Input
-            placeholder="Enter your password."
+            placeholder="Enter your password"
             width="100%"
             autoFocus
             type="password"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1549101328).<!-- Sticky Header Marker -->

Remove full stop