### PR TITLE
fix(ledger): unsupported browser modal not opening

### DIFF
--- a/src/app/pages/onboarding/welcome/welcome.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.tsx
@@ -40,19 +40,18 @@ export const WelcomePage = memo(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const supportsWebUsbAction = whenPageMode({
-    full() {
-      navigate(RouteUrls.ConnectLedger);
-    },
-    popup() {
-      void openIndexPageInNewTab(`${RouteUrls.Onboarding}/${RouteUrls.ConnectLedger}`);
-    },
-  });
+  const pageModeRoutingAction = (url: RouteUrls) =>
+    whenPageMode({
+      full() {
+        navigate(url);
+      },
+      popup() {
+        void openIndexPageInNewTab(`${RouteUrls.Onboarding}/${url}`);
+      },
+    });
 
-  const doesNotSupportWebUsbAction = whenPageMode({
-    full: navigate as any,
-    popup: openIndexPageInNewTab,
-  });
+  const supportsWebUsbAction = pageModeRoutingAction(RouteUrls.ConnectLedger);
+  const doesNotSupportWebUsbAction = pageModeRoutingAction(RouteUrls.LedgerUnsupportedBrowser);
 
   return (
     <WelcomeLayout


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2655542798).<!-- Sticky Header Marker -->

Unsupported browser modal wasn't opening

<img width="1372" alt="image" src="https://user-images.githubusercontent.com/1618764/178459520-f79a375d-8bfd-4683-af7d-71ff5be42655.png">
