### PR TITLE
fix: null rendering when accounts are `undefined`

### DIFF
--- a/src/features/account-switch-drawer/components/account-list-unavailable.tsx
+++ b/src/features/account-switch-drawer/components/account-list-unavailable.tsx
@@ -1,0 +1,21 @@
+import React, { memo } from 'react';
+import { Box, Flex } from '@stacks/ui';
+import { Body, Title } from '@components/typography';
+
+export const AccountListUnavailable = memo(() => (
+  <Flex
+    flexDirection="column"
+    justifyContent="center"
+    px="loose"
+    minHeight="120px"
+    mb="extra-loose"
+  >
+    <Box>
+      <Title>Unable to load account information</Title>
+      <Body mt="base-tight">
+        We're unable to load information about your accounts. This may be a problem with the
+        wallet's API. If this problem persists, please contact support.
+      </Body>
+    </Box>
+  </Flex>
+));

--- a/src/features/account-switch-drawer/components/create-account-action.tsx
+++ b/src/features/account-switch-drawer/components/create-account-action.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box, Button } from '@stacks/ui';
+
+interface CreateAccountActionProps {
+  onCreateAccount(): void;
+}
+export function CreateAccountAction({ onCreateAccount }: CreateAccountActionProps) {
+  return (
+    <Box pt="base" pb="loose" px="loose">
+      <Button onClick={() => onCreateAccount()}>Create an account</Button>
+    </Box>
+  );
+}

--- a/src/features/account-switch-drawer/switch-accounts.tsx
+++ b/src/features/account-switch-drawer/switch-accounts.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from 'react';
-import { Box, Button } from '@stacks/ui';
 
 import { useUpdateAccountDrawerStep } from '@store/ui/ui.hooks';
 import { AccountStep } from '@store/ui/ui.models';
@@ -7,6 +6,8 @@ import { useAccounts } from '@store/accounts/account.hooks';
 import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 
 import { AccountList } from './components/account-list';
+import { AccountListUnavailable } from './components/account-list-unavailable';
+import { CreateAccountAction } from './components/create-account-action';
 
 interface SwitchAccountProps {
   close(): void;
@@ -15,17 +16,21 @@ export const SwitchAccounts = memo(({ close }: SwitchAccountProps) => {
   const setAccountDrawerStep = useUpdateAccountDrawerStep();
   const accounts = useAccounts();
   const analytics = useAnalytics();
+
   const setCreateAccountStep = () => {
     void analytics.track('choose_to_create_account');
     setAccountDrawerStep(AccountStep.Create);
   };
 
+  if (!accounts) {
+    void analytics.track('account_list_unavailable_warning_displayed');
+    return <AccountListUnavailable />;
+  }
+
   return (
     <>
-      {accounts ? <AccountList accounts={accounts} handleClose={close} /> : null}
-      <Box pt="base" pb="loose" px="loose">
-        <Button onClick={setCreateAccountStep}>Create an account</Button>
-      </Box>
+      <AccountList accounts={accounts} handleClose={close} />
+      <CreateAccountAction onCreateAccount={() => setCreateAccountStep()} />
     </>
   );
 });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1581907656).<!-- Sticky Header Marker -->

#2000 highlights a case where, likely, there are no accounts and the ternary in the existing component renders `null`.

I was unable to replicate this issue, however if a bug does cause the component to render with `undefined` accounts, we should render _something_, at least.

This PR adds a warning display when the switch account modal renders and there are no accounts. Nonetheless, this should _never_ show, so I've not spent time making a beautiful error screen. Please feel free to suggest other copy, I haven't given it a great deal of thought. It also fires an analytics event if this error is ever rendered.

![image](https://user-images.githubusercontent.com/1618764/145976237-1cfe90ba-7b30-4d34-b8a9-b454c373d6ef.png)

