### PR TITLE
fix: filter nonce txs by sender address

### DIFF
--- a/src/app/query/nonce/account-nonces.hooks.ts
+++ b/src/app/query/nonce/account-nonces.hooks.ts
@@ -1,17 +1,26 @@
 import { useGetAccountNonces } from '@app/query/nonce/account-nonces.query';
 import { useCurrentAccountFilteredMempoolTransactionsState } from '@app/query/mempool/mempool.hooks';
-import { useAccountConfirmedTransactions } from '@app/store/accounts/account.hooks';
+import {
+  useAccountConfirmedTransactions,
+  useCurrentAccount,
+} from '@app/store/accounts/account.hooks';
 
 import { getNextNonce, NonceTypes } from './account-nonces.utils';
 
 export function useNextNonce() {
+  const currentAccount = useCurrentAccount();
   const confirmedTransactions = useAccountConfirmedTransactions();
   const pendingTransactions = useCurrentAccountFilteredMempoolTransactionsState();
 
   const { data: addressNonces } = useGetAccountNonces();
 
   const nextNonce = addressNonces
-    ? getNextNonce(addressNonces, confirmedTransactions, pendingTransactions)
+    ? getNextNonce({
+        addressNonces,
+        confirmedTransactions,
+        pendingTransactions,
+        senderAddress: currentAccount?.address ?? '',
+      })
     : { nonce: undefined, nonceType: NonceTypes.undefinedNonce };
 
   return nextNonce;

--- a/src/app/query/nonce/account-nonces.query.spec.ts
+++ b/src/app/query/nonce/account-nonces.query.spec.ts
@@ -7,86 +7,112 @@ import { getNextNonce, NonceTypes } from './account-nonces.utils';
 
 describe(getNextNonce, () => {
   setupHeystackEnv();
+  const senderAddress = 'ST2PHCPANVT8DVPSY5W2ZZ81M285Q5Z8Y6DQMZE7Z';
 
   test('possible_next_nonce', () => {
-    const response: AddressNonces = {
+    const addressNonces: AddressNonces = {
       detected_missing_nonces: [],
       last_executed_tx_nonce: 53,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 54,
     };
-    const confirmedTxs: Transaction[] = [];
-    const pendingTxs: MempoolTransaction[] = [];
-    const { nonce, nonceType } = getNextNonce(response, confirmedTxs, pendingTxs);
+    const confirmedTransactions: Transaction[] = [];
+    const pendingTransactions: MempoolTransaction[] = [];
+    const { nonce, nonceType } = getNextNonce({
+      addressNonces,
+      confirmedTransactions,
+      pendingTransactions,
+      senderAddress,
+    });
     expect(nonce).toEqual(54);
     expect(nonceType).toEqual(NonceTypes.apiSuggestedNonce);
   });
 
   test('detected_missing_nonces', () => {
-    const response: AddressNonces = {
+    const addressNonces: AddressNonces = {
       detected_missing_nonces: [49],
       last_executed_tx_nonce: 48,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 54,
     };
-    const confirmedTxs: Transaction[] = [];
-    const pendingTxs: MempoolTransaction[] = [];
-    const { nonce, nonceType } = getNextNonce(response, confirmedTxs, pendingTxs);
+    const confirmedTransactions: Transaction[] = [];
+    const pendingTransactions: MempoolTransaction[] = [];
+    const { nonce, nonceType } = getNextNonce({
+      addressNonces,
+      confirmedTransactions,
+      pendingTransactions,
+      senderAddress,
+    });
     expect(nonce).toEqual(49);
     expect(nonceType).toEqual(NonceTypes.apiSuggestedNonce);
   });
 
   test('possible_next_nonce is less than missing nonce', () => {
-    const response: AddressNonces = {
+    const addressNonces: AddressNonces = {
       detected_missing_nonces: [49],
       last_executed_tx_nonce: 48,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 24,
     };
-    const confirmedTxs: Transaction[] = [];
-    const pendingTxs: MempoolTransaction[] = [];
-    const { nonce, nonceType } = getNextNonce(response, confirmedTxs, pendingTxs);
+    const confirmedTransactions: Transaction[] = [];
+    const pendingTransactions: MempoolTransaction[] = [];
+    const { nonce, nonceType } = getNextNonce({
+      addressNonces,
+      confirmedTransactions,
+      pendingTransactions,
+      senderAddress,
+    });
     expect(nonce).toEqual(49);
     expect(nonceType).toEqual(NonceTypes.apiSuggestedNonce);
   });
 
   test('invalid state: last_executed_tx_nonce is more than or equal to missing nonce', () => {
-    const response: AddressNonces = {
+    const addressNonces: AddressNonces = {
       detected_missing_nonces: [49],
       last_executed_tx_nonce: 49,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 50,
     };
-    const confirmedTxs: Transaction[] = [];
-    const pendingTxs: MempoolTransaction[] = [];
-    const { nonce, nonceType } = getNextNonce(response, confirmedTxs, pendingTxs);
+    const confirmedTransactions: Transaction[] = [];
+    const pendingTransactions: MempoolTransaction[] = [];
+    const { nonce, nonceType } = getNextNonce({
+      addressNonces,
+      confirmedTransactions,
+      pendingTransactions,
+      senderAddress,
+    });
     expect(nonce).toEqual(50);
     expect(nonceType).toEqual(NonceTypes.apiSuggestedNonce);
   });
 
   test('new account with zero nonce', () => {
-    const response: AddressNonces = {
+    const addressNonces: AddressNonces = {
       detected_missing_nonces: [],
       last_executed_tx_nonce: null,
       last_mempool_tx_nonce: null,
       possible_next_nonce: 0,
     };
-    const confirmedTxs: Transaction[] = [];
-    const pendingTxs: MempoolTransaction[] = [];
-    const { nonce, nonceType } = getNextNonce(response, confirmedTxs, pendingTxs);
+    const confirmedTransactions: Transaction[] = [];
+    const pendingTransactions: MempoolTransaction[] = [];
+    const { nonce, nonceType } = getNextNonce({
+      addressNonces,
+      confirmedTransactions,
+      pendingTransactions,
+      senderAddress,
+    });
     expect(nonce).toEqual(0);
     expect(nonceType).toEqual(NonceTypes.apiSuggestedNonce);
   });
 
   test('last_mempool_tx_nonce', () => {
-    const response: AddressNonces = {
+    const addressNonces: AddressNonces = {
       detected_missing_nonces: [71],
       last_executed_tx_nonce: 70,
       last_mempool_tx_nonce: 72,
       possible_next_nonce: 73,
     };
-    const confirmedTxs: Transaction[] = [];
-    const pendingTxs: MempoolTransaction[] = [
+    const confirmedTransactions: Transaction[] = [];
+    const pendingTransactions: MempoolTransaction[] = [
       {
         anchor_mode: 'any',
         fee_rate: '200',
@@ -107,39 +133,46 @@ describe(getNextNonce, () => {
         nonce: 72,
       },
     ];
-    const { nonce, nonceType } = getNextNonce(response, confirmedTxs, pendingTxs);
+    const { nonce, nonceType } = getNextNonce({
+      addressNonces,
+      confirmedTransactions,
+      pendingTransactions,
+      senderAddress,
+    });
     expect(nonce).toEqual(71);
     expect(nonceType).toEqual(NonceTypes.apiSuggestedNonce);
   });
 
   test('multiple missing nonces', () => {
-    const response1: AddressNonces = {
+    const addressNonces1: AddressNonces = {
       detected_missing_nonces: [73, 71],
       last_executed_tx_nonce: 70,
       last_mempool_tx_nonce: 74,
       possible_next_nonce: 75,
     };
-    const confirmedTxs: Transaction[] = [];
-    const pendingTxs: MempoolTransaction[] = [];
-    const { nonce: nonce1, nonceType: nonceType1 } = getNextNonce(
-      response1,
-      confirmedTxs,
-      pendingTxs
-    );
+    const confirmedTransactions: Transaction[] = [];
+    const pendingTransactions: MempoolTransaction[] = [];
+    const { nonce: nonce1, nonceType: nonceType1 } = getNextNonce({
+      addressNonces: addressNonces1,
+      confirmedTransactions,
+      pendingTransactions,
+      senderAddress,
+    });
     expect(nonce1).toEqual(71);
     expect(nonceType1).toEqual(NonceTypes.apiSuggestedNonce);
 
-    const response2: AddressNonces = {
+    const addressNonces2: AddressNonces = {
       detected_missing_nonces: [71, 73],
       last_executed_tx_nonce: 70,
       last_mempool_tx_nonce: 74,
       possible_next_nonce: 75,
     };
-    const { nonce: nonce2, nonceType: nonceType2 } = getNextNonce(
-      response2,
-      confirmedTxs,
-      pendingTxs
-    );
+    const { nonce: nonce2, nonceType: nonceType2 } = getNextNonce({
+      addressNonces: addressNonces2,
+      confirmedTransactions,
+      pendingTransactions,
+      senderAddress,
+    });
     expect(nonce2).toEqual(71);
     expect(nonceType2).toEqual(NonceTypes.apiSuggestedNonce);
   });

--- a/src/app/query/nonce/account-nonces.utils.ts
+++ b/src/app/query/nonce/account-nonces.utils.ts
@@ -42,19 +42,31 @@ function findAnyMissingPendingTxsNonces(pendingNonces: number[]) {
   return missingNonces;
 }
 
-export function getNextNonce(
-  accountNonces: AddressNonces,
-  confirmedTransactions: Transaction[],
-  pendingTransactions: MempoolTransaction[]
-): { nonce: number; nonceType: NonceTypes } {
-  const detectedMissingNonces = accountNonces.detected_missing_nonces;
-  const lastExecutedNonce = accountNonces.last_executed_tx_nonce;
-  const possibleNextNonce = accountNonces.possible_next_nonce;
+interface GetNextNonceArgs {
+  addressNonces: AddressNonces;
+  confirmedTransactions: Transaction[];
+  pendingTransactions: MempoolTransaction[];
+  senderAddress: string;
+}
+export function getNextNonce({
+  addressNonces,
+  confirmedTransactions,
+  pendingTransactions,
+  senderAddress,
+}: GetNextNonceArgs) {
+  const detectedMissingNonces = addressNonces.detected_missing_nonces;
+  const lastExecutedNonce = addressNonces.last_executed_tx_nonce;
+  const possibleNextNonce = addressNonces.possible_next_nonce;
 
   const firstMissingNonce = detectedMissingNonces?.sort()[0];
-  const pendingTxsNonces = pendingTransactions.map(tx => tx.nonce);
+  const pendingTxsNonces = pendingTransactions
+    .filter(tx => tx.sender_address === senderAddress)
+    ?.map(tx => tx.nonce);
   const lastPendingTxNonce = pendingTransactions[0]?.nonce;
-  const lastConfirmedTxNonceIncremented = confirmedTransactions[0]?.nonce + 1;
+  const confirmedTxsNonces = confirmedTransactions
+    .filter(tx => tx.sender_address === senderAddress)
+    ?.map(tx => tx.nonce);
+  const lastConfirmedTxNonceIncremented = confirmedTxsNonces[0] + 1;
   const lastPendingTxNonceIncremented = lastPendingTxNonce + 1;
   const pendingTxsNoncesIncludesApiPossibleNextNonce = pendingTxsNonces.includes(possibleNextNonce);
   const pendingTxsMissingNonces = findAnyMissingPendingTxsNonces(pendingTxsNonces);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2741706851).<!-- Sticky Header Marker -->

Came across a small bug with the nonce refactor. I forgot to filter the pending/confirmed txs by the sender address.

cc/ @kyranjamie @fbwoolf
