### PR TITLE
refactor: account avatars

### DIFF
--- a/src/app/common/derive-public-key.ts
+++ b/src/app/common/derive-public-key.ts
@@ -1,0 +1,5 @@
+import { createStacksPrivateKey, getPublicKey, publicKeyToString } from '@stacks/transactions';
+
+export function derivePublicKey(key: string) {
+  return publicKeyToString(getPublicKey(createStacksPrivateKey(key)));
+}

--- a/src/app/common/hooks/account/use-account-gradient.ts
+++ b/src/app/common/hooks/account/use-account-gradient.ts
@@ -1,16 +1,7 @@
 import { useMemo } from 'react';
-import { Account, getStxAddress } from '@stacks/wallet-sdk';
-import { TransactionVersion } from '@stacks/transactions';
+
 import { generateHash, hashValue, moduloRange, stringToHslColor } from '@stacks/ui-utils';
 import chroma from 'chroma-js';
-
-function toHex(str: string) {
-  let result = '';
-  for (let i = 0; i < str.length; i++) {
-    result += str.charCodeAt(i).toString(16);
-  }
-  return result;
-}
 
 function generateGradientType(string: string) {
   const gradientType = `${hashValue(string, ['linear', 'radial'])}-gradient`;
@@ -32,17 +23,15 @@ function generateGradientType(string: string) {
   }
 }
 
-export function useAccountGradient(account: Account) {
+export function useAccountGradient(publicKey: string) {
   return useMemo(() => {
-    // always mainnet, so people can associate color with an account regardless of network
-    const transactionVersion = TransactionVersion.Mainnet;
+    const keyLength = publicKey.length;
+    const part1 = publicKey.substring(0, keyLength / 2);
+    const part2 = publicKey.substring(keyLength / 2, keyLength);
 
-    const stxAddress = getStxAddress({ account, transactionVersion });
-    const pubKeyLikeString = toHex(stxAddress);
-
-    const bg = stringToHslColor(stxAddress, 50, 60);
-    let bg2 = stringToHslColor(pubKeyLikeString, 50, 60);
-    const bg3 = stringToHslColor(pubKeyLikeString + '__' + stxAddress, 50, 60);
+    const bg = stringToHslColor(part1, 50, 60);
+    let bg2 = stringToHslColor(part2, 50, 60);
+    const bg3 = stringToHslColor(part2 + '__' + part1, 50, 60);
 
     const contrast = chroma.contrast(bg, bg2);
 
@@ -50,9 +39,9 @@ export function useAccountGradient(account: Account) {
       bg2 = chroma(bg2).darken(1.25).hex();
     }
 
-    const gradientTypeString = stxAddress + '__' + pubKeyLikeString;
+    const gradientTypeString = part1 + '__' + part2;
     const gradientType = generateGradientType(gradientTypeString);
 
     return `${gradientType}, ${bg3} 0%, ${bg2} 70%, ${bg} 100%)`;
-  }, [account]);
+  }, [publicKey]);
 }

--- a/src/app/common/hooks/use-public-key-to-address.ts
+++ b/src/app/common/hooks/use-public-key-to-address.ts
@@ -1,0 +1,7 @@
+import { useAddressNetworkVersion } from '@app/store/accounts/account.hooks';
+import { publicKeyToAddress, createStacksPublicKey } from '@stacks/transactions';
+
+export function usePublicKeyToAddress(publicKey: string) {
+  const addressVersion = useAddressNetworkVersion();
+  return publicKeyToAddress(addressVersion, createStacksPublicKey(publicKey));
+}

--- a/src/app/common/hooks/use-wallet.ts
+++ b/src/app/common/hooks/use-wallet.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { getAccountDisplayName } from '@stacks/wallet-sdk';
 
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 
@@ -25,6 +24,7 @@ import {
   useNetworkState,
 } from '@app/store/network/networks.hooks';
 import { finalizeAuthResponse } from '@app/common/actions/finalize-auth-response';
+import { getAccountDisplayName } from '../utils/get-account-display-name';
 
 export function useWallet() {
   const [wallet, setWallet] = useWalletState();

--- a/src/app/common/utils/get-account-display-name.ts
+++ b/src/app/common/utils/get-account-display-name.ts
@@ -1,0 +1,15 @@
+// This method exists to replicate the behaviour of the method by the same name
+// from `@stacks/wallet-sdk`. This method demands that type `Account` is given,
+// despite the fact only two properties are used. This means that, even if you
+// have the necessary properties, you can't use the method as unneeded
+// properties are unavailable.
+interface GetAccountDisplayNameArgs {
+  username?: string;
+  index: number;
+}
+export function getAccountDisplayName(args: GetAccountDisplayNameArgs) {
+  if (args.username) {
+    return args.username.split('.')[0];
+  }
+  return `Account ${args.index + 1}`;
+}

--- a/src/app/components/account-avatar/account-avatar.tsx
+++ b/src/app/components/account-avatar/account-avatar.tsx
@@ -1,43 +1,41 @@
+import { memo, Suspense } from 'react';
 import { BoxProps, color, Circle } from '@stacks/ui';
-import { Suspense } from 'react';
-import { Account, getAccountDisplayName } from '@stacks/wallet-sdk';
 
 import { useAccountGradient } from '@app/common/hooks/account/use-account-gradient';
-import { AccountWithAddress } from '@app/store/accounts/account.models';
 
 interface AccountAvatarProps extends BoxProps {
-  account: AccountWithAddress | Account;
-  name?: string;
+  publicKey: string;
+  name: string;
 }
-export const AccountAvatar = ({ account, name, ...props }: AccountAvatarProps) => {
-  const displayName = name && name.includes('.') ? name : getAccountDisplayName(account);
-  const gradient = useAccountGradient(account);
+export const AccountAvatar = memo(({ publicKey, name, ...props }: AccountAvatarProps) => {
+  const gradient = useAccountGradient(publicKey ?? '');
 
-  const circleText = displayName?.includes('Account') ? displayName.split(' ')[1] : displayName[0];
+  const circleText = name?.includes('Account') ? name.split(' ')[1] : name[0];
   return (
     <Circle flexShrink={0} backgroundImage={gradient} color={color('bg')} {...props}>
       {circleText.toUpperCase()}
     </Circle>
   );
-};
+});
 
 interface AccountAvatarWithNameInnerProps extends BoxProps {
   name: string;
-  account: AccountWithAddress | Account;
+  publicKey: string;
 }
 const AccountAvatarWithNameInner = (props: AccountAvatarWithNameInnerProps) => {
-  const { account, name, ...rest } = props;
-  return <AccountAvatar account={account} name={name} {...rest} />;
+  const { publicKey, name, ...rest } = props;
+  return <AccountAvatar publicKey={publicKey} name={name} {...rest} />;
 };
 
 interface AccountAvatarWithNameProps extends BoxProps {
   name: string;
-  account: AccountWithAddress | Account;
+  publicKey: string;
 }
-export const AccountAvatarWithName = ({ account, name, ...props }: AccountAvatarWithNameProps) => {
+export const AccountAvatarWithName = (props: AccountAvatarWithNameProps) => {
+  const { name, publicKey, ...rest } = props;
   return (
-    <Suspense fallback={<AccountAvatar account={account} {...props} />}>
-      <AccountAvatarWithNameInner account={account} name={name} {...props} />
+    <Suspense fallback={<AccountAvatar publicKey={publicKey} name={name} {...rest} />}>
+      <AccountAvatarWithNameInner publicKey={publicKey} name={name} {...rest} />
     </Suspense>
   );
 };

--- a/src/app/features/account-switch-drawer/components/account-avatar.tsx
+++ b/src/app/features/account-switch-drawer/components/account-avatar.tsx
@@ -1,25 +1,27 @@
 import { Suspense, memo } from 'react';
 import { Box, BoxProps } from '@stacks/ui';
 
-import { AccountWithAddress } from '@app/store/accounts/account.models';
 import { AccountAvatar } from '@app/components/account-avatar/account-avatar';
-import { getAccountDisplayName } from '@stacks/wallet-sdk';
 import { useGetAccountNamesByAddressQuery } from '@app/query/bns/bns.hooks';
+import { getAccountDisplayName } from '@app/common/utils/get-account-display-name';
+import { usePublicKeyToAddress } from '@app/common/hooks/use-public-key-to-address';
 
-interface AccountAvatarProps extends BoxProps {
-  account: AccountWithAddress;
+interface AccountAvatarItemProps extends BoxProps {
+  publicKey: string;
+  index: number;
 }
-const AccountAvatarSuspense = memo(({ account }: AccountAvatarProps) => {
-  const name = useGetAccountNamesByAddressQuery(account.address);
-  return <AccountAvatar name={name[0] ?? getAccountDisplayName(account)} account={account} />;
+const AccountAvatarSuspense = memo(({ publicKey, index }: AccountAvatarItemProps) => {
+  const address = usePublicKeyToAddress(publicKey);
+  const name = useGetAccountNamesByAddressQuery(address);
+  return <AccountAvatar name={name[0] ?? getAccountDisplayName({ index })} publicKey={publicKey} />;
 });
 
-export const AccountAvatarItem = memo(({ account, ...rest }: AccountAvatarProps) => {
-  const defaultName = getAccountDisplayName(account);
+export const AccountAvatarItem = memo(({ publicKey, index, ...rest }: AccountAvatarItemProps) => {
+  const defaultName = getAccountDisplayName({ index });
   return (
     <Box {...rest}>
-      <Suspense fallback={<AccountAvatar name={defaultName} account={account} />}>
-        <AccountAvatarSuspense account={account} />
+      <Suspense fallback={<AccountAvatar name={defaultName} publicKey={publicKey} />}>
+        <AccountAvatarSuspense publicKey={publicKey} index={index} />
       </Suspense>
     </Box>
   );

--- a/src/app/features/account-switch-drawer/components/account-list-item-layout.tsx
+++ b/src/app/features/account-switch-drawer/components/account-list-item-layout.tsx
@@ -4,13 +4,13 @@ import { FiCheck as IconCheck } from 'react-icons/fi';
 
 import { SpaceBetween } from '@app/components/space-between';
 import { SettingsSelectors } from '@tests/integration/settings.selectors';
-import { AccountWithAddress } from '@app/store/accounts/account.models';
+import { SoftwareWalletAccountWithAddress } from '@app/store/accounts/account.models';
 import { Caption } from '@app/components/typography';
 
 interface AccountListItemLayoutProps extends StackProps {
   isLoading: boolean;
   isActive: boolean;
-  account: AccountWithAddress;
+  account: SoftwareWalletAccountWithAddress;
   accountName: JSX.Element;
   avatar: JSX.Element;
   balanceLabel: JSX.Element;

--- a/src/app/features/account-switch-drawer/components/account-list-item.tsx
+++ b/src/app/features/account-switch-drawer/components/account-list-item.tsx
@@ -6,9 +6,9 @@ import { AccountBalanceCaption } from '@app/components/account-balance-caption';
 import { Caption } from '@app/components/typography';
 import { AccountName, AccountNameFallback } from './account-name';
 import { useAddressBalances } from '@app/query/balance/balance.hooks';
-import { AccountWithAddress } from '@app/store/accounts/account.models';
 import { AccountListItemLayout } from './account-list-item-layout';
 import { AccountAvatarItem } from './account-avatar';
+import { SoftwareWalletAccountWithAddress } from '@app/store/accounts/account.models';
 
 interface AccountBalanceLabelProps {
   address: string;
@@ -19,7 +19,7 @@ const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
 });
 
 interface AccountListItemProps {
-  account: AccountWithAddress;
+  account: SoftwareWalletAccountWithAddress;
   handleClose(): void;
 }
 export const AccountListItem = memo(({ account, handleClose }: AccountListItemProps) => {
@@ -39,11 +39,11 @@ export const AccountListItem = memo(({ account, handleClose }: AccountListItemPr
       account={account}
       isLoading={isLoading}
       isActive={getIsActive(account.index)}
-      avatar={<AccountAvatarItem account={account} />}
+      avatar={<AccountAvatarItem publicKey={account.stxPublicKey} index={account.index} />}
       onSelectAccount={handleClick}
       accountName={
         <Suspense fallback={<AccountNameFallback account={account} />}>
-          <AccountName account={account} />
+          <AccountName address={account.address} index={account.index} />
         </Suspense>
       }
       balanceLabel={

--- a/src/app/features/account-switch-drawer/components/account-list.tsx
+++ b/src/app/features/account-switch-drawer/components/account-list.tsx
@@ -1,14 +1,14 @@
 import { memo } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
-import { AccountWithAddress } from '@app/store/accounts/account.models';
+import { SoftwareWalletAccountWithAddress } from '@app/store/accounts/account.models';
 import { AccountListItem } from './account-list-item';
 
 const smallNumberOfAccountsToRenderWholeList = 10;
 
 interface AccountListProps {
   handleClose: () => void;
-  accounts: AccountWithAddress[];
+  accounts: SoftwareWalletAccountWithAddress[];
   currentAccountIndex: number;
 }
 export const AccountList = memo(

--- a/src/app/features/account-switch-drawer/components/account-name.tsx
+++ b/src/app/features/account-switch-drawer/components/account-name.tsx
@@ -1,33 +1,34 @@
-import { memo } from 'react';
-import { AccountWithAddress } from '@app/store/accounts/account.models';
+import { FC, memo } from 'react';
+import { SoftwareWalletAccountWithAddress } from '@app/store/accounts/account.models';
 import { BoxProps } from '@stacks/ui';
-import { getAccountDisplayName } from '@stacks/wallet-sdk';
 
 import { Title } from '@app/components/typography';
 import { useGetAccountNamesByAddressQuery } from '@app/query/bns/bns.hooks';
+import { getAccountDisplayName } from '@app/common/utils/get-account-display-name';
+
+const AccountNameLayout: FC = memo(({ children }) => (
+  <Title fontSize={2} lineHeight="1rem" fontWeight="400">
+    {children}
+  </Title>
+));
 
 interface AccountNameProps extends BoxProps {
-  account: AccountWithAddress;
+  address: string;
+  index: number;
 }
-export const AccountName = memo(({ account }: AccountNameProps) => {
-  const name = useGetAccountNamesByAddressQuery(account.address);
-
+export const AccountName = memo(({ address, index }: AccountNameProps) => {
+  const name = useGetAccountNamesByAddressQuery(address);
   return (
-    <Title fontSize={2} lineHeight="1rem" fontWeight="400">
-      {name[0] ?? getAccountDisplayName(account)}
-    </Title>
+    <AccountNameLayout>
+      {name[0] ?? (index ? getAccountDisplayName({ index }) : '')}
+    </AccountNameLayout>
   );
 });
 
 interface AccountNameFallbackProps {
-  account: AccountWithAddress;
+  account: SoftwareWalletAccountWithAddress;
 }
 export const AccountNameFallback = memo(({ account }: AccountNameFallbackProps) => {
   const defaultName = getAccountDisplayName(account);
-
-  return (
-    <Title fontSize={2} lineHeight="1rem" fontWeight="400">
-      {defaultName}
-    </Title>
-  );
+  return <AccountNameLayout>{defaultName}</AccountNameLayout>;
 });

--- a/src/app/features/current-account/current-account-avatar.tsx
+++ b/src/app/features/current-account/current-account-avatar.tsx
@@ -1,15 +1,17 @@
 import { memo, Suspense } from 'react';
+import { BoxProps } from '@stacks/ui';
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { useCurrentAccountDisplayName } from '@app/common/hooks/account/use-account-names';
-import { getAccountDisplayName } from '@stacks/wallet-sdk';
 import { AccountAvatar } from '@app/components/account-avatar/account-avatar';
-import { BoxProps } from '@stacks/ui';
+import { getAccountDisplayName } from '@app/common/utils/get-account-display-name';
 
 const AccountAvatarSuspense = memo((props: BoxProps) => {
   const currentAccount = useCurrentAccount();
   const name = useCurrentAccountDisplayName();
   if (!currentAccount) return null;
-  return <AccountAvatar name={name} flexShrink={0} account={currentAccount} {...props} />;
+  return (
+    <AccountAvatar name={name} publicKey={currentAccount.stxPublicKey} flexShrink={0} {...props} />
+  );
 });
 
 export const CurrentAccountAvatar = memo((props: BoxProps) => {
@@ -19,7 +21,12 @@ export const CurrentAccountAvatar = memo((props: BoxProps) => {
   return (
     <Suspense
       fallback={
-        <AccountAvatar name={defaultName} flexShrink={0} account={currentAccount} {...props} />
+        <AccountAvatar
+          name={defaultName}
+          publicKey={currentAccount.stxPublicKey}
+          flexShrink={0}
+          {...props}
+        />
       }
     >
       <AccountAvatarSuspense {...props} />

--- a/src/app/features/current-account/current-account-name.tsx
+++ b/src/app/features/current-account/current-account-name.tsx
@@ -1,23 +1,25 @@
 import { memo, Suspense } from 'react';
 import { BoxProps } from '@stacks/ui';
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
-import { getAccountDisplayName } from '@stacks/wallet-sdk';
 import { truncateString } from '@app/common/utils';
 import { Tooltip } from '@app/components/tooltip';
 import { Title } from '@app/components/typography';
 import { memoWithAs } from '@stacks/ui-core';
 import { useCurrentAccountDisplayName } from '@app/common/hooks/account/use-account-names';
+import { getAccountDisplayName } from '@app/common/utils/get-account-display-name';
 
-const AccountNameTitle = (props: BoxProps) => (
-  <Title
-    data-testid="home-current-display-name"
-    as="h1"
-    lineHeight="1rem"
-    fontSize={4}
-    fontWeight={500}
-    {...props}
-  />
-);
+function AccountNameTitle(props: BoxProps) {
+  return (
+    <Title
+      data-testid="home-current-display-name"
+      as="h1"
+      lineHeight="1rem"
+      fontSize={4}
+      fontWeight={500}
+      {...props}
+    />
+  );
+}
 
 const AccountNameSuspense = memo((props: BoxProps) => {
   const currentAccount = useCurrentAccount();

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -9,7 +9,7 @@ import { useWallet } from '@app/common/hooks/use-wallet';
 import { truncateMiddle } from '@stacks/ui-utils';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 
-import type { AccountWithAddress } from '@app/store/accounts/account.models';
+import type { SoftwareWalletAccountWithAddress } from '@app/store/accounts/account.models';
 import { AccountAvatarWithName } from '@app/components/account-avatar/account-avatar';
 import { SpaceBetween } from '@app/components/space-between';
 
@@ -29,7 +29,7 @@ const loadingProps = { color: '#A1A7B3' };
 const getLoadingProps = (loading: boolean) => (loading ? loadingProps : {});
 
 interface AccountTitlePlaceholderProps extends BoxProps {
-  account: AccountWithAddress;
+  account: SoftwareWalletAccountWithAddress;
 }
 const AccountTitlePlaceholder = ({ account, ...rest }: AccountTitlePlaceholderProps) => {
   const name = `Account ${account?.index + 1}`;
@@ -41,7 +41,7 @@ const AccountTitlePlaceholder = ({ account, ...rest }: AccountTitlePlaceholderPr
 };
 
 interface AccountTitleProps extends BoxProps {
-  account: AccountWithAddress;
+  account: SoftwareWalletAccountWithAddress;
   name: string;
 }
 const AccountTitle = ({ account, name, ...rest }: AccountTitleProps) => {
@@ -55,7 +55,7 @@ const AccountTitle = ({ account, name, ...rest }: AccountTitleProps) => {
 interface AccountItemProps extends FlexProps {
   selectedAddress?: string | null;
   isLoading: boolean;
-  account: AccountWithAddress;
+  account: SoftwareWalletAccountWithAddress;
   onSelectAccount(index: number): void;
 }
 const AccountItem = memo((props: AccountItemProps) => {
@@ -77,7 +77,7 @@ const AccountItem = memo((props: AccountItemProps) => {
     >
       <Box {...bind}>
         <Stack spacing="base" alignSelf="center" isInline>
-          <AccountAvatarWithName name={name} flexGrow={0} account={account} />
+          <AccountAvatarWithName name={name} flexGrow={0} publicKey={account.stxPublicKey} />
           <SpaceBetween width="100%" alignItems="center">
             <Stack textAlign="left" spacing="base-tight">
               <Suspense

--- a/src/app/pages/receive-tokens/receive-tokens.tsx
+++ b/src/app/pages/receive-tokens/receive-tokens.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { Box, useClipboard, Stack, color, Button } from '@stacks/ui';
 import { truncateMiddle } from '@stacks/ui-utils';
-import { getAccountDisplayName } from '@stacks/wallet-sdk';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { useWallet } from '@app/common/hooks/use-wallet';
@@ -12,6 +11,7 @@ import { Header } from '@app/components/header';
 import { Caption, Text, Title } from '@app/components/typography';
 import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
 import { RouteUrls } from '@shared/route-urls';
+import { getAccountDisplayName } from '@app/common/utils/get-account-display-name';
 
 import { QrCode } from './components/address-qr-code';
 

--- a/src/app/store/accounts/account.hooks.ts
+++ b/src/app/store/accounts/account.hooks.ts
@@ -1,6 +1,9 @@
 import { useAtom } from 'jotai';
 import { useAtomValue, useUpdateAtom } from 'jotai/utils';
-import { transactionNetworkVersionState } from '@app/store/transactions';
+import {
+  addressNetworkVersionState,
+  transactionNetworkVersionState,
+} from '@app/store/transactions';
 import {
   accountsWithAddressState,
   currentAccountAvailableAnchoredStxBalanceState,
@@ -50,6 +53,10 @@ export function useTransactionAccountIndex() {
 
 export function useTransactionNetworkVersion() {
   return useAtomValue(transactionNetworkVersionState);
+}
+
+export function useAddressNetworkVersion() {
+  return useAtomValue(addressNetworkVersionState);
 }
 
 export function useHasSwitchedAccounts() {

--- a/src/app/store/accounts/account.models.ts
+++ b/src/app/store/accounts/account.models.ts
@@ -1,7 +1,11 @@
 import { AccountBalanceStxKeys } from '@shared/models/account-types';
 import { Account } from '@stacks/wallet-sdk';
 
-export type AccountWithAddress = Account & { address: string };
+export type SoftwareWalletAccountWithAddress = Account & {
+  address: string;
+  stxPublicKey: string;
+  dataPublicKey: string;
+};
 
 export const accountBalanceStxKeys: AccountBalanceStxKeys[] = [
   'balance',

--- a/src/app/store/transactions/index.ts
+++ b/src/app/store/transactions/index.ts
@@ -119,6 +119,7 @@ export const transactionNetworkVersionState = atom(get => {
     [ChainID.Testnet]: TransactionVersion.Testnet,
   });
 });
+
 export const addressNetworkVersionState = atom(get => {
   const chainId = get(currentNetworkState)?.chainId;
   return whenChainId(chainId)({

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -113,6 +113,9 @@ export const TEST_ACCOUNTS_WITH_ADDRESS = [
   {
     stxPrivateKey: 'cc440106121617d5ea23646552aa40a62316878293a1baa7a02fbb071b8cbe2901',
     dataPrivateKey: '504b91ea465bb9f6c28a38432869bd04dbeb85b46525bcf5e9615a9ddfcc178c',
+    dataPublicKey:
+      '049463d20793c454256d876ca307976d47389eabf4ad18634d1ba24b873a2bb9987f8ee2fb9967ab67240911faae32bf8f0ddf2c2ff75264080bb1921309b58844',
+    stxPublicKey: '02c2a10447387399dd89634965a64c26292b7e0b7fc229d6eb262d3d8b69639fae',
     appsKey:
       'xprvA2KzZmgR2PMM55CgbWxRC6K74n4ANrBitjxKnKmEJYLq4tfQX5p17NpUx9gvk4fnnJDym14E1hixmDzjfbt4Fmf73g1RcvQZpMzih81Lg1S',
     salt: 'e95b8fed404c4130267b15be0df5aecb7c118f1297bf25d096e2bf442ec7b1a7',
@@ -122,6 +125,9 @@ export const TEST_ACCOUNTS_WITH_ADDRESS = [
   {
     stxPrivateKey: '1499c9194feed4cbca3bd9f7a2b3413684d30c1a9d8a7f044398f9e27ae5d00301',
     dataPrivateKey: 'f96a1e65ce95db1ee6ff2e53988d4a3524c433548758d95354ea05fc24cc4505',
+    dataPublicKey:
+      '0494ac74cc518c3d30fbd9a6775c3b82f69c5609d789ae250bed502003e2ab1235db5125573a29a27c30b86883114d228c04603bfd526890e9e35f74ddd8c018e8',
+    stxPublicKey: '03a7bb275b5672a2f8b9041be18e88b67dcfb9f861713ce8b60e2c086665cd8060',
     appsKey:
       'xprvA1eQc5DGP8KU275yPdXUbWXPW4Ba2h2poSpXnV5jxxfpPghuaP4p8R1YHg8MsmqGpwFQU4R74cU5x8E7dExQN14cvPHn6c1vxajxWjQxTpM',
     salt: 'e95b8fed404c4130267b15be0df5aecb7c118f1297bf25d096e2bf442ec7b1a7',
@@ -131,6 +137,9 @@ export const TEST_ACCOUNTS_WITH_ADDRESS = [
   {
     stxPrivateKey: 'b8e5b2c33be621fb16a5260b30d526cadc7087d58736f2f3c6f84d31be452b6601',
     dataPrivateKey: 'bdcc48a4b8c098a7cb06e7221ee0b784c05083353dad964674a4eebfaa104f0d',
+    dataPublicKey:
+      '04af5f37b6a17ddc33076f2d510aae54ad53bd1df48e1967013766fcde556277432c628b5c821aed4e1bb9b6b4bd2c3fa125ab8ec567056d9dfd5989e669de8c5e',
+    stxPublicKey: '03ab173ad9e6559a073883da533d964f8804faebcf2ecc4f660e10006073da65ab',
     appsKey:
       'xprvA1vvF4rkEyBDLuvQKTa9YvCNKHcTNsrBwD5imsnnatG9RiyF5634o2GBwb5YvjC237LK6k273xRmaiCsNKpbS2EXUGPTtWo3CBFKRmzEHti',
     salt: 'e95b8fed404c4130267b15be0df5aecb7c118f1297bf25d096e2bf442ec7b1a7',
@@ -140,6 +149,9 @@ export const TEST_ACCOUNTS_WITH_ADDRESS = [
   {
     stxPrivateKey: 'da62811e06fe6fb394982a740fdcab6f1194ed85c5f6421021777638512d41ee01',
     dataPrivateKey: '522a6fb27d2255c30ab7d83ffc3b43cda4627c505619f0bb1e7de66c297bc53c',
+    dataPublicKey:
+      '0422591d65340340c5514ec1f60050a331646a6763a7c54d37f915b44483690c563490e74a160f1dc0c061dfd803cd59a7e74a7556538039ef5e6d833720d4c186',
+    stxPublicKey: '0222c8e23d47e31d27ed8018bc0abb0ce9f138a07680cd2627e7c3f32a34478a23',
     appsKey:
       'xprvA23n53oLHrMsQcVULk6UBg3PJUWHC3L6W8DmKqzGEVprqjSF1qs8hcZfP3H1zg1asSUDDZBXNw81p5BBALZorQz2fKNeWGfwmRhUsbMiVsH',
     salt: 'e95b8fed404c4130267b15be0df5aecb7c118f1297bf25d096e2bf442ec7b1a7',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3688,7 +3688,19 @@
     schema-inspector "^2.0.1"
     zone-file "^1.0.0"
 
-"@stacks/profile@^3.0.0", "@stacks/profile@^3.2.0":
+"@stacks/profile@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@stacks/profile/-/profile-3.1.0.tgz#b2d016dec1cb156df265cdf867863e5411cb303b"
+  integrity sha512-XkuuzRVLXn45+4o8JHJ9RsWQn9Vahm2vBnbFHY/f0FAywK+D06VBpse9qj9ZbtsYtolB1pjdy+6kLsewPiBNIw==
+  dependencies:
+    "@stacks/common" "^3.0.0"
+    "@stacks/network" "^3.0.0"
+    "@stacks/transactions" "^3.1.0"
+    jsontokens "^3.0.0"
+    schema-inspector "^2.0.1"
+    zone-file "^2.0.0-beta.3"
+
+"@stacks/profile@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@stacks/profile/-/profile-3.2.0.tgz#f5972cc1cdbf10d18446cc662c6a968ea1ec4055"
   integrity sha512-IjW+LXbb+Tz0nt9t8CXpuCCv/9gZQ8s3Hgz3uEe8HGALvqAAwYc2ZQvHQ0vf58Cdezr1gIbY0OaWm3UkaHKdmg==


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1840655605).<!-- Sticky Header Marker -->

In building a Ledger POC, I've ran into a pretty blocking problem where, the `Account` type from `@stacks/wallet-sdk` is used **everywhere**. In many functions and components, just one or two properties of this type are used, yet the whole object is required anyway.

This is an anti-pattern (see [_principal of least knowledge_](https://en.wikipedia.org/wiki/Law_of_Demeter)). By requiring the whole object, the properties that aren't used, are tightly coupled to its use, entirely unnecessarily.

This problem manifests itself especially in the account avatar code. `Account` is used in many places, despite only `index` and the private key being required for the gradient generation. This PR refactors this to only require the _needed properties of_ `Account` are passed in, and utilises the _public key_, rather than the private one.

We extend the `AccountWithAddress` type to include the public keys too, as this is where the different wallet types overlap.