### PR TITLE
fix: silent error failures on broadcast response

### DIFF
--- a/src/app/common/transactions/broadcast-transaction.ts
+++ b/src/app/common/transactions/broadcast-transaction.ts
@@ -30,6 +30,8 @@ export async function broadcastTransaction(options: BroadcastTransactionOptions)
       attachment ? Buffer.from(attachment, 'hex') : undefined
     );
 
+    if (response.error) throw new Error(response.error);
+
     const isValidTxId = validateTxId(response.txid);
     if (isValidTxId)
       return {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2610026750).<!-- Sticky Header Marker -->

⚠️ I haven't tested this fix ⚠️ 

------------------------------

https://github.com/hirosystems/stacks-wallet-web/issues/2409 makes sense as we consider "txid present in response" to mean successful transaction. This PR throws an error if error is in the response, prompting it to get caught by the try/catch.