### PR TITLE
refactor: reuse temp key handling logic

### DIFF
--- a/src/app/common/hooks/auth/use-magic-recovery-code.ts
+++ b/src/app/common/hooks/auth/use-magic-recovery-code.ts
@@ -7,7 +7,7 @@ import { useWallet } from '@app/common/hooks/use-wallet';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 import { RouteUrls } from '@shared/route-urls';
 import { decrypt } from '@stacks/wallet-sdk';
-import { keyActions } from '@app/store/keys/key.actions';
+import { inMemoryKeyActions } from '@app/store/in-memory-key/in-memory-key.actions';
 import { delay } from '@app/common/utils';
 import { useAppDispatch } from '@app/store';
 
@@ -50,7 +50,7 @@ export function useMagicRecoveryCode() {
         const secretKey = await decrypt(codeBuffer, password);
         toast.success('Password correct');
         await simulateShortDelayToAvoidImmediateNavigation();
-        dispatch(keyActions.saveUsersSecretKeyToBeRestored(secretKey));
+        dispatch(inMemoryKeyActions.saveUsersSecretKeyToBeRestored(secretKey));
         handleNavigate();
       } catch (error) {
         setPasswordError(`Incorrect password, try again.`);

--- a/src/app/common/hooks/use-key-actions.ts
+++ b/src/app/common/hooks/use-key-actions.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Wallet } from '@stacks/wallet-sdk';
+import { generateSecretKey, Wallet } from '@stacks/wallet-sdk';
 
 import { useAppDispatch } from '@app/store';
 import { clearSessionLocalData } from '@app/common/store-utils';
@@ -22,7 +22,12 @@ export function useKeyActions() {
       },
 
       generateWalletKey() {
-        return dispatch(keyActions.generateWalletKey());
+        const secretKey = generateSecretKey(256);
+        sendMessage({
+          method: InternalMethods.ShareInMemoryKeyToBackground,
+          payload: { secretKey, keyId: 'default' },
+        });
+        return dispatch(inMemoryKeyActions.generateWalletKey(secretKey));
       },
 
       async unlockWallet(password: string) {

--- a/src/app/pages/onboarding/back-up-secret-key/back-up-secret-key.tsx
+++ b/src/app/pages/onboarding/back-up-secret-key/back-up-secret-key.tsx
@@ -2,14 +2,15 @@ import { memo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
-import { BackUpSecretKeyLayout } from './back-up-secret-key.layout';
-import { useGeneratedSecretKey } from '@app/store/keys/key.selectors';
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { Header } from '@app/components/header';
 import { SecretKeyDisplayer } from '@app/features/secret-key-displayer/secret-key-displayer';
+import { useDefaultWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
+
+import { BackUpSecretKeyLayout } from './back-up-secret-key.layout';
 
 export const BackUpSecretKeyPage = memo(() => {
-  const secretKey = useGeneratedSecretKey();
+  const secretKey = useDefaultWalletSecretKey();
   const navigate = useNavigate();
 
   useRouteHeader(<Header hideActions />);

--- a/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
+++ b/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { validateMnemonic } from 'bip39';
+import toast from 'react-hot-toast';
 
 import {
   extractPhraseFromPasteEvent,
@@ -13,8 +14,7 @@ import { useLoading } from '@app/common/hooks/use-loading';
 import { useSeedInputErrorState } from '@app/store/onboarding/onboarding.hooks';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useAppDispatch } from '@app/store';
-import { keyActions } from '@app/store/keys/key.actions';
-import toast from 'react-hot-toast';
+import { inMemoryKeyActions } from '@app/store/in-memory-key/in-memory-key.actions';
 
 async function simulateShortDelayToAvoidImmediateNavigation() {
   await delay(600);
@@ -77,7 +77,7 @@ export function useSignIn() {
 
       await simulateShortDelayToAvoidImmediateNavigation();
       toast.success('Secret Key valid');
-      dispatch(keyActions.saveUsersSecretKeyToBeRestored(parsedKeyInput));
+      dispatch(inMemoryKeyActions.saveUsersSecretKeyToBeRestored(parsedKeyInput));
       void analytics.track('submit_valid_secret_key');
       navigate(RouteUrls.SetPassword);
       setIsIdle();

--- a/src/app/pages/onboarding/welcome/welcome.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.tsx
@@ -6,8 +6,8 @@ import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 import { Header } from '@app/components/header';
 import { RouteUrls } from '@shared/route-urls';
-import { useHasAllowedDiagnostics } from '@app/store/onboarding/onboarding.hooks';
 import { WelcomeLayout } from './welcome.layout';
+import { useHasAllowedDiagnostics } from '@app/store/onboarding/onboarding.hooks';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 
 export const WelcomePage = memo(() => {
@@ -23,11 +23,8 @@ export const WelcomePage = memo(() => {
 
   const startOnboarding = useCallback(async () => {
     setIsGeneratingWallet(true);
-
     keyActions.generateWalletKey();
-
     void analytics.track('generate_new_secret_key');
-
     if (decodedAuthRequest) {
       navigate(RouteUrls.SetPassword);
     }
@@ -36,7 +33,6 @@ export const WelcomePage = memo(() => {
 
   useEffect(() => {
     if (hasAllowedDiagnostics === undefined) navigate(RouteUrls.RequestDiagnostics);
-
     return () => setIsGeneratingWallet(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/app/pages/onboarding/welcome/welcome.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.tsx
@@ -9,6 +9,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { WelcomeLayout } from './welcome.layout';
 import { useHasAllowedDiagnostics } from '@app/store/onboarding/onboarding.hooks';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
+import { useDefaultWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
 
 export const WelcomePage = memo(() => {
   const [hasAllowedDiagnostics] = useHasAllowedDiagnostics();
@@ -16,6 +17,7 @@ export const WelcomePage = memo(() => {
   const { decodedAuthRequest } = useOnboardingState();
   const analytics = useAnalytics();
   const keyActions = useKeyActions();
+  const currentInMemoryKey = useDefaultWalletSecretKey();
 
   useRouteHeader(<Header hideActions />);
 
@@ -33,6 +35,8 @@ export const WelcomePage = memo(() => {
 
   useEffect(() => {
     if (hasAllowedDiagnostics === undefined) navigate(RouteUrls.RequestDiagnostics);
+    if (currentInMemoryKey) navigate(RouteUrls.BackUpSecretKey);
+
     return () => setIsGeneratingWallet(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/app/routes/account-gate.spec.ts
+++ b/src/app/routes/account-gate.spec.ts
@@ -1,20 +1,7 @@
 import {
-  shouldNavigateBackToBackupSecretKeyPage,
   shouldNavigateToOnboardingStartPage,
   shouldNavigateToUnlockWalletPage,
 } from './account-gate';
-
-describe(shouldNavigateBackToBackupSecretKeyPage.name, () => {
-  test('that it navigates to backup page when no wallet yet created, but key generated', () => {
-    const result = shouldNavigateBackToBackupSecretKeyPage(undefined, 'some-encrypted-key');
-    expect(result).toBeTruthy();
-  });
-
-  test('that it does not navigate to backup page when no wallet yet created, but key generated', () => {
-    const result = shouldNavigateBackToBackupSecretKeyPage(undefined, null);
-    expect(result).toBeFalsy();
-  });
-});
 
 describe(shouldNavigateToOnboardingStartPage.name, () => {
   test('that it navigates to onboarding when no key details set', () => {

--- a/src/app/routes/account-gate.tsx
+++ b/src/app/routes/account-gate.tsx
@@ -2,15 +2,8 @@ import { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
-import { useCurrentKeyDetails, useGeneratedSecretKey } from '@app/store/keys/key.selectors';
+import { useCurrentKeyDetails } from '@app/store/keys/key.selectors';
 import { useDefaultWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
-
-export function shouldNavigateBackToBackupSecretKeyPage(
-  currentKeyDetails: any,
-  yetToBeEncryptedKey?: string | null
-) {
-  return !currentKeyDetails && yetToBeEncryptedKey;
-}
 
 export function shouldNavigateToOnboardingStartPage(currentKeyDetails?: any) {
   return !currentKeyDetails;
@@ -25,11 +18,7 @@ interface AccountGateProps {
 }
 export const AccountGate = ({ children }: AccountGateProps) => {
   const currentKeyDetails = useCurrentKeyDetails();
-  const yetToBeEncryptedKey = useGeneratedSecretKey();
   const currentInMemorySecretKey = useDefaultWalletSecretKey();
-
-  if (shouldNavigateBackToBackupSecretKeyPage(currentKeyDetails, yetToBeEncryptedKey))
-    return <Navigate to={RouteUrls.BackUpSecretKey} />;
 
   if (shouldNavigateToOnboardingStartPage(currentKeyDetails))
     return <Navigate to={RouteUrls.Onboarding} />;

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -27,6 +27,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { useOnWalletLock } from './hooks/use-on-wallet-lock';
 import { useOnSignOut } from './hooks/use-on-sign-out';
+import { OnboardingGate } from './onboarding-gate';
 
 export function AppRoutes(): JSX.Element | null {
   const { pathname } = useLocation();
@@ -59,10 +60,31 @@ export function AppRoutes(): JSX.Element | null {
         >
           <Route path={RouteUrls.SignOutConfirm} element={<SignOutConfirmDrawer />} />
         </Route>
-        <Route path={RouteUrls.Onboarding} element={<WelcomePage />} />
-        <Route path={RouteUrls.BackUpSecretKey} element={<BackUpSecretKeyPage />} />
+        <Route
+          path={RouteUrls.Onboarding}
+          element={
+            <OnboardingGate>
+              <WelcomePage />
+            </OnboardingGate>
+          }
+        />
+        <Route
+          path={RouteUrls.BackUpSecretKey}
+          element={
+            <OnboardingGate>
+              <BackUpSecretKeyPage />
+            </OnboardingGate>
+          }
+        />
+        <Route
+          path={RouteUrls.SetPassword}
+          element={
+            <OnboardingGate>
+              <SetPasswordPage />
+            </OnboardingGate>
+          }
+        />
         <Route path={RouteUrls.RequestDiagnostics} element={<AllowDiagnosticsPage />} />
-        <Route path={RouteUrls.SetPassword} element={<SetPasswordPage />} />
         <Route path={RouteUrls.SignIn} element={<SignIn />} />
         <Route path={RouteUrls.MagicRecoveryCode} element={<MagicRecoveryCode />} />
         <Route

--- a/src/app/routes/onboarding-gate.tsx
+++ b/src/app/routes/onboarding-gate.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+
+import { RouteUrls } from '@shared/route-urls';
+import { useCurrentKeyDetails } from '@app/store/keys/key.selectors';
+import { useDefaultWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
+
+function hasAlreadyMadeWalletAndPlaintextKeyInMemory(encryptedKey?: string, inMemoryKey?: string) {
+  return !!encryptedKey && !!inMemoryKey;
+}
+
+interface OnboardingGateProps {
+  children: ReactNode;
+}
+export const OnboardingGate = ({ children }: OnboardingGateProps) => {
+  const keyDetails = useCurrentKeyDetails();
+  const currentInMemoryKey = useDefaultWalletSecretKey();
+
+  if (
+    hasAlreadyMadeWalletAndPlaintextKeyInMemory(keyDetails?.encryptedSecretKey, currentInMemoryKey)
+  ) {
+    return <Navigate to={RouteUrls.Home} />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/app/store/in-memory-key/in-memory-key.slice.ts
+++ b/src/app/store/in-memory-key/in-memory-key.slice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { keySlice } from '../keys/key.slice';
+import { defaultKeyId, keySlice } from '../keys/key.slice';
+import { isUndefined } from '@app/common/utils';
 
 interface InMemoryKeyState {
   hasRestoredKeys: boolean;
@@ -15,9 +16,24 @@ export const inMemoryKeySlice = createSlice({
   name: 'inMemoryKey',
   initialState,
   reducers: {
-    setKeysInMemory(state, action: PayloadAction<Record<string, string>>) {
-      return { hasRestoredKeys: true, keys: { ...state.keys, ...action.payload } };
+    generateWalletKey(state, action: PayloadAction<string>) {
+      if (!isUndefined(state.keys[defaultKeyId])) {
+        throw new Error('Cannot generate new key for existing wallet');
+      }
+      state.keys[defaultKeyId] = action.payload;
     },
+
+    saveUsersSecretKeyToBeRestored(state, action: PayloadAction<string>) {
+      if (!isUndefined(state.keys[defaultKeyId])) {
+        throw new Error('Cannot restore key for pre-existing wallet');
+      }
+      state.keys[defaultKeyId] = action.payload;
+    },
+
+    setKeysInMemory(state, action: PayloadAction<Record<string, string>>) {
+      return { ...state, hasRestoredKeys: true, keys: { ...state.keys, ...action.payload } };
+    },
+
     lockWallet(state) {
       state.keys = {};
     },

--- a/src/app/store/keys/key.actions.ts
+++ b/src/app/store/keys/key.actions.ts
@@ -6,10 +6,11 @@ import { AppThunk } from '@app/store';
 
 import { stxChainSlice } from '../chains/stx-chain.slice';
 import { defaultKeyId, keySlice } from './key.slice';
-import { selectCurrentKey, selectGeneratedSecretKey } from './key.selectors';
+import { selectCurrentKey } from './key.selectors';
 import { sendMessage } from '@shared/messages';
 import { InternalMethods } from '@shared/message-types';
 import { inMemoryKeySlice } from '../in-memory-key/in-memory-key.slice';
+import { selectDefaultWalletKey } from '../in-memory-key/in-memory-key.selectors';
 
 async function restoredWalletHighestGeneratedAccountIndex(secretKey: string) {
   try {
@@ -29,7 +30,7 @@ async function restoredWalletHighestGeneratedAccountIndex(secretKey: string) {
 
 const setWalletEncryptionPassword = (password: string): AppThunk => {
   return async (dispatch, getState) => {
-    const secretKey = selectGeneratedSecretKey(getState());
+    const secretKey = selectDefaultWalletKey(getState());
     if (!secretKey) throw new Error('Cannot generate wallet without first having generated a key');
     const { encryptedSecretKey, salt } = await encryptMnemonic({ secretKey, password });
     const highestAccountIndex = await restoredWalletHighestGeneratedAccountIndex(secretKey);

--- a/src/app/store/keys/key.selectors.ts
+++ b/src/app/store/keys/key.selectors.ts
@@ -6,8 +6,6 @@ import { defaultKeyId } from './key.slice';
 
 const selectWalletSlice = (state: RootState) => state.keys;
 
-export const selectGeneratedSecretKey = createSelector(selectWalletSlice, state => state.secretKey);
-
 export const selectCurrentKey = createSelector(
   selectWalletSlice,
   state => state.entities[defaultKeyId]
@@ -15,8 +13,4 @@ export const selectCurrentKey = createSelector(
 
 export function useCurrentKeyDetails() {
   return useSelector(selectCurrentKey);
-}
-
-export function useGeneratedSecretKey() {
-  return useSelector(selectGeneratedSecretKey);
 }

--- a/src/app/store/keys/key.slice.ts
+++ b/src/app/store/keys/key.slice.ts
@@ -1,5 +1,4 @@
 import { createEntityAdapter, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { generateSecretKey } from '@stacks/wallet-sdk';
 
 import { migrateVaultReducerStoreToNewStateStructure } from '../utils/vault-reducer-migration';
 
@@ -14,32 +13,13 @@ interface KeyConfigSoftware {
 
 const keyAdapter = createEntityAdapter<KeyConfigSoftware>();
 
-// Only used during onboarding, pre-wallet creation
-// Could well be persisted elsewhere
-interface ExtraKeyState {
-  secretKey?: null | string;
-}
-
-export const initialKeysState = keyAdapter.getInitialState<ExtraKeyState>({ secretKey: null });
+export const initialKeysState = keyAdapter.getInitialState();
 
 export const keySlice = createSlice({
   name: 'keys',
   initialState: migrateVaultReducerStoreToNewStateStructure(initialKeysState),
   reducers: {
-    generateWalletKey(state) {
-      state.secretKey = generateSecretKey(256);
-    },
-
-    saveUsersSecretKeyToBeRestored(state, action: PayloadAction<string>) {
-      state.secretKey = action.payload;
-    },
-
-    clearWalletKey(state) {
-      state.secretKey = null;
-    },
-
     createNewWalletComplete(state, action: PayloadAction<KeyConfigSoftware>) {
-      state.secretKey = null;
       keyAdapter.addOne(state, action.payload);
     },
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1894167754).<!-- Sticky Header Marker -->

This PR will merge into `refactor/vault-reducer` branch.

Previously, I'd built separate handling for keys generated _before_ having encrypted the wallet (onboarding flow), and keys decrypted (unlock time).

Conceptually, we can think of these as exactly the same, and considering them so simplifies the implementation. Whether you've encrypted your key or not, it's just a key in memory. This PR utilises the same in memory key slice for both onboarding/unlock. As such, no plaintext key is ever persited in `chrome.storage`.