### PR TITLE
fix: routing sign out and signed out

### DIFF
--- a/src/app/pages/choose-account/choose-account.tsx
+++ b/src/app/pages/choose-account/choose-account.tsx
@@ -1,5 +1,4 @@
 import { memo, useCallback, useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
 import { Stack, Text } from '@stacks/ui';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
@@ -9,11 +8,10 @@ import { useWallet } from '@app/common/hooks/use-wallet';
 import { useAppDetails } from '@app/common/hooks/auth/use-app-details';
 import { Header } from '@app/components/header';
 import { Accounts } from '@app/pages/choose-account/components/accounts';
-import { RouteUrls } from '@shared/route-urls';
 
 export const ChooseAccount = memo(() => {
   const { name: appName } = useAppDetails();
-  const { hasGeneratedWallet, cancelAuthentication, encryptedSecretKey } = useWallet();
+  const { cancelAuthentication } = useWallet();
 
   useRouteHeader(<Header hideActions />);
 
@@ -25,10 +23,6 @@ export const ChooseAccount = memo(() => {
     window.addEventListener('beforeunload', handleUnmount);
     return () => window.removeEventListener('beforeunload', handleUnmount);
   }, [handleUnmount]);
-
-  // Keeps routing in sync b/w view modes
-  if (!hasGeneratedWallet && encryptedSecretKey) return <Navigate to={RouteUrls.Unlock} />;
-  if (!hasGeneratedWallet) return <Navigate to={RouteUrls.Onboarding} />;
 
   return (
     <Stack spacing="loose" textAlign="center">

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -1,9 +1,8 @@
 import { Suspense, useEffect } from 'react';
-import { Navigate, Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { Stack } from '@stacks/ui';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
-import { useWallet } from '@app/common/hooks/use-wallet';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 import { Header } from '@app/components/header';
 import { HiroMessages } from '@app/features/hiro-messages/hiro-messages';
@@ -19,7 +18,6 @@ import { AccountInfoFetcher, BalanceFetcher } from './components/fetchers';
 
 export const Home = () => {
   const { decodedAuthRequest } = useOnboardingState();
-  const { hasGeneratedWallet, encryptedSecretKey } = useWallet();
   const navigate = useNavigate();
 
   const account = useCurrentAccount();
@@ -35,9 +33,6 @@ export const Home = () => {
     if (decodedAuthRequest) navigate(RouteUrls.ChooseAccount);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Keeps locking in sync b/w view modes
-  if (!hasGeneratedWallet && encryptedSecretKey) return <Navigate to={RouteUrls.Unlock} />;
 
   return (
     <>

--- a/src/app/pages/onboarding/welcome/welcome.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.tsx
@@ -14,7 +14,7 @@ import { WelcomeLayout } from './welcome.layout';
 export const WelcomePage = memo(() => {
   const [hasAllowedDiagnostics] = useHasAllowedDiagnostics();
   const navigate = useNavigate();
-  const { hasGeneratedWallet, hasSetPassword, encryptedSecretKey, makeWallet } = useWallet();
+  const { makeWallet } = useWallet();
   const { decodedAuthRequest } = useOnboardingState();
   const analytics = useAnalytics();
 
@@ -40,11 +40,6 @@ export const WelcomePage = memo(() => {
     return () => setIsGeneratingWallet(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    // Catch if onboarding has been completed and route to Home
-    if ((hasGeneratedWallet || encryptedSecretKey) && hasSetPassword) navigate(RouteUrls.Home);
-  }, [encryptedSecretKey, hasGeneratedWallet, hasSetPassword, navigate]);
 
   return (
     <WelcomeLayout

--- a/src/app/pages/send-tokens/send-tokens-form.tsx
+++ b/src/app/pages/send-tokens/send-tokens-form.tsx
@@ -58,7 +58,14 @@ function SendTokensFormBase() {
       toast.error('Unable to broadcast transaction');
       return;
     }
+
     const signedTx = signSoftwareWalletTx(transaction);
+    if (!signedTx) {
+      logger.error('Cannot sign transaction, no account in state');
+      toast.error('Unable to broadcast transaction');
+      return;
+    }
+
     await broadcastTransactionFn({
       transaction: signedTx,
       onClose() {

--- a/src/app/pages/sign-transaction/sign-transaction.tsx
+++ b/src/app/pages/sign-transaction/sign-transaction.tsx
@@ -28,6 +28,7 @@ import { useFeeEstimationsState } from '@app/store/transactions/fees.hooks';
 
 import { FeeForm } from './components/fee-form';
 import { SubmitAction } from './components/submit-action';
+import { UnauthorizedErrorMessage } from './components/transaction-error/error-messages';
 
 function SignTransactionBase(): JSX.Element | null {
   useNextTxNonce();
@@ -72,6 +73,9 @@ function SignTransactionBase(): JSX.Element | null {
   );
 
   if (!transactionRequest) return null;
+  // This renders when a user has not properly signed out of an app
+  // and attempts to perform a transaction
+  if (!handleBroadcastTransaction) return <UnauthorizedErrorMessage />;
 
   return (
     <Stack spacing="loose">

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -42,9 +42,13 @@ export function AppRoutes(): JSX.Element | null {
 
   useEffect(() => {
     const hasSetPassword = getHasSetPassword();
-    const pathToGuard = pathname === RouteUrls.Home || pathname === RouteUrls.Transaction;
+    const shouldRedirectToOnboarding =
+      pathname === RouteUrls.Home ||
+      (pathname === RouteUrls.ChooseAccount || pathname) === RouteUrls.Transaction;
+    const shouldRedirectToHome = pathname === RouteUrls.Onboarding;
     // This ensures the route is correct bc the vault is slow to set wallet state
-    if (pathToGuard && !hasSetPassword) navigate(RouteUrls.Onboarding);
+    if (shouldRedirectToOnboarding && !hasSetPassword) navigate(RouteUrls.Onboarding);
+    if (shouldRedirectToHome && hasSetPassword) navigate(RouteUrls.Home);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1730150581).<!-- Sticky Header Marker -->

This PR further refines the code around routing sign out and when a user is signed out. Before, when a user signed out of our wallet, but hadn't signed out thru an app, and attempt to perform a tx they would get a white screen with no feedback (we were just throwing a console error). Here, I replaced that with the `UnauthorizedErrorMessage` so the user has a way out of this screen.

Before:
![Screen Shot 2022-01-21 at 9 32 52 AM](https://user-images.githubusercontent.com/6493321/150575095-369abc2f-5216-47ca-8cd7-2f0edee4787c.png)

After:
![Screen Shot 2022-01-21 at 9 52 53 AM](https://user-images.githubusercontent.com/6493321/150575103-e99ca7f3-d7ed-43f9-8b15-bf179f69b679.png)

cc/ @kyranjamie @MrHeidar @beguene 
