### PR TITLE
Encourage users to onboard via the full page mode

### DIFF
--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -282,3 +282,13 @@ export function formatContractId(address: string, name: string) {
 
 export const isFullPage = document.location.pathname.startsWith('/index.html');
 export const isPopup = !isFullPage;
+
+const pageMode = isFullPage ? 'full' : 'popup';
+
+type PageMode = 'popup' | 'full';
+
+type WhenPageModeMap<T> = Record<PageMode, T>;
+
+export function whenPageMode<T>(pageModeMap: WhenPageModeMap<T>) {
+  return pageModeMap[pageMode];
+}

--- a/src/app/components/centered-page-container.tsx
+++ b/src/app/components/centered-page-container.tsx
@@ -6,7 +6,7 @@ export function CenteredPageContainer(props: FlexProps) {
       alignItems={['left', 'center']}
       flexGrow={1}
       flexDirection="column"
-      height={['70vh', '90vh']}
+      height={['70vh', 'calc(90vh - 68px)']}
       justifyContent={['start', 'center']}
       mb="loose"
       {...props}

--- a/src/app/pages/onboarding/welcome/welcome.layout.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.layout.tsx
@@ -1,6 +1,6 @@
 import { Box, color, Flex, Stack } from '@stacks/ui';
 
-import { isFullPage } from '@app/common/utils';
+import { isFullPage, whenPageMode } from '@app/common/utils';
 import { Caption, Text } from '@app/components/typography';
 import { Link } from '@app/components/link';
 import { PageTitle } from '@app/components/page-title';
@@ -33,36 +33,70 @@ export function WelcomeLayout(props: WelcomeLayoutProps): JSX.Element {
   const { isGeneratingWallet, onStartOnboarding, onRestoreWallet } = props;
 
   return (
-    <CenteredPageContainer>
+    <CenteredPageContainer mt={whenPageMode({ full: undefined, popup: 'base-loose' })}>
       <Stack isInline={isFullPage} width="100%">
         <Flex flexGrow={1} justifyContent="center" order={[0, 1, 1]}>
           <WelcomeIllustration />
         </Flex>
         <Flex alignItems="center" flexGrow={1} justifyContent="center" mt={['base', 'unset']}>
           <Stack maxWidth="500px" spacing={['base', 'base-loose', 'loose']}>
-            <PageTitle isHeadline>Explore the world of Stacks</PageTitle>
+            <PageTitle isHeadline maxWidth="unset">
+              {whenPageMode({
+                full: <>Explore the world of Stacks</>,
+                popup: (
+                  <>
+                    Welcome to <br /> Hiro Wallet
+                  </>
+                ),
+              })}
+            </PageTitle>
             <Text pr={['unset', '60px']}>
               Hiro Wallet connects you to Stacks apps while keeping your account, data, and crypto
-              secure. Create your Stacks account to get started.
+              secure.{' '}
+              {whenPageMode({
+                full: 'Create your Stacks account to get started.',
+                popup: null,
+              })}
             </Text>
-            <PrimaryButton
-              data-testid={OnboardingSelectors.SignUpBtn}
-              isLoading={isGeneratingWallet}
-              onClick={onStartOnboarding}
-              width="198px"
-            >
-              Create Stacks Account
-            </PrimaryButton>
-            <Stack mt={['base', 'base-tight', 'tight']} spacing="tight">
-              <Caption>Already have a Stacks account?</Caption>
-              <Link
-                data-testid={OnboardingSelectors.SignInLink}
-                fontSize="14px"
-                onClick={onRestoreWallet}
-              >
-                Sign in with Secret Key
-              </Link>
-            </Stack>
+            {whenPageMode({
+              popup: (
+                <>
+                  <PrimaryButton
+                    mt="base"
+                    data-testid={OnboardingSelectors.SignUpBtn}
+                    isLoading={isGeneratingWallet}
+                    onClick={onStartOnboarding}
+                  >
+                    Get started
+                  </PrimaryButton>
+                  <Caption mt="extra-tight" textAlign="center">
+                    You'll be taken to a new tab
+                  </Caption>
+                </>
+              ),
+              full: (
+                <>
+                  <PrimaryButton
+                    data-testid={OnboardingSelectors.SignUpBtn}
+                    isLoading={isGeneratingWallet}
+                    onClick={onStartOnboarding}
+                    width="198px"
+                  >
+                    Create Stacks Account
+                  </PrimaryButton>
+                  <Stack mt={['base', 'base-tight', 'tight']} spacing="tight">
+                    <Caption>Already have a Stacks account?</Caption>
+                    <Link
+                      data-testid={OnboardingSelectors.SignInLink}
+                      fontSize="14px"
+                      onClick={onRestoreWallet}
+                    >
+                      Sign in with Secret Key
+                    </Link>
+                  </Stack>
+                </>
+              ),
+            })}
           </Stack>
         </Flex>
       </Stack>

--- a/src/background/init-context-menus.ts
+++ b/src/background/init-context-menus.ts
@@ -1,6 +1,4 @@
-function openNewTabWithWallet() {
-  return chrome.tabs.create({ url: 'index.html' });
-}
+import { openNewTabWalletPage } from '@shared/utils/open-wallet-page';
 
 export function initContextMenuActions() {
   chrome.contextMenus.removeAll();
@@ -9,7 +7,7 @@ export function initContextMenuActions() {
     title: 'Open Hiro Wallet in a new tab',
     contexts: ['browser_action'],
     async onclick() {
-      await openNewTabWithWallet();
+      await openNewTabWalletPage();
     },
   });
 }

--- a/src/shared/utils/open-wallet-page.ts
+++ b/src/shared/utils/open-wallet-page.ts
@@ -1,0 +1,3 @@
+export function openNewTabWalletPage() {
+  return chrome.tabs.create({ url: 'index.html' });
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1927415940).<!-- Sticky Header Marker -->

Much like Metamask, it's better to encourage users to onboard via the full screen mode. Consider https://github.com/hirosystems/stacks-wallet-web/issues/2191, the user wants to use a password manager but they have to deal with opening/closing the popup. They likely don't know they can do this in a whole page.

We _could_ send them straight to back up secret key page (a bit more work, and plus then they don't have chance to change mind and say user Ledger for example), but even just opening the whole page full screen is an improvement imo. 

https://user-images.githubusercontent.com/1618764/155570365-4483be9e-0c98-49e8-9080-edb7c92ed6b4.mp4

