### PR TITLE
fix: account names not displayed on sign in screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "mdi-react": "7.5.0",
     "object-hash": "2.2.0",
     "pino": "7.6.0",
-    "prismjs": "1.25.0",
+    "prismjs": "1.27.0",
     "react": "17.0.2",
     "react-async-hook": "4.0.0",
     "react-dom": "17.0.2",
@@ -251,7 +251,7 @@
     "yup": "0.32.9"
   },
   "resolutions": {
-    "**/**/prismjs": "1.25.0",
+    "**/**/prismjs": "1.27.0",
     "**/**/xmldom": "github:xmldom/xmldom#0.7.0",
     "**/**/@stacks/network": "3.0.0",
     "bn.js": "5.2.0",

--- a/src/app/common/hooks/account/use-account-names.ts
+++ b/src/app/common/hooks/account/use-account-names.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { useCurrentAccountNames, useGetAccountNamesByAddressQuery } from '@app/query/bns/bns.hooks';
+import { getAccountDisplayName } from '@stacks/wallet-sdk';
+import { AccountWithAddress } from '@app/store/accounts/account.models';
 
 export function useCurrentAccountDisplayName() {
   const names = useCurrentAccountNames();
@@ -12,11 +14,8 @@ export function useCurrentAccountDisplayName() {
   }, [account, names]);
 }
 
-export function useAccountDisplayName(address: string, index: number) {
-  const names = useGetAccountNamesByAddressQuery(address);
+export function useAccountDisplayName(account: AccountWithAddress) {
+  const names = useGetAccountNamesByAddressQuery(account.address);
 
-  return useMemo(() => {
-    if (!names.length) return `Account ${index + 1}`;
-    return names[0];
-  }, [index, names]);
+  return useMemo(() => names[0] ?? getAccountDisplayName(account), [account, names]);
 }

--- a/src/app/features/account-switch-drawer/components/account-name.tsx
+++ b/src/app/features/account-switch-drawer/components/account-name.tsx
@@ -4,17 +4,17 @@ import { BoxProps } from '@stacks/ui';
 import { getAccountDisplayName } from '@stacks/wallet-sdk';
 
 import { Title } from '@app/components/typography';
-import { useGetAccountNamesByAddressQuery } from '@app/query/bns/bns.hooks';
+import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 
 interface AccountNameProps extends BoxProps {
   account: AccountWithAddress;
 }
 export const AccountName = memo(({ account }: AccountNameProps) => {
-  const name = useGetAccountNamesByAddressQuery(account.address);
+  const name = useAccountDisplayName(account);
 
   return (
     <Title fontSize={2} lineHeight="1rem" fontWeight="400">
-      {name[0] ?? getAccountDisplayName(account)}
+      {name}
     </Title>
   );
 });

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -62,7 +62,7 @@ const AccountItem = memo((props: AccountItemProps) => {
   const { selectedAddress, account, isLoading, onSelectAccount, ...rest } = props;
   const [component, bind] = usePressable(true);
   const { decodedAuthRequest } = useOnboardingState();
-  const name = useAccountDisplayName(account.address, account.index);
+  const name = useAccountDisplayName(account);
   const { data: balances, isLoading: isBalanceLoading } = useAddressBalances(account.address);
   const showLoadingProps = !!selectedAddress || !decodedAuthRequest;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14123,10 +14123,10 @@ prism-react-renderer@^1.2.0:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz#392460acf63540960e5e3caa699d851264e99b89"
   integrity sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==
 
-prismjs@1.25.0, prismjs@^1.23.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756"
-  integrity sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==
+prismjs@1.27.0, prismjs@^1.23.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1958735235).<!-- Sticky Header Marker -->

@fbwoolf @beguene we need this fix for the user names in production to help @larrysalibra with the launch of his BNS app. It's quite an isolated change, so it is safe to merge straight to `main`.

Can you release and make sure it's okay? See original PR for changes/related issue