### PR TITLE
fix: suggested steps only updating with refresh

### DIFF
--- a/src/app/features/suggested-first-steps/components/add-funds-step.tsx
+++ b/src/app/features/suggested-first-steps/components/add-funds-step.tsx
@@ -1,27 +1,16 @@
-import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
-
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
-import { useSuggestedFirstStepsStatus } from '@app/store/onboarding/onboarding.selectors';
 import AddFundsFull from '@assets/images/onboarding/steps/add-funds-light.png';
 import AddFundsFullDone from '@assets/images/onboarding/steps/add-funds-light-done.png';
 import AddFundsPopup from '@assets/images/onboarding/steps/add-funds-light-sm.png';
 import AddFundsPopupDone from '@assets/images/onboarding/steps/add-funds-light-done-sm.png';
-import { SuggestedFirstSteps, SuggestedFirstStepStatus } from '@shared/models/onboarding-types';
-import { RouteUrls } from '@shared/route-urls';
+import { SuggestedFirstSteps } from '@shared/models/onboarding-types';
 
 import { SuggestedFirstStep } from './suggested-first-step';
 
-export function AddFundsStep() {
-  const analytics = useAnalytics();
-  const navigate = useNavigate();
-  const stepsStatus = useSuggestedFirstStepsStatus();
-
-  const onSelectStep = useCallback(() => {
-    void analytics.track('select_next_step', { step: 'add_funds' });
-    navigate(RouteUrls.Fund);
-  }, [analytics, navigate]);
-
+interface AddFundsStepProps {
+  isComplete: boolean;
+  onSelectStep(): void;
+}
+export function AddFundsStep({ isComplete, onSelectStep }: AddFundsStepProps) {
   return (
     <SuggestedFirstStep
       action="Get STX"
@@ -30,7 +19,7 @@ export function AddFundsStep() {
       imageFullDone={AddFundsFullDone}
       imagePopup={AddFundsPopup}
       imagePopupDone={AddFundsPopupDone}
-      isComplete={stepsStatus[SuggestedFirstSteps.AddFunds] === SuggestedFirstStepStatus.Complete}
+      isComplete={isComplete}
       key={SuggestedFirstSteps.AddFunds}
       onClick={onSelectStep}
       title="Add funds"

--- a/src/app/features/suggested-first-steps/components/back-up-secret-key-step.tsx
+++ b/src/app/features/suggested-first-steps/components/back-up-secret-key-step.tsx
@@ -1,27 +1,16 @@
-import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
-
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
-import { useSuggestedFirstStepsStatus } from '@app/store/onboarding/onboarding.selectors';
 import BackUpSecretKeyFull from '@assets/images/onboarding/steps/backup-key-light.png';
 import BackUpSecretKeyFullDone from '@assets/images/onboarding/steps/backup-key-light-done.png';
 import BackUpSecretKeyPopup from '@assets/images/onboarding/steps/backup-key-light-sm.png';
 import BackUpSecretKeyPopupDone from '@assets/images/onboarding/steps/backup-key-light-done-sm.png';
-import { SuggestedFirstSteps, SuggestedFirstStepStatus } from '@shared/models/onboarding-types';
-import { RouteUrls } from '@shared/route-urls';
+import { SuggestedFirstSteps } from '@shared/models/onboarding-types';
 
 import { SuggestedFirstStep } from './suggested-first-step';
 
-export function BackUpSecretKeyStep() {
-  const analytics = useAnalytics();
-  const navigate = useNavigate();
-  const stepsStatus = useSuggestedFirstStepsStatus();
-
-  const onSelectStep = useCallback(() => {
-    void analytics.track('select_next_step', { step: 'back_up_secret_key' });
-    navigate(RouteUrls.ViewSecretKey);
-  }, [analytics, navigate]);
-
+interface BackUpSecretKeyStepProps {
+  isComplete: boolean;
+  onSelectStep(): void;
+}
+export function BackUpSecretKeyStep({ isComplete, onSelectStep }: BackUpSecretKeyStepProps) {
   return (
     <SuggestedFirstStep
       action="View secret key"
@@ -30,9 +19,7 @@ export function BackUpSecretKeyStep() {
       imageFullDone={BackUpSecretKeyFullDone}
       imagePopup={BackUpSecretKeyPopup}
       imagePopupDone={BackUpSecretKeyPopupDone}
-      isComplete={
-        stepsStatus[SuggestedFirstSteps.BackUpSecretKey] === SuggestedFirstStepStatus.Complete
-      }
+      isComplete={isComplete}
       key={SuggestedFirstSteps.BackUpSecretKey}
       onClick={onSelectStep}
       title="Back up secret key"

--- a/src/app/features/suggested-first-steps/components/buy-nft-step.tsx
+++ b/src/app/features/suggested-first-steps/components/buy-nft-step.tsx
@@ -1,27 +1,16 @@
-import { useCallback } from 'react';
-
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
-import { openInNewTab } from '@app/common/utils/open-in-new-tab';
-import { useSuggestedFirstStepsStatus } from '@app/store/onboarding/onboarding.selectors';
 import BuyNftFull from '@assets/images/onboarding/steps/buy-nft-light.png';
 import BuyNftFullDone from '@assets/images/onboarding/steps/buy-nft-light-done.png';
 import BuyNftPopup from '@assets/images/onboarding/steps/buy-nft-light-sm.png';
 import BuyNftPopupDone from '@assets/images/onboarding/steps/buy-nft-light-done-sm.png';
-import { SuggestedFirstSteps, SuggestedFirstStepStatus } from '@shared/models/onboarding-types';
+import { SuggestedFirstSteps } from '@shared/models/onboarding-types';
 
 import { SuggestedFirstStep } from './suggested-first-step';
 
-const buyNftExternalRoute = 'https://www.hiro.so/wallet-faq/nfts';
-
-export function BuyNftStep() {
-  const analytics = useAnalytics();
-  const stepsStatus = useSuggestedFirstStepsStatus();
-
-  const onSelectStep = useCallback(() => {
-    void analytics.track('select_next_step', { step: 'buy_nft' });
-    openInNewTab(buyNftExternalRoute);
-  }, [analytics]);
-
+interface BuyNftStepProps {
+  isComplete: boolean;
+  onSelectStep(): void;
+}
+export function BuyNftStep({ isComplete, onSelectStep }: BuyNftStepProps) {
   return (
     <SuggestedFirstStep
       action="Find NFT"
@@ -30,7 +19,7 @@ export function BuyNftStep() {
       imageFullDone={BuyNftFullDone}
       imagePopup={BuyNftPopup}
       imagePopupDone={BuyNftPopupDone}
-      isComplete={stepsStatus[SuggestedFirstSteps.BuyNft] === SuggestedFirstStepStatus.Complete}
+      isComplete={isComplete}
       isExternalRoute
       key={SuggestedFirstSteps.BuyNft}
       onClick={onSelectStep}

--- a/src/app/features/suggested-first-steps/components/explore-apps-step.tsx
+++ b/src/app/features/suggested-first-steps/components/explore-apps-step.tsx
@@ -1,33 +1,16 @@
-import { useCallback } from 'react';
-
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
-import { openInNewTab } from '@app/common/utils/open-in-new-tab';
-import { useAppDispatch } from '@app/store';
-import { useSuggestedFirstStepsStatus } from '@app/store/onboarding/onboarding.selectors';
 import ExploreAppsFull from '@assets/images/onboarding/steps/explore-apps-light.png';
 import ExploreAppsFullDone from '@assets/images/onboarding/steps/explore-apps-light-done.png';
 import ExploreAppsPopup from '@assets/images/onboarding/steps/explore-apps-light-sm.png';
 import ExploreAppsPopupDone from '@assets/images/onboarding/steps/explore-apps-light-done-sm.png';
-import { SuggestedFirstSteps, SuggestedFirstStepStatus } from '@shared/models/onboarding-types';
-import { onboardingActions } from '@app/store/onboarding/onboarding.actions';
+import { SuggestedFirstSteps } from '@shared/models/onboarding-types';
 
 import { SuggestedFirstStep } from './suggested-first-step';
 
-const exploreAppsExternalRoute = 'https://www.stacks.co/explore/discover-apps#apps';
-
-export function ExploreAppsStep() {
-  const analytics = useAnalytics();
-  const dispatch = useAppDispatch();
-  const stepsStatus = useSuggestedFirstStepsStatus();
-
-  const onSelectStep = useCallback(() => {
-    void analytics.track('select_next_step', { step: 'explore_apps' });
-    dispatch(
-      onboardingActions.userCompletedSuggestedFirstStep({ step: SuggestedFirstSteps.ExploreApps })
-    );
-    openInNewTab(exploreAppsExternalRoute);
-  }, [analytics, dispatch]);
-
+interface ExploreAppsStepProps {
+  isComplete: boolean;
+  onSelectStep(): void;
+}
+export function ExploreAppsStep({ isComplete, onSelectStep }: ExploreAppsStepProps) {
   return (
     <SuggestedFirstStep
       action="Find apps"
@@ -36,9 +19,7 @@ export function ExploreAppsStep() {
       imageFullDone={ExploreAppsFullDone}
       imagePopup={ExploreAppsPopup}
       imagePopupDone={ExploreAppsPopupDone}
-      isComplete={
-        stepsStatus[SuggestedFirstSteps.ExploreApps] === SuggestedFirstStepStatus.Complete
-      }
+      isComplete={isComplete}
       isExternalRoute
       key={SuggestedFirstSteps.ExploreApps}
       onClick={onSelectStep}

--- a/src/app/features/suggested-first-steps/hooks/use-suggested-first-steps.ts
+++ b/src/app/features/suggested-first-steps/hooks/use-suggested-first-steps.ts
@@ -40,10 +40,7 @@ export function useSuggestedFirstSteps() {
     return Object.values(stepsStatus).every(val => val === SuggestedFirstStepStatus.Complete);
   }, [stepsStatus]);
 
-  const showSuggestedFirstSteps =
-    accounts?.length === 1 && !hasCompletedSuggestedFirstSteps && !hasHiddenSuggestedFirstSteps;
-
-  return {
-    showSuggestedFirstSteps,
-  };
+  return (
+    accounts?.length === 1 && !hasCompletedSuggestedFirstSteps && !hasHiddenSuggestedFirstSteps
+  );
 }

--- a/src/app/features/suggested-first-steps/suggested-first-steps.tsx
+++ b/src/app/features/suggested-first-steps/suggested-first-steps.tsx
@@ -1,33 +1,83 @@
 import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { useAppDispatch } from '@app/store';
 import { onboardingActions } from '@app/store/onboarding/onboarding.actions';
-
-import { useSuggestedFirstSteps } from './hooks/use-suggested-first-steps';
+import { useSuggestedFirstStepsStatus } from '@app/store/onboarding/onboarding.selectors';
+import {
+  SuggestedFirstSteps as Steps,
+  SuggestedFirstStepStatus,
+} from '@shared/models/onboarding-types';
+import { RouteUrls } from '@shared/route-urls';
 
 import { SuggestedFirstStepsLayout } from './suggested-first-steps.layout';
 import { AddFundsStep } from './components/add-funds-step';
 import { BackUpSecretKeyStep } from './components/back-up-secret-key-step';
 import { ExploreAppsStep } from './components/explore-apps-step';
 import { BuyNftStep } from './components/buy-nft-step';
+import { useSuggestedFirstSteps } from './hooks/use-suggested-first-steps';
+
+const eventName = 'select_next_step';
+const exploreAppsExternalRoute = 'https://www.stacks.co/explore/discover-apps#apps';
+const buyNftExternalRoute = 'https://www.hiro.so/wallet-faq/nfts';
 
 export function SuggestedFirstSteps() {
   const analytics = useAnalytics();
   const dispatch = useAppDispatch();
-  useSuggestedFirstSteps();
+  const navigate = useNavigate();
+  const showSuggestedFirstSteps = useSuggestedFirstSteps();
+  const stepsStatus = useSuggestedFirstStepsStatus();
 
   const onDismissSteps = useCallback(() => {
     void analytics.track('dismiss_suggested_first_steps');
     dispatch(onboardingActions.hideSuggestedFirstSteps(true));
   }, [analytics, dispatch]);
 
+  const onSelectBackUpSecretKeyStep = useCallback(() => {
+    void analytics.track(eventName, { step: 'back_up_secret_key' });
+    navigate(RouteUrls.ViewSecretKey);
+  }, [analytics, navigate]);
+
+  const onSelectAddFundsStep = useCallback(() => {
+    void analytics.track(eventName, { step: 'add_funds' });
+    navigate(RouteUrls.Fund);
+  }, [analytics, navigate]);
+
+  const onSelectExploreAppsStep = useCallback(() => {
+    void analytics.track(eventName, { step: 'explore_apps' });
+    dispatch(onboardingActions.userCompletedSuggestedFirstStep({ step: Steps.ExploreApps }));
+    openInNewTab(exploreAppsExternalRoute);
+  }, [analytics, dispatch]);
+
+  const onSelectBuyNftStep = useCallback(() => {
+    void analytics.track(eventName, { step: 'buy_nft' });
+    openInNewTab(buyNftExternalRoute);
+  }, [analytics]);
+
+  const hasCompletedBackUpSecretKeyStep =
+    stepsStatus[Steps.BackUpSecretKey] === SuggestedFirstStepStatus.Complete;
+  const hasCompletedAddFundsStep =
+    stepsStatus[Steps.AddFunds] === SuggestedFirstStepStatus.Complete;
+  const hasCompletedExploreAppsStep =
+    stepsStatus[Steps.ExploreApps] === SuggestedFirstStepStatus.Complete;
+  const hasCompletedBuyNftStep = stepsStatus[Steps.BuyNft] === SuggestedFirstStepStatus.Complete;
+
+  if (!showSuggestedFirstSteps) return null;
+
   return (
     <SuggestedFirstStepsLayout onDismissSteps={onDismissSteps}>
-      <BackUpSecretKeyStep />
-      <AddFundsStep />
-      <ExploreAppsStep />
-      <BuyNftStep />
+      <BackUpSecretKeyStep
+        isComplete={hasCompletedBackUpSecretKeyStep}
+        onSelectStep={onSelectBackUpSecretKeyStep}
+      />
+      <AddFundsStep isComplete={hasCompletedAddFundsStep} onSelectStep={onSelectAddFundsStep} />
+      <ExploreAppsStep
+        isComplete={hasCompletedExploreAppsStep}
+        onSelectStep={onSelectExploreAppsStep}
+      />
+      <BuyNftStep isComplete={hasCompletedBuyNftStep} onSelectStep={onSelectBuyNftStep} />
     </SuggestedFirstStepsLayout>
   );
 }

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -11,7 +11,6 @@ import { HiroMessages } from '@app/features/hiro-messages/hiro-messages';
 import { ActivityList } from '@app/features/activity-list/account-activity';
 import { BalancesList } from '@app/features/balances-list/balances-list';
 import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggested-first-steps';
-import { useSuggestedFirstSteps } from '@app/features/suggested-first-steps/hooks/use-suggested-first-steps';
 import { CurrentAccount } from '@app/pages/home/components/account-area';
 import { HomeActions } from '@app/pages/home/components/home-actions';
 import { RouteUrls } from '@shared/route-urls';
@@ -27,7 +26,6 @@ import { HomeTabs } from './components/home-tabs';
 
 export function Home() {
   const { decodedAuthRequest } = useOnboardingState();
-  const { showSuggestedFirstSteps } = useSuggestedFirstSteps();
   const navigate = useNavigate();
   const account = useCurrentAccount();
   const availableStxBalance = useCurrentAccountAvailableStxBalance();
@@ -57,7 +55,7 @@ export function Home() {
         {account?.address && <AccountInfoFetcher address={account.address} />}
       </Suspense>
       <Stack alignItems="center" width="100%" spacing="extra-tight">
-        {showSuggestedFirstSteps && <SuggestedFirstSteps />}
+        <SuggestedFirstSteps />
         <Stack
           data-testid={HomePageSelectors.HomePageContainer}
           maxWidth={['unset', HOME_FULL_PAGE_MAX_WIDTH]}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2468685600).<!-- Sticky Header Marker -->

~~I noticed now that we've broken up the steps into their own components, they are not updating when complete unless a user refreshes. This fixes it. Another alternative would be to pass down `isComplete` as a prop to each one.~~

EDIT: Newest version leaves using persisted state for now, but fixes the update issue.

cc/ @kyranjamie
