### PR TITLE
refactor: request password to view secret key

### DIFF
--- a/src/app/components/request-password.tsx
+++ b/src/app/components/request-password.tsx
@@ -1,0 +1,95 @@
+import { useState, useCallback, FormEvent } from 'react';
+import { Box, color, Input, Stack } from '@stacks/ui';
+import UnlockSession from '@assets/images/unlock-session.png';
+import { Text } from '@app/components/typography';
+import { PageTitle } from '@app/components/page-title';
+import { useWaitingMessage, WaitingMessages } from '@app/common/utils/use-waiting-message';
+import { useWallet } from '@app/common/hooks/use-wallet';
+import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { SettingsSelectors } from '@tests/integration/settings.selectors';
+import { buildEnterKeyEvent } from './link';
+import { ErrorLabel } from './error-label';
+import { PrimaryButton } from './primary-button';
+
+const waitingMessages: WaitingMessages = {
+  '2': 'Verifying password…',
+  '10': 'Still working…',
+  '20': 'Almost there.',
+};
+
+interface RequestPasswordProps {
+  onSuccess: (password: string) => void;
+  title?: string;
+  caption?: string;
+}
+
+export function RequestPassword({ title, caption, onSuccess }: RequestPasswordProps): JSX.Element {
+  const [loading, setLoading] = useState(false);
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const { unlockWallet } = useWallet();
+  const analytics = useAnalytics();
+  const [waitingMessage, startWaitingMessage, stopWaitingMessage] =
+    useWaitingMessage(waitingMessages);
+
+  const submit = useCallback(async () => {
+    const startUnlockTimeMs = performance.now();
+    void analytics.track('start_unlock');
+    setLoading(true);
+    startWaitingMessage();
+    setError('');
+
+    try {
+      await unlockWallet(password);
+      onSuccess?.(password);
+    } catch (error) {
+      setError('The password you entered is invalid.');
+    }
+    setLoading(false);
+    stopWaitingMessage();
+    const unlockSuccessTimeMs = performance.now();
+    void analytics.track('complete_unlock', {
+      durationMs: unlockSuccessTimeMs - startUnlockTimeMs,
+    });
+  }, [startWaitingMessage, analytics, stopWaitingMessage, unlockWallet, password]);
+
+  return (
+    <>
+      <Box alignSelf={['start', 'center']} mt={['base', 'unset']} width={['97px', '115px']}>
+        <img src={UnlockSession} />
+      </Box>
+      <PageTitle fontSize={[4, 7]}>{title}</PageTitle>
+      <Text color={color('text-caption')}>{waitingMessage || caption}</Text>
+      <Stack spacing="base">
+        <Input
+          autoFocus
+          borderRadius="10px"
+          data-testid={SettingsSelectors.EnterPasswordInput}
+          height="64px"
+          isDisabled={loading}
+          onChange={(e: FormEvent<HTMLInputElement>) => setPassword(e.currentTarget.value)}
+          onKeyUp={buildEnterKeyEvent(submit)}
+          placeholder="Enter your password"
+          type="password"
+          value={password}
+          width="100%"
+        />
+        {error && (
+          <Box>
+            <ErrorLabel>
+              <Text textStyle="caption">{error}</Text>
+            </ErrorLabel>
+          </Box>
+        )}
+      </Stack>
+      <PrimaryButton
+        data-testid={SettingsSelectors.UnlockWalletBtn}
+        isDisabled={loading}
+        isLoading={loading}
+        onClick={submit}
+      >
+        Continue
+      </PrimaryButton>
+    </>
+  );
+}

--- a/src/app/pages/unlock.tsx
+++ b/src/app/pages/unlock.tsx
@@ -1,79 +1,31 @@
-import { useState, useCallback, FormEvent } from 'react';
+import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Box, color, Input, Stack } from '@stacks/ui';
+import { Stack } from '@stacks/ui';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
-import { useWallet } from '@app/common/hooks/use-wallet';
 import { useDrawers } from '@app/common/hooks/use-drawers';
-import { buildEnterKeyEvent } from '@app/components/link';
-import { ErrorLabel } from '@app/components/error-label';
 import { Header } from '@app/components/header';
 import { CenteredPageContainer } from '@app/components/centered-page-container';
-import { PrimaryButton } from '@app/components/primary-button';
-import { PageTitle } from '@app/components/page-title';
 import { SignOutConfirmDrawer } from '@app/pages/sign-out-confirm/sign-out-confirm';
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
-import { Text } from '@app/components/typography';
-import { useWaitingMessage, WaitingMessages } from '@app/common/utils/use-waiting-message';
 import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
-import UnlockSession from '@assets/images/unlock-session.png';
 import { RouteUrls } from '@shared/route-urls';
-import { SettingsSelectors } from '@tests/integration/settings.selectors';
-
-const waitingMessages: WaitingMessages = {
-  '2': 'Verifying password…',
-  '10': 'Still working…',
-  '20': 'Almost there.',
-};
+import { RequestPassword } from '@app/components/request-password';
 
 export function Unlock(): JSX.Element {
-  const [loading, setLoading] = useState(false);
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-  const { unlockWallet } = useWallet();
   const { decodedAuthRequest } = useOnboardingState();
   const { showSignOut } = useDrawers();
-  const analytics = useAnalytics();
   const navigate = useNavigate();
-  const [waitingMessage, startWaitingMessage, stopWaitingMessage] =
-    useWaitingMessage(waitingMessages);
 
   useRouteHeader(<Header />);
 
-  const submit = useCallback(async () => {
-    const startUnlockTimeMs = performance.now();
-    void analytics.track('start_unlock');
-    setLoading(true);
-    startWaitingMessage();
-    setError('');
-
-    try {
-      await unlockWallet(password);
-
-      if (decodedAuthRequest) {
-        navigate(RouteUrls.ChooseAccount);
-      } else {
-        navigate(RouteUrls.Home);
-      }
-    } catch (error) {
-      setError('The password you entered is invalid.');
+  const handleSuccess = useCallback(async () => {
+    if (decodedAuthRequest) {
+      navigate(RouteUrls.ChooseAccount);
+    } else {
+      navigate(RouteUrls.Home);
     }
-    setLoading(false);
-    stopWaitingMessage();
-    const unlockSuccessTimeMs = performance.now();
-    void analytics.track('complete_unlock', {
-      durationMs: unlockSuccessTimeMs - startUnlockTimeMs,
-    });
-  }, [
-    startWaitingMessage,
-    analytics,
-    stopWaitingMessage,
-    unlockWallet,
-    password,
-    decodedAuthRequest,
-    navigate,
-  ]);
+  }, [decodedAuthRequest, navigate]);
 
   return (
     <CenteredPageContainer>
@@ -84,44 +36,11 @@ export function Unlock(): JSX.Element {
         textAlign={['left', 'center']}
         width="100%"
       >
-        <Box alignSelf={['start', 'center']} mt={['base', 'unset']} width={['97px', '115px']}>
-          <img src={UnlockSession} />
-        </Box>
-        <PageTitle fontSize={[4, 7]}>Your session is locked</PageTitle>
-        <Text color={color('text-caption')}>
-          {waitingMessage ||
-            'Enter the password you previously set to access your accounts on this device'}
-        </Text>
-        <Stack spacing="base">
-          <Input
-            autoFocus
-            borderRadius="10px"
-            data-testid={SettingsSelectors.EnterPasswordInput}
-            height="64px"
-            isDisabled={loading}
-            onChange={(e: FormEvent<HTMLInputElement>) => setPassword(e.currentTarget.value)}
-            onKeyUp={buildEnterKeyEvent(submit)}
-            placeholder="Enter your password"
-            type="password"
-            value={password}
-            width="100%"
-          />
-          {error && (
-            <Box>
-              <ErrorLabel>
-                <Text textStyle="caption">{error}</Text>
-              </ErrorLabel>
-            </Box>
-          )}
-        </Stack>
-        <PrimaryButton
-          data-testid={SettingsSelectors.UnlockWalletBtn}
-          isDisabled={loading}
-          isLoading={loading}
-          onClick={submit}
-        >
-          Continue
-        </PrimaryButton>
+        <RequestPassword
+          title="Your session is locked"
+          caption="Enter the password you previously set to access your accounts on this device"
+          onSuccess={handleSuccess}
+        />
         {/* TODO: Add this back when check for matching secret key is ready */}
         {/* <Caption textAlign="left">
           Forgot your password? Unlock your account by{' '}

--- a/src/app/pages/view-secret-key/view-secret-key.tsx
+++ b/src/app/pages/view-secret-key/view-secret-key.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { color, Stack } from '@stacks/ui';
 
@@ -13,11 +13,13 @@ import { Text } from '@app/components/typography';
 import { PageTitle } from '@app/components/page-title';
 import { RouteUrls } from '@shared/route-urls';
 import { useDefaultWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
+import { RequestPassword } from '@app/components/request-password';
 
 export const ViewSecretKey = memo(() => {
   const analytics = useAnalytics();
   const navigate = useNavigate();
   const defaultWalletSecretKey = useDefaultWalletSecretKey();
+  const [canShowSecretKey, setCanShowSecretKey] = useState(false);
 
   useRouteHeader(<Header onClose={() => navigate(RouteUrls.Home)} />);
 
@@ -34,16 +36,26 @@ export const ViewSecretKey = memo(() => {
         spacing="loose"
         textAlign={['left', 'center']}
       >
-        <PageTitle fontSize={[4, 7]}>Your Secret Key</PageTitle>
-        <Text color={color('text-caption')}>
-          These 24 words are your Secret Key. They create your account, and you sign in on different
-          devices with them. Make sure to save these somewhere safe.{' '}
-          <Text display="inline" fontWeight={500}>
-            If you lose these words, you lose your account.
-          </Text>
-        </Text>
-        <SecretKeyDisplayer secretKey={defaultWalletSecretKey ?? ''} />
-        <PrimaryButton onClick={() => navigate(RouteUrls.Home)}>I've saved it</PrimaryButton>
+        {!canShowSecretKey ? (
+          <RequestPassword
+            title="View Secret Key"
+            caption="Enter the password you previously set to view your Secret Key"
+            onSuccess={() => setCanShowSecretKey(true)}
+          />
+        ) : (
+          <>
+            <PageTitle fontSize={[4, 7]}>Your Secret Key</PageTitle>
+            <Text color={color('text-caption')}>
+              These 24 words are your Secret Key. They create your account, and you sign in on
+              different devices with them. Make sure to save these somewhere safe.{' '}
+              <Text display="inline" fontWeight={500}>
+                If you lose these words, you lose your account.
+              </Text>
+            </Text>
+            <SecretKeyDisplayer secretKey={defaultWalletSecretKey ?? ''} />
+            <PrimaryButton onClick={() => navigate(RouteUrls.Home)}>I've saved it</PrimaryButton>
+          </>
+        )}
       </Stack>
     </CenteredPageContainer>
   );


### PR DESCRIPTION
Fixes #1246 

Not sure if we could store the wallet password used to unlock in memory and just do a sync check (eg: `storedPassword === typedPassword`) instead of decrypting it again.

cc/ @kyranjamie @fbwoolf @beguene @He1DAr
