### PR TITLE
fix: transaction page, keep padding at all breakpoints

### DIFF
--- a/src/app/pages/transaction-request/transaction-request.tsx
+++ b/src/app/pages/transaction-request/transaction-request.tsx
@@ -88,7 +88,7 @@ function TransactionRequestBase(): JSX.Element | null {
   if (!transactionRequest) return null;
 
   return (
-    <Stack px={['loose', 'unset']} spacing="loose">
+    <Stack px='loose' spacing="loose">
       <PageTop />
       <PostConditionModeWarning />
       <TransactionError />


### PR DESCRIPTION
<!--
PR reminders:
  - Link issues to PR
  - Update UserX board
  - Use checkmarks for progress
  - Link PRs in other issues

Tips for good PR etiquette https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/
-->

Fixes #2391 

Using `<Stack px={['loose', 'unset']}>` meant that the horizontal padding was removed at a larger width, and the content went right to the edges:
![Screenshot 2022-04-28 at 16 03 04](https://user-images.githubusercontent.com/1711350/165783206-698f4dff-c92f-42e7-8c31-062b2eb5c5d4.png)

I've changed this to just `<Stack px='loose'>` so the padding stays the same at all widths:
![Screenshot 2022-04-28 at 15 55 48](https://user-images.githubusercontent.com/1711350/165782402-4a08af76-e715-4281-908a-de9b2108ac0b.png)

cc/ @kyranjamie @fbwoolf @beguene @He1DAr