### PR TITLE
fix: account names not displayed on sign in screen

### DIFF
--- a/src/app/common/hooks/account/use-account-names.ts
+++ b/src/app/common/hooks/account/use-account-names.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { useCurrentAccountNames, useGetAccountNamesByAddressQuery } from '@app/query/bns/bns.hooks';
+import { getAccountDisplayName } from '@stacks/wallet-sdk';
+import { AccountWithAddress } from '@app/store/accounts/account.models';
 
 export function useCurrentAccountDisplayName() {
   const names = useCurrentAccountNames();
@@ -12,11 +14,8 @@ export function useCurrentAccountDisplayName() {
   }, [account, names]);
 }
 
-export function useAccountDisplayName(address: string, index: number) {
-  const names = useGetAccountNamesByAddressQuery(address);
+export function useAccountDisplayName(account: AccountWithAddress) {
+  const names = useGetAccountNamesByAddressQuery(account.address);
 
-  return useMemo(() => {
-    if (!names.length) return `Account ${index + 1}`;
-    return names[0];
-  }, [index, names]);
+  return useMemo(() => names[0] ?? getAccountDisplayName(account), [account, names]);
 }

--- a/src/app/features/account-switch-drawer/components/account-name.tsx
+++ b/src/app/features/account-switch-drawer/components/account-name.tsx
@@ -4,17 +4,17 @@ import { BoxProps } from '@stacks/ui';
 import { getAccountDisplayName } from '@stacks/wallet-sdk';
 
 import { Title } from '@app/components/typography';
-import { useGetAccountNamesByAddressQuery } from '@app/query/bns/bns.hooks';
+import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 
 interface AccountNameProps extends BoxProps {
   account: AccountWithAddress;
 }
 export const AccountName = memo(({ account }: AccountNameProps) => {
-  const name = useGetAccountNamesByAddressQuery(account.address);
+  const name = useAccountDisplayName(account);
 
   return (
     <Title fontSize={2} lineHeight="1rem" fontWeight="400">
-      {name[0] ?? getAccountDisplayName(account)}
+      {name}
     </Title>
   );
 });

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -62,7 +62,7 @@ const AccountItem = memo((props: AccountItemProps) => {
   const { selectedAddress, account, isLoading, onSelectAccount, ...rest } = props;
   const [component, bind] = usePressable(true);
   const { decodedAuthRequest } = useOnboardingState();
-  const name = useAccountDisplayName(account.address, account.index);
+  const name = useAccountDisplayName(account);
   const { data: balances, isLoading: isBalanceLoading } = useAddressBalances(account.address);
   const showLoadingProps = !!selectedAddress || !decodedAuthRequest;
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1876834756).<!-- Sticky Header Marker -->

Fixes #2241

Issue where account name isn't displayed, only when connecting to an app. This refactors the logic so both switch account & choose account display the same.

cc/ @dantrevino