### PR TITLE
fix: backup old wallet salt key to gaia using background script

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@sentry/tracing": "6.16.1",
     "@stacks/blockchain-api-client": "0.65.0",
     "@stacks/common": "3.0.0",
+    "@stacks/storage": "3.2.0",
     "@stacks/connect": "6.4.0",
     "@stacks/connect-ui": "5.2.0",
     "@stacks/encryption": "3.0.0",

--- a/src/app/store/utils/vault-reducer-migration.ts
+++ b/src/app/store/utils/vault-reducer-migration.ts
@@ -9,6 +9,7 @@ const hiroWalletEncryptionKey = 'stacks-wallet-encrypted-key';
 export function migrateVaultReducerStoreToNewStateStructure(initialState: typeof initialKeysState) {
   const salt = localStorage.getItem(hiroWalletSalt);
   const encryptedSecretKey = localStorage.getItem(hiroWalletEncryptionKey);
+
   if (salt && encryptedSecretKey) {
     logger.debug(
       'VaultReducer generated Hiro Wallet detected. Running migration to keys store structure'

--- a/src/app/store/wallet/wallet.ts
+++ b/src/app/store/wallet/wallet.ts
@@ -14,6 +14,7 @@ export const walletState = atom(async get => {
   return deriveWalletWithAccounts(defaultInMemoryKey, store.chains.stx.default.highestAccountIndex);
 });
 
+// TOREMOVE
 export const walletConfigState = atom(async get => {
   const wallet = get(walletState);
   if (!wallet) return null;

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -19,12 +19,14 @@ import {
 import { popupCenter } from '@background/popup-center';
 import { initContextMenuActions } from '@background/init-context-menus';
 import { backgroundMessageHandler } from './message-handler';
+import { backupOldWalletSalt } from './backup-old-wallet-salt';
 
 const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 
 initSentry();
 
 initContextMenuActions();
+backupOldWalletSalt();
 
 //
 // Playwright does not currently support Chrome extension popup testing:

--- a/src/background/backup-old-wallet-salt.ts
+++ b/src/background/backup-old-wallet-salt.ts
@@ -1,0 +1,108 @@
+import { logger } from '@shared/logger';
+import { gaiaUrl } from '@shared/constants';
+import { createWalletGaiaConfig, generateWallet } from '@stacks/wallet-sdk';
+import { GaiaHubConfig, uploadToGaiaHub } from '@stacks/storage';
+import { decryptContent, encryptContent, getPublicKeyFromPrivate } from '@stacks/encryption';
+import { fetchPrivate } from '@stacks/common';
+
+const walletSaltBackup = 'wallet-salt-backup';
+
+export function backupOldWalletSalt() {
+  const salt = localStorage.getItem('stacks-wallet-salt');
+  // Save the previous wallet salt to later store on gaia encrypted
+  if (salt !== null) localStorage.setItem(walletSaltBackup, salt);
+}
+
+interface WalletDataMigrationConfig {
+  version: string;
+  walletSaltThatGeneratesIncorrectAppKey: string;
+  meta?: {
+    [key: string]: any;
+  };
+}
+
+async function fetchWalletMigrationData({
+  configPrivateKey,
+  gaiaHubConfig,
+}: {
+  configPrivateKey: string;
+  gaiaHubConfig: GaiaHubConfig;
+}) {
+  try {
+    const response = await fetchPrivate(
+      `${gaiaHubConfig.url_prefix}${gaiaHubConfig.address}/wallet-migration-data.json`
+    );
+    if (!response.ok) return null;
+    const encrypted = await response.text();
+    const configJSON = (await decryptContent(encrypted, {
+      privateKey: configPrivateKey,
+    })) as string;
+    const config: WalletDataMigrationConfig = JSON.parse(configJSON);
+    return config;
+  } catch (error) {
+    logger.error(error);
+    return null;
+  }
+}
+
+const walletMigrationFilename = 'wallet-migration-data.json';
+const walletMigrationVersion = '1.0';
+
+async function storeToGaia(
+  configPrivateKey: string,
+  gaiaHubConfig: GaiaHubConfig,
+  walletSaltThatGeneratesIncorrectAppKey: string
+) {
+  const migrationData: WalletDataMigrationConfig = {
+    version: walletMigrationVersion,
+    walletSaltThatGeneratesIncorrectAppKey,
+  };
+  const publicKey = getPublicKeyFromPrivate(configPrivateKey);
+  const encrypted = await encryptContent(JSON.stringify(migrationData), { publicKey });
+  try {
+    await uploadToGaiaHub(
+      walletMigrationFilename,
+      encrypted,
+      gaiaHubConfig,
+      undefined,
+      undefined,
+      undefined,
+      true
+    );
+  } catch (e) {
+    logger.error(e);
+    return;
+  }
+  return migrationData;
+}
+
+const saltUsedInAppKeyInGaia = 'salt-used-in-app-key-in-gaia';
+
+export async function backupWalletSaltForGaia(secretKey: string) {
+  // If we already stored in gaia and fetched it, just look up localStorage
+  // We did not do the migration yet, check if previous salt (before this release) is in localStorage
+  const localSalt = localStorage.getItem(walletSaltBackup);
+  const wallet = await generateWallet({ secretKey, password: '' });
+
+  if (localStorage.getItem(saltUsedInAppKeyInGaia)) return;
+  if (!wallet) return;
+  const gaiaHubConfig = await createWalletGaiaConfig({ gaiaHubUrl: gaiaUrl, wallet });
+  if (localSalt) {
+    const migrationData = await storeToGaia(wallet.configPrivateKey, gaiaHubConfig, localSalt);
+    if (!migrationData) return;
+    localStorage.setItem(saltUsedInAppKeyInGaia, localSalt);
+    return localSalt;
+  }
+  // Fetch Gaia wallet migration data file
+  const migrationData = await fetchWalletMigrationData({
+    configPrivateKey: wallet.configPrivateKey,
+    gaiaHubConfig,
+  });
+  if (!migrationData) return;
+  // Store salt in localStorage so we don't have to fetch Gaia again and that salt is never updated again
+  localStorage.setItem(
+    saltUsedInAppKeyInGaia,
+    migrationData.walletSaltThatGeneratesIncorrectAppKey
+  );
+  return migrationData.walletSaltThatGeneratesIncorrectAppKey;
+}

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -4,6 +4,7 @@ import { InternalMethods } from '@shared/message-types';
 import { BackgroundActions } from '@shared/messages';
 import { generateNewAccount, generateWallet, restoreWalletAccounts } from '@stacks/wallet-sdk';
 import memoize from 'promise-memoize';
+import { backupWalletSaltForGaia } from './backup-old-wallet-salt';
 
 function validateMessagesAreFromExtension(sender: chrome.runtime.MessageSender) {
   // Only respond to internal messages from our UI, not content scripts in other applications
@@ -33,7 +34,7 @@ const deriveWalletWithAccounts = memoize(async (secretKey: string, highestAccoun
   }
 });
 
-// Persists keys in memory for the durtion of the background scripts life
+// Persists keys in memory for the duration of the background scripts life
 const inMemoryKeys = new Map();
 
 export async function backgroundMessageHandler(
@@ -56,7 +57,9 @@ export async function backgroundMessageHandler(
 
     case InternalMethods.ShareInMemoryKeyToBackground: {
       const { keyId, secretKey } = message.payload;
+
       inMemoryKeys.set(keyId, secretKey);
+      await backupWalletSaltForGaia(secretKey);
       break;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,7 +3730,7 @@
   resolved "https://registry.yarnpkg.com/@stacks/stacks-blockchain-api-types/-/stacks-blockchain-api-types-0.65.0.tgz#38cd10571e38f314dbcd6f6244d6042f7d6a8e0a"
   integrity sha512-V0ko6Cge+IP/XV352rHDDPYYz84gSCRbeklyor3FaUdSZFZIXjVM1upIbo5FDQ6Enygbcpve+vpbbajiWMB16A==
 
-"@stacks/storage@^3.0.0":
+"@stacks/storage@3.2.0", "@stacks/storage@^3.0.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@stacks/storage/-/storage-3.2.0.tgz#eb8c26a96eca96d5e7cf55d284e1d4fa07518c15"
   integrity sha512-turWq288tGOxWZdX0XW157GmNelnUCWl5rw770OZqsC4g4RI8wPYaeBB/M0rhuGP6CDXUds/YImV/WE8o32dxA==


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1962887358).<!-- Sticky Header Marker -->

This PR uses background script to handle the backup
closes #2238

Previous PR https://github.com/hirosystems/stacks-wallet-web/pull/2286

@fbwoolf I moved the logic to the background message handler
Since we only have the secret key, I recreated the wallet with the secret key instead of using the WalletState which is not accessible in the background.