### PR TITLE
fix: fund page layout shift

### DIFF
--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -1,13 +1,13 @@
 import { memo, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { color, Box, Flex, FlexProps, IconButton, Stack, useMediaQuery } from '@stacks/ui';
+import { color, Box, Flex, FlexProps, IconButton, Stack, Text, useMediaQuery } from '@stacks/ui';
 import { FiMoreHorizontal, FiArrowLeft } from 'react-icons/fi';
 
 import { DESKTOP_VIEWPORT_MIN_WIDTH } from '@app/components/global-styles/full-page-styles';
 import { HiroWalletLogo } from '@app/components/hiro-wallet-logo';
 import { useDrawers } from '@app/common/hooks/use-drawers';
 import { NetworkModeBadge } from '@app/components/network-mode-badge';
-import { Caption, Title } from '@app/components/typography';
+import { Title } from '@app/components/typography';
 import { OnboardingSelectors } from '@tests/integration/onboarding/onboarding.selectors';
 import { RouteUrls } from '@shared/route-urls';
 import { SettingsSelectors } from '@tests/integration/settings.selectors';
@@ -75,17 +75,18 @@ export const Header: React.FC<HeaderProps> = memo(props => {
               isClickable={hiroWalletLogoIsClickable}
               onClick={hiroWalletLogoIsClickable ? () => navigate(RouteUrls.Home) : undefined}
             />
-            <Caption
+            <Text
               color={color('text-caption')}
               display={!version ? 'none' : 'unset'}
               fontFamily="mono"
+              fontSize="10px"
+              lineHeight="10px"
               marginRight="10px"
               mb="2px"
               ml="tight"
-              variant="c3"
             >
               {version}
-            </Caption>
+            </Text>
           </Flex>
         </Flex>
       ) : (

--- a/src/app/components/hiro-wallet-logo.tsx
+++ b/src/app/components/hiro-wallet-logo.tsx
@@ -4,10 +4,10 @@ import { Stack, StackProps, color } from '@stacks/ui';
 import { HiroIcon } from './icons/hiro-icon';
 import { HiroWalletText } from './icons/hiro-wallet-text';
 
-interface HiroWalletPageLogo extends StackProps {
+interface HiroWalletLogoProps extends StackProps {
   isClickable: boolean;
 }
-export const HiroWalletLogo = memo((props: HiroWalletPageLogo) => {
+export const HiroWalletLogo = memo((props: HiroWalletLogoProps) => {
   const { isClickable, ...rest } = props;
 
   return (

--- a/src/app/pages/fund/components/fiat-providers-list.tsx
+++ b/src/app/pages/fund/components/fiat-providers-list.tsx
@@ -3,6 +3,7 @@ import { Grid } from '@stacks/ui';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import { LoadingSpinner } from '@app/components/loading-spinner';
 import {
   useActiveFiatProviders,
   useHasFiatProviders,
@@ -23,12 +24,12 @@ export const FiatProvidersList = (props: FiatProvidersProps) => {
   const hasProviders = useHasFiatProviders();
   const analytics = useAnalytics();
 
-  if (!hasProviders) return null;
-
   const goToProviderExternalWebsite = (provider: string, providerUrl: string) => {
     void analytics.track('select_buy_option', { provider });
     openInNewTab(providerUrl);
   };
+
+  if (!hasProviders) return <LoadingSpinner />;
 
   return (
     <Grid

--- a/src/app/pages/fund/fund.layout.tsx
+++ b/src/app/pages/fund/fund.layout.tsx
@@ -1,13 +1,13 @@
-import { Box, color, Stack, useMediaQuery } from '@stacks/ui';
+import { Box, color, Flex, Stack, useMediaQuery } from '@stacks/ui';
 
 import { Text } from '@app/components/typography';
 import { PageTitle } from '@app/components/page-title';
-import { CenteredPageContainer } from '@app/components/centered-page-container';
 import {
   CENTERED_FULL_PAGE_MAX_WIDTH,
   DESKTOP_VIEWPORT_MIN_WIDTH,
 } from '@app/components/global-styles/full-page-styles';
 import AddFunds from '@assets/images/fund/add-funds.png';
+
 import { FiatProvidersList } from './components/fiat-providers-list';
 
 interface FundLayoutProps {
@@ -19,7 +19,15 @@ export const FundLayout = (props: FundLayoutProps) => {
   const [desktopViewport] = useMediaQuery(`(min-width: ${DESKTOP_VIEWPORT_MIN_WIDTH})`);
 
   return (
-    <CenteredPageContainer>
+    <Flex
+      alignItems={['left', 'center']}
+      flexGrow={1}
+      flexDirection="column"
+      minHeight={['70vh', '90vh']}
+      justifyContent="start"
+      mb="loose"
+      {...props}
+    >
       <Stack
         alignItems={['left', 'center']}
         pb={['loose', 'unset']}
@@ -27,8 +35,8 @@ export const FundLayout = (props: FundLayoutProps) => {
         spacing={['base', 'loose']}
         mt={['base', 'unset']}
       >
-        <Box display={['none', 'block']} width={['100px', '84px']}>
-          <img src={AddFunds} />
+        <Box display={['none', 'block']}>
+          <img src={AddFunds} height="84px" width="84px" />
         </Box>
         <PageTitle
           fontSize={['24px', '32px', '48px']}
@@ -50,6 +58,6 @@ export const FundLayout = (props: FundLayoutProps) => {
         </Text>
       </Stack>
       <FiatProvidersList address={address} />
-    </CenteredPageContainer>
+    </Flex>
   );
 };

--- a/src/app/pages/fund/fund.tsx
+++ b/src/app/pages/fund/fund.tsx
@@ -10,9 +10,9 @@ import {
 import { RouteUrls } from '@shared/route-urls';
 import { useAppDispatch } from '@app/store';
 import { onboardingActions } from '@app/store/onboarding/onboarding.actions';
+import { useSkipFundAccount } from '@app/store/onboarding/onboarding.selectors';
 
 import { FundLayout } from './fund.layout';
-import { useSkipFundAccount } from '@app/store/onboarding/onboarding.selectors';
 import { SkipFundAccountButton } from './components/skip-fund-account-button';
 
 interface LocationStateProps {
@@ -34,13 +34,6 @@ export function FundPage() {
     navigate(RouteUrls.Home);
   };
 
-  useEffect(() => {
-    // This handles syncing b/w views, so it can likely be removed
-    // once we force onboarding via full page view
-    if (isOnboarding && hasSkippedFundAccount) navigate(RouteUrls.Home);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   useRouteHeader(
     <Header
       actionButton={
@@ -51,6 +44,13 @@ export function FundPage() {
       title={isOnboarding ? undefined : ' '}
     />
   );
+
+  useEffect(() => {
+    // This handles syncing b/w views, so it can likely be removed
+    // once we force onboarding via full page view
+    if (isOnboarding && hasSkippedFundAccount) navigate(RouteUrls.Home);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!currentAccount) return null;
 

--- a/src/app/pages/home/components/account-area.tsx
+++ b/src/app/pages/home/components/account-area.tsx
@@ -39,8 +39,6 @@ const AccountAddress = memo((props: StackProps) => {
 });
 
 export const CurrentAccount = memo((props: StackProps) => {
-  const currentAccount = useCurrentAccount();
-  if (!currentAccount) return null;
   return (
     <Stack spacing="base-tight" alignItems="center" isInline {...props}>
       <CurrentAccountAvatar />

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -66,25 +66,27 @@ export function Home() {
           spacing="loose"
           width="100%"
         >
-          <Flex
-            flexDirection={['column', 'column', 'unset']}
-            alignItems={['start', 'start', 'center']}
-            justifyContent={['unset', 'space-between']}
-          >
-            <CurrentAccount />
-            <HomeActions />
-          </Flex>
-          {account && (
-            <HomeTabs
-              balances={
-                <BalancesList
-                  address={account?.address}
-                  data-testid={HomePageSelectors.BalancesList}
-                />
-              }
-              activity={<ActivityList />}
-            />
-          )}
+          {account ? (
+            <>
+              <Flex
+                flexDirection={['column', 'column', 'unset']}
+                alignItems={['start', 'start', 'center']}
+                justifyContent={['unset', 'space-between']}
+              >
+                <CurrentAccount />
+                <HomeActions />
+              </Flex>
+              <HomeTabs
+                balances={
+                  <BalancesList
+                    address={account?.address}
+                    data-testid={HomePageSelectors.BalancesList}
+                  />
+                }
+                activity={<ActivityList />}
+              />
+            </>
+          ) : null}
         </Stack>
       </Stack>
       <Outlet />


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2439956215).<!-- Sticky Header Marker -->

This PR fixes the layout on the fund page. It was shifting quite a bit after the fiat providers loaded bc it was wrapped in a component centering it vertically. I also added a height and width directly to the image, and added a loading spinner for the fiat provider list.

In addition, this fixes a flash that was occurring on the home page where the account was loading but the action buttons would flash render in the header > then relocate.

EDIT: Added a commit to fix version alignment in header.

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
