### PR TITLE
refactor: upgrade `jotai@1.5.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "fast-deep-equal": "3.1.3",
     "formik": "2.2.9",
     "http-server": "14.0.0",
-    "jotai": "1.3.2",
+    "jotai": "1.5.3",
     "jotai-query-toolkit": "0.1.7",
     "jsontokens": "3.0.0",
     "mdi-react": "7.5.0",

--- a/src/app/common/hooks/use-submit-stx-transaction.ts
+++ b/src/app/common/hooks/use-submit-stx-transaction.ts
@@ -63,12 +63,12 @@ export function useSubmitTransactionCallback({ loadingKey }: UseSubmitTransactio
         const nonce = !replaceByFee && Number(transaction.auth.spendingCondition?.nonce);
         try {
           const response = await broadcastTransaction(transaction, stacksNetwork);
-          if (typeof response !== 'string') {
+          if (response.error) {
             if (response.reason) toast.error(getErrorMessage(response.reason));
             onClose();
             setIsIdle();
           } else {
-            const txid = `0x${response}`;
+            const txid = `0x${response.txid}`;
             if (!externalTxid.includes(txid)) {
               await setLocalTxs({
                 rawTx: transaction.serialize().toString('hex'),

--- a/src/app/store/accounts/account-activity.ts
+++ b/src/app/store/accounts/account-activity.ts
@@ -18,7 +18,7 @@ type LocalTx = Record<
     timestamp: string;
   }
 >;
-const currentAccountLocallySubmittedTxsRootState = atomFamily<[string, string], LocalTx, LocalTx>(
+const currentAccountLocallySubmittedTxsRootState = atomFamily(
   ([_address, _network]) =>
     atomWithStorage<LocalTx>(makeLocalDataKey([_address, _network, 'LOCAL_TXS']), {}),
   deepEqual

--- a/src/app/store/accounts/api.ts
+++ b/src/app/store/accounts/api.ts
@@ -2,11 +2,7 @@ import { atomFamilyWithInfiniteQuery, atomFamilyWithQuery } from 'jotai-query-to
 import { QueryRefreshRates } from '@shared/constants';
 import { apiClientAnchoredState, apiClientState } from '@app/store/common/api-clients';
 
-import type {
-  AccountBalanceResponseBigNumber,
-  AddressBalanceResponse,
-  AccountBalanceStxKeys,
-} from '@shared/models/account-types';
+import type { AddressBalanceResponse, AccountBalanceStxKeys } from '@shared/models/account-types';
 
 import BigNumber from 'bignumber.js';
 import { atomFamily } from 'jotai/utils';
@@ -68,10 +64,7 @@ const accountBalancesAnchoredClient = atomFamilyWithQuery<
   }
 );
 
-export const accountBalancesAnchoredBigNumber = atomFamily<
-  PrincipalWithNetworkUrl,
-  AccountBalanceResponseBigNumber
->(
+export const accountBalancesAnchoredBigNumber = atomFamily(
   ({ principal, networkUrl }) =>
     atom(get => {
       const balances = get(accountBalancesAnchoredClient({ principal, networkUrl }));

--- a/src/app/store/accounts/index.ts
+++ b/src/app/store/accounts/index.ts
@@ -112,7 +112,7 @@ export const currentAccountStxAddressState = atom<string | undefined>(
   get => get(currentAccountState)?.address
 );
 
-const accountAvailableAnchoredStxBalanceState = atomFamily<string, BigNumber | undefined>(
+const accountAvailableAnchoredStxBalanceState = atomFamily(
   principal =>
     atom(get => {
       const networkUrl = get(currentNetworkState).url;

--- a/src/app/store/accounts/nonce.ts
+++ b/src/app/store/accounts/nonce.ts
@@ -12,7 +12,7 @@ import { currentNetworkState } from '@app/store/network/networks';
 import { makeLocalDataKey } from '@app/common/store-utils';
 import { currentAccountLocallySubmittedLatestNonceState } from '@app/store/accounts/account-activity';
 
-export const localNonceState = atomFamily<[principal: string, networkUrl: string], number, number>(
+export const localNonceState = atomFamily(
   params => atomWithStorage(makeLocalDataKey(['LOCAL_NONCE_STATE', params]), 0),
   deepEqual
 );

--- a/src/app/store/transactions/fees.hooks.ts
+++ b/src/app/store/transactions/fees.hooks.ts
@@ -24,7 +24,7 @@ export const useReplaceByFeeSubmitCallBack = () => {
   return useAtomCallback<void, { fee: number; nonce: number }>(
     useCallback(
       async get => {
-        const unsignedTx = await get(rawDeserializedTxState, true);
+        const unsignedTx = await get(rawDeserializedTxState, { unstable_promise: true });
         if (!unsignedTx) return;
         const signedTx = signTx(unsignedTx);
         if (!signedTx) return;

--- a/src/app/store/transactions/index.ts
+++ b/src/app/store/transactions/index.ts
@@ -72,7 +72,7 @@ export const unsignedStacksTransactionBaseState = atom(get => {
 export const unsignedStacksTransactionState = atom(get => {
   const { transaction, options } = get(unsignedStacksTransactionBaseState);
   if (!transaction) return;
-  return generateUnsignedTransaction({ ...options });
+  return generateUnsignedTransaction({ ...options } as any);
 });
 
 export function prepareTxDetailsForBroadcast(tx: StacksTransaction) {

--- a/src/app/store/transactions/transaction.hooks.ts
+++ b/src/app/store/transactions/transaction.hooks.ts
@@ -107,7 +107,7 @@ export function useTransactionBroadcast() {
             network: currentNetworkState,
             unsignedStacksTransaction: unsignedStacksTransactionState,
           }),
-          true
+          { unstable_promise: true }
         );
 
         if (!account || !requestToken || !unsignedStacksTransaction) {

--- a/src/app/store/ui/ui.ts
+++ b/src/app/store/ui/ui.ts
@@ -3,7 +3,7 @@ import { atom } from 'jotai';
 import { makeLocalDataKey } from '@app/common/store-utils';
 import { AccountStep } from './ui.models';
 
-export const tabState = atomFamily<string, number, number>(param => {
+export const tabState = atomFamily(param => {
   const anAtom = atomWithStorage<number>(makeLocalDataKey(['HOME_TABS', param]), 0);
   anAtom.debugLabel = `TABS__${param}`;
   return anAtom;
@@ -11,7 +11,7 @@ export const tabState = atomFamily<string, number, number>(param => {
 
 type LoadingState = 'idle' | 'loading';
 
-export const loadingState = atomFamily<string, LoadingState, LoadingState>(_param => {
+export const loadingState = atomFamily(_param => {
   const anAtom = atom<LoadingState>('idle');
   anAtom.debugLabel = `loading-atom/${_param}`;
   return anAtom;

--- a/src/app/store/wallet/wallet.ts
+++ b/src/app/store/wallet/wallet.ts
@@ -1,17 +1,12 @@
 import { atom } from 'jotai';
-import {
-  Wallet,
-  WalletConfig,
-  fetchWalletConfig,
-  createWalletGaiaConfig,
-} from '@stacks/wallet-sdk';
+import { Wallet, fetchWalletConfig, createWalletGaiaConfig } from '@stacks/wallet-sdk';
 import { gaiaUrl } from '@shared/constants';
 
 export const secretKeyState = atom<Uint8Array | undefined>(undefined);
 export const hasSetPasswordState = atom<boolean>(false);
 export const walletState = atom<Wallet | undefined>(undefined);
 export const encryptedSecretKeyState = atom<string | undefined>(undefined);
-export const walletConfigState = atom<WalletConfig | null>(async get => {
+export const walletConfigState = atom(async get => {
   const wallet = get(walletState);
   if (!wallet) return null;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11494,10 +11494,10 @@ jotai-query-toolkit@0.1.7:
     fast-deep-equal "3.1.3"
     proxy-memoize "^0.3.5"
 
-jotai@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.3.2.tgz#955cdeaa35b0b792ac452c90646b52362d998f98"
-  integrity sha512-if3G/ic6PhGFPc0ypVi4F6gcfkfLN76iN4K0hayK+O+7Z0IUEQOow2w8NCDeZ2ES9DHmGpNh2pkbSxxU3kv2NQ==
+jotai@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.5.3.tgz#0157f962c6cd7d28389f9606a1eefebf223801ed"
+  integrity sha512-iD8MkbehxTjfRUtIJJdyQcjbAe2MqjW1+oFc5lvfgRjLHwjRQyWnZC3gdGAOQCOqUSPZHOBGgWyP/8gBDckaNQ==
 
 joycon@^3.0.1:
   version "3.1.1"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1723944839).<!-- Sticky Header Marker -->

Closes #1862 

Wouldn't @aulneau be proud? :trollface: 

This PR upgrades Jotai to the latest version. Some behaviours in earlier versions of jotai have gotten in the way of Ledger work. It's mostly just killing the types from `atomFamily`.

