### PR TITLE
fix: thrown error with sponsored tx

### DIFF
--- a/src/app/common/transactions/broadcast-transaction.ts
+++ b/src/app/common/transactions/broadcast-transaction.ts
@@ -2,6 +2,11 @@ import { broadcastRawTransaction } from '@stacks/transactions';
 import { Buffer } from 'buffer';
 import { logger } from '@shared/logger';
 import { validateTxId } from '@app/common/validation/validate-tx-id';
+import { delay } from '@app/common/utils';
+
+async function simulateShortDelayToAvoidUndefinedTabId() {
+  await delay(1000);
+}
 
 interface BroadcastTransactionOptions {
   txRaw: string;
@@ -13,7 +18,10 @@ interface BroadcastTransactionOptions {
 export async function broadcastTransaction(options: BroadcastTransactionOptions) {
   const { txRaw, serialized, isSponsored, attachment, networkUrl } = options;
 
-  if (isSponsored) return { txRaw };
+  if (isSponsored) {
+    await simulateShortDelayToAvoidUndefinedTabId();
+    return { txRaw };
+  }
 
   try {
     const response = await broadcastRawTransaction(

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -64,7 +64,7 @@ export const Debugger = () => {
     };
 
     const sponsoredTx = await sponsorTransaction(sponsorOptions);
-    return broadcastTransaction(sponsoredTx, network);
+    return await broadcastTransaction(sponsoredTx, network);
   };
 
   const callBnsTransfer = async () => {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1779451510).<!-- Sticky Header Marker -->

There was an error flashing up in the test-app when performing a sponsored tx. The tx was successful but the `tabId` was undefined in `finalizeTxSignature`. Adding this delay here allows time for `finalizeTxSignature` to happen w/out throwing an error.

![Screen Shot 2022-01-22 at 10 23 53 AM](https://user-images.githubusercontent.com/6493321/152001527-ac59e9bc-c25c-453e-ab4d-05c318055925.png)

cc/ @kyranjamie @beguene @He1DAr 
