### PR TITLE
ci: remove failing checkout that isn't needed

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -17,19 +17,13 @@ jobs:
 
   update-pull-request-body:
     name: Add links to built extensions
-    if: github.repository == 'hirosystems/stacks-wallet-web'
+    # Don't run on forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs:
       - pre_run
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
       - uses: kyranjamie/pull-request-fixed-header@v1.0.1
-        # Don't run on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: '> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2596298356).<!-- Sticky Header Marker -->

This task is failing on a fork, for some reason, and afaict, isn't needed anyway