### PR TITLE
fix: add `all_frames` option, closes #2351

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -44,6 +44,7 @@ const manifest = {
     {
       js: ['browser-polyfill.js', 'content-script.js'],
       matches: ['*://*/*'],
+      all_frames: true,
     },
   ],
   browser_specific_settings: {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2773793003).<!-- Sticky Header Marker -->

Should ensure wallet works with web containers, codesandbox/stackblitz etc