### PR TITLE
Update NFTs URL

### DIFF
--- a/src/app/pages/home/components/onboarding-steps-list.tsx
+++ b/src/app/pages/home/components/onboarding-steps-list.tsx
@@ -63,7 +63,7 @@ const onboardingSteps = [
     event: 'buy_nft',
     imageFull: BuyNftFull,
     imagePopup: BuyNftPopup,
-    route: 'https://stxnft.com/',
+    route: 'https://www.hiro.so/wallet-faq/nfts',
     routeType: RouteType.External,
     title: OnboardingSteps.BuyNft,
   },


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2269229018).<!-- Sticky Header Marker -->

Per a request on Twitter in which we should rightfully not link to just one NFT marketplace but rather provide users choice: https://twitter.com/markymark/status/1521724281532657665

Please suggest others for the linked FAQ that I may have missed! https://www.hiro.so/wallet-faq/nfts

If there's a better list of marketplaces elsewhere, we could also just link there. Or we can evolve this FAQ's design over time / bring the list into the wallet at some point like we have the fiat onramp options.

https://www.hiro.so/wallet-faq/nfts
