### PR TITLE
fix: is asset transferable logic

### DIFF
--- a/src/app/common/asset-types.ts
+++ b/src/app/common/asset-types.ts
@@ -16,7 +16,6 @@ interface FtMeta {
   name: string;
   symbol: string;
   decimals: number;
-  ftTrait?: boolean | null;
 }
 
 export interface NftMeta {

--- a/src/app/common/transactions/is-transferable-asset.spec.ts
+++ b/src/app/common/transactions/is-transferable-asset.spec.ts
@@ -1,0 +1,74 @@
+import { AssetWithMeta } from '../asset-types';
+import { isTransferableAsset } from './is-transferable-asset';
+
+describe(isTransferableAsset.name, () => {
+  test('assets with a name, symbol and decimals are allowed to be transferred', () => {
+    const asset = {
+      type: 'ft',
+      meta: {
+        name: 'Test token',
+        symbol: 'TEST',
+        decimals: 2,
+      },
+    } as AssetWithMeta;
+    expect(isTransferableAsset(asset)).toBeTruthy();
+  });
+
+  test('stella the cat token', () => {
+    const asset = {
+      type: 'ft',
+      subtitle: 'ST6G7…PSTK7.stella-the-cat',
+      contractAddress: 'ST6G7N19FKNW24XH5JQ5P5WR1DN10QWMKQSPSTK7',
+      contractName: 'stella-the-cat',
+      name: 'stella-token',
+      canTransfer: true,
+      meta: {
+        token_uri: 'https://example.com',
+        name: 'SteLLa the Cat',
+        description: '',
+        image_uri: '',
+        image_canonical_uri: '',
+        symbol: 'CAT',
+        decimals: 9,
+        tx_id: '0x56c6381874c8f6b152c8815d950764b8759b97660fdc50091f3c1368d7f1c514',
+        sender_address: 'ST6G7N19FKNW24XH5JQ5P5WR1DN10QWMKQSPSTK7',
+      },
+    } as unknown as AssetWithMeta;
+    expect(isTransferableAsset(asset)).toBeTruthy();
+  });
+
+  test('a token with no decimals is transferable', () => {
+    const asset = {
+      type: 'ft',
+      meta: {
+        token_uri: 'https://example.com',
+        name: 'SteLLa the Cat',
+        description: '',
+        image_uri: '',
+        image_canonical_uri: '',
+        symbol: 'CAT',
+        decimals: 0,
+        tx_id: '0x56c6381874c8f6b152c8815d950764b8759b97660fdc50091f3c1368d7f1c514',
+        sender_address: 'ST6G7N19FKNW24XH5JQ5P5WR1DN10QWMKQSPSTK7',
+      },
+    } as unknown as AssetWithMeta;
+    expect(isTransferableAsset(asset)).toBeTruthy();
+  });
+
+  test('assets missing either name, symbol or decimals may not be transferred', () => {
+    const asset = {
+      type: 'ft',
+      meta: {
+        name: 'Test token',
+        symbol: 'TEST',
+        decimals: undefined,
+      },
+    } as unknown as AssetWithMeta;
+    expect(isTransferableAsset(asset)).toBeFalsy();
+  });
+
+  test('NFTs cannot be sent', () => {
+    const asset = { type: 'nft' } as unknown as AssetWithMeta;
+    expect(isTransferableAsset(asset)).toBeFalsy();
+  });
+});

--- a/src/app/common/transactions/is-transferable-asset.ts
+++ b/src/app/common/transactions/is-transferable-asset.ts
@@ -1,0 +1,14 @@
+import { AssetWithMeta } from '../asset-types';
+import { isUndefined } from '../utils';
+
+export function isTransferableAsset(asset: AssetWithMeta) {
+  if (asset.type === 'stx') return true;
+  if (asset.type === 'ft') {
+    return asset.meta
+      ? !isUndefined(asset.meta.decimals) &&
+          !isUndefined(asset.meta.name) &&
+          !isUndefined(asset.meta.symbol)
+      : false;
+  }
+  return false;
+}

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -270,6 +270,10 @@ export function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
 
+export function isUndefined(value: unknown): value is undefined {
+  return typeof value === 'undefined';
+}
+
 export function isEmpty(value: Object) {
   return Object.keys(value).length === 0;
 }

--- a/src/app/query/tokens/fungible-token-metadata.hook.ts
+++ b/src/app/query/tokens/fungible-token-metadata.hook.ts
@@ -1,6 +1,35 @@
-import { useGetFungibleTokenMetadataQuery } from './fungible-token-metadata.query';
+import { useMemo } from 'react';
+
+import { useAssets } from '@app/store/assets/asset.hooks';
+import { isTransferableAsset } from '@app/common/transactions/is-transferable-asset';
+import { formatContractId } from '@app/common/utils';
+import {
+  useGetFungibleTokenMetadataListQuery,
+  useGetFungibleTokenMetadataQuery,
+} from './fungible-token-metadata.query';
+import { AssetWithMeta } from '@app/common/asset-types';
 
 export function useFungibleTokenMetadata(contractId: string) {
   const { data: ftMetadata } = useGetFungibleTokenMetadataQuery(contractId);
   return ftMetadata;
+}
+
+export function useAssetsWithMetadata(): AssetWithMeta[] {
+  const assets = useAssets();
+  const assetMetadata = useGetFungibleTokenMetadataListQuery(
+    assets.map(a => formatContractId(a.contractAddress, a.contractName))
+  );
+  return useMemo(
+    () =>
+      assets
+        .map((asset, i) => ({ ...asset, meta: assetMetadata[i].data }))
+        .map(assetWithMetaData => ({
+          ...assetWithMetaData,
+          canTransfer: isTransferableAsset(assetWithMetaData),
+          hasMemo: isTransferableAsset(assetWithMetaData),
+        })),
+    // We don't want to reevaluate on assetMetadata reference change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [assets]
+  );
 }

--- a/src/app/query/tokens/fungible-token-metadata.query.ts
+++ b/src/app/query/tokens/fungible-token-metadata.query.ts
@@ -1,11 +1,7 @@
-import { useMemo } from 'react';
 import { useQueries, useQuery } from 'react-query';
 
 import { useApi, Api } from '@app/store/common/api-clients.hooks';
-
 import { useCurrentNetwork } from '@app/common/hooks/use-current-network';
-import { useAssets } from '@app/store/assets/asset.hooks';
-import { formatContractId } from '@app/common/utils';
 
 const staleTime = 10 * 60 * 1000;
 
@@ -32,7 +28,7 @@ export function useGetFungibleTokenMetadataQuery(contractId: string) {
   });
 }
 
-function useGetFungibleTokenMetadataListQuery(contractIds: string[]) {
+export function useGetFungibleTokenMetadataListQuery(contractIds: string[]) {
   const api = useApi();
   const network = useCurrentNetwork();
   return useQueries(
@@ -41,18 +37,5 @@ function useGetFungibleTokenMetadataListQuery(contractIds: string[]) {
       queryFn: fetchUnanchoredAccountInfo(api)(contractId),
       ...queryOptions,
     }))
-  );
-}
-
-export function useAssetsWithMetadata() {
-  const assets = useAssets();
-  const assetMetadata = useGetFungibleTokenMetadataListQuery(
-    assets.map(a => formatContractId(a.contractAddress, a.contractName))
-  );
-  return useMemo(
-    () => assets.map((asset, i) => ({ ...asset, canTransfer: true, meta: assetMetadata[i].data })),
-    // We don't want to reevaluate on assetMetadata reference change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [assets]
   );
 }

--- a/tests/integration/send-tokens/send-tokens.spec.ts
+++ b/tests/integration/send-tokens/send-tokens.spec.ts
@@ -21,7 +21,6 @@ describe(`Send tokens flow`, () => {
     await walletPage.waitForHomePage();
     await walletPage.goToSendForm();
     sendForm = new SendPage(walletPage.page);
-    await sendForm.selectStxFromDropdown();
     await sendForm.waitForSendMaxButton();
   }, 30_000);
 
@@ -133,7 +132,6 @@ describe('Preview for sending token', () => {
     await walletPage.waitForHomePage();
     await walletPage.goToSendForm();
     sendForm = new SendPage(walletPage.page);
-    await sendForm.selectStxFromDropdown();
     await sendForm.waitForSendMaxButton();
   }, 30_000);
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1745220744).<!-- Sticky Header Marker -->

This logic branch was broken in my refactor work. Below is the only place `ftTrait` is set in `main`, so hopefully my fix will address this.

https://github.com/hirosystems/stacks-wallet-web/blob/6c97a4f3b41cc7a52c9fa70c0c9e15f2a1fc4889/src/store/assets/fungible-tokens.ts#L63-L68

@timstackblock @Eshwari007 to test this, you must make sure the same tokens appear in the dropdown list as on `main`. The cases where _invalid amount shows_ up in all the screenshots of the issue, are all tokens that weren't transferable before.