### PR TITLE
fix: can't unlock wallet after upgrade

### DIFF
--- a/src/background/vault.ts
+++ b/src/background/vault.ts
@@ -162,7 +162,7 @@ const vaultReducer = async (message: VaultActions): Promise<InMemoryVault> => {
         };
       }
       // Since the user does not have the gaia wallet config saved locally, we use the legacy way
-      // i.e fetching it vis storeSeed. This can only happen when users have their wallet locked
+      // i.e fetching it via storeSeed. This can only happen when users have their wallet locked
       // and then got the wallet upgraded. They won't have the config saved yet (this is done on account creation and login)
       // This code path can be deleted after some months
       const decryptedData = await decryptMnemonic({

--- a/src/background/wallet/unlock-wallet.ts
+++ b/src/background/wallet/unlock-wallet.ts
@@ -25,6 +25,7 @@ export async function getDecryptedWalletDetails(
     salt: decryptedData.salt,
     password,
   });
+  if (!wallet) return;
 
   const result = {
     ...keyInfo,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1687011236).<!-- Sticky Header Marker -->

closes #2124
User could not unlock because they did not have the locally stored gaia config
The check for this was present but the function that returns the vault
was not returning null in that scenario (only null wallet)
This is fixed by always returning null when there is no locally stored config

To test: See #2124 

cc/ @kyranjamie @fbwoolf
