### PR TITLE
fix: firefox white screen with referer header

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@stacks/wallet-sdk": "4.2.2",
     "@styled-system/theme-get": "5.1.2",
     "@tippyjs/react": "4.2.6",
+    "@types/webextension-polyfill": "0.9.0",
     "@vkontakte/vk-qr": "2.0.13",
     "@zondax/ledger-blockstack": "0.24.0",
     "are-passive-events-supported": "1.1.1",
@@ -166,6 +167,7 @@
     "use-events": "1.4.2",
     "use-latest": "1.2.0",
     "valid-url": "1.0.9",
+    "webextension-polyfill": "0.9.0",
     "zxcvbn": "4.4.2"
   },
   "devDependencies": {

--- a/src/app/common/signature/requests.ts
+++ b/src/app/common/signature/requests.ts
@@ -1,14 +1,15 @@
+import { deserializeCV } from '@stacks/transactions';
+import { getAppPrivateKey } from '@stacks/wallet-sdk';
+import { decodeToken, TokenInterface, TokenVerifier } from 'jsontokens';
+import { getPublicKeyFromPrivate } from '@stacks/encryption';
+
 import { AccountWithAddress } from '@app/store/accounts/account.models';
+import { isString } from '@shared/utils';
 import {
   CommonSignaturePayload,
   SignaturePayload,
   StructuredDataSignaturePayload,
 } from '@stacks/connect';
-import { getPublicKeyFromPrivate } from '@stacks/encryption';
-import { deserializeCV } from '@stacks/transactions';
-import { getAppPrivateKey } from '@stacks/wallet-sdk';
-import { decodeToken, TokenInterface, TokenVerifier } from 'jsontokens';
-import { isString } from '../utils';
 
 export function getGenericSignaturePayloadFromToken(requestToken: string): CommonSignaturePayload {
   const token = decodeToken(requestToken);

--- a/src/app/common/token-utils.ts
+++ b/src/app/common/token-utils.ts
@@ -1,4 +1,5 @@
-import { abbreviateNumber, isUndefined } from '@app/common/utils';
+import { abbreviateNumber } from '@app/common/utils';
+import { isUndefined } from '@shared/utils';
 import { AssetWithMeta, FtMeta } from './asset-types';
 import { convertUnicodeToAscii } from './string-utils';
 import { isValidUrl } from './validation/validate-url';

--- a/src/app/common/transactions/is-transferable-asset.ts
+++ b/src/app/common/transactions/is-transferable-asset.ts
@@ -1,5 +1,5 @@
+import { isUndefined } from '@shared/utils';
 import { AssetWithMeta } from '../asset-types';
-import { isUndefined } from '../utils';
 
 export function isTransferableAsset(asset: AssetWithMeta) {
   if (asset.type === 'stx') return true;

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -267,24 +267,6 @@ export function pullContractIdFromIdentity(identifier: string) {
   return identifier.split('::')[0];
 }
 
-export function isNumber(value: unknown): value is number {
-  return typeof value === 'number';
-}
-
-export function isString(value: unknown): value is string {
-  return typeof value === 'string';
-}
-
-export function isUndefined(value: unknown): value is undefined {
-  return typeof value === 'undefined';
-}
-
-export function isEmpty(value: Object) {
-  return Object.keys(value).length === 0;
-}
-
-export function noop() {}
-
 export function formatContractId(address: string, name: string) {
   return `${address}.${name}`;
 }

--- a/src/app/common/validation/currency-schema.ts
+++ b/src/app/common/validation/currency-schema.ts
@@ -1,6 +1,8 @@
-import { STX_DECIMALS } from '@shared/constants';
-import { countDecimals, isNumber } from '@app/common/utils';
 import * as yup from 'yup';
+
+import { STX_DECIMALS } from '@shared/constants';
+import { countDecimals } from '@app/common/utils';
+import { isNumber } from '@shared/utils';
 
 function curencyAmountSchema() {
   return yup.number().positive('Amount must be positive').typeError('Currency be a number');

--- a/src/app/common/validation/stx-address-schema.ts
+++ b/src/app/common/validation/stx-address-schema.ts
@@ -1,6 +1,7 @@
 import * as yup from 'yup';
+
+import { isString } from '@shared/utils';
 import { validateAddressChain, validateStacksAddress } from '@app/common/stacks-utils';
-import { isString } from '@app/common/utils';
 import { Network } from '@shared/constants';
 
 export function stxAddressNetworkValidatorFactory(currentNetwork: Network) {

--- a/src/app/common/validation/use-fee-schema.ts
+++ b/src/app/common/validation/use-fee-schema.ts
@@ -5,7 +5,7 @@ import { STX_DECIMALS } from '@shared/constants';
 import { stxAmountSchema } from '@app/common/validation/currency-schema';
 import { formatInsufficientBalanceError, formatPrecisionError } from '@app/common/error-formatters';
 import { SendFormErrorMessages } from '@app/common/error-messages';
-import { isNumber } from '@app/common/utils';
+import { isNumber } from '@shared/utils';
 import { useCurrentAccountAvailableStxBalance } from '@app/store/accounts/account.hooks';
 import { stxToMicroStx } from '@app/common/stacks-utils';
 

--- a/src/app/common/validation/validate-memo.ts
+++ b/src/app/common/validation/validate-memo.ts
@@ -1,6 +1,7 @@
 import * as yup from 'yup';
 import { MEMO_MAX_LENGTH_BYTES } from '@stacks/transactions';
-import { isString } from '@app/common/utils';
+
+import { isString } from '@shared/utils';
 
 const exceedsMaxLengthBytes = (string: string, maxLengthBytes: number): boolean =>
   string ? Buffer.from(string).length > maxLengthBytes : false;

--- a/src/app/components/drawer/index.tsx
+++ b/src/app/components/drawer/index.tsx
@@ -4,7 +4,7 @@ import { FiX as IconX } from 'react-icons/fi';
 import { css } from '@emotion/react';
 
 import { useOnClickOutside } from '@app/common/hooks/use-onclickoutside';
-import { isString, noop } from '@app/common/utils';
+import { isString, noop } from '@shared/utils';
 import { Title } from '@app/components/typography';
 import { hideScrollbarStyle } from '../global-styles/hide-scrollbar';
 

--- a/src/app/features/ledger/flows/tx-signing/ledger-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/tx-signing/ledger-sign-tx-container.tsx
@@ -4,7 +4,8 @@ import { Box } from '@stacks/ui';
 import { LedgerError } from '@zondax/ledger-blockstack';
 import get from 'lodash.get';
 
-import { delay, noop } from '@app/common/utils';
+import { delay } from '@app/common/utils';
+import { noop } from '@shared/utils';
 import {
   getAppVersion,
   prepareLedgerDeviceConnection,

--- a/src/app/features/ledger/ledger-jwt-signing.context.ts
+++ b/src/app/features/ledger/ledger-jwt-signing.context.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-import { noop } from '@app/common/utils';
+import { noop } from '@shared/utils';
 import { getAppVersion } from './ledger-utils';
 
 export interface LedgerJwtSigningProvider {

--- a/src/app/features/ledger/ledger-request-keys.context.ts
+++ b/src/app/features/ledger/ledger-request-keys.context.ts
@@ -1,4 +1,4 @@
-import { noop } from '@app/common/utils';
+import { noop } from '@shared/utils';
 import { createContext } from 'react';
 import { getAppVersion } from './ledger-utils';
 

--- a/src/app/features/ledger/ledger-tx-signing.context.ts
+++ b/src/app/features/ledger/ledger-tx-signing.context.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 import { StacksTransaction } from '@stacks/transactions';
 
-import { noop } from '@app/common/utils';
+import { noop } from '@shared/utils';
 import { getAppVersion } from './ledger-utils';
 
 export interface LedgerTxSigningProvider {

--- a/src/app/features/ledger/ledger-utils.ts
+++ b/src/app/features/ledger/ledger-utils.ts
@@ -163,6 +163,9 @@ export function isStacksLedgerAppClosed(response: ResponseVersion) {
 }
 
 function reformatDerSignatureToJose(derSignature: Uint8Array) {
+  // Stacks authentication uses `ES256k`, however `ecdsa-sig-formatter` doesn't
+  // accept this. As it only uses this to validate key length, and the key
+  // lengths are the same, it works despite this confusing disparity.
   return ecdsaFormat.derToJose(Buffer.from(derSignature), 'ES256');
 }
 

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -12,7 +12,7 @@ import { App } from './app';
 
 initSentry();
 void initSegment();
-addRefererHeaderRequestListener();
+void addRefererHeaderRequestListener();
 
 declare global {
   interface Window {

--- a/src/app/pages/send-tokens/components/send-form-inner.tsx
+++ b/src/app/pages/send-tokens/components/send-form-inner.tsx
@@ -5,7 +5,7 @@ import { Box, Text, Stack } from '@stacks/ui';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { HIGH_FEE_AMOUNT_STX } from '@shared/constants';
 import { useDrawers } from '@app/common/hooks/use-drawers';
-import { isEmpty } from '@app/common/utils';
+import { isEmpty } from '@shared/utils';
 import { isTxSponsored, TransactionFormValues } from '@app/common/transactions/transaction-utils';
 import {
   useFeeEstimationsMaxValues,

--- a/src/app/pages/send-tokens/components/send-max-button.tsx
+++ b/src/app/pages/send-tokens/components/send-max-button.tsx
@@ -4,7 +4,7 @@ import { Box, ButtonProps, color } from '@stacks/ui';
 
 import { AssetWithMeta } from '@app/common/asset-types';
 import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
-import { isUndefined } from '@app/common/utils';
+import { isUndefined } from '@shared/utils';
 
 function SendMaxButtonAction(props: ButtonProps) {
   return (

--- a/src/app/pages/send-tokens/hooks/use-send-form-validation.ts
+++ b/src/app/pages/send-tokens/hooks/use-send-form-validation.ts
@@ -4,7 +4,7 @@ import { stxToMicroStx } from '@stacks/ui-utils';
 
 import { useWallet } from '@app/common/hooks/use-wallet';
 import { STX_DECIMALS } from '@shared/constants';
-import { countDecimals, isNumber } from '@app/common/utils';
+import { countDecimals } from '@app/common/utils';
 import { transactionMemoSchema } from '@app/common/validation/validate-memo';
 import { stxAmountSchema } from '@app/common/validation/currency-schema';
 import {
@@ -19,6 +19,7 @@ import { useFeeSchema } from '@app/common/validation/use-fee-schema';
 import { useSelectedAsset } from '@app/pages/send-tokens/hooks/use-selected-asset';
 import { useCurrentAccountAvailableStxBalance } from '@app/store/accounts/account.hooks';
 import { nonceSchema } from '@app/common/validation/nonce-schema';
+import { isNumber } from '@shared/utils';
 
 interface UseSendFormValidationArgs {
   setAssetError(error: string | undefined): void;

--- a/src/app/pages/signature-request/components/sign-action.tsx
+++ b/src/app/pages/signature-request/components/sign-action.tsx
@@ -1,15 +1,17 @@
+import { useCallback, useState } from 'react';
+import { ClarityValue, createStacksPrivateKey } from '@stacks/transactions';
+import { Button, Stack } from '@stacks/ui';
+import { TupleCV } from '@stacks/transactions/dist/esm/clarity';
+
 import { finalizeMessageSignature } from '@app/common/actions/finalize-message-signature';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
-import { delay, isString } from '@app/common/utils';
+import { delay } from '@app/common/utils';
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { useSignatureRequestSearchParams } from '@app/store/signatures/requests.hooks';
 import { signMessage, signStructuredDataMessage } from '@shared/crypto/sign-message';
 import { logger } from '@shared/logger';
 import { SignatureMessage } from '@shared/signature/types';
-import { ClarityValue, createStacksPrivateKey } from '@stacks/transactions';
-import { TupleCV } from '@stacks/transactions/dist/esm/clarity';
-import { Button, Stack } from '@stacks/ui';
-import { useCallback, useState } from 'react';
+import { isString } from '@shared/utils';
 
 function useSignMessageSoftwareWallet() {
   const account = useCurrentAccount();

--- a/src/app/pages/signature-request/signature-request.tsx
+++ b/src/app/pages/signature-request/signature-request.tsx
@@ -7,7 +7,7 @@ import {
   getSignaturePayloadFromToken,
   getStructuredDataPayloadFromToken,
 } from '@app/common/signature/requests';
-import { isUndefined } from '@app/common/utils';
+import { isUndefined } from '@shared/utils';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { Link } from '@app/components/link';
 import { Caption } from '@app/components/typography';

--- a/src/app/pages/transaction-request/components/submit-action.tsx
+++ b/src/app/pages/transaction-request/components/submit-action.tsx
@@ -6,7 +6,7 @@ import { HIGH_FEE_AMOUNT_STX } from '@shared/constants';
 import { useDrawers } from '@app/common/hooks/use-drawers';
 import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
 import { TransactionFormValues } from '@app/common/transactions/transaction-utils';
-import { isEmpty } from '@app/common/utils';
+import { isEmpty } from '@shared/utils';
 import { ShowEditNonceAction, ShowEditNoncePlaceholder } from '@app/components/show-edit-nonce';
 import { useTransactionError } from '@app/pages/transaction-request/hooks/use-transaction-error';
 import { useFeeEstimationsState } from '@app/store/transactions/fees.hooks';

--- a/src/app/query/hiro-config/hiro-config.query.ts
+++ b/src/app/query/hiro-config/hiro-config.query.ts
@@ -1,6 +1,7 @@
-import { isUndefined } from '@app/common/utils';
-import { GITHUB_ORG, GITHUB_REPO } from '@shared/constants';
 import { useQuery } from 'react-query';
+
+import { GITHUB_ORG, GITHUB_REPO } from '@shared/constants';
+import { isUndefined } from '@shared/utils';
 
 export interface HiroMessage {
   title: string;

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -24,11 +24,10 @@ import { backupOldWalletSalt } from './backup-old-wallet-salt';
 
 const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 
+void addRefererHeaderRequestListener();
 initSentry();
-
 initContextMenuActions();
 backupOldWalletSalt();
-addRefererHeaderRequestListener();
 
 //
 // Playwright does not currently support Chrome extension popup testing:

--- a/src/shared/add-referer-header.ts
+++ b/src/shared/add-referer-header.ts
@@ -1,23 +1,49 @@
+import browser from 'webextension-polyfill';
+
+import { isUndefined } from '@shared/utils';
+
 function formatInitiator(initiator: string) {
   const [protocol, host] = initiator.split('://');
   return [protocol, '://hiro-web-extension.', host].join('');
 }
 
-export function addRefererHeaderRequestListener() {
-  const handler = (details: chrome.webRequest.WebRequestHeadersDetails) => {
+function filterOutExtraHeadersArgumentWhenFirefoxExtension(type: string, browserName: string) {
+  if (type === 'extraHeaders') return browserName !== 'Firefox';
+  return true;
+}
+
+async function getBrowserInfo() {
+  // `runtime.getBrowserInfo` only supported in Firefox
+  // https://github.com/mozilla/webextension-polyfill/issues/116
+  if (!isUndefined(browser.runtime.getBrowserInfo)) {
+    return browser.runtime.getBrowserInfo();
+  }
+  return { name: 'unknown-browser' };
+}
+
+export async function addRefererHeaderRequestListener() {
+  const handler = (details: browser.WebRequest.OnBeforeSendHeadersDetailsType) => {
     if (!details.requestHeaders) return;
     const headers = [...details.requestHeaders];
-    if (details.initiator === `chrome-extension://${chrome.runtime.id}`) {
-      headers.push({ name: 'Referer', value: formatInitiator(details.initiator) });
+    const initiatorText = details.documentUrl || details.initiator || '';
+    if (initiatorText) {
+      headers.push({ name: 'Referer', value: formatInitiator(initiatorText) });
     }
     return { requestHeaders: headers };
   };
-  chrome.webRequest.onBeforeSendHeaders.addListener(
+
+  const { name: browserName } = await getBrowserInfo();
+
+  const headerTypes = ['requestHeaders', 'blocking', 'extraHeaders'].filter(type =>
+    filterOutExtraHeadersArgumentWhenFirefoxExtension(type, browserName)
+  ) as browser.WebRequest.OnBeforeSendHeadersOptions[];
+
+  browser.webRequest.onBeforeSendHeaders.addListener(
     handler,
     {
       urls: ['https://*.stacks.co/*'],
     },
-    ['requestHeaders', 'blocking', 'extraHeaders']
+    headerTypes
   );
-  return () => chrome.webRequest.onBeforeSendHeaders.removeListener(handler);
+  return () => browser.webRequest.onBeforeSendHeaders.removeListener(handler);
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,0 +1,17 @@
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number';
+}
+
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+export function isUndefined(value: unknown): value is undefined {
+  return typeof value === 'undefined';
+}
+
+export function isEmpty(value: Object) {
+  return Object.keys(value).length === 0;
+}
+
+export function noop() {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5426,6 +5426,11 @@
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
   integrity sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA==
 
+"@types/webextension-polyfill@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@types/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz#a50b5f03161ef83e46721719b49668cfcaac804a"
+  integrity sha512-HG1y1o2hK8ag6Y7dfkrAbfKmMIP+B0E6SwAzUfmQ1dDxEIdLTtMyrStY26suHBPrAL7Xw/chlDW02ugc3uXWtQ==
+
 "@types/webpack-dev-middleware@*":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz#4d65e1b6058e460bd6cfa3b45320e86654890c1c"
@@ -17487,6 +17492,11 @@ web-ext@6.8.0, web-ext@^6.8.0:
     ws "7.4.6"
     yargs "16.2.0"
     zip-dir "2.0.0"
+
+webextension-polyfill@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz#de6c1941d0ef1b0858b20e9c7b46bbc042c5a960"
+  integrity sha512-LTtHb0yR49xa9irkstDxba4GATDAcDw3ncnFH9RImoFwDlW47U95ME5sn5IiQX2ghfaECaf6xyXM8yvClIBkkw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2582481678).<!-- Sticky Header Marker -->

I neglected to test Firefox when finishing this feature, however came across a full app white screen when testing release https://github.com/hirosystems/stacks-wallet-web/pull/2505

The issue is that Firefox doesn't accept the `extraHeaders` prop (throwing an error), white chrome seems to require it 🤷🏼 