### PR TITLE
fix: remove inline source maps in prod

### DIFF
--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -30,6 +30,6 @@ config.optimization = {
     : {}),
 };
 
-config.devtool = 'inline-source-map';
+config.devtool = 'source-map';
 
 module.exports = config;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1684386940).<!-- Sticky Header Marker -->

Release again with this change, I set the sourcemaps to be inline when testing, and this will surely inflate the file size, breaking FF release build probably. 