### PR TITLE
fix: ff onboarding route

### DIFF
--- a/src/background/vault.ts
+++ b/src/background/vault.ts
@@ -34,7 +34,7 @@ const defaultVault: InMemoryVault = {
   salt: undefined,
 } as const;
 
-function getHasSetPassword() {
+export function getHasSetPassword() {
   const persisted = localStorage.getItem(hasSetPasswordIdentifier);
   if (persisted !== null) {
     return JSON.parse(persisted);

--- a/src/background/vault.ts
+++ b/src/background/vault.ts
@@ -7,12 +7,14 @@ import {
   updateWalletConfig,
   Wallet as SDKWallet,
 } from '@stacks/wallet-sdk';
-import { gaiaUrl } from '@common/constants';
+
 import type { VaultActions } from '@background/vault-types';
 import { decryptMnemonic, encryptMnemonic } from '@background/crypto/mnemonic-encryption';
+import { gaiaUrl } from '@common/constants';
 import { DEFAULT_PASSWORD } from '@common/types';
 import { InternalMethods } from '@common/message-types';
 import { logger } from '@common/logger';
+import { getHasSetPassword, hasSetPasswordIdentifier } from '@common/storage';
 
 // In-memory (background) wallet instance
 export interface InMemoryVault {
@@ -25,7 +27,6 @@ export interface InMemoryVault {
 }
 
 const encryptedKeyIdentifier = 'stacks-wallet-encrypted-key' as const;
-const hasSetPasswordIdentifier = 'stacks-wallet-has-set-password' as const;
 const saltIdentifier = 'stacks-wallet-salt' as const;
 
 const defaultVault: InMemoryVault = {
@@ -33,14 +34,6 @@ const defaultVault: InMemoryVault = {
   hasSetPassword: false,
   salt: undefined,
 } as const;
-
-export function getHasSetPassword() {
-  const persisted = localStorage.getItem(hasSetPasswordIdentifier);
-  if (persisted !== null) {
-    return JSON.parse(persisted);
-  }
-  return false;
-}
 
 let inMemoryVault: InMemoryVault = {
   ...defaultVault,

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -1,3 +1,5 @@
+export const hasSetPasswordIdentifier = 'stacks-wallet-has-set-password' as const;
+
 export enum StorageKey {
   'authenticationRequests',
   'transactionRequests',
@@ -60,4 +62,12 @@ export function getRequestOrigin(storageKey: StorageKey, request: string): strin
 export function deleteTabForRequest(storageKey: StorageKey, request: string) {
   const key = getKeyForRequest(storageKey, request);
   localStorage.removeItem(key);
+}
+
+export function getHasSetPassword() {
+  const persisted = localStorage.getItem(hasSetPasswordIdentifier);
+  if (persisted !== null) {
+    return JSON.parse(persisted);
+  }
+  return false;
 }

--- a/src/routes/app-routes.tsx
+++ b/src/routes/app-routes.tsx
@@ -1,9 +1,9 @@
 import React, { Suspense, useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
-import { getHasSetPassword } from '@background/vault';
 import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 import { useWallet } from '@common/hooks/use-wallet';
+import { getHasSetPassword } from '@common/storage';
 import { Container } from '@components/container/container';
 import { MagicRecoveryCode } from '@pages/onboarding/magic-recovery-code/magic-recovery-code';
 import { ChooseAccount } from '@pages/choose-account/choose-account';

--- a/src/routes/app-routes.tsx
+++ b/src/routes/app-routes.tsx
@@ -1,9 +1,9 @@
 import React, { Suspense, useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
+import { getHasSetPassword } from '@background/vault';
 import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 import { useWallet } from '@common/hooks/use-wallet';
-import { getViewMode } from '@common/utils';
 import { Container } from '@components/container/container';
 import { MagicRecoveryCode } from '@pages/onboarding/magic-recovery-code/magic-recovery-code';
 import { ChooseAccount } from '@pages/choose-account/choose-account';
@@ -25,18 +25,16 @@ import { RouteUrls } from '@routes/route-urls';
 import { WelcomePage } from '@pages/onboarding/welcome/welcome';
 
 export function AppRoutes(): JSX.Element | null {
-  const { hasGeneratedWallet, hasRehydratedVault } = useWallet();
+  const { hasRehydratedVault } = useWallet();
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const analytics = useAnalytics();
   useSaveAuthRequest();
 
-  const mode = getViewMode();
-
   useEffect(() => {
-    // This ensures the ext popup hits the right route on load
-    if (mode === 'popup' && pathname === RouteUrls.Home && !hasGeneratedWallet)
-      navigate(RouteUrls.Onboarding);
+    const hasSetPassword = getHasSetPassword();
+    // This ensures the route is correct bc the VaultLoader is slow to set wallet state
+    if (pathname === RouteUrls.Home && !hasSetPassword) navigate(RouteUrls.Onboarding);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/tests/integration/send-tokens/send-tokens.spec.ts
+++ b/tests/integration/send-tokens/send-tokens.spec.ts
@@ -1,9 +1,10 @@
+import { delay } from '@common/utils';
 import { RouteUrls } from '@routes/route-urls';
+import { SECRET_KEY_2 } from '@tests/mocks';
 
 import { SendPage } from '../../page-objects/send-form.page';
 import { WalletPage } from '../../page-objects/wallet.page';
 import { BrowserDriver, setupBrowser } from '../utils';
-import { SECRET_KEY_2 } from '@tests/mocks';
 
 jest.setTimeout(60_000);
 jest.retryTimes(process.env.CI ? 2 : 0);
@@ -46,6 +47,7 @@ describe(`Send tokens flow`, () => {
       await sendForm.inputToAddressField('slkfjsdlkfjs');
       const defaultFeeEstimate = await sendForm.page.$(sendForm.getSelector('$feeEstimateItem'));
       const label = await defaultFeeEstimate?.innerText();
+      await delay(500);
       expect(label).toEqual('Standard');
     });
 

--- a/tests/integration/settings/create-switch-account.spec.ts
+++ b/tests/integration/settings/create-switch-account.spec.ts
@@ -4,7 +4,7 @@ import { RouteUrls } from '@routes/route-urls';
 import { SettingsSelectors } from '@tests/integration/settings.selectors';
 import { delay } from '@common/utils';
 
-jest.setTimeout(40_000);
+jest.setTimeout(60_000);
 
 jest.retryTimes(process.env.CI ? 2 : 0);
 
@@ -63,6 +63,7 @@ describe(`Create and switch account`, () => {
     for (let i = 0; i < numOfAccountsToTest; i++) {
       await wallet.clickSettingsButton();
       await wallet.page.click(createTestSelector(SettingsSelectors.SwitchAccount));
+      await delay(500);
       await wallet.page.click(createTestSelector(`switch-account-item-${i}`));
       await wallet.page.waitForSelector(
         createTestSelector(`account-checked-${i - 1 + numOfAccountsToTest}`),


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1588298064).<!-- Sticky Header Marker -->

Hopefully this is a better solution for hitting the right route while waiting for the VaultLoader to set the wallet state. There is a method we can export from the vault to check if `hasSetPassword` is true/false in local storage, so if that is false we can route the user to onboarding rather than home as the first index. This seems to work in both Chrome and FF, and in both full page and popup view modes.

cc/ @kyranjamie @beguene
