### PR TITLE
fix: remove conditional code for post conditions in fts

### DIFF
--- a/src/app/store/transactions/fungible-token-transfer.ts
+++ b/src/app/store/transactions/fungible-token-transfer.ts
@@ -1,9 +1,5 @@
 import { useAtomValue } from 'jotai/utils';
-import {
-  currentAccountBalancesUnanchoredState,
-  currentAccountState,
-  currentAccountStxAddressState,
-} from '@app/store/accounts';
+import { currentAccountState, currentAccountStxAddressState } from '@app/store/accounts';
 import { currentStacksNetworkState } from '@app/store/network/networks';
 import { currentAccountNonceState } from '@app/store/accounts/nonce';
 import { useSelectedAssetItem } from '@app/store/assets/asset.hooks';
@@ -13,7 +9,6 @@ export function useMakeFungibleTokenTransfer() {
   const asset = useSelectedAssetItem();
   const currentAccount = useAtomValue(currentAccountState);
   const network = useAtomValue(currentStacksNetworkState);
-  const balances = useAtomValue(currentAccountBalancesUnanchoredState);
   const stxAddress = useAtomValue(currentAccountStxAddressState);
   const nonce = useAtomValue(currentAccountNonceState);
   return useMemo(() => {
@@ -25,7 +20,6 @@ export function useMakeFungibleTokenTransfer() {
         asset,
         stxAddress,
         nonce,
-        balances,
         network,
         assetName,
         contractAddress,
@@ -33,5 +27,5 @@ export function useMakeFungibleTokenTransfer() {
       };
     }
     return;
-  }, [asset, balances, currentAccount, network, nonce, stxAddress]);
+  }, [asset, currentAccount, network, nonce, stxAddress]);
 }

--- a/src/app/store/transactions/local-transactions.ts
+++ b/src/app/store/transactions/local-transactions.ts
@@ -87,36 +87,29 @@ export function useFtTokenTransferUnsignedTx() {
   const selectedAsset = useSelectedAssetItem();
 
   return useAsync(async () => {
-    if (!address) return;
+    if (!address || !assetTransferState || !selectedAsset || !account) return;
 
-    if (!assetTransferState || !selectedAsset || !account) return;
-    const { balances, network, assetName, contractAddress, contractName, nonce, stxAddress } =
+    const { network, assetName, contractAddress, contractName, nonce, stxAddress } =
       assetTransferState;
 
     const functionName = 'transfer';
 
     const txNonce = typeof customNonce === 'number' ? customNonce : nonce;
 
-    const tokenBalanceKey = Object.keys(balances?.fungible_tokens || {}).find(contract => {
-      return contract.startsWith(contractAddress);
-    });
-
     const realAmount =
       selectedAsset.type === 'ft'
         ? ftUnshiftDecimals(txData?.amount || 0, selectedAsset?.meta?.decimals || 0)
         : txData?.amount || 0;
 
-    const postConditionOptions = tokenBalanceKey
-      ? {
-          contractAddress,
-          contractName,
-          assetName,
-          stxAddress,
-          amount: realAmount,
-        }
-      : undefined;
+    const postConditionOptions = {
+      contractAddress,
+      contractName,
+      assetName,
+      stxAddress,
+      amount: realAmount,
+    };
 
-    const postConditions = postConditionOptions ? [makePostCondition(postConditionOptions)] : [];
+    const postConditions = [makePostCondition(postConditionOptions)];
 
     // (transfer (uint principal principal) (response bool uint))
     const functionArgs: ClarityValue[] = [


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2017416451).<!-- Sticky Header Marker -->

Previously, we had some conditional handling for whether to add post conditions to a FT transfer. This worked in a way whereby we'd check if the user had a balance for the given asset at _transaction creation time_.

I don't think this is necessary. The user is prohibited from ever selecting an asset they do not hold, so this PR kills this check. In doing so, we remove any requirement for transaction creation to rely on the balances response, removing a possible race condition where the tx is created post condition-less _before_ the balances have loaded.

Hopefully this closes https://github.com/hirosystems/stacks-wallet-web/issues/2301

 