### PR TITLE
ci: possible fix to merge back ci job failing

### DIFF
--- a/.github/workflows/create-version.yml
+++ b/.github/workflows/create-version.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2.6.0


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2675917285).<!-- Sticky Header Marker -->


Job failing here https://github.com/hirosystems/stacks-wallet-web/runs/7301376984?check_suite_focus=true 

Possible alterntative https://github.com/saitho/semantic-release-backmerge