### PR TITLE
fix: send max invalid fee calculation

### DIFF
--- a/src/app/pages/send-tokens/components/amount-field.tsx
+++ b/src/app/pages/send-tokens/components/amount-field.tsx
@@ -60,7 +60,7 @@ function AmountFieldBase(props: AmountFieldProps) {
           />
           {balances && selectedAsset ? (
             <SendMaxButton
-              isLoadingFee={!values.fee}
+              fee={values.fee}
               onClick={() => handleSetSendMaxTracked()}
               selectedAsset={selectedAsset}
             />

--- a/src/app/pages/send-tokens/components/send-max-button.tsx
+++ b/src/app/pages/send-tokens/components/send-max-button.tsx
@@ -1,8 +1,10 @@
+import { useCallback } from 'react';
 import { toast } from 'react-hot-toast';
 import { Box, ButtonProps, color } from '@stacks/ui';
 
 import { AssetWithMeta } from '@app/common/asset-types';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
+import { isUndefined } from '@app/common/utils';
 
 function SendMaxButtonAction(props: ButtonProps) {
   return (
@@ -28,17 +30,21 @@ function SendMaxButtonAction(props: ButtonProps) {
 }
 
 interface SendMaxProps {
-  isLoadingFee: boolean | undefined;
+  fee: string | number | undefined;
   onClick: () => void;
   selectedAsset: AssetWithMeta | undefined;
 }
-
 export function SendMaxButton(props: SendMaxProps): JSX.Element | null {
-  const { isLoadingFee, onClick, selectedAsset } = props;
+  const { fee, onClick, selectedAsset } = props;
   const isStx = selectedAsset?.type === 'stx';
 
-  return isLoadingFee && isStx ? (
-    <SendMaxButtonAction onClick={() => toast.error('Unable to calculate max. Try Again.')} />
+  const fireInactiveSendMaxButtonToast = useCallback(() => {
+    if (isUndefined(fee)) toast.error('Loading fee, please try again');
+    toast.error('A fee must be set to calculate max STX transfer amount');
+  }, [fee]);
+
+  return !fee && isStx ? (
+    <SendMaxButtonAction onClick={fireInactiveSendMaxButtonToast} />
   ) : (
     <SendMaxButtonAction onClick={onClick} />
   );

--- a/src/app/pages/send-tokens/hooks/use-send-form-validation.ts
+++ b/src/app/pages/send-tokens/hooks/use-send-form-validation.ts
@@ -4,7 +4,7 @@ import { stxToMicroStx } from '@stacks/ui-utils';
 
 import { useWallet } from '@app/common/hooks/use-wallet';
 import { useSelectedAsset } from '@app/common/hooks/use-selected-asset';
-import { STX_DECIMALS, STX_TRANSFER_TX_SIZE_BYTES } from '@shared/constants';
+import { STX_DECIMALS } from '@shared/constants';
 import { countDecimals, isNumber } from '@app/common/utils';
 import { transactionMemoSchema } from '@app/common/validation/validate-memo';
 import { stxAmountSchema } from '@app/common/validation/currency-schema';
@@ -51,8 +51,9 @@ export const useSendFormValidation = ({ setAssetError }: UseSendFormValidationAr
       stxAmountSchema(formatPrecisionError('STX', STX_DECIMALS)).test({
         message: formatInsufficientBalanceError(availableStxBalance, 'STX'),
         test(value: unknown) {
+          const fee = stxToMicroStx(this.parent.fee);
           if (!availableStxBalance || !isNumber(value)) return false;
-          const availableBalanceLessFee = availableStxBalance.minus(STX_TRANSFER_TX_SIZE_BYTES);
+          const availableBalanceLessFee = availableStxBalance.minus(fee);
           return availableBalanceLessFee.isGreaterThanOrEqualTo(stxToMicroStx(value));
         },
       }),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -8,8 +8,6 @@ export const DEFAULT_FEE_RATE = 400;
 
 export const HUMAN_REACTION_DEBOUNCE_TIME = 250;
 
-export const STX_TRANSFER_TX_SIZE_BYTES = 180;
-
 export const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 
 export const PERSISTENCE_CACHE_TIME = 1000 * 60 * 60 * 12; // 12 hours


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1783877189).<!-- Sticky Header Marker -->

Closes #2175

Fixes bug where old fee calculation was used to calculate the send max amount. Now, the value is pulled from `yup` context. Further, I've adjusted the toast message to send alternate messages depending on whether the fee hasn't yet been loaded, _or_ that it hasn't been set by the user.

https://user-images.githubusercontent.com/1618764/152154232-967e3ae0-cd24-402a-af13-8c6d445046f8.mp4


