### PR TITLE
fix: gaia config being fetched on every key press, closes #2101

### DIFF
--- a/src/app/pages/set-password.tsx
+++ b/src/app/pages/set-password.tsx
@@ -43,7 +43,7 @@ export const SetPasswordPage = ({ placeholder }: SetPasswordProps) => {
     // Proactively fetch the gaia wallet config
     if (!wallet) return;
     void getWalletConfig(wallet);
-  });
+  }, [wallet]);
 
   const submit = useCallback(
     async (password: string) => {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1611860283).<!-- Sticky Header Marker -->

A `useEffect` was added with removal of gaia, but it was missing a dependency array, so it would fetch the gaia config on every key press, or render.

This PR adds the dependency array so that it only happens on initial render.