### PR TITLE
fix: fee dropdown positioning

### DIFF
--- a/src/app/components/fee-row/components/fee-estimate-item.tsx
+++ b/src/app/components/fee-row/components/fee-estimate-item.tsx
@@ -1,4 +1,5 @@
-import { FiChevronDown } from 'react-icons/fi';
+import { useCallback } from 'react';
+import { FiCheck, FiChevronDown } from 'react-icons/fi';
 import { color, Stack } from '@stacks/ui';
 
 import { SpaceBetween } from '@app/components/space-between';
@@ -14,7 +15,12 @@ interface FeeEstimateItemProps {
   visible?: boolean;
 }
 export function FeeEstimateItem(props: FeeEstimateItemProps) {
-  const { index, onClick, visible } = props;
+  const { index, onClick, selected, visible } = props;
+
+  const selectedIcon = useCallback(() => {
+    const isSelected = index === selected;
+    return isSelected ? <FiCheck color={color('accent')} size="14px" /> : <></>;
+  }, [index, selected]);
 
   return (
     <Stack
@@ -33,7 +39,7 @@ export function FeeEstimateItem(props: FeeEstimateItemProps) {
     >
       <SpaceBetween flexGrow={1}>
         <Caption ml="2px">{labels[index]}</Caption>
-        {visible ? <></> : <FiChevronDown />}
+        {visible ? selectedIcon() : <FiChevronDown />}
       </SpaceBetween>
     </Stack>
   );

--- a/src/app/components/fee-row/components/fee-estimate-select.tsx
+++ b/src/app/components/fee-row/components/fee-estimate-select.tsx
@@ -10,11 +10,12 @@ import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 interface FeeEstimateSelectProps {
   items: FeeEstimation[];
   onClick: (index: number) => void;
+  selected: number;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   visible: boolean;
 }
 export function FeeEstimateSelect(props: FeeEstimateSelectProps) {
-  const { items, onClick, setIsOpen, visible } = props;
+  const { items, onClick, selected, setIsOpen, visible } = props;
   const ref = useRef<HTMLDivElement | null>(null);
 
   useOnClickOutside(ref, () => setIsOpen(false));
@@ -35,13 +36,24 @@ export function FeeEstimateSelect(props: FeeEstimateSelectProps) {
           position="absolute"
           ref={ref}
           style={styles}
-          top="-32px"
+          top="-100px"
           zIndex={9999}
         >
           {items.map((item, index) => (
-            <FeeEstimateItem index={index} key={item.fee} onClick={onClick} visible />
+            <FeeEstimateItem
+              index={index}
+              key={item.fee}
+              onClick={onClick}
+              selected={selected}
+              visible
+            />
           ))}
-          <FeeEstimateItem index={Estimations.Custom} onClick={onClick} visible />
+          <FeeEstimateItem
+            index={Estimations.Custom}
+            onClick={onClick}
+            selected={selected}
+            visible
+          />
         </Stack>
       )}
     </Fade>

--- a/src/app/components/fee-row/fee-row.tsx
+++ b/src/app/components/fee-row/fee-row.tsx
@@ -90,6 +90,7 @@ export function FeeRow(props: FeeRowProps): JSX.Element {
                 <FeeEstimateSelect
                   items={feeEstimations}
                   onClick={handleSelectedItem}
+                  selected={selected}
                   setIsOpen={setIsOpen}
                   visible={isOpen}
                 />

--- a/src/app/pages/buy/components/onramp-provider-layout.tsx
+++ b/src/app/pages/buy/components/onramp-provider-layout.tsx
@@ -7,11 +7,11 @@ import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { BuyTokensSelectors } from '@tests/page-objects/buy-tokens-selectors';
 
 const providersInfo = {
-  transak: {
-    title: 'Transak',
-    body: 'Non-US residents can purchase STX with credit card, debit card, or bank transfer via Transak.',
-    cta: 'Buy on Transak',
-    test_id: 'BtnTransak',
+  moonpay: {
+    title: 'MoonPay',
+    body: 'US and Non-US residents can purchase STX with credit card, debit card, bank transfer, Apple pay or Google pay via MoonPay.',
+    cta: 'Buy on MoonPay',
+    test_id: 'BtnMoonPay',
   },
   okcoin: {
     title: 'Okcoin',
@@ -19,17 +19,18 @@ const providersInfo = {
     cta: 'Buy on Okcoin',
     test_id: 'BtnOkCoin',
   },
-  moonpay: {
-    title: 'MoonPay',
-    body: 'US and Non-US residents can purchase STX with credit card, debit card, bank transfer, Apple pay or Google pay via MoonPay.',
-    cta: 'Buy on MoonPay',
-    test_id: 'BtnMoonPay',
+  transak: {
+    title: 'Transak',
+    body: 'US and Non-US residents can purchase STX with credit card, debit card, or bank transfer via Transak.',
+    cta: 'Buy on Transak',
+    test_id: 'BtnTransak',
   },
 };
 
 export interface ProvidersUrl {
-  transak: string;
+  moonpay: string;
   okcoin: string;
+  transak: string;
 }
 
 interface OnrampProviderLayoutProps {

--- a/src/app/pages/buy/components/onramp-provider.tsx
+++ b/src/app/pages/buy/components/onramp-provider.tsx
@@ -17,9 +17,9 @@ export const OnrampProviders = (props: OnrampProvidersProps) => {
   if (!hasProviders) return null;
 
   const providersUrl = {
-    transak: makeTransakUrl(address),
-    okcoin: makeOkcoinUrl(address),
     moonpay: makeMoonPayUrl(address),
+    okcoin: makeOkcoinUrl(address),
+    transak: makeTransakUrl(address),
   };
 
   return (


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2059351875).<!-- Sticky Header Marker -->

Simple PR to move the positioning of the fee dropdown so it doesn't overlap the `Confirm' button.

@landitus what do you think? It is a little odd that the dropdown defaults to `Standard` but now when you click on the dropdown and it opens the first time, it opens on `Custom` (the bottom option). Is that ok for now?

![Screen Shot 2022-03-22 at 7 02 04 PM](https://user-images.githubusercontent.com/6493321/159596880-a933cb7c-7919-4f93-8be7-06e30b69afa9.png)

cc/ @kyranjamie @beguene @He1DAr
