### PR TITLE
fix: bug where wallet doesn't sign out

### DIFF
--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -37,7 +37,7 @@ export function AppRoutes(): JSX.Element | null {
   useSaveAuthRequest();
 
   useOnWalletLock(() => navigate(RouteUrls.Unlock));
-  useOnSignOut(() => navigate(RouteUrls.Onboarding));
+  useOnSignOut(() => window.close());
 
   useEffect(() => {
     void analytics.page('view', `${pathname}`);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2076371109).<!-- Sticky Header Marker -->

Closes #2341

The bug here is that, when signing out while there is a additional Hiro Wallet frame open, the other frame restores the `chrome.storage` cache to what's in its local cache. This effectively reverts the sign out action.

The best solution I see here is to close all other frames on sign out. 

<!--
PR reminders:
  - Link issues to PR
  - Update UserX board
  - Use checkmarks for progress
  - Link PRs in other issues

Tips for good PR etiquette https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/
-->

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
