### PR TITLE
fix: hitting api with metadata queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "jotai": "1.5.3",
     "jotai-query-toolkit": "0.1.7",
     "jsontokens": "3.0.0",
+    "limiter": "2.1.0",
     "mdi-react": "7.5.0",
     "object-hash": "2.2.0",
     "pino": "7.6.0",

--- a/src/app/common/network/is-response-code.ts
+++ b/src/app/common/network/is-response-code.ts
@@ -1,0 +1,3 @@
+export function isResponseCode(responseCode: number) {
+  return (response: any) => 'status' in response && response.status === responseCode;
+}

--- a/src/app/query/tokens/fungible-token-metadata.query.ts
+++ b/src/app/query/tokens/fungible-token-metadata.query.ts
@@ -1,21 +1,34 @@
 import { useQueries, useQuery } from 'react-query';
+import { RateLimiter } from 'limiter';
 
 import { useApi, Api } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetwork } from '@app/common/hooks/use-current-network';
+import { isResponseCode } from '@app/common/network/is-response-code';
 
-const staleTime = 10 * 60 * 1000;
+const limiter = new RateLimiter({ tokensPerInterval: 1, interval: 750 });
+
+const staleTime = 20 * 60 * 1000;
 
 const queryOptions = {
   keepPreviousData: true,
   cacheTime: staleTime,
+  staleTime: staleTime,
   refetchOnMount: false,
   refetchInterval: false,
   refetchOnReconnect: false,
-  retryDelay: 120_000,
+  retry: 2,
+  retryDelay: 2 * 60 * 1000,
 } as const;
 
+const is404 = isResponseCode(404);
+
 function fetchUnanchoredAccountInfo(api: Api) {
-  return (contractId: string) => () => api.tokensApi.getContractFtMetadata({ contractId });
+  return (contractId: string) => async () => {
+    await limiter.removeTokens(1);
+    return api.tokensApi
+      .getContractFtMetadata({ contractId })
+      .catch(error => (is404(error) ? undefined : error));
+  };
 }
 
 export function useGetFungibleTokenMetadataQuery(contractId: string) {

--- a/src/app/store/assets/asset.hooks.ts
+++ b/src/app/store/assets/asset.hooks.ts
@@ -42,6 +42,7 @@ export function useAssetWithMetadata(asset: Asset) {
 export function useSelectedAssetItem() {
   const selectedAssetId = useAtomValue(selectedAssetIdState);
   const assetsWithMetadata = useAssetsWithMetadata();
+
   return useMemo(
     () =>
       assetsWithMetadata?.find(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12325,6 +12325,11 @@ just-debounce-it@*:
   resolved "https://registry.yarnpkg.com/just-debounce-it/-/just-debounce-it-3.0.1.tgz#8c8a4c9327c9523366ec79ac9a959a938153bd2f"
   integrity sha512-6EQWOpRV8fm/ame6XvGBSxvsjoMbqj7JS9TV/4Q9aOXt9DQw22GBfTGP6gTAqcBNN/PbzlwtwH7jtM0k9oe9pg==
 
+just-performance@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/just-performance/-/just-performance-4.3.0.tgz#cc2bc8c9227f09e97b6b1df4cd0de2df7ae16db1"
+  integrity sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q==
+
 jwa@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
@@ -12446,6 +12451,13 @@ lighthouse-logger@^1.0.0:
   dependencies:
     debug "^2.6.9"
     marky "^1.2.2"
+
+limiter@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-2.1.0.tgz#d38d7c5b63729bb84fb0c4d8594b7e955a5182a2"
+  integrity sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw==
+  dependencies:
+    just-performance "4.3.0"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1783426263).<!-- Sticky Header Marker -->

I've noticed lately we're hitting the metadata endpoint pretty hard, especially for accounts with a lot of activity/balances.

![image](https://user-images.githubusercontent.com/1618764/152137580-077bb3d8-0619-42ee-80ed-154b6bb2b15f.png)

 This stems from our use of `useAssetWithMetadata`, which iterates all assets, querying the metadata endpoint for them. This was happening pretty often for a couple of reasons:

- `stateTime` was not set (only `cacheTime`)
- `404`s were handled as errors, then subsequently retried

To address this, we now:
- Catch the `404` and return `undefined` so the query counts as a success
- Cache the response of this endpoint for longer, ~20mins~ 6 hours, the API treats this data as immutable.
- Rate limit this endpoint's max requests to 1 in every 750ms. See [limiter](https://github.com/jhurliman/node-rate-limiter) library here ([1.2kb](https://bundlephobia.com/package/limiter@2.1.0))

https://user-images.githubusercontent.com/1618764/152139019-4ba94b67-2902-4784-8c0b-6a7b4ccba7c3.mp4

_Video describes clearing React Query cache, and reloading home screen with rate limiting in place_


