### PR TITLE
refactor: link to fiat provider

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -3,13 +3,6 @@
     "global": []
   },
   "activeFiatProviders": {
-    "coinbase": {
-      "enabled": true,
-      "hasFastCheckoutProcess": true,
-      "name": "Coinbase",
-      "hasTradingFees": true,
-      "hasUnitedStatesAvailability": true
-    },
     "moonPay": {
       "enabled": true,
       "hasFastCheckoutProcess": true,
@@ -51,6 +44,13 @@
       "name": "ByBit",
       "hasTradingFees": true,
       "hasUnitedStatesAvailability": false
+    },
+    "coinbase": {
+      "enabled": true,
+      "hasFastCheckoutProcess": false,
+      "name": "Coinbase",
+      "hasTradingFees": true,
+      "hasUnitedStatesAvailability": true
     },
     "cryptoCom": {
       "enabled": true,

--- a/src/app/pages/fund/components/fiat-providers-list.tsx
+++ b/src/app/pages/fund/components/fiat-providers-list.tsx
@@ -43,7 +43,12 @@ export const FiatProvidersList = (props: FiatProvidersProps) => {
     >
       <ReceiveStxItem onReceiveStx={() => navigate(RouteUrls.FundReceive)} />
       {Object.entries(activeProviders).map(([providerKey, providerValue]) => {
-        const providerUrl = getProviderUrl(address, providerKey, providerValue.name);
+        const providerUrl = getProviderUrl({
+          address,
+          hasFastCheckoutProcess: providerValue.hasFastCheckoutProcess,
+          key: providerKey,
+          name: providerValue.name,
+        });
 
         return (
           <FiatProviderItem

--- a/src/app/pages/fund/components/fiat-providers.utils.ts
+++ b/src/app/pages/fund/components/fiat-providers.utils.ts
@@ -87,8 +87,22 @@ function makeFiatProviderFaqUrl(address: string, provider: string) {
   return `https://hiro.so/wallet-faq/how-do-i-buy-stx-from-an-exchange?provider=${provider}&address=${address}`;
 }
 
-export function getProviderUrl(address: string, providerKey: string, providerName: string) {
-  switch (providerKey) {
+interface GetProviderNameArgs {
+  address: string;
+  hasFastCheckoutProcess: boolean;
+  key: string;
+  name: string;
+}
+export function getProviderUrl({
+  address,
+  hasFastCheckoutProcess,
+  key,
+  name,
+}: GetProviderNameArgs) {
+  if (!hasFastCheckoutProcess) {
+    return makeFiatProviderFaqUrl(address, name);
+  }
+  switch (key) {
     case ActiveFiatProviders.Coinbase:
       return makeCoinbaseUrl(address);
     case ActiveFiatProviders.MoonPay:
@@ -98,6 +112,6 @@ export function getProviderUrl(address: string, providerKey: string, providerNam
     case ActiveFiatProviders.Transak:
       return makeTransakUrl(address);
     default:
-      return makeFiatProviderFaqUrl(address, providerName);
+      return makeFiatProviderFaqUrl(address, name);
   }
 }

--- a/src/app/pages/fund/components/fund-account-tile.tsx
+++ b/src/app/pages/fund/components/fund-account-tile.tsx
@@ -1,6 +1,7 @@
 import { Box, color, Stack, transition } from '@stacks/ui';
 
 import { Caption, Title } from '@app/components/typography';
+import { FundPageSelectors } from '@tests/page-objects/fund.selectors';
 
 interface FundAccountTileProps {
   attributes?: JSX.Element;
@@ -52,7 +53,7 @@ export function FundAccountTile(props: FundAccountTileProps) {
           >
             <img src={icon} width="24px" />
           </Box>
-          <Title>{title}</Title>
+          <Title data-testid={FundPageSelectors.FiatProviderName}>{title}</Title>
         </Stack>
         <Caption>{description}</Caption>
         <Stack isInline spacing="tight">

--- a/tests/integration/fund/fund.spec.ts
+++ b/tests/integration/fund/fund.spec.ts
@@ -32,13 +32,14 @@ describe('Buy tokens test', () => {
   describe('Fiat provider', () => {
     it('should redirect to provider URL', async () => {
       await fundPage.waitForFiatProviderItem();
+      const providerName = await fundPage.getFirstFastCheckoutProviderName();
       await fundPage.clickFirstFastCheckoutProviderItem();
       await fundPage.page.waitForTimeout(2000);
       const allPages = await WalletPage.getAllPages(browser);
       const recentPage = allPages.pop();
       await recentPage?.waitForLoadState();
       const URL = recentPage?.url();
-      expect(URL).toContain('pay.coinbase.com');
+      expect(URL).toContain(providerName);
     });
   });
 });

--- a/tests/page-objects/fund.page.ts
+++ b/tests/page-objects/fund.page.ts
@@ -6,6 +6,7 @@ import { createTestSelector } from '../integration/utils';
 
 const selectors = {
   $fiatProviderItem: createTestSelector(FundPageSelectors.FiatProviderItem),
+  $fiatProviderName: createTestSelector(FundPageSelectors.FiatProviderName),
 };
 
 export class FundPage {
@@ -31,5 +32,11 @@ export class FundPage {
   async clickFirstFastCheckoutProviderItem() {
     const providers = await this.page.$$(this.selectors.$fiatProviderItem);
     await providers[0].click();
+  }
+
+  async getFirstFastCheckoutProviderName() {
+    const providerNames = await this.page.$$(this.selectors.$fiatProviderName);
+    const firstFastCheckoutProviderName = providerNames[0].innerText();
+    return firstFastCheckoutProviderName;
   }
 }

--- a/tests/page-objects/fund.selectors.ts
+++ b/tests/page-objects/fund.selectors.ts
@@ -2,4 +2,5 @@ export enum FundPageSelectors {
   BtnReceiveStx = 'btn-receive-stx',
   BtnSkipFundAccount = 'btn-skip-fund-account',
   FiatProviderItem = 'fiat-provider-item',
+  FiatProviderName = 'fiat-provider-name',
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2698350527).<!-- Sticky Header Marker -->

This PR makes it so that we can control switching a provider from linking to the FAQ page to their fast checkout process through the wallet config.

cc/ @kyranjamie @fbwoolf
