### PR TITLE
fix: sponsored tx fee

### DIFF
--- a/src/app/common/transactions/broadcast-transaction.ts
+++ b/src/app/common/transactions/broadcast-transaction.ts
@@ -25,7 +25,7 @@ export async function broadcastTransaction(options: BroadcastTransactionOptions)
     const isValidTxId = validateTxId(response.txid);
     if (isValidTxId)
       return {
-        txId: response,
+        txId: response.txid,
         txRaw,
       };
     logger.error(`Error broadcasting raw transaction -- ${response}`);

--- a/src/app/components/fee-row/components/transaction-fee.tsx
+++ b/src/app/components/fee-row/components/transaction-fee.tsx
@@ -2,13 +2,8 @@ import { TransactionSigningSelectors } from '@tests/page-objects/transaction-sig
 
 interface TransactionFeeProps {
   fee: number | string;
-  isSponsored: boolean;
 }
 export function TransactionFee(props: TransactionFeeProps): JSX.Element | null {
-  const { fee, isSponsored } = props;
-  return (
-    <span data-testid={TransactionSigningSelectors.FeeToBePaidLabel}>
-      {isSponsored ? '🎉 sponsored' : fee} STX
-    </span>
-  );
+  const { fee } = props;
+  return <span data-testid={TransactionSigningSelectors.FeeToBePaidLabel}>{fee} STX</span>;
 }

--- a/src/app/components/fee-row/fee-row.tsx
+++ b/src/app/components/fee-row/fee-row.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from '@app/components/tooltip';
 import { WarningLabel } from '@app/components/warning-label';
 import { LoadingRectangle } from '@app/components/loading-rectangle';
 import { SpaceBetween } from '@app/components/space-between';
+import { SponsoredLabel } from '@app/components/sponsored-label';
 import { Caption } from '@app/components/typography';
 import { Estimations } from '@shared/models/fees-types';
 import { useFeeEstimationsState } from '@app/store/transactions/fees.hooks';
@@ -30,7 +31,6 @@ interface FeeRowProps {
 }
 export function FeeRow(props: FeeRowProps): JSX.Element {
   const { fieldName, isSponsored } = props;
-
   const [input, meta, helpers] = useField(fieldName);
   const [fieldWarning, setFieldWarning] = useState<string | undefined>(undefined);
   const [isOpen, setIsOpen] = useState(false);
@@ -39,12 +39,14 @@ export function FeeRow(props: FeeRowProps): JSX.Element {
   const [isCustom, setIsCustom] = useState(false);
 
   useEffect(() => {
-    // Set it to the middle estimation on mount
     if (!input.value && !isCustom && feeEstimations.length) {
       helpers.setValue(microStxToStx(feeEstimations[1].fee).toNumber());
     }
+    if (isSponsored) {
+      helpers.setValue(0);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [feeEstimations, helpers, isCustom]);
+  }, [feeEstimations, helpers, isCustom, isSponsored]);
 
   // Handles using the fee estimations selector or custom input
   const handleSelectedItem = useCallback(
@@ -75,35 +77,39 @@ export function FeeRow(props: FeeRowProps): JSX.Element {
       <SpaceBetween position="relative">
         <Stack alignItems="center" isInline>
           <Caption>Fees</Caption>
-          <Stack _hover={{ cursor: 'pointer' }}>
-            <FeeEstimateItem index={selected} onClick={() => setIsOpen(true)} />
-            <FeeEstimateSelect
-              items={feeEstimations}
-              onClick={handleSelectedItem}
-              setIsOpen={setIsOpen}
-              visible={isOpen}
-            />
-          </Stack>
-          <Tooltip label={feesInfo} placement="bottom">
-            <Stack>
-              <Box
-                _hover={{ cursor: 'pointer' }}
-                as={FiInfo}
-                color={color('text-caption')}
-                onClick={() => openInNewTab(url)}
-                size="14px"
-              />
-            </Stack>
-          </Tooltip>
+          {!isSponsored ? (
+            <>
+              <Stack _hover={{ cursor: 'pointer' }}>
+                <FeeEstimateItem index={selected} onClick={() => setIsOpen(true)} />
+                <FeeEstimateSelect
+                  items={feeEstimations}
+                  onClick={handleSelectedItem}
+                  setIsOpen={setIsOpen}
+                  visible={isOpen}
+                />
+              </Stack>
+              <Tooltip label={feesInfo} placement="bottom">
+                <Stack>
+                  <Box
+                    _hover={{ cursor: 'pointer' }}
+                    as={FiInfo}
+                    color={color('text-caption')}
+                    onClick={() => openInNewTab(url)}
+                    size="14px"
+                  />
+                </Stack>
+              </Tooltip>
+            </>
+          ) : null}
         </Stack>
         {isCustom ? (
           <CustomFeeField fieldName={fieldName} setFieldWarning={setFieldWarning} />
-        ) : !input.value ? (
+        ) : !isSponsored && !input.value ? (
           <LoadingRectangle width="50px" height="10px" />
         ) : (
           <Suspense fallback={<></>}>
             <Caption>
-              <TransactionFee isSponsored={isSponsored} fee={input.value} />
+              <TransactionFee fee={input.value} />
             </Caption>
           </Suspense>
         )}
@@ -115,6 +121,7 @@ export function FeeRow(props: FeeRowProps): JSX.Element {
           </Text>
         </ErrorLabel>
       )}
+      {isSponsored && <SponsoredLabel />}
       {!meta.error && fieldWarning && <WarningLabel>{fieldWarning}</WarningLabel>}
     </Stack>
   );

--- a/src/app/components/sponsored-label.tsx
+++ b/src/app/components/sponsored-label.tsx
@@ -1,0 +1,27 @@
+import { FiAlertCircle } from 'react-icons/fi';
+import { Box, color, Stack, Text } from '@stacks/ui';
+
+export function SponsoredLabel(): JSX.Element {
+  return (
+    <Stack width="100%">
+      <Stack
+        alignItems="center"
+        bg={color('bg-4')}
+        borderRadius="10px"
+        height="48px"
+        isInline
+        pl="base"
+      >
+        <Box
+          _hover={{ cursor: 'pointer' }}
+          as={FiAlertCircle}
+          color={color('accent')}
+          size="16px"
+        />
+        <Text color={color('text-title')} fontSize="12px" fontWeight="500">
+          This transaction is sponsored, so no fee is charged
+        </Text>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
@@ -13,7 +13,6 @@ import {
 
 import { SendTokensConfirmActions } from './send-tokens-confirm-actions';
 import { SendTokensConfirmDetails } from './send-tokens-confirm-details';
-import { isTxSponsored } from '@app/common/transactions/transaction-utils';
 
 interface SendTokensConfirmDrawerProps extends BaseDrawerProps {
   onUserSelectBroadcastTransaction(): void;
@@ -24,7 +23,6 @@ export function SendTokensConfirmDrawer(props: SendTokensConfirmDrawerProps) {
   const [txData] = useLocalTransactionInputsState();
   const transaction = useUnsignedTxForSettingsState();
   const { showEditNonce } = useDrawers();
-  const isSponsored = transaction ? isTxSponsored(transaction) : false;
 
   if (!isShowing || !transaction || !txData) return null;
 
@@ -44,7 +42,7 @@ export function SendTokensConfirmDrawer(props: SendTokensConfirmDrawerProps) {
         <SpaceBetween>
           <Caption>Fees</Caption>
           <Caption>
-            <TransactionFee isSponsored={isSponsored} fee={txData.fee} />
+            <TransactionFee fee={txData.fee} />
           </Caption>
         </SpaceBetween>
         <SendTokensConfirmActions

--- a/src/app/pages/sign-transaction/sign-transaction.tsx
+++ b/src/app/pages/sign-transaction/sign-transaction.tsx
@@ -29,6 +29,7 @@ import { useFeeEstimationsState } from '@app/store/transactions/fees.hooks';
 import { FeeForm } from './components/fee-form';
 import { SubmitAction } from './components/submit-action';
 import { UnauthorizedErrorMessage } from './components/transaction-error/error-messages';
+import { useUnsignedTransactionFee } from './hooks/use-signed-transaction-fee';
 
 function SignTransactionBase(): JSX.Element | null {
   useNextTxNonce();
@@ -38,7 +39,10 @@ function SignTransactionBase(): JSX.Element | null {
   const setBroadcastError = useUpdateTransactionBroadcastError();
   const [, setFeeEstimations] = useFeeEstimationsState();
   const [, setTxData] = useLocalTransactionInputsState();
+  const { isSponsored } = useUnsignedTransactionFee();
   const feeSchema = useFeeSchema();
+
+  const validationSchema = !isSponsored ? yup.object({ fee: feeSchema() }) : null;
 
   useRouteHeader(<PopupHeader />);
 
@@ -92,9 +96,7 @@ function SignTransactionBase(): JSX.Element | null {
         validateOnChange={false}
         validateOnBlur={false}
         validateOnMount={false}
-        validationSchema={yup.object({
-          fee: feeSchema(),
-        })}
+        validationSchema={validationSchema}
       >
         {() => (
           <>

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -1,15 +1,9 @@
 import React, { useState } from 'react';
-import { Box, Button, ButtonGroup, Text } from '@stacks/ui';
-
-import {
-  stacksLocalhostNetwork,
-  stacksTestnetNetwork,
-  stacksTestnetNetwork as network,
-} from '@common/utils';
-import { demoTokenContract } from '@common/contracts';
-import { useSTXAddress } from '@common/use-stx-address';
+import BN from 'bn.js';
 import { useConnect } from '@stacks/connect-react';
+import { StacksTestnet } from '@stacks/network';
 import {
+  broadcastTransaction,
   bufferCV,
   bufferCVFromString,
   createAssetInfo,
@@ -22,6 +16,8 @@ import {
   NonFungibleConditionCode,
   PostConditionMode,
   someCV,
+  sponsorTransaction,
+  StacksTransaction,
   standardPrincipalCV,
   stringAsciiCV,
   stringUtf8CV,
@@ -29,10 +25,18 @@ import {
   tupleCV,
   uintCV,
 } from '@stacks/transactions';
+import { Box, Button, ButtonGroup, Text } from '@stacks/ui';
+
+import {
+  stacksLocalhostNetwork,
+  stacksTestnetNetwork,
+  stacksTestnetNetwork as network,
+} from '@common/utils';
+import { demoTokenContract } from '@common/contracts';
+import { useSTXAddress } from '@common/use-stx-address';
 import { TransactionSigningSelectors } from '@tests/page-objects/transaction-signing.selectors';
+
 import { ExplorerLink } from './explorer-link';
-import BN from 'bn.js';
-import { StacksTestnet } from '@stacks/network';
 
 export const Debugger = () => {
   const { doContractCall, doSTXTransfer, doContractDeploy } = useConnect();
@@ -49,6 +53,18 @@ export const Debugger = () => {
   const setState = (type: string, id: string) => {
     setTxId(id);
     setTxType(type);
+  };
+
+  // If need to add more test tokens: STW7PFH79HW1C9Z0SXBP5PTPHKZZ58KK9WP1MZZA
+  const handleSponsoredTransactionBroadcast = async (tx: StacksTransaction) => {
+    const sponsorOptions = {
+      fee: new BN(388),
+      sponsorPrivateKey: 'b8c6aaef4b6de5e62648a59fff13e389856dff5e58163e676c2cfdf9dd5dd11101',
+      transaction: tx,
+    };
+
+    const sponsoredTx = await sponsorTransaction(sponsorOptions);
+    return broadcastTransaction(sponsoredTx, network);
   };
 
   const callBnsTransfer = async () => {
@@ -107,7 +123,11 @@ export const Debugger = () => {
     });
   };
 
-  const callFaker = async (network: StacksTestnet, mode = PostConditionMode.Deny) => {
+  const callFaker = async (
+    network: StacksTestnet,
+    mode = PostConditionMode.Deny,
+    sponsored = false
+  ) => {
     clearState();
     const args = [
       uintCV(1234),
@@ -134,14 +154,15 @@ export const Debugger = () => {
       attachment: 'This is an attachment',
       postConditionMode: mode,
       postConditions,
-      onFinish: data => {
+      onFinish: async (data: any) => {
         console.log('finished faker!', data);
-        console.log(data.stacksTransaction.auth.spendingCondition?.nonce.toNumber());
+        if (sponsored) handleSponsoredTransactionBroadcast(data.stacksTransaction);
         setState('Contract Call', data.txId);
       },
       onCancel: () => {
         console.log('popup closed!');
       },
+      sponsored,
     });
   };
 
@@ -362,6 +383,12 @@ export const Debugger = () => {
           </Button>
           <Button mt={3} onClick={callNullContract}>
             Non-existent contract
+          </Button>
+          <Button
+            mt={3}
+            onClick={() => callFaker(stacksTestnetNetwork, PostConditionMode.Allow, true)}
+          >
+            Sponsored contract call
           </Button>
         </ButtonGroup>
       </Box>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1742170500).<!-- Sticky Header Marker -->

This PR fixes the sponsored tx fee by setting it to 0. In addition, I have added a button to the test-app so we can test sponsored transactions.

![Screen Shot 2022-01-22 at 9 30 31 AM](https://user-images.githubusercontent.com/6493321/150691369-86618fd2-9669-4964-b9d3-030367b6d6ec.png)

![Screen Shot 2022-01-23 at 11 52 56 AM](https://user-images.githubusercontent.com/6493321/150691371-4c7ffb1a-d4eb-45ad-9e1a-ae1342e55e46.png)

cc/ @kyranjamie @beguene @He1DAr 
