### PR TITLE
fix: sign message oncancel

### DIFF
--- a/src/app/components/container/container.tsx
+++ b/src/app/components/container/container.tsx
@@ -3,8 +3,12 @@ import { Outlet } from 'react-router-dom';
 
 import { useWallet } from '@app/common/hooks/use-wallet';
 import { useAuthRequest } from '@app/store/onboarding/onboarding.hooks';
+import {
+  useOnCancelSignMessage,
+  useSignatureRequestSearchParams,
+} from '@app/store/signatures/requests.hooks';
 import { usePendingTransaction } from '@app/store/transactions/transaction.hooks';
-import { useOnCancel } from '@app/store/transactions/requests.hooks';
+import { useOnCancelTransaction } from '@app/store/transactions/requests.hooks';
 import { useRouteHeaderState } from '@app/store/ui/ui.hooks';
 
 import { ContainerLayout } from './container.layout';
@@ -12,8 +16,10 @@ import { ContainerLayout } from './container.layout';
 function UnmountEffectSuspense() {
   const pendingTx = usePendingTransaction();
   const { authRequest } = useAuthRequest();
-  const handleCancelTransaction = useOnCancel();
+  const handleCancelTransaction = useOnCancelTransaction();
   const { cancelAuthentication } = useWallet();
+  const { requestToken: signatureRequest } = useSignatureRequestSearchParams();
+  const handleCancelSignMessage = useOnCancelSignMessage();
 
   /*
    * When the popup is closed, this checks the request type and forces
@@ -24,8 +30,17 @@ function UnmountEffectSuspense() {
       await handleCancelTransaction();
     } else if (!!authRequest) {
       cancelAuthentication();
+    } else if (!!signatureRequest) {
+      handleCancelSignMessage();
     }
-  }, [cancelAuthentication, authRequest, pendingTx, handleCancelTransaction]);
+  }, [
+    pendingTx,
+    authRequest,
+    signatureRequest,
+    handleCancelTransaction,
+    cancelAuthentication,
+    handleCancelSignMessage,
+  ]);
 
   useEffect(() => {
     window.addEventListener('beforeunload', handleUnmount);

--- a/src/app/store/signatures/requests.hooks.ts
+++ b/src/app/store/signatures/requests.hooks.ts
@@ -1,8 +1,10 @@
-import { verifySignatureRequest } from '@app/common/signature/requests';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAsync } from 'react-async-hook';
 import { useSearchParams } from 'react-router-dom';
-import { useAccounts } from '../accounts/account.hooks';
+
+import { finalizeMessageSignature } from '@app/common/actions/finalize-message-signature';
+import { verifySignatureRequest } from '@app/common/signature/requests';
+import { useAccounts } from '@app/store/accounts/account.hooks';
 
 export function useIsSignatureRequestValid() {
   const accounts = useAccounts();
@@ -36,4 +38,15 @@ export function useSignatureRequestSearchParams() {
     }),
     [searchParams]
   );
+}
+
+export function useOnCancelSignMessage() {
+  const { requestToken, tabId } = useSignatureRequestSearchParams();
+
+  return useCallback(() => {
+    if (!requestToken || !tabId) return;
+    const tabIdInt = parseInt(tabId);
+    const data = 'cancel';
+    finalizeMessageSignature(requestToken, tabIdInt, data);
+  }, [requestToken, tabId]);
 }

--- a/src/app/store/transactions/requests.hooks.ts
+++ b/src/app/store/transactions/requests.hooks.ts
@@ -29,7 +29,7 @@ export function useUpdateTransactionBroadcastError() {
   return useUpdateAtom(transactionBroadcastErrorState);
 }
 
-export function useOnCancel() {
+export function useOnCancelTransaction() {
   return useAtomCallback(
     useCallback(async (get, set) => {
       const requestToken = get(requestTokenState);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2480182728).<!-- Sticky Header Marker -->

This PR should fix `onCancel` not firing when a user closes the popup during message signing.

![Screen Shot 2022-06-10 at 2 32 24 PM](https://user-images.githubusercontent.com/6493321/173137214-877e67a3-a1db-4391-be2f-91f4ff8b50b6.png)

cc/ @kyranjamie @fbwoolf @beguene
