### PR TITLE
fix: show unlock waiting message only when loading

### DIFF
--- a/src/app/pages/unlock.tsx
+++ b/src/app/pages/unlock.tsx
@@ -89,7 +89,7 @@ export function Unlock(): JSX.Element {
         </Box>
         <PageTitle fontSize={[4, 7]}>Your session is locked</PageTitle>
         <Text color={color('text-caption')}>
-          {waitingMessage ||
+          {(loading && waitingMessage) ||
             'Enter the password you previously set to access your accounts on this device'}
         </Text>
         <Stack spacing="base">


### PR DESCRIPTION
Fixes #2517 

We could also change the `useWaitingMessage` hook to clear the message, but maybe the caller wants to keep its value, thoughts?

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
