### PR TITLE
Test/data testid attr

### DIFF
--- a/src/app/components/asset-item.tsx
+++ b/src/app/components/asset-item.tsx
@@ -121,8 +121,8 @@ export const AssetItem = memo(
                     placement="left-start"
                     label={formatted.isAbbreviated ? amount : undefined}
                   >
-                    <Text fontVariantNumeric="tabular-nums" textAlign="right">
-                      <span data-testid={name}>{formatted.value}</span>
+                    <Text fontVariantNumeric="tabular-nums" textAlign="right" data-testid={name}>
+                      {formatted.value}
                     </Text>
                   </Tooltip>
                   {isDifferent ? <SubBalance amount={subAmount} /> : null}

--- a/src/app/components/event-card.tsx
+++ b/src/app/components/event-card.tsx
@@ -25,8 +25,8 @@ export function EventCard(props: EventCardProps): JSX.Element {
     <>
       <Stack p="base-loose" spacing="base-loose">
         <SpaceBetween position="relative">
-          <Text fontSize={2} fontWeight={500}>
-            <span data-testid={SendFormSelectors.TransferMessage}>{title}</span>
+          <Text fontSize={2} fontWeight={500} data-testid={SendFormSelectors.TransferMessage}>
+            {title}
           </Text>
           {actions && (
             <IconButton size="24px" icon={FiMoreHorizontal} position="absolute" right={0} />

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -328,10 +328,8 @@ export const Debugger = () => {
       </Text>
       {txId && (
         <Text textStyle="body.large" display="block" my={'base'}>
-          <Text color="green" fontSize={1}>
-            <span data-testId={WalletPageSelectors.StatusMessage}>
-              Successfully broadcasted &quot;{txType}&quot;
-            </span>
+          <Text color="green" fontSize={1} data-testid={WalletPageSelectors.StatusMessage}>
+            Successfully broadcasted &quot;{txType}&quot;
           </Text>
           <ExplorerLink txId={txId} />
         </Text>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1784566710).<!-- Sticky Header Marker -->

Moves `data-testid` tag to `<Text/>` elements.

Let's run this a few times and see if it fails @fbwoolf @timstackblock 

- Test run 1 ✅ 
- Test run 2 ✅
- Test run 3 ✅