### PR TITLE
Fix/ledger improvements

### DIFF
--- a/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
+++ b/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
@@ -20,12 +20,13 @@ import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { makeLedgerCompatibleUnsignedAuthResponsePayload } from '@app/common/unsafe-auth-response';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 
-import { useLedgerNavigate } from '../../hooks/use-ledger-navigate';
-import { LedgerJwtSigningProvider } from '../../ledger-jwt-signing.context';
 import { finalizeAuthResponse } from '@app/common/actions/finalize-auth-response';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 import { useAuthRequestParams } from '@app/common/hooks/auth/use-auth-request-params';
+
+import { useLedgerNavigate } from '../../hooks/use-ledger-navigate';
+import { LedgerJwtSigningProvider } from '../../ledger-jwt-signing.context';
 
 export function LedgerSignJwtContainer() {
   const location = useLocation();
@@ -41,7 +42,6 @@ export function LedgerSignJwtContainer() {
   useEffect(() => {
     const index = parseInt(get(location.state, 'index'), 10);
     if (Number.isFinite(index)) setAccountIndex(index);
-    return () => setAccountIndex(null);
   }, [location.state]);
 
   const [latestDeviceResponse, setLatestDeviceResponse] = useLedgerResponseState();
@@ -53,7 +53,13 @@ export function LedgerSignJwtContainer() {
 
   const signJwtPayload = async () => {
     if (!origin) throw new Error('Cannot sign payload for unknown origin');
-    if (!account || !decodedAuthRequest || !authRequest || accountIndex === null) return;
+
+    if (accountIndex === null) {
+      logger.warn('No account index found');
+      return;
+    }
+
+    if (!account || !decodedAuthRequest || !authRequest);
 
     const stacks = await prepareLedgerDeviceConnection({
       setLoadingState: setAwaitingDeviceConnection,

--- a/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
+++ b/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
@@ -59,7 +59,9 @@ export function LedgerSignJwtContainer() {
       return;
     }
 
-    if (!account || !decodedAuthRequest || !authRequest);
+    if (!account || !decodedAuthRequest || !authRequest) {
+      return;
+    }
 
     const stacks = await prepareLedgerDeviceConnection({
       setLoadingState: setAwaitingDeviceConnection,

--- a/src/app/features/ledger/flows/request-keys/ledger-request-keys-container.tsx
+++ b/src/app/features/ledger/flows/request-keys/ledger-request-keys-container.tsx
@@ -83,6 +83,7 @@ export function LedgerRequestKeysContainer() {
       ledgerAnalytics.publicKeysPulledFromLedgerSuccessfully();
       setAwaitingKeyVerification(false);
       navigate(RouteUrls.Home);
+      await stacks.transport.close();
     } catch (e) {
       logger.info(e);
       setAwaitingKeyVerification(false);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2669241454).<!-- Sticky Header Marker -->

- Closes #2561
- Improves onboarding ux, closes transport

Previously, a common error would occur when, after finishing onboarding and leaving open the app window, all future tx requests would fail, as the existing transport was open.