### PR TITLE
fix: bad ui copy practices

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,4 +15,4 @@ markComment: >
   for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-  This issue has been automatically closed. Please reopen if needed.
+  This issue has been automatically closed. Reopen if needed.

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -16,5 +16,5 @@ jobs:
             First, check to make sure you're using the latest version of Hiro Wallet for Web,
             which can be found at https://www.hiro.so/wallet/install-web
 
-            If you're using the latest version, please make sure to include more relevant information about
+            If you're using the latest version, make sure to include more relevant information about
             your bug in the issue title and description. Once you've updated your issue, feel free to re-open it.

--- a/src/app/features/switch-account-drawer/components/account-list-unavailable.tsx
+++ b/src/app/features/switch-account-drawer/components/account-list-unavailable.tsx
@@ -14,7 +14,7 @@ export const AccountListUnavailable = memo(() => (
       <Title>Unable to load account information</Title>
       <Body mt="base-tight">
         We're unable to load information about your accounts. This may be a problem with the
-        wallet's API. If this problem persists, please contact support.
+        wallet's API. If this problem persists, contact support.
       </Body>
     </Box>
   </Flex>

--- a/src/app/pages/add-network/add-network.tsx
+++ b/src/app/pages/add-network/add-network.tsx
@@ -42,7 +42,7 @@ export const AddNetwork = () => {
         onSubmit={async values => {
           const { name, url, key } = values;
           if (!isValidUrl(url)) {
-            setError('Please enter a valid URL');
+            setError('Enter a valid URL');
             return;
           }
           setLoading(true);

--- a/src/app/pages/onboarding/set-password/set-password.tsx
+++ b/src/app/pages/onboarding/set-password/set-password.tsx
@@ -142,8 +142,8 @@ export const SetPasswordPage = () => {
                 !formik.isSubmitting &&
                 !strengthResult.meetsAllStrengthRequirements ? (
                   <Caption fontSize={0} mt="base-loose">
-                    Please use a stronger password. Longer than 12 characters, with symbols,
-                    numbers, and words.
+                    Use a stronger password. Longer than 12 characters, with symbols, numbers, and
+                    words.
                   </Caption>
                 ) : null}
               </Text>

--- a/src/app/pages/send-tokens/components/send-max-button.tsx
+++ b/src/app/pages/send-tokens/components/send-max-button.tsx
@@ -39,7 +39,7 @@ export function SendMaxButton(props: SendMaxProps): JSX.Element | null {
   const isStx = selectedAsset?.type === 'stx';
 
   const fireInactiveSendMaxButtonToast = useCallback(() => {
-    if (isUndefined(fee)) toast.error('Loading fee, please try again');
+    if (isUndefined(fee)) toast.error('Loading fee, try again');
     toast.error('A fee must be set to calculate max STX transfer amount');
   }, [fee]);
 

--- a/src/app/pages/transaction-request/components/transaction-error/error-messages.tsx
+++ b/src/app/pages/transaction-request/components/transaction-error/error-messages.tsx
@@ -144,7 +144,7 @@ export const ExpiredRequestErrorMessage = memo(props => {
         >
           <ErrorMessage
             title="Expired request"
-            body="This transaction request has expired or cannot be validated, please try to re-initiate this transaction request from the original app."
+            body="This transaction request has expired or cannot be validated, try to re-initiate this transaction request from the original app."
             border={'1px solid'}
             borderColor={color('border')}
             boxShadow="high"

--- a/src/app/pages/unauthorized-request/unauthorized-request.tsx
+++ b/src/app/pages/unauthorized-request/unauthorized-request.tsx
@@ -5,8 +5,8 @@ import { GenericError } from '@app/components/generic-error/generic-error';
 const body = `The transaction request was not properly authorized by any of your Hiro Wallet accounts. This typically happens if you've logged into this app before using another account.`;
 const helpTextList = [
   <Box as="li" mt="base">
-    Please sign out of the app and sign back in to re-authenticate into the application. This should
-    help you successfully sign your transaction with the Hiro Wallet.
+    Sign out of the app and sign back in to re-authenticate into the application. This should help
+    you successfully sign your transaction with the Hiro Wallet.
   </Box>,
 ];
 const title = 'Unauthorized request';

--- a/src/app/pages/unlock.tsx
+++ b/src/app/pages/unlock.tsx
@@ -22,8 +22,8 @@ import { RouteUrls } from '@shared/route-urls';
 import { SettingsSelectors } from '@tests/integration/settings.selectors';
 
 const waitingMessages: WaitingMessages = {
-  '2': 'Please wait a few seconds…',
-  '10': 'Still working, please wait.',
+  '2': 'Verifying password…',
+  '10': 'Still working…',
   '20': 'Almost there.',
 };
 

--- a/tests/integration/network.selectors.ts
+++ b/tests/integration/network.selectors.ts
@@ -4,6 +4,6 @@ export const NetworkSelectors = {
   NetworkKey: 'network-key',
   BtnAddNetwork: 'btn-add-network',
   ErrorText: 'error-text',
-  EmptyAddressError: 'Please enter a valid URL',
+  EmptyAddressError: 'Enter a valid URL',
   NoNodeFetch: 'Unable to fetch info from node.',
 };


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2468643172).<!-- Sticky Header Marker -->

Reading into best practices for UI copy, _please_ is a huge faux pas. This PR suggests a handful of more direct, concise alternatives

References:
- https://medium.muz.li/5-rules-to-ensure-your-ui-copy-doesnt-suck-d0fb7487d84
- https://material.io/design/communication/writing.html