### PR TITLE
fix: refetch account balance

### DIFF
--- a/src/app/query/balance/balance.hooks.ts
+++ b/src/app/query/balance/balance.hooks.ts
@@ -34,7 +34,6 @@ export function useAddressBalances(address: string) {
       setAccountBalanceUnanchoredState(resp),
     keepPreviousData: false,
     useErrorBoundary: false,
-    refetchOnMount: false,
     suspense: false,
   });
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2315997411).<!-- Sticky Header Marker -->

This PR fixes the account balance not refreshing on the accounts list when switching accounts. The issue reported is that its a 'low balance' rounding issue, but it is not. It is the same for all balances if a new tx has just confirmed so that your received balance in that account should update. Likely an edge case bc we test sending STX back/forth b/w accounts in a wallet which is why I think it has only been reported by QA.

Removing the `refetchOnMount` here bc the default is `true`.

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
