### PR TITLE
fix: sign message with line breaks

### DIFF
--- a/src/app/pages/signature-request/components/message-box.tsx
+++ b/src/app/pages/signature-request/components/message-box.tsx
@@ -8,16 +8,15 @@ import { isStructuredMessage, SignatureMessage } from './sign-action';
 
 export function MessageBox(props: SignatureMessage): JSX.Element | null {
   const { message, messageType } = props;
-
   const [hash, setHash] = useState<string | undefined>();
-  const [displayMessage, setDisplayMessage] = useState<string | undefined>();
+  const [displayMessage, setDisplayMessage] = useState<string[] | undefined>();
   const [clarityValueMessage, setClarityValueMessage] = useState<ClarityValue | undefined>();
 
   useEffect(() => {
     if (isStructuredMessage(messageType)) {
       setClarityValueMessage(deserializeCV(Buffer.from(message, 'hex')));
     } else {
-      setDisplayMessage(message);
+      setDisplayMessage(message.split(/\r?\n/));
     }
   }, [message, messageType]);
 
@@ -39,21 +38,22 @@ export function MessageBox(props: SignatureMessage): JSX.Element | null {
           backgroundColor={color('border')}
         >
           <Stack
-            py="loose"
-            px="loose"
-            spacing="loose"
+            bg={color('bg')}
             borderRadius="16px"
-            backgroundColor={'white'}
+            fontSize={2}
+            lineHeight="1.6"
+            px="loose"
+            py="loose"
+            spacing="tight"
+            wordBreak="break-all"
           >
-            <Stack spacing="base-tight">
-              <Text display="block" fontSize={2} lineHeight="1.6" wordBreak="break-all">
-                {clarityValueMessage && messageType === 'structured' ? (
-                  <ClarityValueListDisplayer val={clarityValueMessage} encoding={'tryAscii'} />
-                ) : (
-                  displayMessage
-                )}
+            {clarityValueMessage && messageType === 'structured' ? (
+              <Text>
+                <ClarityValueListDisplayer encoding={'tryAscii'} val={clarityValueMessage} />
               </Text>
-            </Stack>
+            ) : (
+              displayMessage?.map(line => <Text>{line}</Text>)
+            )}
           </Stack>
           {hash ? <HashDrawer hash={hash} /> : null}
         </Stack>

--- a/test-app/src/components/signature.tsx
+++ b/test-app/src/components/signature.tsx
@@ -32,6 +32,8 @@ export const Signature = () => {
   const signatureMessage = 'Hello world!';
   const longSignatureMessage =
     'Nullam eu ante vel est convallis dignissim.  Fusce suscipit, wisi nec facilisis facilisis, est dui fermentum leo, quis tempor ligula erat quis odio.  Nunc porta vulputate tellus.  Nunc rutrum turpis sed pede.  Sed bibendum.  Aliquam posuere.  Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio.  Pellentesque condimentum, magna ut suscipit hendrerit, ipsum augue ornare nulla, non luctus diam neque sit amet urna.  Curabitur vulputate vestibulum lorem.  Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros.  Sed id ligula quis est convallis tempor.  Curabitur lacinia pulvinar nibh.  Nam a sapien.';
+  const signatureMessageWithLineBreaks =
+    'This is line one.\nThis is line two.\nThis is line three.\nThis is line four.\nThis is line five.';
   const ADDRESS = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
 
   const structuredData = tupleCV({
@@ -130,6 +132,10 @@ export const Signature = () => {
       <br />
       <Button mt={3} onClick={() => signMessage(longSignatureMessage)}>
         Signature (long message)
+      </Button>
+      <br />
+      <Button mt={3} onClick={() => signMessage(signatureMessageWithLineBreaks)}>
+        Signature (with line breaks)
       </Button>
       <br />
       <Button mt={3} onClick={() => signStructure(structuredData)}>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2497049332).<!-- Sticky Header Marker -->

This PR addresses line breaks in the message passed to sign. It also adds a new test button to the test-app to test it.

![Screen Shot 2022-06-14 at 12 04 58 PM](https://user-images.githubusercontent.com/6493321/173640640-b43b775c-f3c6-43b1-aa7b-d84a7a8a1042.png)

![Screen Shot 2022-06-14 at 12 22 36 PM](https://user-images.githubusercontent.com/6493321/173640659-52e577b6-eea2-4e30-9bc7-bbba874752b9.png)

cc/ @kyranjamie @fbwoolf @beguene
