### PR TITLE
fix(message-signing): signature defaulting to rsv order

### DIFF
--- a/src/shared/crypto/sign-message.ts
+++ b/src/shared/crypto/sign-message.ts
@@ -7,10 +7,16 @@ import {
   StacksPrivateKey,
 } from '@stacks/transactions';
 
+function convertSignatureVrsToRsvFormat(sig: string) {
+  return Buffer.from(sig.slice(2) + sig.slice(0, 2), 'hex').toString('hex');
+}
+
 export function signMessage(message: string, privateKey: StacksPrivateKey): SignatureData {
   const hash = hashMessage(message);
+  const signatureVrs = signWithKey(privateKey, hash.toString('hex')).data;
+  const signatureRsv = convertSignatureVrsToRsvFormat(signatureVrs);
   return {
-    signature: signWithKey(privateKey, hash.toString('hex')).data,
+    signature: signatureRsv,
     publicKey: publicKeyToString(getPublicKey(privateKey)),
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,20 +3091,6 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
-"@stacks/auth@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@stacks/auth/-/auth-2.0.1.tgz#cd774036f5edd1c8bdc5270dddb8bc06d41b74cf"
-  integrity sha512-RwKu3+Z2ryxOuS6wB8Y9hFeTnKM+31tOR4toalyPJRbkNsAqWWb0kuuPu7N5hD65zZsiyCImubAzNphJW1MGYw==
-  dependencies:
-    "@stacks/common" "^2.0.1"
-    "@stacks/encryption" "^2.0.1"
-    "@stacks/network" "^2.0.1"
-    "@stacks/profile" "^2.0.1"
-    c32check "^1.1.2"
-    cross-fetch "^3.1.4"
-    jsontokens "^3.0.0"
-    query-string "^6.13.1"
-
 "@stacks/auth@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@stacks/auth/-/auth-4.0.0.tgz#51e3eb6c240c82ef6dd8749a9c2f0cd1784bb492"
@@ -3154,16 +3140,6 @@
     buffer "^6.0.3"
     cross-fetch "^3.1.4"
 
-"@stacks/common@^2.0.1":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@stacks/common/-/common-2.0.2.tgz#ac9822b0afabdc9c1ae4a0aea77f97d943d197c9"
-  integrity sha512-RpuNIqf+XmcHlMjXeVZE4fS3yIUlCvOYmxyBKOarh010Kx3Gs/LhAeejn/329lYcIE6VwNPoeXPSE9deq7Yjcw==
-  dependencies:
-    "@types/node" "^14.14.43"
-    bn.js "^4.12.0"
-    buffer "^6.0.3"
-    cross-fetch "^3.1.4"
-
 "@stacks/connect-react@16.0.0":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/@stacks/connect-react/-/connect-react-16.0.0.tgz#737e7f85c57a0f964d2101bb18c25fb31c54edc4"
@@ -3172,13 +3148,6 @@
     "@stacks/auth" "4.0.0"
     "@stacks/connect" "6.7.0"
     jsontokens "^3.0.0"
-
-"@stacks/connect-ui@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@stacks/connect-ui/-/connect-ui-5.4.0.tgz#79306b096b60ab5234ed1d2aff420773ae2370ff"
-  integrity sha512-S4Tz60nnZNX11uphssCZ9yVKMKJP1KeOG3S4yi1EXLapaJkElicB4aOOSUtlfqY1d6V+Q7lSMrVem2uQoa6Vkg==
-  dependencies:
-    "@stencil/core" "^2.6.0"
 
 "@stacks/connect-ui@5.5.0":
   version "5.5.0"
@@ -3220,22 +3189,6 @@
     sha.js "^2.4.11"
     varuint-bitcoin "^1.1.2"
 
-"@stacks/encryption@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@stacks/encryption/-/encryption-2.0.1.tgz#da960e6054245fe25020ee0ac8b5872f433a557f"
-  integrity sha512-EoEhVJDf6JUGa0mEJO8aLl0tdAVbhoyMDWqsNkJu3dZS3IyHbg9ahY+uU0Po4j5IPTIXKLTt4AOePFdUj0d8hg==
-  dependencies:
-    "@stacks/common" "^2.0.1"
-    "@types/bn.js" "^4.11.6"
-    "@types/node" "^14.14.43"
-    bip39 "^3.0.2"
-    bitcoinjs-lib "^5.2.0"
-    bn.js "^4.12.0"
-    elliptic "^6.5.4"
-    randombytes "^2.1.0"
-    ripemd160-min "^0.0.6"
-    sha.js "^2.4.11"
-
 "@stacks/eslint-config@1.0.10":
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/@stacks/eslint-config/-/eslint-config-1.0.10.tgz#6dab91e4ba346b38f9520dba63582efcd0b1a7cf"
@@ -3250,7 +3203,7 @@
     eslint-plugin-import ">=2.23.3"
     eslint-plugin-prettier "4.0.0"
 
-"@stacks/network@2.0.1", "@stacks/network@4.0.0", "@stacks/network@^1.2.2", "@stacks/network@^2.0.1", "@stacks/network@^4.0.0", "@stacks/network@^4.0.1":
+"@stacks/network@4.0.0", "@stacks/network@^4.0.0", "@stacks/network@^4.0.1":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@stacks/network/-/network-4.0.0.tgz#1375a1aeec9fdf6a8102557132f055ba14db91e5"
   integrity sha512-EcZRBUCio1K/YcL0BvA4uOPuyidiTsyDGwEY6O/aft1c+okrOwuk9blGLmwSfMvGXKD7R6o9Y3DBix55oofFnA==
@@ -3284,18 +3237,6 @@
   integrity sha512-N+KC3LUL/qSrmjGaFRNaJtBSL1ZBJn5nPEsZf4DpYXDiFhIN1WWDRi79nuuAZD1K6mq+dZWsCwJp8rhI7kLi8w==
   dependencies:
     prettier "2.4.1"
-
-"@stacks/profile@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@stacks/profile/-/profile-2.0.1.tgz#d053aaa88563cea0fc7df1197da262847fc6f296"
-  integrity sha512-mS/JDo5edBXfr00huc+PzlkjRszYwcUwV/5klhQYzjxpN71JyHfAQgXggEEFCdONj2j79GKXqdD1bsLoEY1lgQ==
-  dependencies:
-    "@stacks/common" "^2.0.1"
-    "@stacks/network" "^1.2.2"
-    "@stacks/transactions" "^2.0.1"
-    jsontokens "^3.0.0"
-    schema-inspector "^2.0.1"
-    zone-file "^1.0.0"
 
 "@stacks/profile@^4.0.0":
   version "4.0.1"
@@ -3338,24 +3279,22 @@
     bitcoinjs-lib "^5.2.0"
     jsontokens "^3.0.0"
 
-"@stacks/transactions@2.0.1", "@stacks/transactions@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-2.0.1.tgz#6a9270d49f2b93067f678fe45474a1d72247d4c1"
-  integrity sha512-q+8nCbn+0m1T8NbGG2sfMcBcCxdaH/F+vgBEHkhMIFHFLYXVYBGYbTX2llGS9StLp/tQq6p2Bfb1kzKFSw8FRQ==
+"@stacks/transactions@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-4.0.0.tgz#9abe8004ce97723da41520d6b22b261eb9799340"
+  integrity sha512-84FKWlr2BZKisIMHdEjmmHzP+KmKLF2LCN18U8e4gYYlElqI+DsUTMquA9acPA820JgWoEBUiSu82KLsz0sxJA==
   dependencies:
-    "@stacks/common" "^2.0.1"
-    "@stacks/network" "^1.2.2"
+    "@noble/hashes" "^1.0.0"
+    "@noble/secp256k1" "^1.5.5"
+    "@stacks/common" "^4.0.0"
+    "@stacks/network" "^4.0.0"
     "@types/bn.js" "^4.11.6"
-    "@types/elliptic" "^6.4.12"
     "@types/node" "^14.14.43"
-    "@types/randombytes" "^2.0.0"
     "@types/sha.js" "^2.4.0"
-    bn.js "^4.12.0"
-    c32check "^1.1.2"
+    bn.js "^5.2.0"
+    c32check "^1.1.3"
     cross-fetch "^3.1.4"
-    elliptic "^6.5.4"
-    lodash "^4.17.20"
-    randombytes "^2.1.0"
+    lodash.clonedeep "^4.5.0"
     ripemd160-min "^0.0.6"
     sha.js "^2.4.11"
     smart-buffer "^4.1.0"
@@ -4252,11 +4191,6 @@
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.15.0.tgz#cc49f090a24906b28c926e2f6dc49e75c4adaedf"
   integrity sha512-58+FPFpJCJScd5nmqVsZN+qk7aui57wFcMHWzySr1SQzoY8Efst9OPG7XRf27UsNj1DNeEdYWTtdrTfJyn3mZg==
-
-"@stencil/core@^2.6.0":
-  version "2.15.2"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.15.2.tgz#73a18050714a9edc488e6a2ea3380f5a91a04690"
-  integrity sha512-D6dv2KAXlWt9mjC28q0s6anghQgXRn0k93suOf+4pqsv1Uq19zNJXpYL68N5GxMSiNZyMPTU4Tt2NCbut7DVGg==
 
 "@styled-system/background@^5.1.2":
   version "5.1.2"
@@ -6492,7 +6426,7 @@ bip32@2.0.6, bip32@^2.0.4:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
-bip39@3.0.4, bip39@^3.0.2:
+bip39@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
   integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
@@ -6562,7 +6496,7 @@ bluebird@~2.9.24:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.34.tgz#2f7b4ec80216328a9fddebdf69c8d4942feff7d8"
   integrity sha1-L3tOyAIWMoqf3evfacjUlC/v99g=
 
-bn.js@5.2.0, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.12.0, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0:
+bn.js@5.2.0, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
@@ -8626,7 +8560,7 @@ electron-to-chromium@^1.4.118, electron-to-chromium@^1.4.17:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5.4:
+elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -18160,11 +18094,6 @@ zip-dir@2.0.0:
   dependencies:
     async "^3.2.0"
     jszip "^3.2.2"
-
-zone-file@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/zone-file/-/zone-file-1.0.0.tgz#93f4ae26d1a13974f8178f6dfff14b41466c6029"
-  integrity sha512-dJynTf/5XCobE6diQBpNWQQRBzXE8d1QhHKemzrkffrZ36F9uKlbBVyIXXbG2CJoaTGZGh8zt2AHX/mG4txtqA==
 
 zone-file@^2.0.0-beta.3:
   version "2.0.0-beta.3"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2338896701).<!-- Sticky Header Marker -->

Per @MarvinJanssen's comment in #2419, this defaults the signature to rsv order.

Alternatively, we could return both? I wonder if that's a better solution?

cc/ @pradel @aulneau 