### PR TITLE
fix: popup redirects to unlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stacks/wallet-web",
   "description": "The Hiro Wallet is browser extension for interacting with Stacks apps.",
   "private": true,
-  "version": "2.24.1",
+  "version": "2.25.1",
   "author": "Hiro Systems PBC",
   "scripts": {
     "dev": "node webpack/dev-server.js",

--- a/src/app/pages/choose-account/choose-account.tsx
+++ b/src/app/pages/choose-account/choose-account.tsx
@@ -13,7 +13,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 export const ChooseAccount = memo(() => {
   const { name: appName } = useAppDetails();
-  const { wallet, cancelAuthentication } = useWallet();
+  const { hasGeneratedWallet, cancelAuthentication, encryptedSecretKey } = useWallet();
 
   useRouteHeader(<Header hideActions />);
 
@@ -26,7 +26,9 @@ export const ChooseAccount = memo(() => {
     return () => window.removeEventListener('beforeunload', handleUnmount);
   }, [handleUnmount]);
 
-  if (!wallet) return <Navigate to={RouteUrls.Onboarding} />;
+  // Keeps routing in sync b/w view modes
+  if (!hasGeneratedWallet && encryptedSecretKey) return <Navigate to={RouteUrls.Unlock} />;
+  if (!hasGeneratedWallet) return <Navigate to={RouteUrls.Onboarding} />;
 
   return (
     <Stack spacing="loose" textAlign="center">

--- a/src/app/pages/sign-transaction/components/transaction-error/error-message.tsx
+++ b/src/app/pages/sign-transaction/components/transaction-error/error-message.tsx
@@ -68,6 +68,7 @@ export const ErrorMessage = memo(({ title, body, actions, ...rest }: ErrorMessag
           p={0}
           flexGrow={1}
           borderRadius="12px"
+          mt="extra-loose"
           onClick={() => window.close()}
           variant="secondary"
         >

--- a/src/app/routes/account-gate.tsx
+++ b/src/app/routes/account-gate.tsx
@@ -16,9 +16,9 @@ export const AccountGate = ({ children }: AccountGateProps) => {
   const needsToCompleteOnboarding = (hasGeneratedWallet || encryptedSecretKey) && !hasSetPassword;
 
   if (!hasRehydratedVault) return null;
-  if (isWalletActive) return <>{children}</>;
   if (isWalletLocked) return <Navigate to={RouteUrls.Unlock} />;
   if (needsToCompleteOnboarding) return <Navigate to={RouteUrls.SaveSecretKey} />;
+  if (isWalletActive) return <>{children}</>;
 
   return null;
 };

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -26,6 +26,9 @@ import { RouteUrls } from '@shared/route-urls';
 import { WelcomePage } from '@app/pages/onboarding/welcome/welcome';
 import { useVaultMessenger } from '@app/common/hooks/use-vault-messenger';
 
+import { useOnWalletLock } from './hooks/use-on-wallet-lock';
+import { useOnSignOut } from './hooks/use-on-sign-out';
+
 export function AppRoutes(): JSX.Element | null {
   const { hasRehydratedVault } = useWallet();
   const { pathname } = useLocation();
@@ -34,10 +37,14 @@ export function AppRoutes(): JSX.Element | null {
   const { getWallet } = useVaultMessenger();
   useSaveAuthRequest();
 
+  useOnWalletLock(() => navigate(RouteUrls.Unlock));
+  useOnSignOut(() => navigate(RouteUrls.Onboarding));
+
   useEffect(() => {
     const hasSetPassword = getHasSetPassword();
-    // This ensures the route is correct bc the VaultLoader is slow to set wallet state
-    if (pathname === RouteUrls.Home && !hasSetPassword) navigate(RouteUrls.Onboarding);
+    const pathToGuard = pathname === RouteUrls.Home || pathname === RouteUrls.Transaction;
+    // This ensures the route is correct bc the vault is slow to set wallet state
+    if (pathToGuard && !hasSetPassword) navigate(RouteUrls.Onboarding);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/app/routes/hooks/use-on-sign-out.ts
+++ b/src/app/routes/hooks/use-on-sign-out.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+import { InternalMethods } from '@shared/message-types';
+
+export function useOnSignOut(handler: () => void) {
+  useEffect(() => {
+    chrome.runtime.onMessage.addListener(message => {
+      if (message.method === InternalMethods.signOut) handler();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/app/routes/hooks/use-on-wallet-lock.ts
+++ b/src/app/routes/hooks/use-on-wallet-lock.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+import { InternalMethods } from '@shared/message-types';
+
+export function useOnWalletLock(handler: () => void) {
+  useEffect(() => {
+    chrome.runtime.onMessage.addListener(message => {
+      if (message.method === InternalMethods.lockWallet) handler();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1725890779).<!-- Sticky Header Marker -->

This fixes the loop with trying to connect to the wallet when locked. I'm not sure L31 is needed, but I remember it was there originally when I refactored.

~~I feel like behavior has changed with the routing since moving the `VaultLoader`, was that tested? @kyranjamie it is still erroring in `useSignTransactionSoftwareWallet` when trying to perform a tx with a locked wallet. I can't quite figure out the best way to redirect the user before hitting this error? Any ideas?~~

Nvm, not sure why this surfaced exactly.

cc/ @kyranjamie @beguene @He1DAr 
