### PR TITLE
fix: show fiat onramp buy button only on mainnet

### DIFF
--- a/src/pages/home/components/buy-button.tsx
+++ b/src/pages/home/components/buy-button.tsx
@@ -1,14 +1,17 @@
 import React, { memo, Suspense } from 'react';
-
+import { ChainID } from '@stacks/transactions';
 import { useHasFiatProviders } from '@query/hiro-config/hiro-config.query';
-
 import { BuyTxButton } from './tx-button';
+import { useCurrentNetworkState } from '@store/network/networks.hooks';
 
 const BuyButtonFallback = memo(() => <BuyTxButton isDisabled />);
 
 export const BuyButton = () => {
   const hasFiatProviders = useHasFiatProviders();
+  const currentNetwork = useCurrentNetworkState();
   if (!hasFiatProviders) return null;
+  if (currentNetwork.chainId !== ChainID.Mainnet) return null;
+
   return (
     <Suspense fallback={<BuyButtonFallback />}>
       <BuyTxButton />


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1572870097).<!-- Sticky Header Marker -->

closes #2049.
We want to show the buy button only when the user is on Mainnet.

cc/ @kyranjamie @fbwoolf
