### PR TITLE
refactor: receive page to drawer

### DIFF
--- a/src/app/pages/fund/components/fiat-providers-list.tsx
+++ b/src/app/pages/fund/components/fiat-providers-list.tsx
@@ -40,7 +40,7 @@ export const FiatProvidersList = (props: FiatProvidersProps) => {
       templateColumns="repeat(auto-fill, minmax(270px, 1fr))"
       width="100%"
     >
-      <ReceiveStxItem onReceiveStx={() => navigate(RouteUrls.Receive)} />
+      <ReceiveStxItem onReceiveStx={() => navigate(RouteUrls.FundReceive)} />
       {Object.entries(activeProviders).map(([providerKey, providerValue]) => {
         const providerUrl = getProviderUrl(address, providerKey);
 

--- a/src/app/pages/fund/fund.tsx
+++ b/src/app/pages/fund/fund.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { Header } from '@app/components/header';
@@ -57,5 +57,10 @@ export function FundPage() {
   if (isOnboarding && availableStxBalance?.isGreaterThan(0))
     return <Navigate to={RouteUrls.Home} />;
 
-  return <FundLayout address={currentAccount.address} />;
+  return (
+    <>
+      <FundLayout address={currentAccount.address} />
+      <Outlet />
+    </>
+  );
 }

--- a/src/app/pages/receive-tokens/components/address-qr-code.tsx
+++ b/src/app/pages/receive-tokens/components/address-qr-code.tsx
@@ -19,14 +19,14 @@ export const QrCode = memo(({ principal, ...rest }: { principal: string } & Flex
   return (
     <Flex
       alignItems="center"
-      justifyContent="center"
-      p="loose"
-      borderRadius="18px"
-      boxShadow="mid"
       border="1px solid"
       borderColor={color('border')}
-      position="relative"
+      borderRadius="18px"
+      boxShadow="low"
+      justifyContent="center"
       mx="auto"
+      p="loose"
+      position="relative"
       {...rest}
     >
       {qr}

--- a/src/app/pages/receive-tokens/receive-tokens.tsx
+++ b/src/app/pages/receive-tokens/receive-tokens.tsx
@@ -1,74 +1,67 @@
 import { useNavigate } from 'react-router-dom';
-import { Box, useClipboard, Stack, color, Button } from '@stacks/ui';
+import toast from 'react-hot-toast';
+import { FiCopy } from 'react-icons/fi';
+import { Box, Flex, useClipboard, Stack, color, Button } from '@stacks/ui';
 import { truncateMiddle } from '@stacks/ui-utils';
 
-import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { useWallet } from '@app/common/hooks/use-wallet';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
-import { CenteredPageContainer } from '@app/components/centered-page-container';
-import { PrimaryButton } from '@app/components/primary-button';
-import { Header } from '@app/components/header';
+
 import { Caption, Text, Title } from '@app/components/typography';
-import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
-import { RouteUrls } from '@shared/route-urls';
+
 import { getAccountDisplayName } from '@app/common/utils/get-account-display-name';
 
 import { QrCode } from './components/address-qr-code';
+import { BaseDrawer } from '@app/components/drawer';
 
 export const ReceiveTokens = () => {
   const { currentAccount, currentAccountStxAddress } = useWallet();
   const navigate = useNavigate();
   const address = currentAccountStxAddress || '';
   const analytics = useAnalytics();
-  const { onCopy, hasCopied } = useClipboard(address);
-
-  useRouteHeader(<Header title="Receive" onClose={() => navigate(RouteUrls.Home)} />);
+  const { onCopy } = useClipboard(address);
 
   const copyToClipboard = () => {
     void analytics.track('copy_address_to_clipboard');
+    toast.success('Copied to clipboard!');
     onCopy();
   };
 
   return (
-    <CenteredPageContainer>
-      <Stack
-        maxWidth={CENTERED_FULL_PAGE_MAX_WIDTH}
-        px={['loose', 'base-loose']}
-        spacing="loose"
-        textAlign="center"
-      >
-        <Text textAlign={['left', 'center']}>
-          Share your unique address to receive any token or collectible. Including a memo is not
-          required.
+    <BaseDrawer title="Receive" isShowing onClose={() => navigate(-1)}>
+      <Flex alignItems="center" flexDirection="column" pb="48px" px="loose">
+        <Text color={color('text-caption')} mb="tight" textAlign="left">
+          Share your account’s unique address to receive any token or collectible. Including a memo
+          is not required.
         </Text>
-        <Box mx="auto">
+        <Box mt="extra-loose" mx="auto">
           <QrCode principal={address} />
         </Box>
-        {currentAccount && (
-          <Title fontSize={3} lineHeight="1rem">
-            {getAccountDisplayName(currentAccount)}
-          </Title>
-        )}
-        <Caption userSelect="none">{truncateMiddle(address, 4)}</Caption>
-        {!hasCopied ? (
-          <PrimaryButton onClick={copyToClipboard}>Copy your address</PrimaryButton>
-        ) : (
+        <Stack alignItems="center" spacing="base">
+          {currentAccount && (
+            <Title fontSize={3} lineHeight="1rem" mt="loose">
+              {getAccountDisplayName(currentAccount)}
+            </Title>
+          )}
+          <Caption userSelect="none">{truncateMiddle(address, 4)}</Caption>
           <Button
+            _focus={{
+              boxShadow: 'none',
+            }}
             _hover={{
               boxShadow: 'none',
             }}
-            border="1px solid"
-            borderColor={color('border')}
             borderRadius="10px"
             boxShadow="none"
-            color={color('accent')}
-            height="48px"
+            height="40px"
             mode="tertiary"
+            onClick={copyToClipboard}
           >
-            Copied to clipboard!
+            <FiCopy />
+            <Text ml="tight">Copy address</Text>
           </Button>
-        )}
-      </Stack>
-    </CenteredPageContainer>
+        </Stack>
+      </Flex>
+    </BaseDrawer>
   );
 };

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -62,6 +62,7 @@ export function AppRoutes(): JSX.Element | null {
             </AccountGate>
           }
         >
+          <Route path={RouteUrls.Receive} element={<ReceiveTokens />} />
           <Route path={RouteUrls.SignOutConfirm} element={<SignOutConfirmDrawer />} />
         </Route>
         <Route
@@ -118,15 +119,9 @@ export function AppRoutes(): JSX.Element | null {
               </Suspense>
             </AccountGate>
           }
-        />
-        <Route
-          path={RouteUrls.Receive}
-          element={
-            <AccountGate>
-              <ReceiveTokens />
-            </AccountGate>
-          }
-        />
+        >
+          <Route path={RouteUrls.FundReceive} element={<ReceiveTokens />} />
+        </Route>
         <Route
           path={RouteUrls.Send}
           element={

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -12,6 +12,7 @@ export enum RouteUrls {
   AddNetwork = '/add-network',
   ChooseAccount = '/choose-account',
   Fund = '/fund',
+  FundReceive = '/fund/receive',
   Receive = '/receive',
   Send = '/send',
   SignOutConfirm = '/sign-out',


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2387861801).<!-- Sticky Header Marker -->

This PR refactors the current receive page into a modal popup/drawer and adds a success toast on copy.

![Screen Shot 2022-05-25 at 7 01 32 PM](https://user-images.githubusercontent.com/6493321/170389459-7aa6311f-7aeb-4ed4-8ea5-de783898eafc.png)

![Screen Shot 2022-05-25 at 7 01 50 PM](https://user-images.githubusercontent.com/6493321/170389401-a3ed7935-3c5e-40f9-8529-922a3d0118b0.png)

![Screen Shot 2022-05-25 at 3 18 08 PM](https://user-images.githubusercontent.com/6493321/170389412-120be189-b615-47d9-9839-6feb7a9c1fd7.png)

![Screen Shot 2022-05-25 at 7 08 19 PM](https://user-images.githubusercontent.com/6493321/170389422-b8d348dc-2bb7-4b6b-bc0b-9cfbb9be87b1.png)

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
