### PR TITLE
refactor: suggested steps logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@segment/analytics-next": "1.31.1",
     "@sentry/react": "6.16.1",
     "@sentry/tracing": "6.16.1",
-    "@stacks/blockchain-api-client": "0.65.0",
+    "@stacks/blockchain-api-client": "4.0.1",
     "@stacks/common": "4.0.1",
     "@stacks/connect": "6.7.0",
     "@stacks/connect-ui": "5.5.0",

--- a/src/app/components/transaction/components/ft-transfer-item.tsx
+++ b/src/app/components/transaction/components/ft-transfer-item.tsx
@@ -7,7 +7,7 @@ import {
   getTxCaption,
 } from '@app/common/transactions/transaction-utils';
 import { pullContractIdFromIdentity } from '@app/common/utils';
-import { useFungibleTokenMetadata } from '@app/query/tokens/fungible-token-metadata.hook';
+import { useFungibleTokenMetadata } from '@app/query/fungible-tokens/fungible-token-metadata.hooks';
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 
 import { imageCanonicalUriFromFtMetadata } from '@app/common/token-utils';

--- a/src/app/features/suggested-first-steps/hooks/use-suggested-first-steps.ts
+++ b/src/app/features/suggested-first-steps/hooks/use-suggested-first-steps.ts
@@ -1,7 +1,13 @@
 import { useEffect, useMemo } from 'react';
 
 import {
+  useAccountsNonFungibleTokenHoldings,
+  useNonFungibleTokenHoldings,
+} from '@app/query/non-fungible-tokens/non-fungible-token-holdings.hooks';
+import {
   useAccounts,
+  useAccountsAvailableStxBalance,
+  useCurrentAccount,
   useCurrentAccountAvailableStxBalance,
 } from '@app/store/accounts/account.hooks';
 import { useAppDispatch } from '@app/store';
@@ -10,37 +16,37 @@ import {
   useSuggestedFirstStepsStatus,
 } from '@app/store/onboarding/onboarding.selectors';
 import { onboardingActions } from '@app/store/onboarding/onboarding.actions';
-import { useCurrentAccountUnanchoredBalances } from '@app/query/balance/balance.hooks';
 import { SuggestedFirstSteps, SuggestedFirstStepStatus } from '@shared/models/onboarding-types';
 
 export function useSuggestedFirstSteps() {
   const dispatch = useAppDispatch();
+  const accounts = useAccounts();
+  const currentAccount = useCurrentAccount();
   const hasHiddenSuggestedFirstSteps = useHideSuggestedFirstSteps();
   const stepsStatus = useSuggestedFirstStepsStatus();
   const availableStxBalance = useCurrentAccountAvailableStxBalance();
-  const { data: balances } = useCurrentAccountUnanchoredBalances();
-  const accounts = useAccounts();
+  const accountsAvailableStxBalance = useAccountsAvailableStxBalance();
+  const nonFungibleTokenHoldings = useNonFungibleTokenHoldings(currentAccount?.address);
+  const accountsNonFungibleTokenHoldings = useAccountsNonFungibleTokenHoldings(accounts);
 
   useEffect(() => {
-    if (availableStxBalance?.isGreaterThan(0)) {
+    if (accountsAvailableStxBalance?.isGreaterThan(0)) {
       dispatch(
         onboardingActions.userCompletedSuggestedFirstStep({ step: SuggestedFirstSteps.AddFunds })
       );
     }
 
-    if (balances && Object.keys(balances?.non_fungible_tokens).length > 0) {
+    if (accountsNonFungibleTokenHoldings.isGreaterThan(0)) {
       dispatch(
         onboardingActions.userCompletedSuggestedFirstStep({ step: SuggestedFirstSteps.BuyNft })
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [availableStxBalance, balances?.non_fungible_tokens]);
+  }, [availableStxBalance, nonFungibleTokenHoldings]);
 
   const hasCompletedSuggestedFirstSteps = useMemo(() => {
     return Object.values(stepsStatus).every(val => val === SuggestedFirstStepStatus.Complete);
   }, [stepsStatus]);
 
-  return (
-    accounts?.length === 1 && !hasCompletedSuggestedFirstSteps && !hasHiddenSuggestedFirstSteps
-  );
+  return !hasCompletedSuggestedFirstSteps && !hasHiddenSuggestedFirstSteps;
 }

--- a/src/app/query/bns/bns.query.ts
+++ b/src/app/query/bns/bns.query.ts
@@ -15,7 +15,7 @@ const bnsQueryOptions = {
 
 function getBnsNameFetcherFactory(api: Api) {
   return (address: string) => () =>
-    api.bnsApi.getNamesOwnedByAddress({ address, blockchain: 'stacks' });
+    api.namesApi.getNamesOwnedByAddress({ address, blockchain: 'stacks' });
 }
 
 export function useGetBnsNamesOwnedByAddress(address: string) {

--- a/src/app/query/fungible-tokens/fungible-token-metadata.hooks.ts
+++ b/src/app/query/fungible-tokens/fungible-token-metadata.hooks.ts
@@ -1,13 +1,14 @@
 import { useMemo } from 'react';
 
-import { useAssets } from '@app/store/assets/asset.hooks';
+import { AssetWithMeta } from '@app/common/asset-types';
 import { isTransferableAsset } from '@app/common/transactions/is-transferable-asset';
 import { formatContractId } from '@app/common/utils';
+import { useAssets } from '@app/store/assets/asset.hooks';
+
 import {
   useGetFungibleTokenMetadataListQuery,
   useGetFungibleTokenMetadataQuery,
 } from './fungible-token-metadata.query';
-import { AssetWithMeta } from '@app/common/asset-types';
 
 export function useFungibleTokenMetadata(contractId: string) {
   const { data: ftMetadata } = useGetFungibleTokenMetadataQuery(contractId);

--- a/src/app/query/fungible-tokens/fungible-token-metadata.query.ts
+++ b/src/app/query/fungible-tokens/fungible-token-metadata.query.ts
@@ -25,7 +25,7 @@ const is404 = isResponseCode(404);
 function fetchUnanchoredAccountInfo(api: Api) {
   return (contractId: string) => async () => {
     await limiter.removeTokens(1);
-    return api.tokensApi
+    return api.fungibleTokensApi
       .getContractFtMetadata({ contractId })
       .catch(error => (is404(error) ? undefined : error));
   };

--- a/src/app/query/non-fungible-tokens/non-fungible-token-holdings.hooks.ts
+++ b/src/app/query/non-fungible-tokens/non-fungible-token-holdings.hooks.ts
@@ -1,0 +1,21 @@
+import BigNumber from 'bignumber.js';
+
+import { SoftwareWalletAccountWithAddress } from '@app/store/accounts/account.models';
+
+import {
+  useGetNonFungibleTokenHoldingsListQuery,
+  useGetNonFungibleTokenHoldingsQuery,
+} from './non-fungible-token-holdings.query';
+
+export function useNonFungibleTokenHoldings(address?: string) {
+  const { data: nftHoldings } = useGetNonFungibleTokenHoldingsQuery(address);
+  return nftHoldings;
+}
+
+export function useAccountsNonFungibleTokenHoldings(accounts?: SoftwareWalletAccountWithAddress[]) {
+  const accountsNftHoldings = useGetNonFungibleTokenHoldingsListQuery(accounts);
+
+  return accountsNftHoldings.reduce((acc, nftHoldings) => {
+    return acc.plus(nftHoldings.data?.total || 0);
+  }, new BigNumber(0));
+}

--- a/src/app/query/non-fungible-tokens/non-fungible-token-holdings.query.ts
+++ b/src/app/query/non-fungible-tokens/non-fungible-token-holdings.query.ts
@@ -1,0 +1,36 @@
+import { useQueries, useQuery } from 'react-query';
+
+import { useCurrentNetwork } from '@app/common/hooks/use-current-network';
+import { SoftwareWalletAccountWithAddress } from '@app/store/accounts/account.models';
+import { Api, useApi } from '@app/store/common/api-clients.hooks';
+
+function fetchNonFungibleTokenHoldings(api: Api) {
+  return (address?: string) => async () => {
+    if (!address) return;
+    return api.nonFungibleTokensApi.getNftHoldings({ principal: address, limit: 50 });
+  };
+}
+
+export function useGetNonFungibleTokenHoldingsQuery(address?: string) {
+  const api = useApi();
+  const network = useCurrentNetwork();
+
+  return useQuery({
+    queryKey: ['get-nft-holdings', address, network.url],
+    queryFn: fetchNonFungibleTokenHoldings(api)(address),
+  });
+}
+
+export function useGetNonFungibleTokenHoldingsListQuery(
+  accounts?: SoftwareWalletAccountWithAddress[]
+) {
+  const api = useApi();
+  const network = useCurrentNetwork();
+
+  return useQueries(
+    (accounts || []).map(account => ({
+      queryKey: ['get-ft-metadata', account.address, network.url],
+      queryFn: fetchNonFungibleTokenHoldings(api)(account.address),
+    }))
+  );
+}

--- a/src/app/store/accounts/account.hooks.ts
+++ b/src/app/store/accounts/account.hooks.ts
@@ -17,6 +17,7 @@ import {
   hasCreatedAccountState,
   refreshAccountDataState,
   transactionAccountIndexState,
+  accountsAvailableStxBalanceState,
 } from '@app/store/accounts';
 import { currentAccountIndexState } from '../wallet/wallet';
 
@@ -34,6 +35,10 @@ export function useSetMempoolTransactions() {
 
 export function useAccounts() {
   return useAtomValue(accountsWithAddressState);
+}
+
+export function useAccountsAvailableStxBalance() {
+  return useAtomValue(accountsAvailableStxBalanceState);
 }
 
 export function useCurrentAccountStxAddressState() {

--- a/src/app/store/accounts/index.ts
+++ b/src/app/store/accounts/index.ts
@@ -73,6 +73,15 @@ export const accountsWithAddressState = atom<SoftwareWalletAccountWithAddress[] 
   }
 );
 
+export const accountsAvailableStxBalanceState = atom<BigNumber | undefined>(get => {
+  const accounts = get(accountsWithAddressState);
+  if (!accounts) return undefined;
+
+  return accounts.reduce((acc, account) => {
+    return acc.plus(get(accountAvailableAnchoredStxBalanceState(account.address)));
+  }, new BigNumber(0));
+});
+
 //--------------------------------------
 // Current account
 //--------------------------------------

--- a/src/app/store/assets/asset.hooks.ts
+++ b/src/app/store/assets/asset.hooks.ts
@@ -14,7 +14,7 @@ import { transformAssets } from './utils';
 import {
   useAssetsWithMetadata,
   useFungibleTokenMetadata,
-} from '@app/query/tokens/fungible-token-metadata.hook';
+} from '@app/query/fungible-tokens/fungible-token-metadata.hooks';
 import { formatContractId, getFullyQualifiedAssetName } from '@app/common/utils';
 import { isTransferableAsset } from '@app/common/transactions/is-transferable-asset';
 

--- a/src/app/store/common/api-clients.ts
+++ b/src/app/store/common/api-clients.ts
@@ -10,13 +10,13 @@ import {
   TransactionsApi,
   BlocksApi,
   FaucetsApi,
-  BNSApi,
-  BurnchainApi,
+  NamesApi,
   FeesApi,
   SearchApi,
   RosettaApi,
   MicroblocksApi,
-  TokensApi,
+  FungibleTokensApi,
+  NonFungibleTokensApi,
 } from '@stacks/blockchain-api-client';
 
 import type { Middleware, RequestContext } from '@stacks/blockchain-api-client';
@@ -34,12 +34,12 @@ function apiClients(config: Configuration) {
   const microblocksApi = new MicroblocksApi(config);
   const blocksApi = new BlocksApi(config);
   const faucetsApi = new FaucetsApi(config);
-  const bnsApi = new BNSApi(config);
-  const burnchainApi = new BurnchainApi(config);
+  const namesApi = new NamesApi(config);
   const feesApi = new FeesApi(config);
   const searchApi = new SearchApi(config);
   const rosettaApi = new RosettaApi(config);
-  const tokensApi = new TokensApi(config);
+  const fungibleTokensApi = new FungibleTokensApi(config);
+  const nonFungibleTokensApi = new NonFungibleTokensApi(config);
 
   return {
     smartContractsApi,
@@ -49,12 +49,12 @@ function apiClients(config: Configuration) {
     microblocksApi,
     blocksApi,
     faucetsApi,
-    bnsApi,
-    burnchainApi,
+    namesApi,
     feesApi,
     searchApi,
     rosettaApi,
-    tokensApi,
+    fungibleTokensApi,
+    nonFungibleTokensApi,
   };
 }
 

--- a/src/app/store/transactions/post-conditions.hooks.ts
+++ b/src/app/store/transactions/post-conditions.hooks.ts
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai/utils';
 import { addressToString, FungiblePostCondition } from '@stacks/transactions';
 import { postConditionModeState } from '@app/store/transactions/post-conditions';
-import { useFungibleTokenMetadata } from '@app/query/tokens/fungible-token-metadata.hook';
+import { useFungibleTokenMetadata } from '@app/query/fungible-tokens/fungible-token-metadata.hooks';
 
 export const usePostConditionModeState = () => {
   return useAtomValue(postConditionModeState);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,10 +3117,10 @@
     jsontokens "^3.0.0"
     query-string "^6.13.1"
 
-"@stacks/blockchain-api-client@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@stacks/blockchain-api-client/-/blockchain-api-client-0.65.0.tgz#bd972375d4e2e5aa56edfbfb897aef7d29445301"
-  integrity sha512-SaKjSm0P0d/y6IPRJtGAKUxgcsz1WeMDQm7kZu2PZha7f6FqsuWNtWBmiZOnOtEhF7cqyP1MdST3Q0okY85UcQ==
+"@stacks/blockchain-api-client@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@stacks/blockchain-api-client/-/blockchain-api-client-4.0.1.tgz#534f5c6b8a73644330a3dd2800de1d35fd3589ab"
+  integrity sha512-RK8Nffx9ny+XV1dZBnC1tpJyAIKuPrw14NTTkQpMwLsY/nqXh1bQ0OKztMsqT2jMRFvb8I1me9I6pcSbu7LE2A==
   dependencies:
     "@stacks/stacks-blockchain-api-types" "*"
     "@types/ws" "^7.4.0"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2468995984).<!-- Sticky Header Marker -->

This PR refactors the onboarding suggested steps logic so that it checks all accounts in the wallet rather than just the current account and not showing if the wallet has more than one account. To implement this, I needed to update `@stacks/blockchain-api-client` to the latest version so that we have access to `NonFungibleTokensApi` and `getNftHoldings`. There are a few minor changes in the code here related to that update (ex. `BNSApi ` is now `NamesApi`).

*This fixes the suggested first steps not working with ledger bc it loads with five accounts.

cc/ @kyranjamie @fbwoolf @beguene
