### PR TITLE
chore: use main branch for wallet config

### DIFF
--- a/src/app/query/hiro-config/hiro-config.query.ts
+++ b/src/app/query/hiro-config/hiro-config.query.ts
@@ -29,7 +29,7 @@ interface HiroConfig {
   feeEstimations?: FeeEstimationsConfig;
 }
 
-const GITHUB_PRIMARY_BRANCH = 'dev';
+const GITHUB_PRIMARY_BRANCH = 'main';
 const githubWalletConfigRawUrl = `https://raw.githubusercontent.com/${GITHUB_ORG}/${GITHUB_REPO}/${GITHUB_PRIMARY_BRANCH}/config/wallet-config.json`;
 
 async function fetchHiroMessages(): Promise<HiroConfig> {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2003755747).<!-- Sticky Header Marker -->

instead of dev.

It's better to fetch the wallet-config.json from main branch rather than dev. If we keep dev, then anything we merge in dev in preparation for release might impact the production wallet in an unexpected way.

To release https://github.com/hirosystems/stacks-wallet-web/pull/2312 we must release this PR first.

