### PR TITLE
chore: regression test refactor Feb

### DIFF
--- a/src/app/common/error-messages.ts
+++ b/src/app/common/error-messages.ts
@@ -4,10 +4,12 @@ export enum SendFormErrorMessages {
   SameAddress = 'Cannot send to yourself',
   AmountRequired = 'You must specify an amount',
   MustNotBeZero = 'Must be more than zero',
+  MustBeNumber = 'Amount of STX must be a number',
   DoesNotSupportDecimals = 'This token does not support decimal places',
   InsufficientBalance = 'Insufficient balance. Available:',
   MustSelectAsset = 'You must select a valid token to transfer',
   TooMuchPrecision = '{token} can only have {decimals} decimals',
   MemoExceedsLimit = 'Memo must be less than 34-bytes',
   AdjustedFeeExceedsBalance = 'The fee added now exceeds your current STX balance.',
+  CastToNumber = 'Amount must be a `number` type, but the final value was: `NaN`',
 }

--- a/src/app/components/asset-item.tsx
+++ b/src/app/components/asset-item.tsx
@@ -121,8 +121,8 @@ export const AssetItem = memo(
                     placement="left-start"
                     label={formatted.isAbbreviated ? amount : undefined}
                   >
-                    <Text fontVariantNumeric="tabular-nums" textAlign="right">
-                      <span data-testid={name}>{formatted.value}</span>
+                    <Text fontVariantNumeric="tabular-nums" textAlign="right" data-testid={name}>
+                      {formatted.value}
                     </Text>
                   </Tooltip>
                   {isDifferent ? <SubBalance amount={subAmount} /> : null}

--- a/src/app/components/asset-row.tsx
+++ b/src/app/components/asset-row.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import { StackProps } from '@stacks/ui';
 import { ftDecimals, stacksValue } from '@app/common/stacks-utils';
-import type { AssetWithMeta } from '@app/common/asset-types';
+import { AssetWithMeta } from '@app/common/asset-types';
 import { getAssetName } from '@stacks/ui-utils';
 import { AssetItem } from '@app/components/asset-item';
 import { formatContractId, getTicker } from '@app/common/utils';
@@ -48,6 +48,7 @@ export const AssetRow = forwardRef<HTMLDivElement, AssetRowProps>((props, ref) =
       subAmount={subAmount}
       isDifferent={isDifferent}
       name={name}
+      data-testid={`asset-${name}`}
       {...rest}
     />
   );

--- a/src/app/components/event-card.tsx
+++ b/src/app/components/event-card.tsx
@@ -5,6 +5,7 @@ import { Caption } from '@app/components/typography';
 import { SpaceBetween } from '@app/components/space-between';
 
 import { TxAssetItem } from './tx-asset-item';
+import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
 interface EventCardProps {
   actions?: string;
@@ -24,7 +25,7 @@ export function EventCard(props: EventCardProps): JSX.Element {
     <>
       <Stack p="base-loose" spacing="base-loose">
         <SpaceBetween position="relative">
-          <Text fontSize={2} fontWeight={500}>
+          <Text fontSize={2} fontWeight={500} data-testid={SendFormSelectors.TransferMessage}>
             {title}
           </Text>
           {actions && (

--- a/src/app/components/fee-row/components/fee-estimate-item.tsx
+++ b/src/app/components/fee-row/components/fee-estimate-item.tsx
@@ -3,9 +3,9 @@ import { color, Stack } from '@stacks/ui';
 
 import { SpaceBetween } from '@app/components/space-between';
 import { Caption } from '@app/components/typography';
-import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
-const LABELS = ['Low', 'Standard', 'High', 'Custom'];
+const labels = ['Low', 'Standard', 'High', 'Custom'];
+const testLabels = labels.map(label => label.toLowerCase());
 
 interface FeeEstimateItemProps {
   index: number;
@@ -13,7 +13,6 @@ interface FeeEstimateItemProps {
   selected?: number;
   visible?: boolean;
 }
-
 export function FeeEstimateItem(props: FeeEstimateItemProps) {
   const { index, onClick, visible } = props;
 
@@ -23,7 +22,7 @@ export function FeeEstimateItem(props: FeeEstimateItemProps) {
       border={visible ? 'none' : '1px solid #EFEFF2'}
       borderRadius={visible ? '0px' : '10px'}
       bg={color('bg')}
-      data-testid={SendFormSelectors.FeeEstimateItem}
+      data-testid={`${testLabels[index]}-fee`}
       _hover={{ bg: visible ? color('bg-alt') : 'none', borderRadius: '8px' }}
       height="32px"
       isInline
@@ -33,7 +32,7 @@ export function FeeEstimateItem(props: FeeEstimateItemProps) {
       onClick={() => onClick(index)}
     >
       <SpaceBetween flexGrow={1}>
-        <Caption ml="2px">{LABELS[index]}</Caption>
+        <Caption ml="2px">{labels[index]}</Caption>
         {visible ? <></> : <FiChevronDown />}
       </SpaceBetween>
     </Stack>

--- a/src/app/components/tx-item.tsx
+++ b/src/app/components/tx-item.tsx
@@ -31,6 +31,7 @@ import {
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useFungibleTokenMetadata } from '@app/query/tokens/fungible-token-metadata.hook';
 import { pullContractIdFromIdentity } from '@app/common/utils';
+import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
 type Tx = MempoolTransaction | Transaction;
 
@@ -40,7 +41,11 @@ const Status = ({ transaction, ...rest }: { transaction: Tx } & BoxProps) => {
   return isFailed || isPending ? (
     <Box {...rest}>
       {isPending && (
-        <Caption variant="c2" color={color('feedback-alert')}>
+        <Caption
+          color={color('feedback-alert')}
+          data-testid={SendFormSelectors.PendingStatus}
+          variant="c2"
+        >
           Pending
         </Caption>
       )}
@@ -301,7 +306,7 @@ export const TxItem = ({ transaction, ...rest }: TxItemProps) => {
           </Stack>
           <Stack alignItems="flex-end" spacing="base-tight">
             {value && (
-              <Title as="h3" fontWeight="normal">
+              <Title as="h3" fontWeight="normal" data-testid={SendFormSelectors.SentTokenValue}>
                 {value}
               </Title>
             )}

--- a/src/app/pages/allow-diagnostics/allow-diagnostics-layout.tsx
+++ b/src/app/pages/allow-diagnostics/allow-diagnostics-layout.tsx
@@ -68,6 +68,7 @@ export function AllowDiagnosticsLayout(props: AllowDiagnosticsLayoutProps) {
             onClick={() => onUserDenyDiagnosticsPermissions()}
             type="button"
             variant="link"
+            data-testid={OnboardingSelectors.AnalyticsDenyBtn}
           >
             Deny
           </Button>

--- a/src/app/pages/buy/components/onramp-provider-layout.tsx
+++ b/src/app/pages/buy/components/onramp-provider-layout.tsx
@@ -4,17 +4,20 @@ import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { Caption, Title } from '@app/components/typography';
 import { PrimaryButton } from '@app/components/primary-button';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { BuyTokensSelectors } from '@tests/page-objects/buy-tokens-selectors';
 
 const providersInfo = {
   transak: {
     title: 'Transak',
     body: 'Non-US residents can purchase STX with credit card, debit card, or bank transfer via Transak.',
     cta: 'Buy on Transak',
+    test_id: 'BtnTransak',
   },
   okcoin: {
     title: 'Okcoin',
     body: 'Non-US residents can purchase STX with credit card, debit card, or bank transfer via Okcoin.',
     cta: 'Buy on Okcoin',
+    test_id: 'BtnOkCoin',
   },
 };
 
@@ -29,7 +32,7 @@ interface OnrampProviderLayoutProps {
 }
 
 export const OnrampProviderLayout = ({ provider, providerUrl }: OnrampProviderLayoutProps) => {
-  const { title, cta, body } = providersInfo[provider as keyof ProvidersUrl];
+  const { title, cta, body, test_id } = providersInfo[provider as keyof ProvidersUrl];
   const analytics = useAnalytics();
   const goToProviderWebsite = () => {
     void analytics.track('select_buy_option', { provider });
@@ -41,7 +44,12 @@ export const OnrampProviderLayout = ({ provider, providerUrl }: OnrampProviderLa
         <Title marginBottom="10">{title}</Title>
         <Caption>{body}</Caption>
       </Stack>
-      <PrimaryButton onClick={goToProviderWebsite}>{cta}</PrimaryButton>
+      <PrimaryButton
+        onClick={goToProviderWebsite}
+        data-testid={BuyTokensSelectors[test_id as keyof typeof BuyTokensSelectors]}
+      >
+        {cta}
+      </PrimaryButton>
     </Stack>
   );
 };

--- a/src/app/pages/home/components/buy-button.tsx
+++ b/src/app/pages/home/components/buy-button.tsx
@@ -3,6 +3,7 @@ import { ChainID } from '@stacks/transactions';
 import { useHasFiatProviders } from '@app/query/hiro-config/hiro-config.query';
 import { BuyTxButton } from './tx-button';
 import { useCurrentNetworkState } from '@app/store/network/networks.hooks';
+import { BuyTokensSelectors } from '@tests/page-objects/buy-tokens-selectors';
 
 const BuyButtonFallback = memo(() => <BuyTxButton isDisabled />);
 
@@ -14,7 +15,7 @@ export const BuyButton = () => {
 
   return (
     <Suspense fallback={<BuyButtonFallback />}>
-      <BuyTxButton />
+      <BuyTxButton data-testid={BuyTokensSelectors.BtnBuyTokens} />
     </Suspense>
   );
 };

--- a/src/app/pages/onboarding/magic-recovery-code/magic-recovery-code.tsx
+++ b/src/app/pages/onboarding/magic-recovery-code/magic-recovery-code.tsx
@@ -7,6 +7,7 @@ import { useMountEffect } from '@app/common/hooks/use-mount-effect';
 import { ErrorLabel } from '@app/components/error-label';
 import { Caption } from '@app/components/typography';
 import { Header } from '@app/components/header';
+import { WalletPageSelectors } from '@tests/page-objects/wallet.selectors';
 import { PrimaryButton } from '@app/components/primary-button';
 import { CenteredPageContainer } from '@app/components/centered-page-container';
 import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
@@ -25,7 +26,10 @@ export const MagicRecoveryCode = memo(() => {
   return (
     <CenteredPageContainer>
       <Stack as="form" maxWidth={CENTERED_FULL_PAGE_MAX_WIDTH} onSubmit={onSubmit} spacing="loose">
-        <Caption textAlign={['left', 'center']}>
+        <Caption
+          textAlign={['left', 'center']}
+          data-testid={WalletPageSelectors.MagicRecoveryMessage}
+        >
           You entered a Magic Recovery Code. Enter the password you set when you first created your
           Blockstack ID.
         </Caption>

--- a/src/app/pages/send-tokens/components/asset-search/asset-search.tsx
+++ b/src/app/pages/send-tokens/components/asset-search/asset-search.tsx
@@ -148,6 +148,7 @@ const AssetSearchField = memo(
             onFocus={() => {
               openMenu();
             }}
+            data-testid={`asset-select`}
             autoFocus={autoFocus}
           />
         </Box>

--- a/src/app/pages/send-tokens/components/asset-search/selected-asset.tsx
+++ b/src/app/pages/send-tokens/components/asset-search/selected-asset.tsx
@@ -52,7 +52,13 @@ const SelectedAssetItem = memo(({ hideArrow, ...rest }: { hideArrow?: boolean } 
         </AssetAvatar>
 
         <Stack flexGrow={1}>
-          <Text display="block" fontWeight="400" fontSize={2} color="ink.1000">
+          <Text
+            display="block"
+            fontWeight="400"
+            fontSize={2}
+            color="ink.1000"
+            data-testid={'selected-asset-option'}
+          >
             {name}
           </Text>
           <Caption>{ticker}</Caption>

--- a/src/app/pages/send-tokens/components/memo-field.tsx
+++ b/src/app/pages/send-tokens/components/memo-field.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { useFormikContext } from 'formik';
 import { Input, InputGroup, Stack, StackProps, Text } from '@stacks/ui';
 import { ErrorLabel } from '@app/components/error-label';
+import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
 interface FieldProps extends StackProps {
   value: string;
@@ -26,10 +27,11 @@ export const MemoField = memo(({ value, error, ...props }: FieldProps) => {
           onChange={handleChange}
           placeholder="Enter an message (optional)"
           autoComplete="off"
+          data-testid={SendFormSelectors.MemoField}
         />
       </InputGroup>
       {error && (
-        <ErrorLabel>
+        <ErrorLabel data-testid={SendFormSelectors.MemoFieldErrorLabel}>
           <Text textStyle="caption">{error}</Text>
         </ErrorLabel>
       )}

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-actions.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-actions.tsx
@@ -2,6 +2,7 @@ import { StacksTransaction } from '@stacks/transactions';
 import { Button, Stack } from '@stacks/ui';
 
 import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
+import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
 interface SendTokensConfirmActionsProps {
   onUserConfirmBroadcast: () => void;
@@ -21,6 +22,7 @@ export function SendTokensConfirmActions(props: SendTokensConfirmActionsProps): 
         onClick={handleSubmit}
         isLoading={!transaction || isLoading}
         type="submit"
+        data-testid={SendFormSelectors.SendToken}
       >
         Send
       </Button>

--- a/test-app/src/components/auth.tsx
+++ b/test-app/src/components/auth.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button, Text, Box, ButtonGroup } from '@stacks/ui';
 import { useConnect } from '@stacks/connect-react';
+import { OnboardingSelectors } from '@tests/integration/onboarding.selectors';
 
 export const Auth: React.FC = () => {
   const { doOpenAuth } = useConnect();
@@ -10,7 +11,12 @@ export const Auth: React.FC = () => {
         Sign in with your Hiro Wallet to try out a demo of the Stacks 2.0 blockchain.
       </Text>
       <ButtonGroup spacing={'base'} mt={'base-loose'}>
-        <Button size="lg" mode="primary" onClick={() => doOpenAuth()} data-testid="sign-up">
+        <Button
+          size="lg"
+          mode="primary"
+          onClick={() => doOpenAuth()}
+          data-testid={OnboardingSelectors.SignUpBtn}
+        >
           Sign up
         </Button>
       </ButtonGroup>

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -37,6 +37,7 @@ import { useSTXAddress } from '@common/use-stx-address';
 import { TransactionSigningSelectors } from '@tests/page-objects/transaction-signing.selectors';
 
 import { ExplorerLink } from './explorer-link';
+import { WalletPageSelectors } from '@tests/page-objects/wallet.selectors';
 
 export const Debugger = () => {
   const { doContractCall, doSTXTransfer, doContractDeploy } = useConnect();
@@ -64,7 +65,7 @@ export const Debugger = () => {
     };
 
     const sponsoredTx = await sponsorTransaction(sponsorOptions);
-    return await broadcastTransaction(sponsoredTx, network);
+    return broadcastTransaction(sponsoredTx, network);
   };
 
   const callBnsTransfer = async () => {
@@ -327,7 +328,7 @@ export const Debugger = () => {
       </Text>
       {txId && (
         <Text textStyle="body.large" display="block" my={'base'}>
-          <Text color="green" fontSize={1}>
+          <Text color="green" fontSize={1} data-testid={WalletPageSelectors.StatusMessage}>
             Successfully broadcasted &quot;{txType}&quot;
           </Text>
           <ExplorerLink txId={txId} />

--- a/tests/integration/buy-tokens/buy-tokens.spec.ts
+++ b/tests/integration/buy-tokens/buy-tokens.spec.ts
@@ -1,0 +1,45 @@
+import { RouteUrls } from '@shared/route-urls';
+
+import { WalletPage } from '../../page-objects/wallet.page';
+import { BrowserDriver, setupBrowser } from '../utils';
+import { SECRET_KEY_2 } from '@tests/mocks';
+import { BuyTokensPage } from '@tests/page-objects/buy-tokens-page';
+
+jest.setTimeout(60_0000);
+jest.retryTimes(process.env.CI ? 2 : 0);
+
+describe('Buy tokens test', () => {
+  const BEFORE_EACH_TIMEOUT = 600000;
+
+  let browser: BrowserDriver;
+  let walletPage: WalletPage;
+  let buyTokensPage: BuyTokensPage;
+
+  beforeEach(async () => {
+    browser = await setupBrowser();
+    walletPage = await WalletPage.init(browser, RouteUrls.Onboarding);
+    await walletPage.signIn(SECRET_KEY_2);
+    await walletPage.waitForHomePage();
+    await walletPage.goToBuyForm();
+    buyTokensPage = new BuyTokensPage(walletPage.page);
+  }, BEFORE_EACH_TIMEOUT);
+
+  afterEach(async () => {
+    try {
+      await browser.context.close();
+    } catch (error) {}
+  });
+
+  describe('Transak test', () => {
+    it('click button should redirect to transak URL', async () => {
+      await buyTokensPage.waitForBtnTransak();
+      await buyTokensPage.clickBtnTransak();
+      await buyTokensPage.page.waitForTimeout(2000);
+      const allPages = await WalletPage.getAllPages(browser);
+      const recentPage = allPages.pop();
+      await recentPage?.waitForLoadState();
+      const URL = await recentPage?.url();
+      expect(URL).toContain('https://staging-global.transak.com');
+    });
+  });
+});

--- a/tests/integration/onboarding.selectors.ts
+++ b/tests/integration/onboarding.selectors.ts
@@ -1,5 +1,6 @@
 export enum OnboardingSelectors {
   AnalyticsAllowBtn = 'analytics-allow-btn',
+  AnalyticsDenyBtn = 'analytics-deny-btn',
   BackUpSecretKeyBtn = 'back-up-secret-key-btn',
   NewPasswordInput = 'set-or-enter-password-input',
   ConfirmPasswordInput = 'confirm-password-input',

--- a/tests/integration/send-tokens/send-tokens.spec.ts
+++ b/tests/integration/send-tokens/send-tokens.spec.ts
@@ -1,10 +1,12 @@
 import { delay } from '@app/common/utils';
 import { RouteUrls } from '@shared/route-urls';
 import { SECRET_KEY_2 } from '@tests/mocks';
+import { SendFormErrorMessages } from '@app/common/error-messages';
+import { UserAreaSelectors } from '@tests/integration/user-area.selectors';
 
 import { SendPage } from '../../page-objects/send-form.page';
 import { WalletPage } from '../../page-objects/wallet.page';
-import { BrowserDriver, setupBrowser } from '../utils';
+import { BrowserDriver, createTestSelector, setupBrowser } from '../utils';
 
 jest.setTimeout(120_000);
 jest.retryTimes(process.env.CI ? 2 : 0);
@@ -13,16 +15,24 @@ describe(`Send tokens flow`, () => {
   let browser: BrowserDriver;
   let walletPage: WalletPage;
   let sendForm: SendPage;
+  let copiedAddress: string;
+
+  const readClipboard = async () => {
+    return await walletPage.page.evaluate(() => window.navigator.clipboard.readText());
+  };
 
   beforeEach(async () => {
     browser = await setupBrowser();
     walletPage = await WalletPage.init(browser, RouteUrls.Onboarding);
     await walletPage.signIn(SECRET_KEY_2);
     await walletPage.waitForHomePage();
+    await walletPage.page.click(createTestSelector(UserAreaSelectors.AccountCopyAddress));
+    copiedAddress = await readClipboard();
+
     await walletPage.goToSendForm();
     sendForm = new SendPage(walletPage.page);
     await sendForm.waitForSendMaxButton();
-  }, 30_000);
+  }, 40_000);
 
   afterEach(async () => {
     try {
@@ -44,7 +54,8 @@ describe(`Send tokens flow`, () => {
     it('defaults to the middle fee estimate', async () => {
       await sendForm.inputToAmountField('100000000');
       await sendForm.inputToAddressField('slkfjsdlkfjs');
-      const defaultFeeEstimate = await sendForm.page.$(sendForm.getSelector('$feeEstimateItem'));
+      await sendForm.waitForFeeEstimateItem();
+      const defaultFeeEstimate = await sendForm.page.$(sendForm.getSelector('$standardFeeSelect'));
       const label = await defaultFeeEstimate?.innerText();
       await delay(500);
       expect(label).toEqual('Standard');
@@ -53,8 +64,9 @@ describe(`Send tokens flow`, () => {
     it('can select the low fee estimate', async () => {
       await sendForm.inputToAmountField('100000000');
       await sendForm.inputToAddressField('slkfjsdlkfjs');
+      await sendForm.waitForFeeEstimateItem();
       await sendForm.selectFirstFeeEstimate();
-      const lowFeeEstimate = await sendForm.page.$(sendForm.getSelector('$feeEstimateItem'));
+      const lowFeeEstimate = await sendForm.page.$(sendForm.getSelector('$lowFeeSelect'));
       const label = await lowFeeEstimate?.innerText();
       expect(label).toEqual('Low');
     });
@@ -87,6 +99,33 @@ describe(`Send tokens flow`, () => {
       const errorMsgElement = await sendForm.page.$$(sendForm.getSelector('$stxAddressFieldError'));
       const errorMessage = await errorMsgElement[0].innerText();
       expect(errorMessage).toContain('The address is for the incorrect Stacks network');
+    });
+
+    it('validates that the address used is invalid', async () => {
+      await sendForm.inputToAmountField('0.000001');
+      await sendForm.inputToAddressField('ST3TZVWsss4VTZA1WZN2TB6RQ5J8RACHZYMWMM2N1HT2');
+      await sendForm.clickPreviewTxBtn();
+      const errorMsgElement = await sendForm.page.$$(sendForm.getSelector('$stxAddressFieldError'));
+      const errorMessage = await errorMsgElement[0].innerText();
+      expect(errorMessage).toContain(SendFormErrorMessages.InvalidAddress);
+    });
+
+    it('validates that the address is same as sender', async () => {
+      await sendForm.inputToAmountField('0.000001');
+      await sendForm.inputToAddressField(copiedAddress);
+      await sendForm.clickPreviewTxBtn();
+      const errorMsgElement = await sendForm.page.$$(sendForm.getSelector('$stxAddressFieldError'));
+      const errorMessage = await errorMsgElement[0].innerText();
+      expect(errorMessage).toContain(SendFormErrorMessages.SameAddress);
+    });
+
+    it('validates that the amount must be number', async () => {
+      await sendForm.inputToAmountField('aaaaaa');
+      await sendForm.inputToAddressField('SP15DFMYE5JDDKRMAZSC6947TCERK36JM4KD5VKZD');
+      await sendForm.clickPreviewTxBtn();
+      const errorMsgElement = await sendForm.page.$$(sendForm.getSelector('$amountFieldError'));
+      const errorMessage = await errorMsgElement[0].innerText();
+      expect(errorMessage).toContain(SendFormErrorMessages.MustBeNumber);
     });
 
     it('validates against a negative amount of tokens', async () => {

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -145,7 +145,7 @@ export const debug = async (page: Page) => {
 export const selectTestnet = async (wallet: WalletPage) => {
   await wallet.clickSettingsButton();
   await wallet.page.click(createTestSelector(SettingsSelectors.ChangeNetworkAction));
-  await wait(1000);
+  await wait(1500);
 
   const networkListItems = await wallet.page.$$(
     createTestSelector(SettingsSelectors.NetworkListItem)

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -149,3 +149,8 @@ export const TEST_ACCOUNTS_WITH_ADDRESS = [
 ];
 export const SECRET_KEY_2 =
   'derive plug aerobic cook until crucial school fine cushion panda ready crew photo typical nuclear ride steel indicate cupboard potato ignore bamboo script galaxy';
+
+export const MAGIC_RECOVERY_KEY =
+  'KDR6O8gKXGmstxj4d2oQqCi806M/Cmrbiatc6g7MkQQLVreRA95IoPtvrI3N230jTTGb2XWT5joRFKPfY/2YlmRz1brxoaDJCNS4z18Iw5Y=';
+
+export const MAGIC_RECOVERY_PASSWORD = 'test202020';

--- a/tests/page-objects/buy-tokens-page.ts
+++ b/tests/page-objects/buy-tokens-page.ts
@@ -1,0 +1,42 @@
+import { Page } from 'playwright-core';
+import { createTestSelector } from '../integration/utils';
+import { BuyTokensSelectors } from '@tests/page-objects/buy-tokens-selectors';
+
+const selectors = {
+  $btnBuyTokens: createTestSelector(BuyTokensSelectors.BtnBuyTokens),
+  $btnTransak: createTestSelector(BuyTokensSelectors.BtnTransak),
+  $btnOkCoin: createTestSelector(BuyTokensSelectors.BtnOkCoin),
+};
+
+export class BuyTokensPage {
+  selectors = selectors;
+  page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async select(selector: keyof typeof selectors) {
+    return this.page.$(selectors[selector]);
+  }
+
+  getSelector(selector: keyof typeof selectors) {
+    return this.selectors[selector];
+  }
+
+  async waitForBtnTransak() {
+    await this.page.waitForSelector(this.selectors.$btnTransak);
+  }
+
+  async clickBtnTransak() {
+    await this.page.click(this.selectors.$btnTransak);
+  }
+
+  async waitForBtnOkCoin() {
+    await this.page.waitForSelector(this.selectors.$btnOkCoin);
+  }
+
+  async clickBtnOkCoin() {
+    await this.page.click(this.selectors.$btnOkCoin);
+  }
+}

--- a/tests/page-objects/buy-tokens-selectors.ts
+++ b/tests/page-objects/buy-tokens-selectors.ts
@@ -1,0 +1,5 @@
+export enum BuyTokensSelectors {
+  BtnBuyTokens = 'btn-buy-tokens',
+  BtnTransak = 'btn-transak',
+  BtnOkCoin = 'btn-okcoin',
+}

--- a/tests/page-objects/demo.page.ts
+++ b/tests/page-objects/demo.page.ts
@@ -1,9 +1,10 @@
 import { Page, BrowserContext } from 'playwright-core';
 import { createTestSelector } from '../integration/utils';
+import { OnboardingSelectors } from '@tests/integration/onboarding.selectors';
 
 export class DemoPage {
   static url = 'http://localhost:3000';
-  openConnectBtn = createTestSelector('sign-up');
+  openConnectBtn = createTestSelector(OnboardingSelectors.SignUpBtn);
 
   page: Page;
 

--- a/tests/page-objects/send-form.page.ts
+++ b/tests/page-objects/send-form.page.ts
@@ -1,18 +1,37 @@
 import { Page } from 'playwright-core';
 import { createTestSelector } from '../integration/utils';
 import { SendFormSelectors } from './send-form.selectors';
+import { TransactionSigningSelectors } from '@tests/page-objects/transaction-signing.selectors';
+import { WalletPageSelectors } from '@tests/page-objects/wallet.selectors';
 
 const selectors = {
   $btnSendMaxBalance: createTestSelector(SendFormSelectors.BtnSendMaxBalance),
   $amountField: createTestSelector(SendFormSelectors.InputAmountField),
   $amountFieldError: createTestSelector(SendFormSelectors.InputAmountFieldErrorLabel),
+  $memoField: createTestSelector(SendFormSelectors.MemoField),
+  $memoFieldError: createTestSelector(SendFormSelectors.MemoFieldErrorLabel),
   $stxAddressField: createTestSelector(SendFormSelectors.InputRecipientField),
   $stxAddressFieldError: createTestSelector(SendFormSelectors.InputRecipientFieldErrorLabel),
-  $feeEstimateItem: createTestSelector(SendFormSelectors.FeeEstimateItem),
   $feeEstimateSelect: createTestSelector(SendFormSelectors.FeeEstimateSelect),
   $customFeeField: createTestSelector(SendFormSelectors.InputCustomFeeField),
   $previewBtn: createTestSelector(SendFormSelectors.BtnPreviewSendTx),
   $confirmDetails: createTestSelector(SendFormSelectors.ConfirmDetails),
+  $stxTokenOption: createTestSelector(SendFormSelectors.StxTokenOption),
+  $stellaTokenOption: createTestSelector(SendFormSelectors.StellaTokenOption),
+  $lowFeeSelect: createTestSelector(SendFormSelectors.LowFeeOption),
+  $highFeeSelect: createTestSelector(SendFormSelectors.HighFeeOption),
+  $standardFeeSelect: createTestSelector(SendFormSelectors.StandardFeeOption),
+  $customFeeSelect: createTestSelector(SendFormSelectors.CustomFeeOption),
+  $assetSelect: createTestSelector(SendFormSelectors.AssetSelect),
+  $selectedAssetOption: createTestSelector(SendFormSelectors.SelectedAssetOption),
+  $transferMessage: createTestSelector(SendFormSelectors.TransferMessage),
+  $feeError: createTestSelector(SendFormSelectors.InputCustomFeeFieldError),
+  $account1: createTestSelector(SendFormSelectors.OptionAccount1),
+  $confirmTransaction: createTestSelector(TransactionSigningSelectors.BtnConfirmTransaction),
+  $statusMessage: createTestSelector(WalletPageSelectors.StatusMessage),
+  $sendToken: createTestSelector(SendFormSelectors.SendToken),
+  $pendingStatus: createTestSelector(SendFormSelectors.PendingStatus),
+  $sentTokenValue: createTestSelector(SendFormSelectors.SentTokenValue),
 };
 
 export class SendPage {
@@ -55,13 +74,18 @@ export class SendPage {
     await field?.type(input);
   }
 
+  async inputToMemoField(input: string) {
+    const field = await this.page.$(this.selectors.$memoField);
+    await field?.type(input);
+  }
+
   async waitForFeeEstimateItem() {
-    await this.page.waitForSelector(this.selectors.$feeEstimateItem);
+    await this.page.waitForSelector(this.selectors.$standardFeeSelect);
   }
 
   async clickFeeEstimateItem() {
     await this.waitForFeeEstimateItem();
-    await this.page.click(this.selectors.$feeEstimateItem);
+    await this.page.click(this.selectors.$standardFeeSelect);
   }
 
   async waitForFeeEstimateSelect() {
@@ -71,13 +95,13 @@ export class SendPage {
   async selectFirstFeeEstimate() {
     await this.clickFeeEstimateItem();
     await this.waitForFeeEstimateSelect();
-    await this.page.locator(this.getSelector('$feeEstimateItem')).nth(1).click();
+    await this.page.locator(this.getSelector('$lowFeeSelect')).click();
   }
 
   async inputToCustomFeeField(input: string) {
     await this.clickFeeEstimateItem();
     await this.waitForFeeEstimateSelect();
-    await this.page.locator(this.getSelector('$feeEstimateItem')).last().click();
+    await this.page.locator(this.getSelector('$customFeeSelect')).click();
 
     const field = await this.page.$(this.selectors.$customFeeField);
     await field?.type(input);
@@ -94,5 +118,74 @@ export class SendPage {
   async selectStxFromDropdown() {
     await this.page.waitForSelector('[data-asset="stx"]');
     await this.page.click('[data-asset="stx"]');
+  }
+
+  async clickSTXTokenOption() {
+    await this.page.click(this.selectors.$stxTokenOption);
+  }
+
+  async clickStellaTokenOption() {
+    await this.page.click(this.selectors.$stellaTokenOption);
+  }
+
+  async clickAssetSelect() {
+    await this.page.click(this.selectors.$assetSelect);
+  }
+
+  async clickSelectedAsset() {
+    await this.page.click(this.selectors.$selectedAssetOption);
+  }
+
+  async clickFeeEstimateSelect(value: keyof typeof selectors) {
+    await this.page.click(this.selectors[value]);
+  }
+
+  async selectLowFeeOption() {
+    await this.page.click(this.selectors.$lowFeeSelect);
+  }
+
+  async selectHighFeeOption() {
+    await this.page.click(this.selectors.$highFeeSelect);
+  }
+
+  async selectCustomFeeOption() {
+    await this.page.click(this.selectors.$customFeeSelect);
+  }
+
+  async waitForAmountField() {
+    await this.page.waitForSelector(this.selectors.$amountField);
+  }
+
+  async waitForSelectedAssetOption() {
+    await this.page.waitForSelector(this.selectors.$selectedAssetOption);
+  }
+
+  async waitForAssetSelect() {
+    await this.page.waitForSelector(this.selectors.$assetSelect);
+  }
+
+  async waitForPreview(selector: keyof typeof selectors) {
+    await this.page.waitForSelector(this.selectors[selector]);
+  }
+
+  async inputFee(input: string) {
+    const field = await this.page.$(this.selectors.$customFeeField);
+    await field?.type(input);
+  }
+
+  async getCustomFeeValue() {
+    return this.page.$eval(this.selectors.$customFeeField, (el: HTMLInputElement) => el.value);
+  }
+
+  async clickFirstAccount() {
+    await this.page.click(this.selectors.$account1);
+  }
+
+  async clickConfirmTransaction() {
+    await this.page.click(this.selectors.$confirmTransaction);
+  }
+
+  async clickSendToken() {
+    await this.page.click(this.selectors.$sendToken);
   }
 }

--- a/tests/page-objects/send-form.selectors.ts
+++ b/tests/page-objects/send-form.selectors.ts
@@ -7,12 +7,31 @@ export enum SendFormSelectors {
   InputRecipientField = 'input-recipient-field',
   InputRecipientFieldErrorLabel = 'input-recipient-field-error-label',
 
-  FeeEstimateItem = 'fee-estimate-item',
+  MemoField = 'memo-field',
+  MemoFieldErrorLabel = 'memo-field-error-label',
+
   FeeEstimateSelect = 'fee-estimate-select',
+  LowFeeOption = 'low-fee',
+  HighFeeOption = 'high-fee',
+  StandardFeeOption = 'standard-fee',
+  CustomFeeOption = 'custom-fee',
 
   InputCustomFeeField = 'input-custom-fee-field',
   InputCustomFeeFieldErrorLabel = 'input-custom-fee-field-error-label',
+  InputCustomFeeFieldError = 'input-custom-fee-field-error',
 
   BtnPreviewSendTx = 'btn-preview-send-tx',
+  TransferMessage = 'transfer-message',
   ConfirmDetails = 'confirm-details',
+  SendToken = 'send-token',
+
+  PendingStatus = 'pending',
+  SentTokenValue = 'sent-token-value',
+
+  AssetSelect = 'asset-select',
+  SelectedAssetOption = 'selected-asset-option',
+  StxTokenOption = 'asset-Stacks Token',
+  StellaTokenOption = 'asset-stella-token',
+
+  OptionAccount1 = 'account-account-1-0',
 }

--- a/tests/page-objects/wallet.page.ts
+++ b/tests/page-objects/wallet.page.ts
@@ -4,6 +4,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { OnboardingSelectors } from '@tests/integration/onboarding.selectors';
 import { HomePageSelectors } from '@tests/page-objects/home-page.selectors';
 import { SettingsSelectors } from '@tests/integration/settings.selectors';
+import { BuyTokensSelectors } from '@tests/page-objects/buy-tokens-selectors';
 
 import {
   createTestSelector,
@@ -19,23 +20,28 @@ export class WalletPage {
   $signUpButton = createTestSelector(OnboardingSelectors.SignUpBtn);
   $signInButton = createTestSelector(OnboardingSelectors.SignInLink);
   $analyticsAllowButton = createTestSelector(OnboardingSelectors.AnalyticsAllowBtn);
+  $analyticsDenyButton = createTestSelector(OnboardingSelectors.AnalyticsDenyBtn);
   homePage = createTestSelector('home-page');
   $textareaReadOnlySeedPhrase = `${createTestSelector('textarea-seed-phrase')}[data-loaded="true"]`;
   $buttonSignInKeyContinue = createTestSelector(OnboardingSelectors.SignInBtn);
   setPasswordDone = createTestSelector(OnboardingSelectors.SetPasswordBtn);
+  $passwordInput = createTestSelector(SettingsSelectors.EnterPasswordInput);
   $newPasswordInput = createTestSelector(OnboardingSelectors.NewPasswordInput);
   $confirmPasswordInput = createTestSelector(OnboardingSelectors.ConfirmPasswordInput);
   sendTokenBtnSelector = createTestSelector(WalletPageSelectors.BtnSendTokens);
+  buyTokenBtnSelector = createTestSelector(BuyTokensSelectors.BtnBuyTokens);
   $confirmBackedUpSecretKey = createTestSelector(OnboardingSelectors.BackUpSecretKeyBtn);
   lowerCharactersErrMsg =
     'text="You can only use lowercase letters (a–z), numbers (0–9), and underscores (_)."';
   signInKeyError = createTestSelector('sign-in-seed-error');
   password = 'mysecretreallylongpassword';
   $settingsButton = createTestSelector(SettingsSelectors.MenuBtn);
+  $contractCallButton = createTestSelector('btn-contract-call');
   $settingsViewSecretKey = createTestSelector(SettingsSelectors.ViewSecretKeyListItem);
   $homePageBalancesList = createTestSelector(HomePageSelectors.BalancesList);
   $createAccountButton = createTestSelector(SettingsSelectors.BtnCreateAccount);
   $createAccountDone = createTestSelector(SettingsSelectors.BtnCreateAccountDone);
+  $statusMessage = createTestSelector(WalletPageSelectors.StatusMessage);
   $hiroWalletLogo = createTestSelector(OnboardingSelectors.HiroWalletLogoRouteToHome);
   $signOutConfirmHasBackupCheckbox = createTestSelector(
     SettingsSelectors.SignOutConfirmHasBackupCheckbox
@@ -43,6 +49,7 @@ export class WalletPage {
   $signOutDeleteWalletBtn = createTestSelector(SettingsSelectors.BtnSignOutActuallyDeleteWallet);
   $enterPasswordInput = createTestSelector(SettingsSelectors.EnterPasswordInput);
   $unlockWalletBtn = createTestSelector(SettingsSelectors.UnlockWalletBtn);
+  $magicRecoveryMessage = createTestSelector(WalletPageSelectors.MagicRecoveryMessage);
 
   page: Page;
 
@@ -61,8 +68,17 @@ export class WalletPage {
     return new this(page);
   }
 
+  static async getAllPages(browser: BrowserDriver) {
+    const pages = await browser.context.pages();
+    return pages;
+  }
+
   async clickAllowAnalytics() {
     await this.page.click(this.$analyticsAllowButton);
+  }
+
+  async clickDenyAnalytics() {
+    await this.page.click(this.$analyticsDenyButton);
   }
 
   async clickSignUp() {
@@ -75,6 +91,10 @@ export class WalletPage {
 
   async clickSettingsButton() {
     await this.page.click(this.$settingsButton);
+  }
+
+  async clickContractCall() {
+    await this.page.click(this.$contractCallButton);
   }
 
   async waitForHomePage() {
@@ -103,6 +123,10 @@ export class WalletPage {
 
   async waitForLoginPage() {
     await this.page.waitForSelector(this.$signInButton, { timeout: 3000 });
+  }
+
+  async waitForStatusMessage() {
+    await this.page.waitForSelector(this.$statusMessage, { timeout: 20000 });
   }
 
   async loginWithPreviousSecretKey(secretKey: string) {
@@ -175,6 +199,14 @@ export class WalletPage {
 
   async goToSendForm() {
     await this.page.click(this.sendTokenBtnSelector);
+  }
+
+  async goToBuyForm() {
+    await this.page.click(this.buyTokenBtnSelector);
+  }
+
+  async waitForMagicRecoveryMessage() {
+    await this.page.waitForSelector(this.$magicRecoveryMessage, { timeout: 30000 });
   }
 
   /** Sign up with a randomly generated seed phrase */

--- a/tests/page-objects/wallet.selectors.ts
+++ b/tests/page-objects/wallet.selectors.ts
@@ -1,3 +1,5 @@
 export enum WalletPageSelectors {
   BtnSendTokens = 'btn-send-tokens',
+  StatusMessage = 'status-message',
+  MagicRecoveryMessage = 'magic-recovery-message',
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1789998377).<!-- Sticky Header Marker -->

Hey team this PR includes 33 new test for bugs we have encountered recently, recommendations by Kyran for functionality that we should test and the addition of test from the automation test documentation in Notion.

MAGIC RECOVERY CODE TEST:
Test users can log in with a magic recover code

LOCKED WALLET TEST:
Test locked wallets display unlocks screen instead of white screen “Stacksart bug”

TRANSACTION SIGNING:
Test transaction signing for token send

ACTIVITY FEED BUG:
Test activity page displays pending transaction

UPDATE TEST TO SKIP METRIC:
Test now select deny button for all automation test to exclude skewing metrics

TRANSACTION FEES TESTING:
For STX Token:
Verify transaction fees work when fees is low
Verify transaction fees work when fees is standard
Verify transaction fees work when fees is high
Verify transaction fees work when fees is custom
validates that custom fee has more than 6 decimal places
validates that custom fee must be positive
validates that the memo must be less than 34-bytes
For STELLA Token:
Verify transaction fees work when fees is low
Verify transaction fees work when fees is standard
Verify transaction fees work when fees is high
Verify transaction fees work when fees is custom
validates that custom fee has more than 6 decimal places
validates that custom fee must be positive
validates that the amount must be more than zero
validates that the memo must be less than 34-bytes
validates that the amount field can have only 9 decimals

ERROR MESSAGING:
Validates that the amount field can only be number
Validates that the address is for the incorrect Stacks network
Validates that amount is greater than the available balance

BUY BUTTON:
Transak test:
Test buy button redirect load and take user to 3rd part site. Clicking button should redirect to transak URL

CONTRACT CALL TRANSACTION FEES:
Verify contract call works when fees is low
Verify contract call works when fees is standard
Verify contract call workswhen fees is high
Verify contract call works when fees is custom
Error messages:
validates that custom fee has more than 6 decimal places
validates that custom fee must be positive
validates that the address used is invalid
validates that the address is same as sender
validates that the amount must be number



<!--
PR reminders:
  - Link issues to PR
  - Update UserX board
  - Use checkmarks for progress
  - Link PRs in other issues

Tips for good PR etiquette https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/
-->

cc/ @kyranjamie @fbwoolf @andresgalante @Eshwari007 @beguene @He1DAr
