### PR TITLE
fix: disable confirm button until fees are loaded

### DIFF
--- a/src/app/pages/transaction-request/components/submit-action.tsx
+++ b/src/app/pages/transaction-request/components/submit-action.tsx
@@ -9,6 +9,7 @@ import { TransactionFormValues } from '@app/common/transactions/transaction-util
 import { isEmpty } from '@app/common/utils';
 import { ShowEditNonceAction, ShowEditNoncePlaceholder } from '@app/components/show-edit-nonce';
 import { useTransactionError } from '@app/pages/transaction-request/hooks/use-transaction-error';
+import { useFeeEstimationsState } from '@app/store/transactions/fees.hooks';
 import { TransactionSigningSelectors } from '@tests/page-objects/transaction-signing.selectors';
 
 function BaseConfirmButton(props: ButtonProps): JSX.Element {
@@ -24,8 +25,9 @@ function SubmitActionSuspense(): JSX.Element {
   const { showHighFeeConfirmation, setShowHighFeeConfirmation } = useDrawers();
   const { isLoading } = useLoading(LoadingKeys.SUBMIT_TRANSACTION);
   const error = useTransactionError();
+  const [feeEstimations] = useFeeEstimationsState();
 
-  const isDisabled = !!error;
+  const isDisabled = !!error || !feeEstimations.length;
 
   return (
     <BaseConfirmButton


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2277652463).<!-- Sticky Header Marker -->

This PR disables the tx confirm button until fee estimations are loaded.

![Screen Shot 2022-05-05 at 1 52 37 PM](https://user-images.githubusercontent.com/6493321/167004238-c4ae0342-647f-48bd-bea1-2ffb3fefdf8c.png)

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
