### PR TITLE
fix: sponsored tx edit nonce

### DIFF
--- a/src/app/components/fee-row/fee-row.tsx
+++ b/src/app/components/fee-row/fee-row.tsx
@@ -51,7 +51,7 @@ export function FeeRow(props: FeeRowProps): JSX.Element {
       feeHelper.setValue(0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [feeEstimations, feeHelper, isCustom]);
+  }, [feeEstimations, isCustom]);
 
   // Handles using the fee estimations selector or custom input
   const handleSelectedItem = useCallback(


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2651071100).<!-- Sticky Header Marker -->

This PR removes a dependency in the useEffect hook that was causing the fee to be (at times) set incorrectly for a sponsored tx and prevented the edit nonce field from working.

cc/ @kyranjamie @fbwoolf
