### PR TITLE
fix: improve Switch Account render performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "react-icons": "4.2.0",
     "react-query": "3.33.4",
     "react-router-dom": "6.0.0",
+    "react-virtuoso": "2.3.1",
     "svg-url-loader": "7.1.1",
     "ts-debounce": "3.0.0",
     "use-events": "1.4.2",

--- a/src/features/account-switch-drawer/components/account-list-unavailable.tsx
+++ b/src/features/account-switch-drawer/components/account-list-unavailable.tsx
@@ -1,0 +1,21 @@
+import React, { memo } from 'react';
+import { Box, Flex } from '@stacks/ui';
+import { Body, Title } from '@components/typography';
+
+export const AccountListUnavailable = memo(() => (
+  <Flex
+    flexDirection="column"
+    justifyContent="center"
+    px="loose"
+    minHeight="120px"
+    mb="extra-loose"
+  >
+    <Box>
+      <Title>Unable to load account information</Title>
+      <Body mt="base-tight">
+        We're unable to load information about your accounts. This may be a problem with the
+        wallet's API. If this problem persists, please contact support.
+      </Body>
+    </Box>
+  </Flex>
+));

--- a/src/features/account-switch-drawer/components/account-list.tsx
+++ b/src/features/account-switch-drawer/components/account-list.tsx
@@ -2,6 +2,7 @@ import React, { memo, useCallback } from 'react';
 import { truncateMiddle } from '@stacks/ui-utils';
 import { Box, Fade, Stack, color, Spinner } from '@stacks/ui';
 import { FiCheck as IconCheck } from 'react-icons/fi';
+import { Virtuoso } from 'react-virtuoso';
 
 import { SpaceBetween } from '@components/space-between';
 import { useSwitchAccount } from '@common/hooks/account/use-switch-account';
@@ -86,10 +87,10 @@ interface AccountListProps {
 }
 export const AccountList = memo(({ accounts, handleClose }: AccountListProps) => {
   return (
-    <>
-      {accounts.map(account => (
-        <AccountListItem handleClose={handleClose} key={account.address} account={account} />
-      ))}
-    </>
+    <Virtuoso
+      style={{ height: '70vh' }}
+      totalCount={accounts.length}
+      itemContent={index => <AccountListItem handleClose={handleClose} account={accounts[index]} />}
+    />
   );
 });

--- a/src/features/account-switch-drawer/components/create-account-action.tsx
+++ b/src/features/account-switch-drawer/components/create-account-action.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box, Button } from '@stacks/ui';
+
+interface CreateAccountActionProps {
+  onCreateAccount(): void;
+}
+export function CreateAccountAction({ onCreateAccount }: CreateAccountActionProps) {
+  return (
+    <Box pt="base" pb="loose" px="loose">
+      <Button onClick={() => onCreateAccount()}>Create an account</Button>
+    </Box>
+  );
+}

--- a/src/features/account-switch-drawer/switch-accounts.tsx
+++ b/src/features/account-switch-drawer/switch-accounts.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from 'react';
-import { Box, Button } from '@stacks/ui';
 
 import { useUpdateAccountDrawerStep } from '@store/ui/ui.hooks';
 import { AccountStep } from '@store/ui/ui.models';
@@ -7,6 +6,8 @@ import { useAccounts } from '@store/accounts/account.hooks';
 import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 
 import { AccountList } from './components/account-list';
+import { AccountListUnavailable } from './components/account-list-unavailable';
+import { CreateAccountAction } from './components/create-account-action';
 
 interface SwitchAccountProps {
   close(): void;
@@ -15,17 +16,21 @@ export const SwitchAccounts = memo(({ close }: SwitchAccountProps) => {
   const setAccountDrawerStep = useUpdateAccountDrawerStep();
   const accounts = useAccounts();
   const analytics = useAnalytics();
+
   const setCreateAccountStep = () => {
     void analytics.track('choose_to_create_account');
     setAccountDrawerStep(AccountStep.Create);
   };
 
+  if (!accounts) {
+    void analytics.track('account_list_unavailable_warning_displayed');
+    return <AccountListUnavailable />;
+  }
+
   return (
     <>
-      {accounts ? <AccountList accounts={accounts} handleClose={close} /> : null}
-      <Box pt="base" pb="loose" px="loose">
-        <Button onClick={setCreateAccountStep}>Create an account</Button>
-      </Box>
+      <AccountList accounts={accounts} handleClose={close} />
+      <CreateAccountAction onCreateAccount={() => setCreateAccountStep()} />
     </>
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4448,6 +4448,18 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
+"@virtuoso.dev/react-urx@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/react-urx/-/react-urx-0.2.12.tgz#6c75cdbea2503c129b34d1ce2ee8cd649503b47c"
+  integrity sha512-Lcrrmq/UztM+rgepAdThdIk8dL3LEi9o2NTkL6ZLKPrTGjr5tSmsauD30/O8yu7Q0ncDnptmMR3OObdvMGuEKQ==
+  dependencies:
+    "@virtuoso.dev/urx" "^0.2.12"
+
+"@virtuoso.dev/urx@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/urx/-/urx-0.2.12.tgz#fa9bd1a2777cf70b19d4c9836b8d92b04f079c64"
+  integrity sha512-Q9nlRqYb5Uq4Ynu8cWPSJ7LxpuZsI+MZ09IJlDAAgwuNgfWRArpVRP0VN0coYgUo2fKMjhmV69MTqaUbIBhu/g==
+
 "@vkontakte/vk-qr@2.0.12":
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/@vkontakte/vk-qr/-/vk-qr-2.0.12.tgz#012bae0c83dd98c20b92d6cf4372fbfbb0492b54"
@@ -13852,6 +13864,14 @@ react-transition-group@^4.4.1:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-virtuoso@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.3.1.tgz#d0305c6bdca3856dde43ed9091549db76fa21397"
+  integrity sha512-Y5qsh5xaGvMAN7S2LOm0n5Hg5gl76GEFSNzD/LNSR6Bm8UFncmEwIKEqp7lJMyM9aLrFV67Ap4rA0JL63Eb/uw==
+  dependencies:
+    "@virtuoso.dev/react-urx" "^0.2.12"
+    "@virtuoso.dev/urx" "^0.2.12"
 
 react@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1582160213).<!-- Sticky Header Marker -->

This PR builds on top of https://github.com/hirosystems/stacks-wallet-web/pull/2073, which adds a handling case when there are no accounts (an improvement, but doesn't address issue).

The problem described https://github.com/hirosystems/stacks-wallet-web/issues/2000 is caused by slow render performance. The `AccountListItem` component is reliant on a handful of hooks, some of which chain atoms back to synchronous localstorage reads. Even without, the components have quite a lot of DOM for a list item, generate avatars etc. 

There's a lot to render, and this problem grows the more accounts you have.

In most testing, I've not encountered the _no accounts shown_ issue, as the problem manifests itself earlier, with a ~3s delay between click of _Switch accounts_ and the list displaying.

The solution I've gone for is to virtualise the list, whereby we only render the list items in view. This drastically speeds up the initial render in cases of many accounts. It does somewhat move the problem, as the slow renders now happen on list scroll, but its still quite an improvement.

I had a look at a few libraries. [`react-virtualized`](https://github.com/bvaughn/react-virtualized) is largely deprecated, by the same author of [`react-window`](https://github.com/bvaughn/react-window). I went for [`react-virtuoso`](https://virtuoso.dev/). It has better documentation and has more recent releases.

**Before**

https://user-images.githubusercontent.com/1618764/146165589-3fdb344a-2162-4ca4-b358-b5a8d21bdf69.mp4

**After**

https://user-images.githubusercontent.com/1618764/146165620-15b89115-2f8b-489f-8e23-a7eedca7c475.mp4


