### PR TITLE
refactor: add test for unlock route

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,11 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { Box, BoxProps, color, Flex, FlexProps, IconButton, Stack } from '@stacks/ui';
 import { FiMoreHorizontal as IconDots, FiArrowLeft as IconArrowLeft } from 'react-icons/fi';
 
-import { StacksWalletLogo } from '@components/stacks-wallet-logo';
+import { HiroWalletLogo } from '@components/hiro-wallet-logo';
 import { useDrawers } from '@common/hooks/use-drawers';
 import { NetworkModeBadge } from '@components/network-mode-badge';
 import { Caption, Title } from '@components/typography';
 import { RouteUrls } from '@routes/route-urls';
+import { OnboardingSelectors } from '@tests/integration/onboarding.selectors';
 
 const MenuButton = memo((props: BoxProps) => {
   const { showSettings, setShowSettings } = useDrawers();
@@ -63,7 +64,10 @@ export const Header: React.FC<HeaderProps> = memo(props => {
     >
       {!title ? (
         <Stack alignItems="center" pt="7px" isInline>
-          <StacksWalletLogo onClick={() => navigate(RouteUrls.Home)} />
+          <HiroWalletLogo
+            data-testid={OnboardingSelectors.HiroWalletLogoRouteToHome}
+            onClick={() => navigate(RouteUrls.Home)}
+          />
           {version ? (
             <Caption
               pt="extra-tight"

--- a/src/components/hiro-wallet-logo.tsx
+++ b/src/components/hiro-wallet-logo.tsx
@@ -17,7 +17,7 @@ const HiroSvg = (props: BoxProps) => (
   </Box>
 );
 
-export const StacksWalletLogo = memo((props: StackProps) => {
+export const HiroWalletLogo = memo((props: StackProps) => {
   return (
     <Stack
       color={color('text-title')}

--- a/src/pages/set-password.tsx
+++ b/src/pages/set-password.tsx
@@ -14,6 +14,7 @@ import { validatePassword, blankPasswordValidation } from '@common/validation/va
 import { Body, Caption } from '@components/typography';
 import { Header } from '@components/header';
 import { RouteUrls } from '@routes/route-urls';
+import { OnboardingSelectors } from '@tests/integration/onboarding.selectors';
 
 interface SetPasswordProps {
   placeholder?: string;
@@ -113,7 +114,7 @@ export const SetPasswordPage = ({ placeholder }: SetPasswordProps) => {
                 key="password-input"
                 width="100%"
                 type="password"
-                data-testid="set-password"
+                data-testid={OnboardingSelectors.SetOrEnterPasswordInput}
                 autoFocus
                 value={formik.values.password}
                 onChange={formik.handleChange}

--- a/src/pages/unlock.tsx
+++ b/src/pages/unlock.tsx
@@ -15,6 +15,7 @@ import { useAnalytics } from '@common/hooks/analytics/use-analytics';
 import { RouteUrls } from '@routes/route-urls';
 import { useOnboardingState } from '@common/hooks/auth/use-onboarding-state';
 import { getViewMode } from '@common/utils';
+import { OnboardingSelectors } from '@tests/integration/onboarding.selectors';
 
 export function Unlock(): JSX.Element {
   const [loading, setLoading] = useState(false);
@@ -75,7 +76,7 @@ export function Unlock(): JSX.Element {
               type="password"
               value={password}
               isDisabled={loading}
-              data-testid="set-password"
+              data-testid={OnboardingSelectors.SetOrEnterPasswordInput}
               onChange={(e: FormEvent<HTMLInputElement>) => setPassword(e.currentTarget.value)}
               onKeyUp={buildEnterKeyEvent(submit)}
             />

--- a/tests/integration/onboarding.selectors.ts
+++ b/tests/integration/onboarding.selectors.ts
@@ -1,0 +1,4 @@
+export enum OnboardingSelectors {
+  SetOrEnterPasswordInput = 'set-or-enter-password-input',
+  HiroWalletLogoRouteToHome = 'hiro-wallet-logo-route-to-home',
+}

--- a/tests/integration/onboarding/onboarding.spec.ts
+++ b/tests/integration/onboarding/onboarding.spec.ts
@@ -1,12 +1,14 @@
-import { BrowserDriver, setupBrowser } from '../utils';
+import { RouteUrls } from '@routes/route-urls';
+
+import { BrowserDriver, createTestSelector, setupBrowser } from '../utils';
 import { SECRET_KEY } from '../../mocks';
 import { WalletPage } from '../../page-objects/wallet.page';
-import { RouteUrls } from '@routes/route-urls';
+import { SettingsSelectors } from '../settings.selectors';
 
 jest.setTimeout(30_000);
 jest.retryTimes(process.env.CI ? 2 : 0);
 
-describe(`Authentication integration tests`, () => {
+describe(`Onboarding integration tests`, () => {
   let browser: BrowserDriver;
   let wallet: WalletPage;
 
@@ -21,7 +23,7 @@ describe(`Authentication integration tests`, () => {
     } catch (error) {}
   });
 
-  it('should be able to sign up from authentication page', async () => {
+  it('should be able to sign up from welcome page', async () => {
     await wallet.clickAllowAnalytics();
     await wallet.clickSignUp();
     await wallet.saveKey();
@@ -32,7 +34,7 @@ describe(`Authentication integration tests`, () => {
     expect(secretKey.split(' ').length).toEqual(24);
   });
 
-  it('should be able to login from authentication page then logout', async () => {
+  it('should be able to login from welcome page then logout', async () => {
     await wallet.clickAllowAnalytics();
     await wallet.clickSignIn();
     await wallet.loginWithPreviousSecretKey(SECRET_KEY);
@@ -46,5 +48,17 @@ describe(`Authentication integration tests`, () => {
     await wallet.page.click(wallet.$signOutConfirmHasBackupCheckbox);
     await wallet.page.click(wallet.$signOutDeleteWalletBtn);
     await wallet.waitForLoginPage();
+  });
+
+  it('should route to unlock page if the wallet is locked', async () => {
+    await wallet.clickAllowAnalytics();
+    await wallet.clickSignUp();
+    await wallet.saveKey();
+    await wallet.waitForHomePage();
+    await wallet.clickSettingsButton();
+    await wallet.page.click(createTestSelector(SettingsSelectors.LockListItem));
+    await wallet.waitForHiroWalletLogo();
+    await wallet.page.click(wallet.$hiroWalletLogo);
+    await wallet.waitForSetOrEnterPasswordInput();
   });
 });

--- a/tests/page-objects/wallet.page.ts
+++ b/tests/page-objects/wallet.page.ts
@@ -1,5 +1,10 @@
-import { RouteUrls } from '@routes/route-urls';
 import { Page } from 'playwright-core';
+
+import { RouteUrls } from '@routes/route-urls';
+import { InitialPageSelectors } from '@tests/integration/initial-page.selectors';
+import { HomePageSelectors } from '@tests/page-objects/home-page.selectors';
+import { SettingsSelectors } from '@tests/integration/settings.selectors';
+
 import {
   createTestSelector,
   wait,
@@ -8,20 +13,18 @@ import {
   timeDifference,
 } from '../integration/utils';
 import { WalletPageSelectors } from './wallet.selectors';
-import { InitialPageSelectors } from '@tests/integration/initial-page.selectors';
-import { HomePageSelectors } from '@tests/page-objects/home-page.selectors';
-import { SettingsSelectors } from '@tests/integration/settings.selectors';
+import { OnboardingSelectors } from '@tests/integration/onboarding.selectors';
 
 export class WalletPage {
   static url = 'http://localhost:8081/index.html#';
   $signUpButton = createTestSelector(InitialPageSelectors.SignUp);
   $signInButton = createTestSelector(InitialPageSelectors.SignIn);
-  $analyticsAllowButton = createTestSelector('analytics-allow');
+  $analyticsAllowButton = createTestSelector(InitialPageSelectors.AnalyticsAllow);
   homePage = createTestSelector('home-page');
   $textareaReadOnlySeedPhrase = `${createTestSelector('textarea-seed-phrase')}[data-loaded="true"]`;
   $buttonSignInKeyContinue = createTestSelector('sign-in-key-continue');
   setPasswordDone = createTestSelector('set-password-done');
-  passwordInput = createTestSelector('set-password');
+  passwordInput = createTestSelector(OnboardingSelectors.SetOrEnterPasswordInput);
   saveKeyButton = createTestSelector('save-key');
   sendTokenBtnSelector = createTestSelector(WalletPageSelectors.BtnSendTokens);
   confirmSavedKey = createTestSelector('confirm-saved-key');
@@ -34,7 +37,7 @@ export class WalletPage {
   $homePageBalancesList = createTestSelector(HomePageSelectors.BalancesList);
   $createAccountButton = createTestSelector(SettingsSelectors.BtnCreateAccount);
   $createAccountDone = createTestSelector(SettingsSelectors.BtnCreateAccountDone);
-
+  $hiroWalletLogo = createTestSelector(OnboardingSelectors.HiroWalletLogoRouteToHome);
   $signOutConfirmHasBackupCheckbox = createTestSelector(
     SettingsSelectors.SignOutConfirmHasBackupCheckbox
   );
@@ -60,6 +63,7 @@ export class WalletPage {
   async clickAllowAnalytics() {
     await this.page.click(this.$analyticsAllowButton);
   }
+
   async clickSignUp() {
     await this.page.click(this.$signUpButton);
   }
@@ -76,12 +80,16 @@ export class WalletPage {
     await this.page.waitForSelector(this.$homePageBalancesList, { timeout: 30000 });
   }
 
-  async waitForSetPassword() {
+  async waitForSetOrEnterPasswordInput() {
     await this.page.waitForSelector(this.passwordInput, { timeout: 30000 });
   }
 
   async waitForMainHomePage() {
     await this.page.waitForSelector(this.homePage, { timeout: 30000 });
+  }
+
+  async waitForHiroWalletLogo() {
+    await this.page.waitForSelector(this.$hiroWalletLogo, { timeout: 3000 });
   }
 
   async waitForLoginPage() {
@@ -151,7 +159,7 @@ export class WalletPage {
     await this.clickSignIn();
     let startTime = new Date();
     await this.enterSecretKey(secretKey);
-    await this.waitForSetPassword();
+    await this.waitForSetOrEnterPasswordInput();
     console.log(
       `Page load time for 12 or 24 word Secret Key: ${timeDifference(
         startTime,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1602503474).<!-- Sticky Header Marker -->

This PR cleans up the onboarding tests a bit and adds a test for the unlock route.

cc/ @kyranjamie @beguene
