### PR TITLE
refactor: initial app route, remove legacy prop

### DIFF
--- a/src/app/common/hooks/use-wallet.ts
+++ b/src/app/common/hooks/use-wallet.ts
@@ -9,7 +9,6 @@ import { bytesToText } from '@app/common/store-utils';
 import {
   useEncryptedSecretKeyState,
   useFinishSignInCallback,
-  useHasSetPasswordState,
   useSecretKey,
   useSetLatestNonceCallback,
   useWalletState,
@@ -32,7 +31,6 @@ export function useWallet() {
   const secretKey = useSecretKey();
   const encryptedSecretKey = useEncryptedSecretKeyState();
   const currentAccountIndex = useCurrentAccountIndex();
-  const hasSetPassword = useHasSetPasswordState();
   const currentAccount = useCurrentAccount();
   const currentAccountStxAddress = useCurrentAccountStxAddressState();
   const transactionVersion = useTransactionNetworkVersion();
@@ -74,7 +72,6 @@ export function useWallet() {
     currentNetwork,
     currentNetworkKey,
     encryptedSecretKey,
-    hasSetPassword,
     finishSignIn,
     setLatestNonce,
     setWallet,

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -22,9 +22,8 @@ import { AllowDiagnosticsPage } from '@app/pages/allow-diagnostics/allow-diagnos
 import { BuyPage } from '@app/pages/buy/buy';
 import { BackUpSecretKeyPage } from '@app/pages/onboarding/back-up-secret-key/back-up-secret-key';
 import { WelcomePage } from '@app/pages/onboarding/welcome/welcome';
-import { RouteUrls } from '@shared/route-urls';
 import { useHasStateRehydrated } from '@app/store';
-import { useCurrentKeyDetails } from '@app/store/keys/key.selectors';
+import { RouteUrls } from '@shared/route-urls';
 
 import { useOnWalletLock } from './hooks/use-on-wallet-lock';
 import { useOnSignOut } from './hooks/use-on-sign-out';
@@ -44,13 +43,6 @@ export function AppRoutes(): JSX.Element | null {
   }, [analytics, pathname]);
 
   const hasStateRehydrated = useHasStateRehydrated();
-  const currentKey = useCurrentKeyDetails();
-
-  useEffect(() => {
-    // This ensures the route is correct bc the VaultLoader is slow to set wallet state
-    if (pathname === RouteUrls.Home && !currentKey?.hasSetPassword) navigate(RouteUrls.Onboarding);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentKey?.hasSetPassword]);
 
   if (!hasStateRehydrated) return <LoadingSpinner />;
 

--- a/src/app/store/keys/key.selectors.ts
+++ b/src/app/store/keys/key.selectors.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { createSelector } from '@reduxjs/toolkit';
 import { useSelector } from 'react-redux';
 
@@ -10,13 +9,8 @@ export const selectGeneratedSecretKey = createSelector(selectWalletSlice, state 
 
 export const selectCurrentKey = createSelector(selectWalletSlice, state => state.entities.default);
 
-export function withDerivedKeyInformation(key: ReturnType<typeof selectCurrentKey>) {
-  return { ...key, hasSetPassword: !!key?.encryptedSecretKey };
-}
-
 export function useCurrentKeyDetails() {
-  const currentKey = useSelector(selectCurrentKey);
-  return useMemo(() => withDerivedKeyInformation(currentKey), [currentKey]);
+  return useSelector(selectCurrentKey);
 }
 
 export function useGeneratedSecretKey() {

--- a/src/app/store/utils/vault-reducer-migration.spec.ts
+++ b/src/app/store/utils/vault-reducer-migration.spec.ts
@@ -29,7 +29,6 @@ describe(migrateVaultReducerStoreToNewStateStructure.name, () => {
             id: 'default',
             encryptedSecretKey: 'test-encrypted-key',
             salt: 'test-salt',
-            hasSetPassword: true,
           },
         },
       });

--- a/src/app/store/utils/vault-reducer-migration.ts
+++ b/src/app/store/utils/vault-reducer-migration.ts
@@ -21,7 +21,6 @@ export function migrateVaultReducerStoreToNewStateStructure(initialState: typeof
           id: 'default',
           encryptedSecretKey,
           salt,
-          hasSetPassword: true,
         },
       },
     };

--- a/src/app/store/wallet/wallet.hooks.ts
+++ b/src/app/store/wallet/wallet.hooks.ts
@@ -15,12 +15,7 @@ import { localNonceState } from '@app/store/accounts/nonce';
 import { currentNetworkState } from '@app/store/network/networks';
 import { finalizeAuthResponse } from '@app/common/actions/finalize-auth-response';
 import { logger } from '@shared/logger';
-import {
-  encryptedSecretKeyState,
-  hasSetPasswordState,
-  secretKeyState,
-  walletState,
-} from './wallet';
+import { encryptedSecretKeyState, secretKeyState, walletState } from './wallet';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 
 export function useWalletState() {
@@ -33,10 +28,6 @@ export function useSecretKey() {
 
 export function useEncryptedSecretKeyState() {
   return useAtomValue(encryptedSecretKeyState);
-}
-
-export function useHasSetPasswordState() {
-  return useAtomValue(hasSetPasswordState);
 }
 
 export function useSetLatestNonceCallback() {

--- a/src/app/store/wallet/wallet.ts
+++ b/src/app/store/wallet/wallet.ts
@@ -4,7 +4,6 @@ import { gaiaUrl } from '@shared/constants';
 import { textToBytes } from '@app/common/store-utils';
 import { storeAtom } from '..';
 import { deriveWalletWithAccounts } from '../chains/stx-chain.selectors';
-import { withDerivedKeyInformation } from '../keys/key.selectors';
 
 export const walletState = atom(async get => {
   const store = get(storeAtom);
@@ -21,12 +20,6 @@ export const walletConfigState = atom(async get => {
   if (!wallet) return null;
   const gaiaHubConfig = await createWalletGaiaConfig({ wallet, gaiaHubUrl: gaiaUrl });
   return fetchWalletConfig({ wallet, gaiaHubConfig });
-});
-
-export const hasSetPasswordState = atom(get => {
-  const store = get(storeAtom);
-  if (!store.keys.entities.default) return;
-  return withDerivedKeyInformation(store.keys.entities.default).hasSetPassword;
 });
 
 export const encryptedSecretKeyState = atom(get => {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1789238736).<!-- Sticky Header Marker -->

This PR merges into the vault reducer PR.

This change removes the `hasSetPassword` value, as this was a legacy implementation detail when a wallet could have a pre-, and post-, having set a password states. As we now only "create" a wallet when setting the password, this state can be inferred, and thus removed. Further, this allows us to simplify the account guard logic.

These changes will help Ledger work in #2193, as it brings software wallets more closely into like with Ledger ones (neither need to be aware of this concept of having set a password).