### PR TITLE
fix: first steps limit to five accounts

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -18,7 +18,7 @@ import { AppRoutes } from '@app/routes/app-routes';
 import { persistor, store } from '@app/store';
 import { jotaiWrappedReactQueryQueryClient as queryClient } from '@app/store/common/common.hooks';
 
-const reactQueryDevToolsEnabled = false;
+const reactQueryDevToolsEnabled = process.env.NODE_ENV === 'development';
 
 export function App() {
   return (

--- a/src/app/features/devtool/devtools.tsx
+++ b/src/app/features/devtool/devtools.tsx
@@ -7,7 +7,7 @@ export function Devtools() {
   const client = useClientQuery();
   return client ? (
     <QueryClientProvider client={client}>
-      <ReactQueryDevtools position={'top-left'} />
+      <ReactQueryDevtools position={'bottom-left'} />
     </QueryClientProvider>
   ) : null;
 }

--- a/src/app/features/suggested-first-steps/hooks/use-suggested-first-steps.ts
+++ b/src/app/features/suggested-first-steps/hooks/use-suggested-first-steps.ts
@@ -25,9 +25,11 @@ export function useSuggestedFirstSteps() {
   const hasHiddenSuggestedFirstSteps = useHideSuggestedFirstSteps();
   const stepsStatus = useSuggestedFirstStepsStatus();
   const availableStxBalance = useCurrentAccountAvailableStxBalance();
-  const accountsAvailableStxBalance = useAccountsAvailableStxBalance(accounts);
   const nonFungibleTokenHoldings = useNonFungibleTokenHoldings(currentAccount?.address);
-  const accountsNonFungibleTokenHoldings = useAccountsNonFungibleTokenHoldings(accounts);
+
+  const firstFiveAccounts = accounts?.slice(0, 5);
+  const accountsAvailableStxBalance = useAccountsAvailableStxBalance(firstFiveAccounts);
+  const accountsNonFungibleTokenHoldings = useAccountsNonFungibleTokenHoldings(firstFiveAccounts);
 
   useEffect(() => {
     if (accountsAvailableStxBalance?.isGreaterThan(0)) {
@@ -48,5 +50,10 @@ export function useSuggestedFirstSteps() {
     return Object.values(stepsStatus).every(val => val === SuggestedFirstStepStatus.Complete);
   }, [stepsStatus]);
 
-  return !hasCompletedSuggestedFirstSteps && !hasHiddenSuggestedFirstSteps;
+  return (
+    accounts &&
+    accounts.length <= 5 &&
+    !hasCompletedSuggestedFirstSteps &&
+    !hasHiddenSuggestedFirstSteps
+  );
 }

--- a/src/app/query/balance/balance.query.ts
+++ b/src/app/query/balance/balance.query.ts
@@ -55,6 +55,7 @@ export function useGetAnchoredAccountBalanceListQuery(accounts?: AccountWithAddr
     (accounts || []).map(account => ({
       queryKey: ['get-address-anchored-stx-balance', account.address],
       queryFn: fetchAccountBalance(api)(account.address),
+      ...balanceQueryOptions,
     }))
   );
 }

--- a/src/app/query/non-fungible-tokens/non-fungible-token-holdings.query.ts
+++ b/src/app/query/non-fungible-tokens/non-fungible-token-holdings.query.ts
@@ -4,6 +4,13 @@ import { useCurrentNetwork } from '@app/common/hooks/use-current-network';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
 import { Api, useApi } from '@app/store/common/api-clients.hooks';
 
+const staleTime = 15 * 60 * 1000; // 15 min
+
+const queryOptions = {
+  cacheTime: staleTime,
+  staleTime,
+} as const;
+
 function fetchNonFungibleTokenHoldings(api: Api) {
   return (address?: string) => async () => {
     if (!address) return;
@@ -18,6 +25,7 @@ export function useGetNonFungibleTokenHoldingsQuery(address?: string) {
   return useQuery({
     queryKey: ['get-nft-holdings', address, network.url],
     queryFn: fetchNonFungibleTokenHoldings(api)(address),
+    ...queryOptions,
   });
 }
 
@@ -29,6 +37,7 @@ export function useGetNonFungibleTokenHoldingsListQuery(accounts?: AccountWithAd
     (accounts || []).map(account => ({
       queryKey: ['get-nft-holdings', account.address, network.url],
       queryFn: fetchNonFungibleTokenHoldings(api)(account.address),
+      ...queryOptions,
     }))
   );
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2614458736).<!-- Sticky Header Marker -->

Putting this up quick as a possible solution to the 429s from checking every account stx and nft balance. Idea here is to limit the steps to show and query for only the first five accounts (which will include ledger). Once the sixth account is created the steps would hide and the queries become disabled.

cc/ @kyranjamie @fbwoolf
