### PR TITLE
fix: slow fetching of metadata, hit api faster

### DIFF
--- a/src/app/query/tokens/fungible-token-metadata.query.ts
+++ b/src/app/query/tokens/fungible-token-metadata.query.ts
@@ -5,9 +5,9 @@ import { useApi, Api } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetwork } from '@app/common/hooks/use-current-network';
 import { isResponseCode } from '@app/common/network/is-response-code';
 
-const limiter = new RateLimiter({ tokensPerInterval: 1, interval: 750 });
+const limiter = new RateLimiter({ tokensPerInterval: 1, interval: 250 });
 
-const staleTime = 20 * 60 * 1000;
+const staleTime = 6 * 60 * 60 * 1000;
 
 const queryOptions = {
   keepPreviousData: true,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1846166456).<!-- Sticky Header Marker -->

On initial load, we need the metadata for each balance to know if it's transferrable.

https://github.com/hirosystems/stacks-wallet-web/issues/2235 highlights a case where it's a bit slow. As we cache this endpoint for a long time anyway, I'm lowering the limiting time.

