### PR TITLE
refactor: skip fund page

### DIFF
--- a/src/app/pages/fund/fund.tsx
+++ b/src/app/pages/fund/fund.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
@@ -8,9 +7,6 @@ import {
   useCurrentAccountAvailableStxBalance,
 } from '@app/store/accounts/account.hooks';
 import { RouteUrls } from '@shared/route-urls';
-import { useAppDispatch } from '@app/store';
-import { onboardingActions } from '@app/store/onboarding/onboarding.actions';
-import { useSkipFundAccount } from '@app/store/onboarding/onboarding.selectors';
 
 import { FundLayout } from './fund.layout';
 import { SkipFundAccountButton } from './components/skip-fund-account-button';
@@ -22,17 +18,12 @@ interface LocationStateProps {
 export function FundPage() {
   const { state } = useLocation() as LocationStateProps;
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
   const currentAccount = useCurrentAccount();
   const availableStxBalance = useCurrentAccountAvailableStxBalance();
-  const hasSkippedFundAccount = useSkipFundAccount();
 
   const isOnboarding = state?.showSkipButton;
 
-  const onSkipFundAccount = () => {
-    dispatch(onboardingActions.userSkippedFundingAccount(true));
-    navigate(RouteUrls.Home);
-  };
+  const onSkipFundAccount = () => navigate(RouteUrls.Home);
 
   useRouteHeader(
     <Header
@@ -44,13 +35,6 @@ export function FundPage() {
       title={isOnboarding ? undefined : ' '}
     />
   );
-
-  useEffect(() => {
-    // This handles syncing b/w views, so it can likely be removed
-    // once we force onboarding via full page view
-    if (isOnboarding && hasSkippedFundAccount) navigate(RouteUrls.Home);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   if (!currentAccount) return null;
 

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -14,11 +14,7 @@ import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggest
 import { CurrentAccount } from '@app/pages/home/components/account-area';
 import { HomeActions } from '@app/pages/home/components/home-actions';
 import { RouteUrls } from '@shared/route-urls';
-import {
-  useCurrentAccount,
-  useCurrentAccountAvailableStxBalance,
-} from '@app/store/accounts/account.hooks';
-import { useSkipFundAccount } from '@app/store/onboarding/onboarding.selectors';
+import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { HomePageSelectors } from '@tests/page-objects/home.selectors';
 
 import { AccountInfoFetcher, BalanceFetcher } from './components/fetchers';
@@ -28,8 +24,6 @@ export function Home() {
   const { decodedAuthRequest } = useOnboardingState();
   const navigate = useNavigate();
   const account = useCurrentAccount();
-  const availableStxBalance = useCurrentAccountAvailableStxBalance();
-  const hasSkippedFundAccount = useSkipFundAccount();
   useTrackFirstDeposit();
 
   useRouteHeader(
@@ -41,10 +35,6 @@ export function Home() {
 
   useEffect(() => {
     if (decodedAuthRequest) navigate(RouteUrls.ChooseAccount);
-    // This handles syncing b/w views, so it can likely be removed
-    // once we force onboarding via full page view
-    if (!hasSkippedFundAccount && !availableStxBalance?.isGreaterThan(0))
-      navigate(RouteUrls.Fund, { state: { showSkipButton: true } });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/app/store/onboarding/onboarding.selectors.ts
+++ b/src/app/store/onboarding/onboarding.selectors.ts
@@ -7,11 +7,6 @@ const selectOnboarding = (state: RootState) => state.onboarding;
 
 const selectHideSuggestedFirstSteps = createSelector(selectOnboarding, state => state.hideSteps);
 
-const selectSkipFundAccount = createSelector(
-  selectOnboarding,
-  state => state.hasSkippedFundAccount
-);
-
 const selectSuggestedFirstStepsStatus = createSelector(
   selectOnboarding,
   state => state.stepsStatus
@@ -19,10 +14,6 @@ const selectSuggestedFirstStepsStatus = createSelector(
 
 export function useHideSuggestedFirstSteps() {
   return useSelector(selectHideSuggestedFirstSteps);
-}
-
-export function useSkipFundAccount() {
-  return useSelector(selectSkipFundAccount);
 }
 
 export function useSuggestedFirstStepsStatus() {

--- a/src/app/store/onboarding/onboarding.slice.ts
+++ b/src/app/store/onboarding/onboarding.slice.ts
@@ -8,13 +8,11 @@ import {
 
 interface OnboardingState {
   hideSteps: boolean;
-  hasSkippedFundAccount: boolean;
   stepsStatus: SuggestedFirstStepsStatus;
 }
 
 const initialState: OnboardingState = {
   hideSteps: false,
-  hasSkippedFundAccount: false,
   stepsStatus: {
     [SuggestedFirstSteps.BackUpSecretKey]: SuggestedFirstStepStatus.Complete,
     [SuggestedFirstSteps.AddFunds]: SuggestedFirstStepStatus.Incomplete,
@@ -29,9 +27,6 @@ export const onboardingSlice = createSlice({
   reducers: {
     hideSuggestedFirstSteps(state, action: PayloadAction<boolean>) {
       state.hideSteps = action.payload;
-    },
-    userSkippedFundingAccount(state, action: PayloadAction<boolean>) {
-      state.hasSkippedFundAccount = action.payload;
     },
     userCompletedSuggestedFirstStep(state, action: PayloadAction<{ step: SuggestedFirstSteps }>) {
       state.stepsStatus[action.payload.step] = SuggestedFirstStepStatus.Complete;

--- a/tests/integration/settings/settings.spec.ts
+++ b/tests/integration/settings/settings.spec.ts
@@ -90,6 +90,7 @@ describe(`Settings integration tests`, () => {
     const password = randomString(15);
     await wallet.enterNewPassword(password);
     await wallet.enterConfirmPasswordAndClickDone(password);
+    await wallet.clickSkipFundAccountButton();
     await wallet.waitForSettingsButton();
     await wallet.clickSettingsButton();
     await wallet.page.click(createTestSelector(SettingsSelectors.LockListItem));


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2476259789).<!-- Sticky Header Marker -->

This PR removes persisted state tracking if a user has skipped the fund account page, and redirecting on the home to keep the views in sync. So, this is simpler but the views will NOT stay in sync during onboarding with this solution, BUT none of our onboarding really stays in sync at this point b/w views. With this solution, the `OnboardingGate` will redirect a user to the home page w/out clicking on `Skip` if they close the ext popup while on the fund page during onboarding and reopen it. This might be ok for now bc with the ledger work we are going to force onboarding via full page, so any effort to keep them in sync here would just be temporary?

cc/ @kyranjamie @fbwoolf @beguene
