### PR TITLE
fix: removing localstorage vaules, add back later

### DIFF
--- a/src/app/store/utils/vault-reducer-migration.spec.ts
+++ b/src/app/store/utils/vault-reducer-migration.spec.ts
@@ -5,6 +5,13 @@ import { migrateVaultReducerStoreToNewStateStructure } from './vault-reducer-mig
 (global as any).localStorage = new LocalStorageMock();
 
 describe(migrateVaultReducerStoreToNewStateStructure.name, () => {
+  describe('no migration needed scenario', () => {
+    test('nothing happens when no localStorage values are detected', () => {
+      const returnedValue = migrateVaultReducerStoreToNewStateStructure({} as any);
+      expect(returnedValue).toEqual({});
+    });
+  });
+
   describe('migration scenario', () => {
     beforeEach(() => {
       localStorage.setItem('stacks-wallet-salt', 'test-salt');
@@ -35,18 +42,12 @@ describe(migrateVaultReducerStoreToNewStateStructure.name, () => {
       });
     });
 
-    test('it removes the existing existing localStorage values', () => {
+    // This functionality should be re-added, post a successful launch of the wallet refactor
+    test.skip('it removes the existing existing localStorage values', () => {
       jest.spyOn(global.localStorage.__proto__, 'removeItem');
       migrateVaultReducerStoreToNewStateStructure({} as any);
       expect(localStorage.removeItem).toHaveBeenCalledWith('stacks-wallet-salt');
       expect(localStorage.removeItem).toHaveBeenCalledWith('stacks-wallet-encrypted-key');
-    });
-  });
-
-  describe('no migration needed scenario', () => {
-    test('nothing happens when no localStorage values are detected', () => {
-      const returnedValue = migrateVaultReducerStoreToNewStateStructure({} as any);
-      expect(returnedValue).toEqual({});
     });
   });
 });

--- a/src/app/store/utils/vault-reducer-migration.ts
+++ b/src/app/store/utils/vault-reducer-migration.ts
@@ -25,8 +25,6 @@ export function migrateVaultReducerStoreToNewStateStructure(initialState: typeof
         },
       },
     };
-    localStorage.removeItem(hiroWalletSalt);
-    localStorage.removeItem(hiroWalletEncryptionKey);
     return deepMerge(initialState, migratedState);
   }
   return initialState;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/1985552443).<!-- Sticky Header Marker -->

This PR enable the possibility to roll back, does the next release fail.

On successful release, these removals should be re-added.