### PR TITLE
fix: current account name

### DIFF
--- a/src/app/pages/home/components/account-area.tsx
+++ b/src/app/pages/home/components/account-area.tsx
@@ -39,6 +39,8 @@ const AccountAddress = memo((props: StackProps) => {
 });
 
 export const CurrentAccount = memo((props: StackProps) => {
+  const currentAccount = useCurrentAccount();
+  if (!currentAccount) return null;
   return (
     <Stack spacing="base-tight" alignItems="center" isInline {...props}>
       <CurrentAccountAvatar />


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2495956535).<!-- Sticky Header Marker -->

I saw the account name loaded w/out my .btc name once with the new release. I realized during testing, I removed these two lines which causes the default account number to render as a fallback. I did not mean to remove this check here and release it.

cc/ @kyranjamie @fbwoolf @beguene
