### PR TITLE
fix: increase fee showing zero

### DIFF
--- a/src/features/increase-fee-drawer/components/increase-fee-form.tsx
+++ b/src/features/increase-fee-drawer/components/increase-fee-form.tsx
@@ -30,7 +30,7 @@ export function IncreaseFeeForm(): JSX.Element | null {
   const feeSchema = useFeeSchema();
   const rawTx = useRawDeserializedTxState();
 
-  const fee = Number(rawTx?.auth.spendingCondition?.fee) || 0;
+  const fee = Number(rawTx?.auth.spendingCondition?.fee);
 
   useEffect(() => {
     if (tx?.tx_status !== 'pending' && rawTx) {
@@ -53,7 +53,7 @@ export function IncreaseFeeForm(): JSX.Element | null {
     [rawTx, refreshAccountData, removeLocallySubmittedTx, replaceByFee, tx]
   );
 
-  if (!tx) return null;
+  if (!tx || !fee) return null;
 
   return (
     <Formik


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1578576476).<!-- Sticky Header Marker -->

This PR fixes the increase fee form loading in `0` at times.

cc/ @kyranjamie @beguene
