### PR TITLE
fix: hide nfts with zero balance

### DIFF
--- a/src/app/features/balances-list/components/collectible-assets.tsx
+++ b/src/app/features/balances-list/components/collectible-assets.tsx
@@ -15,19 +15,22 @@ export const CollectibleAssets = memo((props: StackProps) => {
 
   return (
     <Stack {...props}>
-      {keys.map(key => {
-        const collectible = balances.non_fungible_tokens[key];
-        const { assetName, contractName } = getAssetStringParts(key);
-        return (
-          <AssetItem
-            amount={collectible.count}
-            avatar={key}
-            title={assetName}
-            caption={contractName}
-            key={key}
-          />
-        );
-      })}
+      {keys
+        .filter(key => Number(balances.non_fungible_tokens[key].count) > 0)
+        .map(key => {
+          const collectible = balances.non_fungible_tokens[key];
+          const { assetName, contractName } = getAssetStringParts(key);
+
+          return (
+            <AssetItem
+              amount={collectible.count}
+              avatar={key}
+              title={assetName}
+              caption={contractName}
+              key={key}
+            />
+          );
+        })}
     </Stack>
   );
 });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2327820962).<!-- Sticky Header Marker -->

This PR adds a conditional to only display nfts with a balance greater than zero so that sold/transferred nfts are not shown in a users balances list.

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
