### PR TITLE
Feat/display standardized ft images/i1800

### DIFF
--- a/src/app/common/asset-types.ts
+++ b/src/app/common/asset-types.ts
@@ -12,10 +12,12 @@ export interface Asset {
   subBalance?: BigNumber;
 }
 
-interface FtMeta {
+export interface FtMeta {
   name: string;
   symbol: string;
   decimals: number;
+  image_uri?: string;
+  image_canonical_uri?: string;
 }
 
 export interface NftMeta {

--- a/src/app/common/string-utils.spec.ts
+++ b/src/app/common/string-utils.spec.ts
@@ -1,0 +1,15 @@
+import { convertUnicodeToAscii } from './string-utils';
+
+describe(convertUnicodeToAscii.name, () => {
+  it('should convert unicode to ascii', () => {
+    expect(convertUnicodeToAscii('Á')).toEqual('A');
+    expect(convertUnicodeToAscii('Û')).toEqual('U');
+    expect(convertUnicodeToAscii('ê')).toEqual('e');
+    expect(convertUnicodeToAscii('Ê')).toEqual('E');
+    expect(convertUnicodeToAscii('Î')).toEqual('I');
+    expect(convertUnicodeToAscii('ô')).toEqual('o');
+    expect(convertUnicodeToAscii('Ô')).toEqual('O');
+    expect(convertUnicodeToAscii('Ô')).not.toEqual('o');
+    expect(convertUnicodeToAscii('û')).toEqual('u');
+  });
+});

--- a/src/app/common/string-utils.ts
+++ b/src/app/common/string-utils.ts
@@ -1,0 +1,3 @@
+export function convertUnicodeToAscii(str: string) {
+  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}

--- a/src/app/common/token-utils.spec.ts
+++ b/src/app/common/token-utils.spec.ts
@@ -1,0 +1,24 @@
+import { isFtNameLikeStx, isIconUrl } from './token-utils';
+
+describe(isFtNameLikeStx.name, () => {
+  it('detect impersonating token names', () => {
+    expect(isFtNameLikeStx('STX')).toBeTruthy();
+    expect(isFtNameLikeStx('stx')).toBeTruthy();
+    expect(isFtNameLikeStx('stacks')).toBeTruthy();
+    expect(isFtNameLikeStx('Stäcks')).toBeTruthy();
+    expect(isFtNameLikeStx('Stácks')).toBeTruthy();
+    expect(isFtNameLikeStx('Stáçks')).toBeTruthy();
+    expect(isFtNameLikeStx('stocks')).toBeFalsy();
+    expect(isFtNameLikeStx('miamicoin')).toBeFalsy();
+    expect(isFtNameLikeStx('')).toBeFalsy();
+  });
+});
+
+describe(isIconUrl.name, () => {
+  it('detect valid icon url', () => {
+    expect(isIconUrl('https://example.com/icon.png')).toBeTruthy();
+    expect(isIconUrl('')).toBeFalsy();
+    expect(isIconUrl('https://example.com/icon.png?foo=bar')).toBeTruthy();
+    expect(isIconUrl('SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-token')).toBeFalsy();
+  });
+});

--- a/src/app/common/token-utils.ts
+++ b/src/app/common/token-utils.ts
@@ -1,4 +1,7 @@
-import { abbreviateNumber } from '@app/common/utils';
+import { abbreviateNumber, isUndefined } from '@app/common/utils';
+import { AssetWithMeta, FtMeta } from './asset-types';
+import { convertUnicodeToAscii } from './string-utils';
+import { isValidUrl } from './validation/validate-url';
 
 export function removeCommas(amountWithCommas: string) {
   return amountWithCommas.replace(/,/g, '');
@@ -13,4 +16,29 @@ export function getFormattedAmount(amount: string) {
         value: abbreviateNumber(number),
       }
     : { value: amount, isAbbreviated: false };
+}
+
+export const isIconUrl = isValidUrl;
+
+export function isFtNameLikeStx(name: string) {
+  return ['stx', 'stack', 'stacks'].includes(convertUnicodeToAscii(name).toLocaleLowerCase());
+}
+
+export function imageCanonicalUriFromFtMetadata(meta: FtMeta | undefined) {
+  return meta?.image_canonical_uri &&
+    isIconUrl(meta.image_canonical_uri) &&
+    !isFtNameLikeStx(meta.image_canonical_uri)
+    ? meta.image_canonical_uri
+    : undefined;
+}
+
+export function gradientStringForAsset(asset: AssetWithMeta): string {
+  return `${asset?.contractAddress}.${asset?.contractName}::${asset?.name}`;
+}
+
+export function iconStringForAsset(asset: AssetWithMeta | undefined): string {
+  if (isUndefined(asset)) return 'STX';
+  const imageUri = imageCanonicalUriFromFtMetadata(asset.meta);
+  if (imageUri) return imageUri;
+  return gradientStringForAsset(asset);
 }

--- a/src/app/components/asset-item.tsx
+++ b/src/app/components/asset-item.tsx
@@ -70,6 +70,7 @@ export const AssetItem = memo(
         subAmount,
         isDifferent,
         name,
+        imageCanonicalUri,
         ...rest
       }: {
         isPressable?: boolean;
@@ -80,6 +81,7 @@ export const AssetItem = memo(
         subAmount?: string;
         isDifferent?: boolean;
         name?: string;
+        imageCanonicalUri?: string;
       } & StackProps,
       ref
     ) => {
@@ -102,6 +104,7 @@ export const AssetItem = memo(
           <Stack flexGrow={1} width="100%" isInline spacing="base">
             <AssetAvatar
               size="36px"
+              imageCanonicalUri={imageCanonicalUri}
               gradientString={avatar}
               useStx={caption === 'STX'}
               color="white"

--- a/src/app/components/asset-row.tsx
+++ b/src/app/components/asset-row.tsx
@@ -7,6 +7,7 @@ import { AssetItem } from '@app/components/asset-item';
 import { formatContractId, getTicker } from '@app/common/utils';
 import { useCurrentAccountAvailableStxBalance } from '@app/store/accounts/account.hooks';
 import { BigNumber } from 'bignumber.js';
+import { imageCanonicalUriFromFtMetadata } from '@app/common/token-utils';
 
 interface AssetRowProps extends StackProps {
   asset: AssetWithMeta;
@@ -31,6 +32,7 @@ export const AssetRow = forwardRef<HTMLDivElement, AssetRowProps>((props, ref) =
   const amount = valueFromBalance(correctBalance);
   const subAmount = subBalance && valueFromBalance(subBalance);
   const isDifferent = subBalance && !correctBalance.isEqualTo(subBalance);
+  const imageCanonicalUri = imageCanonicalUriFromFtMetadata(meta);
 
   return (
     <AssetItem
@@ -42,6 +44,7 @@ export const AssetRow = forwardRef<HTMLDivElement, AssetRowProps>((props, ref) =
           ? `${formatContractId(contractAddress, contractName)}::${name}`
           : name
       }
+      imageCanonicalUri={imageCanonicalUri}
       title={friendlyName}
       caption={symbol}
       amount={amount}

--- a/src/app/components/stx-avatar.tsx
+++ b/src/app/components/stx-avatar.tsx
@@ -33,17 +33,25 @@ interface AssetProps extends BoxProps {
   gradientString: string;
   useStx: boolean;
   isUnanchored?: boolean;
+  imageCanonicalUri?: string;
 }
 export const AssetAvatar = ({
   useStx,
   isUnanchored,
   gradientString,
   children,
+  imageCanonicalUri,
   ...props
 }: AssetProps) => {
   if (useStx) {
     return <StxAvatar {...props} />;
   }
+  const { size } = props;
+  const imageDimension = (size && +size) || '36px';
+  if (imageCanonicalUri)
+    return (
+      <img width={imageDimension} height={imageDimension} src={encodeURI(imageCanonicalUri)} />
+    );
   return (
     <DynamicColorCircle {...props} string={gradientString}>
       {children}

--- a/src/app/components/transaction/components/ft-transfer-item.tsx
+++ b/src/app/components/transaction/components/ft-transfer-item.tsx
@@ -1,18 +1,20 @@
-import { FiArrowDown, FiArrowUp } from 'react-icons/fi';
 import type { AddressTransactionWithTransfers } from '@stacks/stacks-blockchain-api-types';
+import { FiArrowDown, FiArrowUp } from 'react-icons/fi';
 
-import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import {
   calculateTokenTransferAmount,
   FtTransfer,
   getTxCaption,
 } from '@app/common/transactions/transaction-utils';
-import { useFungibleTokenMetadata } from '@app/query/tokens/fungible-token-metadata.hook';
 import { pullContractIdFromIdentity } from '@app/common/utils';
+import { useFungibleTokenMetadata } from '@app/query/tokens/fungible-token-metadata.hook';
+import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 
+import { imageCanonicalUriFromFtMetadata } from '@app/common/token-utils';
+import { AssetAvatar } from '@app/components/stx-avatar';
+import { TransactionItem } from './transaction-item';
 import { TxTransferDetails } from './transaction-transfers';
 import { TxTransferIconWrapper } from './tx-transfer-icon-wrapper';
-import { TransactionItem } from './transaction-item';
 
 interface FtTransferItemProps {
   ftTransfer: FtTransfer;
@@ -32,13 +34,27 @@ export function FtTransferItem({ ftTransfer, parentTx }: FtTransferItemProps) {
   if (typeof displayAmount === 'undefined') return null;
 
   const caption = getTxCaption(parentTx.tx) ?? '';
+  const ftImageCanonicalUri = imageCanonicalUriFromFtMetadata(assetMetadata);
   const icon = isOriginator ? FiArrowUp : FiArrowDown;
   const title = `${assetMetadata?.name || 'Token'} Transfer`;
   const value = `${isOriginator ? '-' : ''}${displayAmount.toFormat()}`;
+  const transferIcon = ftImageCanonicalUri ? (
+    <AssetAvatar
+      size="36px"
+      imageCanonicalUri={ftImageCanonicalUri}
+      color="white"
+      gradientString={''}
+      useStx={false}
+    >
+      {title}
+    </AssetAvatar>
+  ) : (
+    <TxTransferIconWrapper icon={icon} />
+  );
 
   const transferDetails: TxTransferDetails = {
     caption,
-    icon: <TxTransferIconWrapper icon={icon} />,
+    icon: transferIcon,
     link: parentTx.tx.tx_id,
     title,
     value,

--- a/src/app/components/tx-asset-item.tsx
+++ b/src/app/components/tx-asset-item.tsx
@@ -2,6 +2,7 @@ import { Stack, StackProps, Text } from '@stacks/ui';
 
 import { AssetAvatar } from '@app/components/stx-avatar';
 import { SpaceBetween } from '@app/components/space-between';
+import { isIconUrl } from '@app/common/token-utils';
 
 interface AssetItemProps extends StackProps {
   iconString: string;
@@ -11,11 +12,17 @@ interface AssetItemProps extends StackProps {
 
 export function TxAssetItem(props: AssetItemProps): JSX.Element {
   const { iconString, amount, ticker, ...rest } = props;
+  const imageCanonicalUri = isIconUrl(iconString) ? iconString : undefined;
 
   return (
     <SpaceBetween alignItems="center" flexGrow={1} width="100%" {...rest}>
       <Stack isInline>
-        <AssetAvatar size="32px" useStx={iconString === 'STX'} gradientString={iconString} />
+        <AssetAvatar
+          size="32px"
+          useStx={iconString === 'STX'}
+          gradientString={iconString}
+          imageCanonicalUri={imageCanonicalUri}
+        />
         <Text fontWeight="500" fontSize={4}>
           {ticker}
         </Text>

--- a/src/app/pages/send-tokens/components/asset-search/selected-asset-item.tsx
+++ b/src/app/pages/send-tokens/components/asset-search/selected-asset-item.tsx
@@ -1,10 +1,10 @@
 import { memo } from 'react';
 import { Box, ChevronIcon, Text, color, Stack, BoxProps } from '@stacks/ui';
 
-import { formatContractId } from '@app/common/utils';
 import { AssetAvatar } from '@app/components/stx-avatar';
 import { Caption } from '@app/components/typography';
 import { useSelectedAsset } from '@app/pages/send-tokens/hooks/use-selected-asset';
+import { gradientStringForAsset, imageCanonicalUriFromFtMetadata } from '@app/common/token-utils';
 
 interface SelectedAssetItemProps extends BoxProps {
   hideArrow?: boolean;
@@ -15,9 +15,9 @@ export const SelectedAssetItem = memo(
     const { name, selectedAsset, ticker } = useSelectedAsset();
 
     if (!selectedAsset) return null;
-    const { contractAddress, contractName, name: _name } = selectedAsset;
     const isStx = name === 'Stacks Token';
-    const gradientString = `${formatContractId(contractAddress, contractName)}::${_name}`;
+    const gradientString = gradientStringForAsset(selectedAsset);
+    const imageCanonicalUri = imageCanonicalUriFromFtMetadata(selectedAsset.meta);
 
     return (
       <Box
@@ -35,6 +35,7 @@ export const SelectedAssetItem = memo(
           <AssetAvatar
             useStx={isStx}
             gradientString={gradientString}
+            imageCanonicalUri={imageCanonicalUri}
             mr="tight"
             size="36px"
             color="white"

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-details.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-details.tsx
@@ -1,10 +1,11 @@
 import { Flex, StackProps } from '@stacks/ui';
 import { color, truncateMiddle } from '@stacks/ui-utils';
 
+import { iconStringForAsset } from '@app/common/token-utils';
 import { EventCard } from '@app/components/event-card';
+import { useSelectedAsset } from '@app/pages/send-tokens/hooks/use-selected-asset';
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
-import { useSelectedAsset } from '@app/pages/send-tokens/hooks/use-selected-asset';
 
 interface SendTokensConfirmDetailsProps extends StackProps {
   amount: number | string;
@@ -17,7 +18,8 @@ export function SendTokensConfirmDetails(props: SendTokensConfirmDetailsProps): 
   const { ticker } = useSelectedAsset();
   const currentAccount = useCurrentAccount();
   const { selectedAsset } = useSelectedAsset();
-  const gradientString = `${selectedAsset?.contractAddress}.${selectedAsset?.contractName}::${selectedAsset?.name}`;
+  const icon = iconStringForAsset(selectedAsset);
+
   return (
     <Flex
       border="4px solid"
@@ -30,7 +32,7 @@ export function SendTokensConfirmDetails(props: SendTokensConfirmDetailsProps): 
     >
       <EventCard
         amount={amount}
-        icon={selectedAsset?.contractAddress ? gradientString : 'STX'}
+        icon={icon}
         ticker={ticker || 'STX'}
         title="You will transfer exactly"
         left={

--- a/src/app/pages/transaction-request/components/post-conditions/fungible-post-condition-item.tsx
+++ b/src/app/pages/transaction-request/components/post-conditions/fungible-post-condition-item.tsx
@@ -17,6 +17,7 @@ import {
 import { EventCard } from '@app/components/event-card';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
 import { useAssetFromFungiblePostCondition } from '@app/store/transactions/post-conditions.hooks';
+import { imageCanonicalUriFromFtMetadata } from '@app/common/token-utils';
 
 interface FungiblePostConditionItemProps {
   isLast?: boolean;
@@ -31,9 +32,11 @@ function FungiblePostConditionItemSuspense(
   const pendingTransaction = useTransactionRequestState();
   // Use token meta data if available
   const asset = useAssetFromFungiblePostCondition(pc);
+  // find the correct asset
+  const imageCanonicalUri = imageCanonicalUriFromFtMetadata(asset);
 
   const title = getPostConditionTitle(pc);
-  const iconString = getIconStringFromPostCondition(pc);
+  const iconString = imageCanonicalUri ?? getIconStringFromPostCondition(pc);
   const pcTicker = getSymbolFromPostCondition(pc);
   const pcAmount = getAmountFromPostCondition(pc);
   const name = getNameFromPostCondition(pc);

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import BN from 'bn.js';
 import { useConnect } from '@stacks/connect-react';
-import { StacksTestnet } from '@stacks/network';
+import { StacksMainnet, StacksTestnet } from '@stacks/network';
 import {
   broadcastTransaction,
   bufferCV,
@@ -285,6 +285,7 @@ export const Debugger = () => {
       },
     });
   };
+
   const sendRocketTokens = async () => {
     clearState();
     await doContractCall({
@@ -319,6 +320,38 @@ export const Debugger = () => {
     });
   };
 
+  const sendMiamiTokens = async () => {
+    clearState();
+    await doContractCall({
+      network: new StacksMainnet(),
+      contractAddress: 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27',
+      contractName: 'miamicoin-token',
+      functionName: 'transfer',
+      functionArgs: [
+        uintCV(1), // amount
+        standardPrincipalCV(address || ''), // sender
+        standardPrincipalCV('ST1X6M947Z7E58CNE0H8YJVJTVKS9VW0PHEG3NHN3'), // recipient
+      ],
+      postConditions: [
+        makeStandardFungiblePostCondition(
+          address || '',
+          FungibleConditionCode.Equal,
+          new BN(1),
+          createAssetInfo(
+            'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27',
+            'miamicoin-token',
+            'miami-token'
+          )
+        ),
+      ],
+      onFinish: data => {
+        setState('Token Faucet', data.txId);
+      },
+      onCancel: () => {
+        console.log('popup closed!');
+      },
+    });
+  };
   return (
     <Box py={6}>
       <Text as="h2" textStyle="display.small">
@@ -382,6 +415,9 @@ export const Debugger = () => {
           </Button>
           <Button mt={3} onClick={sendRocketTokens}>
             Send Rocket tokens
+          </Button>
+          <Button mt={3} onClick={sendMiamiTokens}>
+            Send Miami tokens
           </Button>
           <Button mt={3} onClick={callNullContract}>
             Non-existent contract


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2415450778).<!-- Sticky Header Marker -->

fixes #1800
<img width="433" alt="ft5" src="https://user-images.githubusercontent.com/1501454/167877653-755970f7-f201-4b44-a378-a9457811a1b8.png">
<img width="876" alt="ft4" src="https://user-images.githubusercontent.com/1501454/167877672-9df55325-e5d6-4f76-ad99-bbb25dca8d68.png">
<img width="544" alt="ft3" src="https://user-images.githubusercontent.com/1501454/167877677-1668610c-cf01-4b1d-b969-2daa39f8eaf3.png">
<img width="490" alt="ft2" src="https://user-images.githubusercontent.com/1501454/167877885-4d649725-c6ca-4da0-8723-4820ed355e49.png">
<img width="934" alt="ft1" src="https://user-images.githubusercontent.com/1501454/167877906-568fe4ad-9bb3-4926-a738-ccd01bcc035c.png">


It's almost done, I need to test a bit more and do some cleanup.
You can test the Popup using the test-app, there is 'Send Miamicoin' using Mainnet (to get the correct metadata)

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
