### PR TITLE
fix: change wallet config default branch to main

### DIFF
--- a/src/query/hiro-config/hiro-config.query.ts
+++ b/src/query/hiro-config/hiro-config.query.ts
@@ -20,7 +20,7 @@ interface HiroConfig {
   activeFiatProviders: Record<string, ActiveFiatProviderType>;
 }
 
-const GITHUB_PRIMARY_BRANCH = 'dev'; // TODO change to main after first release since wallet-config is not yet on main
+const GITHUB_PRIMARY_BRANCH = 'main';
 const githubWalletConfigRawUrl = `https://raw.githubusercontent.com/${GITHUB_ORG}/${GITHUB_REPO}/${GITHUB_PRIMARY_BRANCH}/config/wallet-config.json`;
 
 async function fetchHiroMessages(): Promise<HiroConfig> {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1553850198).<!-- Sticky Header Marker -->

This changes the default branch for our new wallet-config.json from 'dev' to 'main'

cc/ @kyranjamie @fbwoolf
