### PR TITLE
fix: add missing tx details

### DIFF
--- a/src/app/features/ledger/components/ledger-wrapper.tsx
+++ b/src/app/features/ledger/components/ledger-wrapper.tsx
@@ -5,6 +5,8 @@ export function LedgerWrapper(props: FlexProps) {
     <Flex
       alignItems="center"
       flexDirection="column"
+      maxHeight="80vh"
+      overflowY="scroll"
       pb="loose"
       px="loose"
       textAlign="center"

--- a/src/app/features/ledger/steps/sign-ledger-transaction.layout.tsx
+++ b/src/app/features/ledger/steps/sign-ledger-transaction.layout.tsx
@@ -12,19 +12,22 @@ import { LedgerSuccessLabel } from '../components/success-label';
 
 interface TransactionDetailProps {
   children: React.ReactNode;
+  isFullPage: boolean;
   title: string;
   tooltipLabel?: string;
 }
 function TransactionDetail(props: TransactionDetailProps) {
+  const { children, isFullPage, title, tooltipLabel } = props;
+
   return (
     <Flex borderColor="#DCDDE2" flexDirection="column">
-      <Caption>{props.title}</Caption>
+      <Caption>{title}</Caption>
       <Flex alignItems="center" mt="base">
-        <Text overflowWrap="break-word" maxWidth="360px">
-          {props.children}
+        <Text overflowWrap="break-word" maxWidth={['280px', '360px']}>
+          {children}
         </Text>
-        {props.tooltipLabel ? (
-          <Tooltip label={props.tooltipLabel} maxWidth="260px" placement="right">
+        {tooltipLabel ? (
+          <Tooltip label={tooltipLabel} maxWidth={isFullPage ? '260px' : '210px'} placement="right">
             <Stack>
               <Box
                 _hover={{ cursor: 'pointer' }}
@@ -43,9 +46,14 @@ function TransactionDetail(props: TransactionDetailProps) {
 
 interface SignLedgerTransactionLayoutProps {
   details: [string, string, string?][];
+  isFullPage: boolean;
   status: 'awaiting-approval' | 'approved';
 }
-export function SignLedgerTransactionLayout({ details, status }: SignLedgerTransactionLayoutProps) {
+export function SignLedgerTransactionLayout({
+  details,
+  isFullPage,
+  status,
+}: SignLedgerTransactionLayoutProps) {
   return (
     <LedgerWrapper>
       <Box mt="tight">
@@ -69,7 +77,7 @@ export function SignLedgerTransactionLayout({ details, status }: SignLedgerTrans
       >
         <DividerSeparator>
           {details.map(([title, value, tooltipLabel]) => (
-            <TransactionDetail title={title} tooltipLabel={tooltipLabel}>
+            <TransactionDetail isFullPage={isFullPage} title={title} tooltipLabel={tooltipLabel}>
               {value}
             </TransactionDetail>
           ))}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2168706791).<!-- Sticky Header Marker -->

This PR adds missing tx details to ledger tx signing.

*The tx details are long enough that I needed to set a maxHeight on the drawer and enable scrolling.

![Screen Shot 2022-04-14 at 12 28 45 PM](https://user-images.githubusercontent.com/6493321/163443549-688c5b10-f29a-471c-b865-93026caeafd6.png)

![Screen Shot 2022-04-14 at 12 28 57 PM](https://user-images.githubusercontent.com/6493321/163443557-3fd0fa1c-b8b4-490e-b373-01d6c9f7c4c3.png)

Changed to maxWidth on the tooltip for the ext popup bc it was overflowing:
![Screen Shot 2022-04-14 at 12 55 36 PM](https://user-images.githubusercontent.com/6493321/163449442-35ec9735-e829-4c85-abf4-eb4bc998d69d.png)

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
