### PR TITLE
chore: update webpack mode to 'production'

### DIFF
--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -4,6 +4,8 @@ const { ESBuildMinifyPlugin } = require('esbuild-loader');
 
 const shouldMinify = JSON.parse(process.env.MINIFY_PRODUCTION_BUILD || false);
 
+config.mode = 'production';
+
 // Basically, disable any code splitting stuff
 config.optimization = {
   ...config.optimization,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1549770243).<!-- Sticky Header Marker -->

I noticed we have this warning coming from our FF builds.

![image](https://user-images.githubusercontent.com/1618764/145043738-3fc787b0-1c0c-452b-943e-7a0b78f4e8d0.png)

Looking into the build output, the Segment build outputs some individual files that use `eval-source-map` when not in production mode. 

We don't have a mode set, so this PR ensures we're using production mode. The output Segment files no longer contain `eval` calls.