### PR TITLE
fix: onclose after confirm ledger tx

### DIFF
--- a/src/app/features/ledger/flows/tx-signing/ledger-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/tx-signing/ledger-sign-tx-container.tsx
@@ -3,8 +3,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { LedgerError } from '@zondax/ledger-blockstack';
 import get from 'lodash.get';
 
-import { delay } from '@app/common/utils';
-import { noop } from '@shared/utils';
+import { delay, whenPageMode } from '@app/common/utils';
 import {
   getAppVersion,
   prepareLedgerDeviceConnection,
@@ -127,10 +126,13 @@ export function LedgerSignTxContainer() {
 
       await broadcastTransactionFn({
         transaction: signedTx,
-        onClose: noop,
+        onClose: () =>
+          whenPageMode({
+            full: () => navigate(RouteUrls.Home),
+            popup: () => window.close(),
+          })(),
       });
       setAwaitingSignedTransaction(false);
-      navigate(RouteUrls.Home);
     } catch (e) {
       setAwaitingSignedTransaction(false);
       ledgerNavigate.toDeviceDisconnectStep();


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2642261502).<!-- Sticky Header Marker -->

I believe we want the popup modal to close after a user confirms and successfully broadcasts a transaction? Currently, the user is routed to the home page when sending tokens or using an app.

Current...
![Screen Shot 2022-07-09 at 1 06 23 PM](https://user-images.githubusercontent.com/6493321/178121150-e9669277-edaf-4c4f-bf8c-0a7eaedc2d9c.png)

cc/ @kyranjamie @fbwoolf
