### PR TITLE
refactor(tests): move select analytics to signup/signin tasks

### DIFF
--- a/tests/integration/balance/balance.spec.ts
+++ b/tests/integration/balance/balance.spec.ts
@@ -19,7 +19,6 @@ describe(`Wallet Balance integration tests`, () => {
   beforeAll(async () => {
     browser = await setupBrowser();
     wallet = await WalletPage.init(browser, RouteUrls.Onboarding);
-    await wallet.clickAllowAnalytics();
     await wallet.signIn(SECRET_KEY_2);
     await selectTestNet(wallet);
     await wallet.waitForHomePage();

--- a/tests/integration/send-tokens/send-tokens.spec.ts
+++ b/tests/integration/send-tokens/send-tokens.spec.ts
@@ -17,7 +17,6 @@ describe(`Send tokens flow`, () => {
   beforeEach(async () => {
     browser = await setupBrowser();
     walletPage = await WalletPage.init(browser, RouteUrls.Onboarding);
-    await walletPage.clickAllowAnalytics();
     await walletPage.signIn(SECRET_KEY_2);
     await walletPage.waitForHomePage();
     await walletPage.goToSendForm();
@@ -129,7 +128,6 @@ describe('Preview for sending token', () => {
   beforeEach(async () => {
     browser = await setupBrowser();
     walletPage = await WalletPage.init(browser, RouteUrls.Onboarding);
-    await walletPage.clickAllowAnalytics();
     await walletPage.signIn(SECRET_KEY_2);
     await walletPage.waitForHomePage();
     await walletPage.goToSendForm();

--- a/tests/integration/settings/copy-address.spec.ts
+++ b/tests/integration/settings/copy-address.spec.ts
@@ -26,7 +26,6 @@ describe(`Copy Address`, () => {
   });
 
   it('should be able to copy address', async () => {
-    await wallet.clickAllowAnalytics();
     await wallet.signUp();
     await wallet.page.click(createTestSelector(UserAreaSelectors.AccountBalancesCopyAddress));
     let copiedAddress = await readClipboard();

--- a/tests/integration/settings/create-switch-account.spec.ts
+++ b/tests/integration/settings/create-switch-account.spec.ts
@@ -25,7 +25,6 @@ describe(`Create and switch account`, () => {
   });
 
   it('should be able to create a new account then switch', async () => {
-    await wallet.clickAllowAnalytics();
     await wallet.signUp();
     await wallet.clickSettingsButton();
     await wallet.page.click(wallet.$createAccountButton);
@@ -48,7 +47,6 @@ describe(`Create and switch account`, () => {
   });
 
   it(`should be able to create ${numOfAccountsToTest} new accounts then switch between them`, async () => {
-    await wallet.clickAllowAnalytics();
     await wallet.signUp();
     for (let i = 0; i < numOfAccountsToTest - 1; i++) {
       await wallet.clickSettingsButton();

--- a/tests/integration/settings/settings.spec.ts
+++ b/tests/integration/settings/settings.spec.ts
@@ -14,7 +14,6 @@ describe(`Settings integration tests`, () => {
   beforeAll(async () => {
     browser = await setupBrowser();
     wallet = await WalletPage.init(browser, RouteUrls.Onboarding);
-    await wallet.clickAllowAnalytics();
     await wallet.signUp();
   });
 

--- a/tests/integration/transactions/transactions.spec.ts
+++ b/tests/integration/transactions/transactions.spec.ts
@@ -1,13 +1,13 @@
-import { BrowserDriver, createTestSelector, getCurrentTestName, setupBrowser } from '../utils';
+import { Page } from 'playwright';
 import { WalletPage } from '@tests/page-objects/wallet.page';
 import { DemoPage } from '@tests/page-objects/demo.page';
 import { RouteUrls } from '@shared/route-urls';
 import { SECRET_KEY_2 } from '@tests/mocks';
 import { TransactionSigningPage } from '@tests/page-objects/transaction-signing.page';
 import { TransactionSigningSelectors } from '@tests/page-objects/transaction-signing.selectors';
-import { Page } from 'playwright';
 import { deserializeTransaction, TokenTransferPayload } from '@stacks/transactions';
 import { stxToMicroStx } from '@app/common/stacks-utils';
+import { BrowserDriver, createTestSelector, getCurrentTestName, setupBrowser } from '../utils';
 
 jest.setTimeout(120_000);
 jest.retryTimes(process.env.CI ? 2 : 0);
@@ -22,7 +22,6 @@ describe(`Transaction signing`, () => {
     await browser.context.tracing.start({ screenshots: true, snapshots: true });
     wallet = await WalletPage.init(browser, RouteUrls.Onboarding);
     demo = browser.demo;
-    await wallet.clickAllowAnalytics();
   });
 
   afterEach(async () => {

--- a/tests/page-objects/wallet.page.ts
+++ b/tests/page-objects/wallet.page.ts
@@ -150,12 +150,14 @@ export class WalletPage {
 
   /** Sign up with a randomly generated seed phrase */
   async signUp() {
+    await this.clickAllowAnalytics();
     await this.clickSignUp();
     await this.saveKey();
     await this.waitForHomePage();
   }
 
   async signIn(secretKey: string) {
+    await this.clickAllowAnalytics();
     await this.clickSignIn();
     let startTime = new Date();
     await this.enterSecretKey(secretKey);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1712383510).<!-- Sticky Header Marker -->

Been fixing some tests and noticed that we call allow analytics everywhere. I'd consider this part of the sign up flow that's abstracted by the page object helper method, so moved there.

Perhaps we should change this action to deny analytics 🤔 