### PR TITLE
fix: add referer headers to api calls 

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -16,7 +16,7 @@ const manifest = {
   author: 'Hiro PBC',
   description:
     'Hiro Wallet is a safe way to manage your STX, sign into apps, and protect your funds while interacting with Clarity smart contracts.',
-  permissions: ['contextMenus', 'storage'],
+  permissions: ['contextMenus', 'storage', 'webRequest', 'webRequestBlocking', '*://*/*'],
   manifest_version: 2,
   background: {
     scripts: ['background.js'],

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -2,15 +2,17 @@ import ReactDOM from 'react-dom';
 
 import { persistAndRenderApp } from '@app/common/persistence';
 import { initSentry } from '@shared/utils/sentry-init';
+import { InternalMethods } from '@shared/message-types';
+import { addRefererHeaderRequestListener } from '@shared/add-referer-header';
+
+import { inMemoryKeyActions } from './store/in-memory-key/in-memory-key.actions';
 import { initSegment } from './common/segment-init';
 import { store } from './store';
-import { InternalMethods } from '@shared/message-types';
-import { inMemoryKeyActions } from './store/in-memory-key/in-memory-key.actions';
-
 import { App } from './app';
 
 initSentry();
 void initSegment();
+addRefererHeaderRequestListener();
 
 declare global {
   interface Window {

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -9,6 +9,7 @@ import * as Sentry from '@sentry/react';
 
 import { storePayload, StorageKey } from '@shared/utils/storage';
 import { RouteUrls } from '@shared/route-urls';
+import { addRefererHeaderRequestListener } from '@shared/add-referer-header';
 import { initSentry } from '@shared/utils/sentry-init';
 import {
   CONTENT_SCRIPT_PORT,
@@ -27,6 +28,7 @@ initSentry();
 
 initContextMenuActions();
 backupOldWalletSalt();
+addRefererHeaderRequestListener();
 
 //
 // Playwright does not currently support Chrome extension popup testing:

--- a/src/shared/add-referer-header.ts
+++ b/src/shared/add-referer-header.ts
@@ -1,0 +1,23 @@
+function formatInitiator(initiator: string) {
+  const [protocol, host] = initiator.split('://');
+  return [protocol, '://hiro-web-extension.', host].join('');
+}
+
+export function addRefererHeaderRequestListener() {
+  const handler = (details: chrome.webRequest.WebRequestHeadersDetails) => {
+    if (!details.requestHeaders) return;
+    const headers = [...details.requestHeaders];
+    if (details.initiator === `chrome-extension://${chrome.runtime.id}`) {
+      headers.push({ name: 'Referer', value: formatInitiator(details.initiator) });
+    }
+    return { requestHeaders: headers };
+  };
+  chrome.webRequest.onBeforeSendHeaders.addListener(
+    handler,
+    {
+      urls: ['https://*.stacks.co/*'],
+    },
+    ['requestHeaders', 'blocking', 'extraHeaders']
+  );
+  return () => chrome.webRequest.onBeforeSendHeaders.removeListener(handler);
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2550815565).<!-- Sticky Header Marker -->

## POC
A minimal app wrapper component, which adds an origin/`referer` header to stacks api requests.

### Scope
- Adds `WebRequestWrapper` component in `app.tsx`
- WebRequestWrapper adds `chrome.webRequest.onBeforeSendHeaders` listener, which adds a `Referer` header on requests made by the stacks-wallet-web extension.

### How To Test
1. Spin up this branch for local development in Chrome with `TEST_ENV=true yarn dev`
2. Open web-wallet (e.g. account-page)
3. In dev-tools inspect network-traffic
4. See that the `Referer` header (`chrome-extension://...`) is being set on outbound requests 🎉

### Todo
- [x] move `WebRequestWrapper` file to somewhere sensible _(or to non-react if that makes more sense)_
- [x] change URL wildcard to match only Hiro APIs e.g. `https://*.stacks.co/*` (not sure, but maybe the `permissions` pattern can be the same as this)
- [x] remove `console.log`s
- [ ] add tests? 🤷‍♂ 

> **Note**
> I'm not very familiar with chrome extension contexts — hope this makes sense. This is as much as I could figure out and would hand-over to the UX-team at this point...

### Background
Chrome is very strict on which headers can be set by extensions. All `referer` headers are automatically removed and can't be set from JavaScript-land unless using the `chrome.webRequest` API.

- [chrome.webRequest →](https://developer.chrome.com/docs/extensions/reference/webRequest/)
- [Forbidden headers →](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name)

**Kyran edit:**
This is ready for review. Note, per Jannik's second bullet point, we're targeting only stacks domain wildcarded domains. I haven't added a test yet, but it'd be straightforward enough to add an integration check that looks up headers. Low priority.