### PR TITLE
fix: onboarding route flashing in url path

### DIFF
--- a/src/routes/app-routes.tsx
+++ b/src/routes/app-routes.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-
 
 import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 import { useWallet } from '@common/hooks/use-wallet';
+import { getViewMode } from '@common/utils';
 import { Container } from '@components/container/container';
 import { MagicRecoveryCode } from '@pages/onboarding/magic-recovery-code/magic-recovery-code';
 import { ChooseAccount } from '@pages/choose-account/choose-account';
@@ -30,9 +31,12 @@ export function AppRoutes(): JSX.Element | null {
   const analytics = useAnalytics();
   useSaveAuthRequest();
 
+  const mode = getViewMode();
+
   useEffect(() => {
     // This ensures the ext popup hits the right route on load
-    if (pathname === RouteUrls.Home && !hasGeneratedWallet) navigate(RouteUrls.Onboarding);
+    if (mode === 'popup' && pathname === RouteUrls.Home && !hasGeneratedWallet)
+      navigate(RouteUrls.Onboarding);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1579215716).<!-- Sticky Header Marker -->

This fixes the `/onboarding` route path flashing in the url path. The on mount check is only in place to make sure the ext popup loads the correct route while waiting for the `VaultLoader`. There is no need to do the check in full-page mode.

cc/ @kyranjamie @beguene
