### PR TITLE
fix: better error handling from apps

### DIFF
--- a/src/app/common/get-error-message.ts
+++ b/src/app/common/get-error-message.ts
@@ -1,0 +1,23 @@
+import { TxBroadcastResultRejected } from '@stacks/transactions';
+
+export function getErrorMessage(
+  reason:
+    | TxBroadcastResultRejected['reason']
+    | 'ConflictingNonceInMempool'
+    | 'TransferRecipientCannotEqualSender'
+) {
+  switch (reason) {
+    case 'TransferRecipientCannotEqualSender':
+      return 'You cannot transfer STX to yourself.';
+    case 'ConflictingNonceInMempool':
+      return 'Nonce conflict, try again soon.';
+    case 'BadNonce':
+      return 'Incorrect nonce.';
+    case 'NotEnoughFunds':
+      return 'Not enough funds.';
+    case 'FeeTooLow':
+      return 'Fee is too low.';
+    default:
+      return 'Something went wrong';
+  }
+}

--- a/src/app/common/hooks/use-submit-stx-transaction.ts
+++ b/src/app/common/hooks/use-submit-stx-transaction.ts
@@ -1,11 +1,7 @@
 import { useCallback } from 'react';
 import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-import {
-  broadcastTransaction,
-  StacksTransaction,
-  TxBroadcastResultRejected,
-} from '@stacks/transactions';
+import { broadcastTransaction, StacksTransaction } from '@stacks/transactions';
 
 import { todaysIsoDate } from '@app/common/date-utils';
 import { useLoading } from '@app/common/hooks/use-loading';
@@ -17,23 +13,7 @@ import { useCurrentStacksNetworkState } from '@app/store/network/networks.hooks'
 import { useCurrentAccountTxIds } from '@app/query/transactions/transaction.hooks';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useSetLocalTxsCallback } from '@app/store/accounts/account-activity.hooks';
-
-function getErrorMessage(
-  reason: TxBroadcastResultRejected['reason'] | 'ConflictingNonceInMempool'
-) {
-  switch (reason) {
-    case 'ConflictingNonceInMempool':
-      return 'Nonce conflict, try again soon.';
-    case 'BadNonce':
-      return 'Incorrect nonce.';
-    case 'NotEnoughFunds':
-      return 'Not enough funds.';
-    case 'FeeTooLow':
-      return 'Fee is too low.';
-    default:
-      return 'Something went wrong';
-  }
-}
+import { getErrorMessage } from '@app/common/get-error-message';
 
 const timeForApiToUpdate = 250;
 


### PR DESCRIPTION
This PR does a few things:

- moves the function `getErrorMessage` to /common (all errors should really be accounted for here imo)
- removes the catch around `broadcastRawTransaction`
- adds better error detection

previously this code was checking only for txid, assuming that meant it was successful. because of this, there are many transactions that likely have failed, but the errors were never caught, hence all the txs that stay in the "submitted" state forever.

To test this out:
- sign into an app
- construct a STX transfer tx to send STX to yourself
- in the current wallet it will seem to work, but the tx stays in pending
- in this branch, the wallet will display an error and not put anything in the submitted state

[It's best to review changes with whitespace ignored](https://github.com/hirosystems/stacks-wallet-web/pull/2575/files?diff=unified&w=1)