### PR TITLE
Feat/arbitrary message signing structured data/i2387

### DIFF
--- a/src/app/common/actions/finalize-message-signature.ts
+++ b/src/app/common/actions/finalize-message-signature.ts
@@ -1,6 +1,6 @@
 import { ExternalMethods, MESSAGE_SOURCE, SignatureResponseMessage } from '@shared/message-types';
 import { logger } from '@shared/logger';
-import { SignatureData } from '@shared/crypto/sign-message';
+import { SignatureData } from '@stacks/connect';
 
 export const finalizeMessageSignature = (
   requestPayload: string,

--- a/src/app/pages/signature-request/components/clarity-value-list.tsx
+++ b/src/app/pages/signature-request/components/clarity-value-list.tsx
@@ -1,0 +1,76 @@
+import { ClarityType, ClarityValue, cvToString } from '@stacks/transactions';
+import { principalToString } from '@stacks/transactions/dist/esm/clarity/types/principalCV';
+
+export function ClarityValueListDisplayer(props: {
+  val: ClarityValue;
+  encoding?: 'tryAscii' | 'hex';
+  isRoot?: boolean;
+}): JSX.Element {
+  const { val, encoding, isRoot = true } = props;
+
+  function wrapText(text: string): JSX.Element {
+    return <>{text}</>;
+  }
+  switch (val.type) {
+    case ClarityType.BoolTrue:
+      return wrapText('true');
+    case ClarityType.BoolFalse:
+      return wrapText('false');
+    case ClarityType.Int:
+      return wrapText(val.value.toString());
+    case ClarityType.UInt:
+      return wrapText(`u${val.value.toString()}`);
+    case ClarityType.Buffer:
+      if (encoding === 'tryAscii') {
+        const str = val.buffer.toString('ascii');
+        if (/[ -~]/.test(str)) {
+          return wrapText(JSON.stringify(str));
+        }
+      }
+      return wrapText(`0x${val.buffer.toString('hex')}`);
+    case ClarityType.OptionalNone:
+      return wrapText('none');
+    case ClarityType.OptionalSome:
+      return wrapText(`some ${cvToString(val.value, encoding)}`);
+    case ClarityType.ResponseErr:
+      return wrapText(`err ${cvToString(val.value, encoding)}`);
+    case ClarityType.ResponseOk:
+      return wrapText(`ok ${cvToString(val.value, encoding)}`);
+    case ClarityType.PrincipalStandard:
+    case ClarityType.PrincipalContract:
+      return wrapText(principalToString(val));
+    case ClarityType.List:
+      return wrapText(`[${val.list.map(v => cvToString(v, encoding)).join(', ')}]`);
+    case ClarityType.Tuple:
+      return (
+        <dl
+          style={{
+            display: 'flex',
+            flexFlow: 'row',
+            flexWrap: 'wrap',
+            paddingTop: isRoot ? '0' : '20px',
+            overflow: 'visible',
+          }}
+        >
+          {Object.keys(val.data).map(key => {
+            return (
+              <>
+                <dt style={{ flex: '0 0 20%', color: '#74777D' }}>{key}:</dt>
+                <dd style={{ flex: '0 0 80%' }}>
+                  <ClarityValueListDisplayer
+                    val={val.data[key]}
+                    encoding={'tryAscii'}
+                    isRoot={false}
+                  />
+                </dd>
+              </>
+            );
+          })}
+        </dl>
+      );
+    case ClarityType.StringASCII:
+      return wrapText(`"${val.data}"`);
+    case ClarityType.StringUTF8:
+      return wrapText(`u"${val.data}"`);
+  }
+}

--- a/src/app/pages/signature-request/components/sign-action.tsx
+++ b/src/app/pages/signature-request/components/sign-action.tsx
@@ -21,10 +21,24 @@ function useSignMessageSoftwareWallet() {
   );
 }
 
-interface SignActionProps {
+export type SignatureMessageType = 'utf8' | 'structured';
+
+export interface SignatureMessage {
   message: string;
+  messageType: SignatureMessageType;
 }
-export function SignAction(props: SignActionProps): JSX.Element | null {
+
+export function isStructuredMessage(
+  messageType: SignatureMessageType
+): messageType is 'structured' {
+  return messageType === 'structured';
+}
+
+export function isSignatureMessageType(message: unknown): message is SignatureMessageType {
+  return typeof message === 'string' || typeof message === 'object';
+}
+
+export function SignAction(props: SignatureMessage): JSX.Element | null {
   const { message } = props;
   const signSoftwareWalletMessage = useSignMessageSoftwareWallet();
   const { tabId, requestToken } = useSignatureRequestSearchParams();

--- a/src/app/pages/signature-request/signature-request.tsx
+++ b/src/app/pages/signature-request/signature-request.tsx
@@ -10,7 +10,12 @@ import {
 import { PageTop } from './components/page-top';
 import { MessageBox } from './components/message-box';
 import { NetworkRow } from './components/network-row';
-import { SignAction } from './components/sign-action';
+import {
+  isSignatureMessageType,
+  SignAction,
+  SignatureMessage,
+  SignatureMessageType,
+} from './components/sign-action';
 import { StacksNetwork, StacksTestnet } from '@stacks/network';
 import { FiAlertTriangle } from 'react-icons/fi';
 import { Caption } from '@app/components/typography';
@@ -22,15 +27,17 @@ import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 
 function SignatureRequestBase(): JSX.Element | null {
   const validSignatureRequest = useIsSignatureRequestValid();
-  const { requestToken } = useSignatureRequestSearchParams();
+  const { requestToken, messageType } = useSignatureRequestSearchParams();
+
   useRouteHeader(<PopupHeader />);
 
-  if (!requestToken) return null;
+  if (!requestToken || !messageType) return null;
   const signatureRequest = getPayloadFromToken(requestToken);
   if (!signatureRequest) return null;
   if (isUndefined(validSignatureRequest)) return null;
   const appName = signatureRequest?.appDetails?.name;
   const { message, network } = signatureRequest;
+  if (!isSignatureMessageType(message)) return null;
 
   return (
     <Stack px={['loose', 'unset']} spacing="loose" width="100%">
@@ -42,6 +49,7 @@ function SignatureRequestBase(): JSX.Element | null {
           message={message}
           network={network || new StacksTestnet()}
           appName={appName}
+          messageType={messageType as unknown as SignatureMessageType}
         />
       )}
     </Stack>
@@ -73,19 +81,18 @@ function Disclaimer(props: DisclaimerProps) {
   );
 }
 
-interface SignatureRequestContentProps {
+interface SignatureRequestContentProps extends SignatureMessage {
   network: StacksNetwork;
-  message: string;
   appName: string | undefined;
 }
 
 function SignatureRequestContent(props: SignatureRequestContentProps) {
-  const { message, network, appName } = props;
+  const { message, messageType, appName, network } = props;
   return (
     <>
-      <MessageBox message={message} />
+      <MessageBox message={message} messageType={messageType} />
       <NetworkRow network={network} />
-      <SignAction message={message} />
+      <SignAction message={message} messageType={messageType} />
       <hr />
       <Disclaimer appName={appName} />
     </>

--- a/src/app/store/signatures/requests.hooks.ts
+++ b/src/app/store/signatures/requests.hooks.ts
@@ -32,6 +32,7 @@ export function useSignatureRequestSearchParams() {
       requestToken: searchParams.get('request'),
       tabId: searchParams.get('tabId'),
       origin: searchParams.get('origin'),
+      messageType: searchParams.get('messageType'),
     }),
     [searchParams]
   );

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -71,6 +71,24 @@ chrome.runtime.onConnect.addListener(port =>
             }
             break;
           }
+          case ExternalMethods.structuredDataSignatureRequest: {
+            const path = RouteUrls.SignatureRequest; // TODO refactor
+            const urlParams = new URLSearchParams();
+            if (!port.sender) return;
+            const { tab, url } = port.sender;
+            if (!tab?.id || !url) return;
+            const origin = new URL(url).origin;
+            urlParams.set('request', payload);
+            urlParams.set('tabId', tab.id.toString());
+            urlParams.set('origin', origin);
+            urlParams.set('messageType', 'structured');
+            if (IS_TEST_ENV) {
+              await openRequestInFullPage(path, urlParams);
+            } else {
+              popupCenter({ url: `/popup-center.html#${path}?${urlParams.toString()}` });
+            }
+            break;
+          }
           case ExternalMethods.signatureRequest: {
             const path = RouteUrls.SignatureRequest;
             const urlParams = new URLSearchParams();
@@ -81,6 +99,7 @@ chrome.runtime.onConnect.addListener(port =>
             urlParams.set('request', payload);
             urlParams.set('tabId', tab.id.toString());
             urlParams.set('origin', origin);
+            urlParams.set('messageType', 'utf8');
             if (IS_TEST_ENV) {
               await openRequestInFullPage(path, urlParams);
             } else {

--- a/src/content-scripts/content-script.ts
+++ b/src/content-scripts/content-script.ts
@@ -105,6 +105,18 @@ document.addEventListener(DomEventName.signatureRequest, ((event: SignatureReque
   });
 }) as EventListener);
 
+// Listen for a CustomEvent (structured data signature request) coming from the web app
+document.addEventListener(DomEventName.structuredDataSignatureRequest, ((
+  event: SignatureRequestEvent
+) => {
+  forwardDomEventToBackground({
+    path: RouteUrls.SignatureRequest,
+    payload: event.detail.signatureRequest,
+    urlParam: 'request',
+    method: ExternalMethods.structuredDataSignatureRequest,
+  });
+}) as EventListener);
+
 // Inject inpage script (Stacks Provider)
 const inpage = document.createElement('script');
 inpage.src = chrome.runtime.getURL('inpage.js');

--- a/src/shared/crypto/sign-message.ts
+++ b/src/shared/crypto/sign-message.ts
@@ -1,3 +1,4 @@
+import { SignatureData } from '@stacks/connect';
 import { hashMessage } from '@stacks/encryption';
 import {
   getPublicKey,
@@ -5,11 +6,6 @@ import {
   signWithKey,
   StacksPrivateKey,
 } from '@stacks/transactions';
-
-export interface SignatureData {
-  signature: string; // - Hex encoded DER signature
-  publicKey: string; // - Hex encoded private string taken from privateKey
-}
 
 export function signMessage(message: string, privateKey: StacksPrivateKey): SignatureData {
   const hash = hashMessage(message);

--- a/src/shared/inpage-types.ts
+++ b/src/shared/inpage-types.ts
@@ -4,6 +4,7 @@
 export enum DomEventName {
   authenticationRequest = 'stacksAuthenticationRequest',
   signatureRequest = 'signatureRequest',
+  structuredDataSignatureRequest = 'structuredDataSignatureRequest',
   transactionRequest = 'stacksTransactionRequest',
 }
 

--- a/src/shared/message-types.ts
+++ b/src/shared/message-types.ts
@@ -1,5 +1,4 @@
-import { FinishedTxPayload, SponsoredFinishedTxPayload } from '@stacks/connect';
-import { SignatureData } from './crypto/sign-message';
+import { FinishedTxPayload, SignatureData, SponsoredFinishedTxPayload } from '@stacks/connect';
 
 export const MESSAGE_SOURCE = 'stacks-wallet' as const;
 
@@ -12,6 +11,8 @@ export enum ExternalMethods {
   authenticationResponse = 'authenticationResponse',
   signatureRequest = 'signatureRequest',
   signatureResponse = 'signatureResponse',
+  structuredDataSignatureRequest = 'structuredDataSignatureRequest',
+  structuredDataSignatureResponse = 'structuredDataSignatureResponse',
 }
 
 export enum InternalMethods {
@@ -57,6 +58,11 @@ export type SignatureResponseMessage = Message<
   }
 >;
 
+type StructuredDataSignatureRequestMessage = Message<
+  ExternalMethods.structuredDataSignatureRequest,
+  string
+>;
+
 type TransactionRequestMessage = Message<ExternalMethods.transactionRequest, string>;
 
 export type TxResult = SponsoredFinishedTxPayload | FinishedTxPayload;
@@ -72,7 +78,8 @@ export type TransactionResponseMessage = Message<
 export type MessageFromContentScript =
   | AuthenticationRequestMessage
   | TransactionRequestMessage
-  | SignatureRequestMessage;
+  | SignatureRequestMessage
+  | StructuredDataSignatureRequestMessage;
 export type MessageToContentScript =
   | AuthenticationResponseMessage
   | TransactionResponseMessage

--- a/test-app/src/components/signature.tsx
+++ b/test-app/src/components/signature.tsx
@@ -1,8 +1,29 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Text } from '@stacks/ui';
-import { SignatureData, useConnect } from '@stacks/connect-react';
-import { verifyECDSA, hashMessage } from '@stacks/encryption';
 import { stacksTestnetNetwork as network } from '@common/utils';
+import { SignatureData } from '@stacks/connect';
+
+import {
+  serializeCV,
+  bufferCVFromString,
+  contractPrincipalCV,
+  falseCV,
+  intCV,
+  listCV,
+  noneCV,
+  responseErrorCV,
+  responseOkCV,
+  someCV,
+  standardPrincipalCV,
+  stringAsciiCV,
+  stringUtf8CV,
+  trueCV,
+  TupleCV,
+  tupleCV,
+  uintCV,
+} from '@stacks/transactions';
+import { useConnect } from '@stacks/connect-react';
+import { hashMessage, verifyECDSA } from '@stacks/encryption';
 
 export const Signature = () => {
   const [signature, setSignature] = useState<SignatureData | undefined>();
@@ -11,7 +32,37 @@ export const Signature = () => {
   const signatureMessage = 'Hello world!';
   const longSignatureMessage =
     'Nullam eu ante vel est convallis dignissim.  Fusce suscipit, wisi nec facilisis facilisis, est dui fermentum leo, quis tempor ligula erat quis odio.  Nunc porta vulputate tellus.  Nunc rutrum turpis sed pede.  Sed bibendum.  Aliquam posuere.  Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio.  Pellentesque condimentum, magna ut suscipit hendrerit, ipsum augue ornare nulla, non luctus diam neque sit amet urna.  Curabitur vulputate vestibulum lorem.  Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros.  Sed id ligula quis est convallis tempor.  Curabitur lacinia pulvinar nibh.  Nam a sapien.';
-  const { sign } = useConnect();
+  const ADDRESS = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
+
+  const structuredData = tupleCV({
+    a: intCV(-1),
+    b: uintCV(1),
+    c: bufferCVFromString('test'),
+    d: trueCV(),
+    e: someCV(trueCV()),
+    f: noneCV(),
+    g: standardPrincipalCV(ADDRESS),
+    h: contractPrincipalCV(ADDRESS, 'test'),
+    i: responseOkCV(trueCV()),
+    j: responseErrorCV(falseCV()),
+    k: listCV([trueCV(), falseCV()]),
+    l: tupleCV({
+      a: trueCV(),
+      b: falseCV(),
+    }),
+    m: stringAsciiCV('hello world'),
+    another: tupleCV({
+      a: trueCV(),
+      b: falseCV(),
+      deep: tupleCV({
+        a: trueCV(),
+        b: falseCV(),
+      }),
+    }),
+    n: stringUtf8CV('hello \u{1234}'),
+    o: listCV([]),
+  });
+  const { sign, signStructuredData } = useConnect();
 
   useEffect(() => {
     if (!signature || !currentMessage) return;
@@ -45,6 +96,24 @@ export const Signature = () => {
     });
   };
 
+  const signStructure = async (message: TupleCV) => {
+    clearState();
+    setCurrentMessage(serializeCV(message).toString('hex'));
+    console.log('signStructure', signStructuredData);
+    await signStructuredData({
+      /* network: stacksMainnetNetwork, */
+      network,
+      message,
+      onFinish: (sigObj: SignatureData) => {
+        console.log('signature from debugger', sigObj);
+        setSignature(sigObj);
+      },
+      onCancel: () => {
+        console.log('popup closed!');
+      },
+    });
+  };
+
   return (
     <Box py={6}>
       {signature && (
@@ -61,6 +130,10 @@ export const Signature = () => {
       <br />
       <Button mt={3} onClick={() => signMessage(longSignatureMessage)}>
         Signature (long message)
+      </Button>
+      <br />
+      <Button mt={3} onClick={() => signStructure(structuredData)}>
+        Signature of Structured Data
       </Button>
     </Box>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,6 +3091,20 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@stacks/auth@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stacks/auth/-/auth-2.0.1.tgz#cd774036f5edd1c8bdc5270dddb8bc06d41b74cf"
+  integrity sha512-RwKu3+Z2ryxOuS6wB8Y9hFeTnKM+31tOR4toalyPJRbkNsAqWWb0kuuPu7N5hD65zZsiyCImubAzNphJW1MGYw==
+  dependencies:
+    "@stacks/common" "^2.0.1"
+    "@stacks/encryption" "^2.0.1"
+    "@stacks/network" "^2.0.1"
+    "@stacks/profile" "^2.0.1"
+    c32check "^1.1.2"
+    cross-fetch "^3.1.4"
+    jsontokens "^3.0.0"
+    query-string "^6.13.1"
+
 "@stacks/auth@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@stacks/auth/-/auth-4.0.0.tgz#51e3eb6c240c82ef6dd8749a9c2f0cd1784bb492"
@@ -3140,6 +3154,16 @@
     buffer "^6.0.3"
     cross-fetch "^3.1.4"
 
+"@stacks/common@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@stacks/common/-/common-2.0.2.tgz#ac9822b0afabdc9c1ae4a0aea77f97d943d197c9"
+  integrity sha512-RpuNIqf+XmcHlMjXeVZE4fS3yIUlCvOYmxyBKOarh010Kx3Gs/LhAeejn/329lYcIE6VwNPoeXPSE9deq7Yjcw==
+  dependencies:
+    "@types/node" "^14.14.43"
+    bn.js "^4.12.0"
+    buffer "^6.0.3"
+    cross-fetch "^3.1.4"
+
 "@stacks/connect-react@16.0.0":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/@stacks/connect-react/-/connect-react-16.0.0.tgz#737e7f85c57a0f964d2101bb18c25fb31c54edc4"
@@ -3148,6 +3172,13 @@
     "@stacks/auth" "4.0.0"
     "@stacks/connect" "6.7.0"
     jsontokens "^3.0.0"
+
+"@stacks/connect-ui@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@stacks/connect-ui/-/connect-ui-5.4.0.tgz#79306b096b60ab5234ed1d2aff420773ae2370ff"
+  integrity sha512-S4Tz60nnZNX11uphssCZ9yVKMKJP1KeOG3S4yi1EXLapaJkElicB4aOOSUtlfqY1d6V+Q7lSMrVem2uQoa6Vkg==
+  dependencies:
+    "@stencil/core" "^2.6.0"
 
 "@stacks/connect-ui@5.5.0":
   version "5.5.0"
@@ -3189,6 +3220,22 @@
     sha.js "^2.4.11"
     varuint-bitcoin "^1.1.2"
 
+"@stacks/encryption@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stacks/encryption/-/encryption-2.0.1.tgz#da960e6054245fe25020ee0ac8b5872f433a557f"
+  integrity sha512-EoEhVJDf6JUGa0mEJO8aLl0tdAVbhoyMDWqsNkJu3dZS3IyHbg9ahY+uU0Po4j5IPTIXKLTt4AOePFdUj0d8hg==
+  dependencies:
+    "@stacks/common" "^2.0.1"
+    "@types/bn.js" "^4.11.6"
+    "@types/node" "^14.14.43"
+    bip39 "^3.0.2"
+    bitcoinjs-lib "^5.2.0"
+    bn.js "^4.12.0"
+    elliptic "^6.5.4"
+    randombytes "^2.1.0"
+    ripemd160-min "^0.0.6"
+    sha.js "^2.4.11"
+
 "@stacks/eslint-config@1.0.10":
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/@stacks/eslint-config/-/eslint-config-1.0.10.tgz#6dab91e4ba346b38f9520dba63582efcd0b1a7cf"
@@ -3203,7 +3250,7 @@
     eslint-plugin-import ">=2.23.3"
     eslint-plugin-prettier "4.0.0"
 
-"@stacks/network@4.0.0", "@stacks/network@^4.0.0", "@stacks/network@^4.0.1":
+"@stacks/network@2.0.1", "@stacks/network@4.0.0", "@stacks/network@^1.2.2", "@stacks/network@^2.0.1", "@stacks/network@^4.0.0", "@stacks/network@^4.0.1":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@stacks/network/-/network-4.0.0.tgz#1375a1aeec9fdf6a8102557132f055ba14db91e5"
   integrity sha512-EcZRBUCio1K/YcL0BvA4uOPuyidiTsyDGwEY6O/aft1c+okrOwuk9blGLmwSfMvGXKD7R6o9Y3DBix55oofFnA==
@@ -3237,6 +3284,18 @@
   integrity sha512-N+KC3LUL/qSrmjGaFRNaJtBSL1ZBJn5nPEsZf4DpYXDiFhIN1WWDRi79nuuAZD1K6mq+dZWsCwJp8rhI7kLi8w==
   dependencies:
     prettier "2.4.1"
+
+"@stacks/profile@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stacks/profile/-/profile-2.0.1.tgz#d053aaa88563cea0fc7df1197da262847fc6f296"
+  integrity sha512-mS/JDo5edBXfr00huc+PzlkjRszYwcUwV/5klhQYzjxpN71JyHfAQgXggEEFCdONj2j79GKXqdD1bsLoEY1lgQ==
+  dependencies:
+    "@stacks/common" "^2.0.1"
+    "@stacks/network" "^1.2.2"
+    "@stacks/transactions" "^2.0.1"
+    jsontokens "^3.0.0"
+    schema-inspector "^2.0.1"
+    zone-file "^1.0.0"
 
 "@stacks/profile@^4.0.0":
   version "4.0.1"
@@ -3279,22 +3338,24 @@
     bitcoinjs-lib "^5.2.0"
     jsontokens "^3.0.0"
 
-"@stacks/transactions@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-4.0.0.tgz#9abe8004ce97723da41520d6b22b261eb9799340"
-  integrity sha512-84FKWlr2BZKisIMHdEjmmHzP+KmKLF2LCN18U8e4gYYlElqI+DsUTMquA9acPA820JgWoEBUiSu82KLsz0sxJA==
+"@stacks/transactions@2.0.1", "@stacks/transactions@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-2.0.1.tgz#6a9270d49f2b93067f678fe45474a1d72247d4c1"
+  integrity sha512-q+8nCbn+0m1T8NbGG2sfMcBcCxdaH/F+vgBEHkhMIFHFLYXVYBGYbTX2llGS9StLp/tQq6p2Bfb1kzKFSw8FRQ==
   dependencies:
-    "@noble/hashes" "^1.0.0"
-    "@noble/secp256k1" "^1.5.5"
-    "@stacks/common" "^4.0.0"
-    "@stacks/network" "^4.0.0"
+    "@stacks/common" "^2.0.1"
+    "@stacks/network" "^1.2.2"
     "@types/bn.js" "^4.11.6"
+    "@types/elliptic" "^6.4.12"
     "@types/node" "^14.14.43"
+    "@types/randombytes" "^2.0.0"
     "@types/sha.js" "^2.4.0"
-    bn.js "^5.2.0"
-    c32check "^1.1.3"
+    bn.js "^4.12.0"
+    c32check "^1.1.2"
     cross-fetch "^3.1.4"
-    lodash.clonedeep "^4.5.0"
+    elliptic "^6.5.4"
+    lodash "^4.17.20"
+    randombytes "^2.1.0"
     ripemd160-min "^0.0.6"
     sha.js "^2.4.11"
     smart-buffer "^4.1.0"
@@ -4191,6 +4252,11 @@
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.15.0.tgz#cc49f090a24906b28c926e2f6dc49e75c4adaedf"
   integrity sha512-58+FPFpJCJScd5nmqVsZN+qk7aui57wFcMHWzySr1SQzoY8Efst9OPG7XRf27UsNj1DNeEdYWTtdrTfJyn3mZg==
+
+"@stencil/core@^2.6.0":
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.15.2.tgz#73a18050714a9edc488e6a2ea3380f5a91a04690"
+  integrity sha512-D6dv2KAXlWt9mjC28q0s6anghQgXRn0k93suOf+4pqsv1Uq19zNJXpYL68N5GxMSiNZyMPTU4Tt2NCbut7DVGg==
 
 "@styled-system/background@^5.1.2":
   version "5.1.2"
@@ -6426,7 +6492,7 @@ bip32@2.0.6, bip32@^2.0.4:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
-bip39@3.0.4:
+bip39@3.0.4, bip39@^3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
   integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
@@ -6496,7 +6562,7 @@ bluebird@~2.9.24:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.34.tgz#2f7b4ec80216328a9fddebdf69c8d4942feff7d8"
   integrity sha1-L3tOyAIWMoqf3evfacjUlC/v99g=
 
-bn.js@5.2.0, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0:
+bn.js@5.2.0, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.12.0, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
@@ -8560,7 +8626,7 @@ electron-to-chromium@^1.4.118, electron-to-chromium@^1.4.17:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.3:
+elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -18094,6 +18160,11 @@ zip-dir@2.0.0:
   dependencies:
     async "^3.2.0"
     jszip "^3.2.2"
+
+zone-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/zone-file/-/zone-file-1.0.0.tgz#93f4ae26d1a13974f8178f6dfff14b41466c6029"
+  integrity sha512-dJynTf/5XCobE6diQBpNWQQRBzXE8d1QhHKemzrkffrZ36F9uKlbBVyIXXbG2CJoaTGZGh8zt2AHX/mG4txtqA==
 
 zone-file@^2.0.0-beta.3:
   version "2.0.0-beta.3"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2333155167).<!-- Sticky Header Marker -->

Add support for signing structured data (ClarityValue)

<img width="484" alt="sd0" src="https://user-images.githubusercontent.com/1501454/167130409-ddf27ed3-7248-4e61-9661-9fb0afcfeab0.png">
<img width="467" alt="sd1" src="https://user-images.githubusercontent.com/1501454/167130418-16f6973d-9d04-4a6d-a973-3419084287aa.png">
<img width="467" alt="sd3" src="https://user-images.githubusercontent.com/1501454/167130428-254f5249-6c02-4eff-a1f5-cc400a874431.png">

The web wallet receives the ClarityValue serialized in hex format which is then deserialized to display in the UI in a human readable format. The serialized format is finallly hashed and signed when the user clicks 'Sign'


cc/ @kyranjamie @fbwoolf @beguene @He1DAr
