### PR TITLE
fix: Backup old wallet salt key to gaia

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@sentry/tracing": "6.16.1",
     "@stacks/blockchain-api-client": "0.65.0",
     "@stacks/common": "3.0.0",
+    "@stacks/storage": "3.2.0",
     "@stacks/connect": "6.4.0",
     "@stacks/connect-ui": "5.2.0",
     "@stacks/encryption": "3.0.0",

--- a/src/app/common/hooks/account/use-old-wallet-salt.ts
+++ b/src/app/common/hooks/account/use-old-wallet-salt.ts
@@ -1,0 +1,92 @@
+import { decryptContent, encryptContent, getPublicKeyFromPrivate } from '@stacks/encryption';
+import { createWalletGaiaConfig } from '@stacks/wallet-sdk';
+import { useAsync } from 'react-async-hook';
+import { fetchPrivate } from '@stacks/common';
+import { gaiaUrl } from '@shared/constants';
+import { useWalletState } from '@app/store/wallet/wallet.hooks';
+import { logger } from '@shared/logger';
+import { GaiaHubConfig, uploadToGaiaHub } from '@stacks/storage';
+
+const saltUsedInAppKeyInGaia = 'salt-used-in-app-key-in-gaia';
+const walletSaltBackup = 'wallet-salt-backup';
+
+export function useBackupOldWalletSalt() {
+  // If we already stored in gaia and fetched it, just look up localStorage
+  // We did not do the migration yet, check if previous salt (before this release) is in localStorage
+  const localSalt = localStorage.getItem(walletSaltBackup);
+  const [wallet] = useWalletState();
+
+  return useAsync(async () => {
+    if (localStorage.getItem(saltUsedInAppKeyInGaia)) return;
+    if (!wallet) return;
+    const gaiaHubConfig = await createWalletGaiaConfig({ gaiaHubUrl: gaiaUrl, wallet });
+    if (localSalt) {
+      await storeToGaia(wallet.configPrivateKey, gaiaHubConfig, localSalt);
+      localStorage.setItem(saltUsedInAppKeyInGaia, localSalt);
+      return localSalt;
+    }
+    // Fetch Gaia wallet migration data file
+    const migrationData = await fetchWalletMigrationData({
+      configPrivateKey: wallet.configPrivateKey,
+      gaiaHubConfig,
+    });
+    if (!migrationData) return;
+    // Store salt in localStorage so we don't have to fetch Gaia again and that salt is never updated again
+    localStorage.setItem(saltUsedInAppKeyInGaia, migrationData.oldWalletSalt);
+    return migrationData.oldWalletSalt;
+  }, []).result;
+}
+
+interface WalletDataMigrationConfig {
+  version: string;
+  oldWalletSalt: string;
+  meta?: {
+    [key: string]: any;
+  };
+}
+
+async function fetchWalletMigrationData({
+  configPrivateKey,
+  gaiaHubConfig,
+}: {
+  configPrivateKey: string;
+  gaiaHubConfig: GaiaHubConfig;
+}) {
+  try {
+    const response = await fetchPrivate(
+      `${gaiaHubConfig.url_prefix}${gaiaHubConfig.address}/wallet-migration-data.json`
+    );
+    if (!response.ok) return null;
+    const encrypted = await response.text();
+    const configJSON = (await decryptContent(encrypted, {
+      privateKey: configPrivateKey,
+    })) as string;
+    const config: WalletDataMigrationConfig = JSON.parse(configJSON);
+    return config;
+  } catch (error) {
+    logger.error(error);
+    return null;
+  }
+}
+
+const walletMigrationFilename = 'wallet-migration-data.json';
+
+const walletMigrationVersion = '1.0';
+async function storeToGaia(configPrivateKey: string, gaiaHubConfig: GaiaHubConfig, salt: string) {
+  const migrationData: WalletDataMigrationConfig = {
+    version: walletMigrationVersion,
+    oldWalletSalt: salt,
+  };
+  const publicKey = getPublicKeyFromPrivate(configPrivateKey);
+  const encrypted = await encryptContent(JSON.stringify(migrationData), { publicKey });
+  await uploadToGaiaHub(
+    walletMigrationFilename,
+    encrypted,
+    gaiaHubConfig,
+    undefined,
+    undefined,
+    undefined,
+    true
+  );
+  return migrationData;
+}

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -24,6 +24,7 @@ import { useAccounts } from '@app/store/accounts/account.hooks';
 import { useUpdateAccountDrawerStep, useUpdateShowAccounts } from '@app/store/ui/ui.hooks';
 import { AccountStep } from '@app/store/ui/ui.models';
 import { useAddressBalances } from '@app/query/balance/balance.hooks';
+import { useBackupOldWalletSalt } from '@app/common/hooks/account/use-old-wallet-salt';
 
 const loadingProps = { color: '#A1A7B3' };
 const getLoadingProps = (loading: boolean) => (loading ? loadingProps : {});
@@ -144,6 +145,7 @@ export const Accounts = memo(() => {
   const accounts = useAccounts();
   const { decodedAuthRequest } = useOnboardingState();
   const [selectedAccount, setSelectedAccount] = useState<number | null>(null);
+  useBackupOldWalletSalt();
 
   const signIntoAccount = useCallback(
     async (index: number) => {

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -16,12 +16,14 @@ import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { AccountInfoFetcher, BalanceFetcher } from './components/fetchers';
 import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
 import { HomeTabs } from './components/home-tabs';
+import { useBackupOldWalletSalt } from '@app/common/hooks/account/use-old-wallet-salt';
 
 export function Home() {
   const { decodedAuthRequest } = useOnboardingState();
   const navigate = useNavigate();
 
   const account = useCurrentAccount();
+  useBackupOldWalletSalt();
 
   useRouteHeader(
     <>

--- a/src/app/store/utils/vault-reducer-migration.ts
+++ b/src/app/store/utils/vault-reducer-migration.ts
@@ -9,6 +9,7 @@ const hiroWalletEncryptionKey = 'stacks-wallet-encrypted-key';
 export function migrateVaultReducerStoreToNewStateStructure(initialState: typeof initialKeysState) {
   const salt = localStorage.getItem(hiroWalletSalt);
   const encryptedSecretKey = localStorage.getItem(hiroWalletEncryptionKey);
+
   if (salt && encryptedSecretKey) {
     logger.debug(
       'VaultReducer generated Hiro Wallet detected. Running migration to keys store structure'

--- a/src/app/store/wallet/wallet.ts
+++ b/src/app/store/wallet/wallet.ts
@@ -14,6 +14,7 @@ export const walletState = atom(async get => {
   return deriveWalletWithAccounts(defaultInMemoryKey, store.chains.stx.default.highestAccountIndex);
 });
 
+// TOREMOVE
 export const walletConfigState = atom(async get => {
   const wallet = get(walletState);
   if (!wallet) return null;

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -19,12 +19,14 @@ import {
 import { popupCenter } from '@background/popup-center';
 import { initContextMenuActions } from '@background/init-context-menus';
 import { backgroundMessageHandler } from './message-handler';
+import { backupOldWalletSalt } from './backup-old-wallet-salt';
 
 const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 
 initSentry();
 
 initContextMenuActions();
+backupOldWalletSalt();
 
 //
 // Playwright does not currently support Chrome extension popup testing:

--- a/src/background/backup-old-wallet-salt.ts
+++ b/src/background/backup-old-wallet-salt.ts
@@ -1,0 +1,7 @@
+const walletSaltBackup = 'wallet-salt-backup';
+
+export function backupOldWalletSalt() {
+  const salt = localStorage.getItem('stacks-wallet-salt');
+  // Save the previous wallet salt to later store on gaia encrypted
+  if (salt !== null) localStorage.setItem(walletSaltBackup, salt);
+}

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -33,7 +33,7 @@ const deriveWalletWithAccounts = memoize(async (secretKey: string, highestAccoun
   }
 });
 
-// Persists keys in memory for the durtion of the background scripts life
+// Persists keys in memory for the duration of the background scripts life
 const inMemoryKeys = new Map();
 
 export async function backgroundMessageHandler(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,7 +3730,7 @@
   resolved "https://registry.yarnpkg.com/@stacks/stacks-blockchain-api-types/-/stacks-blockchain-api-types-0.65.0.tgz#38cd10571e38f314dbcd6f6244d6042f7d6a8e0a"
   integrity sha512-V0ko6Cge+IP/XV352rHDDPYYz84gSCRbeklyor3FaUdSZFZIXjVM1upIbo5FDQ6Enygbcpve+vpbbajiWMB16A==
 
-"@stacks/storage@^3.0.0":
+"@stacks/storage@3.2.0", "@stacks/storage@^3.0.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@stacks/storage/-/storage-3.2.0.tgz#eb8c26a96eca96d5e7cf55d284e1d4fa07518c15"
   integrity sha512-turWq288tGOxWZdX0XW157GmNelnUCWl5rw770OZqsC4g4RI8wPYaeBB/M0rhuGP6CDXUds/YImV/WE8o32dxA==


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1934531715).<!-- Sticky Header Marker -->

This PR setup a backup of the user wallet salt in Gaia encrypted. This is to fix #2238
This will be used to pass to the dApp later
 
## Test1
To reproduce you will have to simulate a wallet upgrade (see https://github.com/hirosystems/stacks-wallet-web/pull/2172)

- Install the live wallet (https://github.com/hirosystems/stacks-wallet-web/releases/tag/v3.2.0), place it in a folder `hiro-wallet`
- Setup a wallet (note down the seed)
- Look in the localStorage (open dev tool, tab Application , select Local Storage chrome:extension) and note down the stacks-wallet-salt
- Install the new wallet (using the same instruction as the simulation steps)
- it will be on the unlock screen, unlock it
- Check the localStorage: You should have an entry with key = 'salt-used-in-app-key-in-gaia' and the value is the salt you noted down

## Test 2
- Now completely uninstall the wallet or use another browser, and install this build again.
- Enter the same seed as Test1
- Look in the localStorage: You should have an entry with key = 'salt-used-in-app-key-in-gaia' and the value is the salt you noted down

another test is to login with a dapp in Test1
close the browser and update with the new build. 
Go to the dapp logout/login, the choose account popup should be triggered.
You should have an entry with key = 'salt-used-in-app-key-in-gaia' and the value is the salt you noted down