### PR TITLE
feat: add coinbase pay support

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -3,6 +3,13 @@
     "global": []
   },
   "activeFiatProviders": {
+    "coinbase": {
+      "enabled": true,
+      "hasFastCheckoutProcess": true,
+      "name": "Coinbase",
+      "hasTradingFees": true,
+      "hasUnitedStatesAvailability": true
+    },
     "moonPay": {
       "enabled": true,
       "hasFastCheckoutProcess": true,
@@ -44,13 +51,6 @@
       "name": "ByBit",
       "hasTradingFees": true,
       "hasUnitedStatesAvailability": false
-    },
-    "coinbase": {
-      "enabled": true,
-      "hasFastCheckoutProcess": false,
-      "name": "Coinbase",
-      "hasTradingFees": true,
-      "hasUnitedStatesAvailability": true
     },
     "cryptoCom": {
       "enabled": true,

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     ]
   },
   "dependencies": {
+    "@coinbase/cbpay-js": "1.0.2",
     "@emotion/core": "11.0.0",
     "@emotion/css": "11.7.1",
     "@emotion/react": "11.7.1",

--- a/src/app/common/dev/types/globals.d.ts
+++ b/src/app/common/dev/types/globals.d.ts
@@ -5,3 +5,4 @@ declare const STATS_URL: string;
 declare const COMMIT_SHA: string;
 declare const VERSION: string;
 declare const BRANCH: string;
+declare const BRANCH_NAME: string;

--- a/src/app/pages/fund/components/fiat-provider-item.tsx
+++ b/src/app/pages/fund/components/fiat-provider-item.tsx
@@ -4,8 +4,8 @@ import { FastCheckoutBadge } from './fast-checkout-badge';
 import { ZeroPercentFeesBadge } from './zero-percent-fees-badge';
 import { FundAccountTile } from './fund-account-tile';
 
-const availableInsideUnitedStatesDescription = 'Available in the US and other countries';
-const availableOutsideUnitedStatesDescription = 'Available outside the US and other countries';
+const availableInsideUnitedStatesDescription = 'Available both inside and outside of the US';
+const availableOutsideUnitedStatesDescription = 'Available only outside of the US';
 
 interface FiatProviderProps {
   icon: string;

--- a/src/app/pages/fund/components/fiat-providers.utils.ts
+++ b/src/app/pages/fund/components/fiat-providers.utils.ts
@@ -1,3 +1,5 @@
+import { generateOnRampURL } from '@coinbase/cbpay-js';
+
 import { ActiveFiatProvider } from '@app/query/hiro-config/hiro-config.query';
 import BinanceIcon from '@assets/images/fund/fiat-providers/binance-icon.png';
 import BlockchainComIcon from '@assets/images/fund/fiat-providers/blockchain.com-icon.png';
@@ -11,8 +13,9 @@ import OkcoinIcon from '@assets/images/fund/fiat-providers/okcoin-icon.png';
 import OkxIcon from '@assets/images/fund/fiat-providers/okx-icon.png';
 import TransakIcon from '@assets/images/fund/fiat-providers/transak-icon.png';
 import {
+  COINBASE_APP_ID,
   IS_PRODUCTION_ENV,
-  MOONPAY_API_KEY_PRODUCTION,
+  MOONPAY_API_KEY,
   TRANSAK_API_KEY_PRODUCTION,
   TRANSAK_API_KEY_STAGING,
 } from '@shared/constants';
@@ -46,8 +49,21 @@ export const activeFiatProviderIcons: Record<ActiveFiatProvider['name'], string>
   [ActiveFiatProviders.Transak]: TransakIcon,
 };
 
+function makeCoinbaseUrl(address: string) {
+  const onRampURL = generateOnRampURL({
+    appId: COINBASE_APP_ID,
+    destinationWallets: [
+      {
+        address,
+        assets: ['STX'],
+      },
+    ],
+  });
+  return onRampURL;
+}
+
 function makeMoonPayUrl(address: string) {
-  return `https://buy.moonpay.com?apiKey=${MOONPAY_API_KEY_PRODUCTION}&currencyCode=stx&walletAddress=${address}`;
+  return `https://buy.moonpay.com?apiKey=${MOONPAY_API_KEY}&currencyCode=stx&walletAddress=${address}`;
 }
 
 function makeOkcoinUrl(address: string) {
@@ -73,6 +89,8 @@ function makeFiatProviderFaqUrl(address: string, provider: string) {
 
 export function getProviderUrl(address: string, providerKey: string, providerName: string) {
   switch (providerKey) {
+    case ActiveFiatProviders.Coinbase:
+      return makeCoinbaseUrl(address);
     case ActiveFiatProviders.MoonPay:
       return makeMoonPayUrl(address);
     case ActiveFiatProviders.Okcoin:

--- a/src/app/query/hiro-config/hiro-config.query.ts
+++ b/src/app/query/hiro-config/hiro-config.query.ts
@@ -35,9 +35,10 @@ interface HiroConfig {
   feeEstimationsMinMax?: FeeEstimationsConfig;
 }
 
-// TODO: Change back to 'main' before merging
-const GITHUB_PRIMARY_BRANCH = 'dev';
-const githubWalletConfigRawUrl = `https://raw.githubusercontent.com/${GITHUB_ORG}/${GITHUB_REPO}/${GITHUB_PRIMARY_BRANCH}/config/wallet-config.json`;
+const DEFAULT_BRANCH = 'main';
+const githubWalletConfigRawUrl = `https://raw.githubusercontent.com/${GITHUB_ORG}/${GITHUB_REPO}/${
+  BRANCH_NAME ?? DEFAULT_BRANCH
+}/config/wallet-config.json`;
 
 async function fetchHiroMessages(): Promise<HiroConfig> {
   return fetch(githubWalletConfigRawUrl).then(msg => msg.json());

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -67,8 +67,8 @@ export enum QueryRefreshRates {
 
 export const DEFAULT_LIST_LIMIT = 50;
 
+// TODO: Relocate to env file
+export const COINBASE_APP_ID = 'ca72edbc-0a08-468c-952d-6cde50b1dce6';
+export const MOONPAY_API_KEY = 'pk_live_Bctok4Wp6KZHX0YfS4Ie7dFOYnNw8lqv';
 export const TRANSAK_API_KEY_PRODUCTION = '7300ebf7-c657-46b1-9c72-c0d91bbed0a8';
-
 export const TRANSAK_API_KEY_STAGING = '4055d318-9d41-4b74-9253-e73e3ca13602';
-
-export const MOONPAY_API_KEY_PRODUCTION = 'pk_live_Bctok4Wp6KZHX0YfS4Ie7dFOYnNw8lqv';

--- a/tests/integration/fund/fund.spec.ts
+++ b/tests/integration/fund/fund.spec.ts
@@ -32,13 +32,13 @@ describe('Buy tokens test', () => {
   describe('Fiat provider', () => {
     it('should redirect to provider URL', async () => {
       await fundPage.waitForFiatProviderItem();
-      await fundPage.clickMoonPayProviderItem();
+      await fundPage.clickFirstFastCheckoutProviderItem();
       await fundPage.page.waitForTimeout(2000);
       const allPages = await WalletPage.getAllPages(browser);
       const recentPage = allPages.pop();
       await recentPage?.waitForLoadState();
       const URL = recentPage?.url();
-      expect(URL).toContain('https://buy.moonpay.com');
+      expect(URL).toContain('pay.coinbase.com');
     });
   });
 });

--- a/tests/page-objects/fund.page.ts
+++ b/tests/page-objects/fund.page.ts
@@ -28,7 +28,7 @@ export class FundPage {
     await this.page.waitForSelector(this.selectors.$fiatProviderItem);
   }
 
-  async clickMoonPayProviderItem() {
+  async clickFirstFastCheckoutProviderItem() {
     const providers = await this.page.$$(this.selectors.$fiatProviderItem);
     await providers[0].click();
   }

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const webpack = require('webpack');
+const { execSync } = require('child_process');
 const { version: _version } = require('../package.json');
 const generateManifest = require('../scripts/generate-manifest');
 
@@ -22,6 +23,7 @@ const TEST_ENV = !!process.env.TEST_ENV;
 const ANALYZE_BUNDLE = process.env.ANALYZE === 'true';
 const IS_PUBLISHING = !!process.env.IS_PUBLISHING;
 const MAIN_BRANCH = 'refs/heads/main';
+const GITHUB_HEAD_REF = process.env.GITHUB_HEAD_REF;
 const GITHUB_REF = process.env.GITHUB_REF;
 const GITHUB_SHA = process.env.GITHUB_SHA;
 
@@ -34,6 +36,7 @@ const getVersionWithRandomSuffix = ref => {
 };
 
 const BRANCH = GITHUB_REF;
+const BRANCH_NAME = GITHUB_HEAD_REF;
 const COMMIT_SHA = GITHUB_SHA;
 const VERSION = getVersionWithRandomSuffix(BRANCH);
 
@@ -210,6 +213,7 @@ const config = {
       VERSION: JSON.stringify(VERSION),
       COMMIT_SHA: JSON.stringify(COMMIT_SHA),
       BRANCH: JSON.stringify(BRANCH),
+      BRANCH_NAME: JSON.stringify(BRANCH_NAME),
       'process.env.TEST_ENV': JSON.stringify(TEST_ENV ? 'true' : 'false'),
     }),
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,6 +1108,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@coinbase/cbpay-js@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@coinbase/cbpay-js/-/cbpay-js-1.0.2.tgz#4975efa6b060868c0a6cda20bb6e6169f0d82b0b"
+  integrity sha512-m95VmSQm9xfA5MmOFRcVIPtZxO6GhRJKPbbxKSxGoCYf4SpAm7mz3euU1kiRr7bPMa+3wvyT36n2bHoiyuwseg==
+
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2678491552).<!-- Sticky Header Marker -->

This PR adds Coinbase Pay support so users can buy STX w/ Coinbase as a 'fast checkout' option.

![Screen Shot 2022-07-13 at 12 47 13 PM](https://user-images.githubusercontent.com/6493321/178802645-ac5f2a8b-e38e-40f3-84c3-eb029c6f69d8.png)

cc/ @kyranjamie @fbwoolf