### PR TITLE
fix: new pop up window extension crash

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import { persistAndRenderApp } from '@app/common/persistence';
 import { initSentry } from '@shared/utils/sentry-init';
 import { InternalMethods } from '@shared/message-types';
-import { addRefererHeaderRequestListener } from '@shared/add-referer-header';
 
 import { inMemoryKeyActions } from './store/in-memory-key/in-memory-key.actions';
 import { initSegment } from './common/segment-init';
@@ -12,7 +11,6 @@ import { App } from './app';
 
 initSentry();
 void initSegment();
-void addRefererHeaderRequestListener();
 
 declare global {
   interface Window {

--- a/src/shared/add-referer-header.ts
+++ b/src/shared/add-referer-header.ts
@@ -1,53 +1,53 @@
-import { isUndefined } from '@shared/utils';
-import type Browser from 'webextension-polyfill';
+// import { isUndefined } from '@shared/utils';
+// import type Browser from 'webextension-polyfill';
 
-function formatInitiator(initiator: string) {
-  const [protocol, host] = initiator.split('://');
-  return [protocol, '://hiro-web-extension.', host].join('');
-}
+// function formatInitiator(initiator: string) {
+//   const [protocol, host] = initiator.split('://');
+//   return [protocol, '://hiro-web-extension.', host].join('');
+// }
 
-function filterOutExtraHeadersArgumentWhenFirefoxExtension(type: string, browserName: string) {
-  if (type === 'extraHeaders') return browserName !== 'Firefox';
-  return true;
-}
+// function filterOutExtraHeadersArgumentWhenFirefoxExtension(type: string, browserName: string) {
+//   if (type === 'extraHeaders') return browserName !== 'Firefox';
+//   return true;
+// }
 
-async function getBrowserInfo() {
-  // `runtime.getBrowserInfo` only supported in Firefox
-  // https://github.com/mozilla/webextension-polyfill/issues/116
-  if (!isUndefined(browser.runtime.getBrowserInfo)) {
-    return browser.runtime.getBrowserInfo();
-  }
-  return { name: 'unknown-browser' };
-}
+// async function getBrowserInfo() {
+//   // `runtime.getBrowserInfo` only supported in Firefox
+//   // https://github.com/mozilla/webextension-polyfill/issues/116
+//   if (!isUndefined(browser.runtime.getBrowserInfo)) {
+//     return browser.runtime.getBrowserInfo();
+//   }
+//   return { name: 'unknown-browser' };
+// }
 
-function doesRequestOriginateFromExtension(requestInitiator: string) {
-  return requestInitiator.includes(browser.runtime.id);
-}
+// function doesRequestOriginateFromExtension(requestInitiator: string) {
+//   return requestInitiator.includes(browser.runtime.id);
+// }
 
-export async function addRefererHeaderRequestListener() {
-  const handler = (details: Browser.WebRequest.OnBeforeSendHeadersDetailsType) => {
-    if (!details.requestHeaders) return;
-    const headers = [...details.requestHeaders];
-    const initiatorText = details.documentUrl || details.initiator || '';
+// export async function addRefererHeaderRequestListener() {
+//   const handler = (details: Browser.WebRequest.OnBeforeSendHeadersDetailsType) => {
+//     if (!details.requestHeaders) return;
+//     const headers = [...details.requestHeaders];
+//     const initiatorText = details.documentUrl || details.initiator || '';
 
-    if (initiatorText && doesRequestOriginateFromExtension(initiatorText)) {
-      headers.push({ name: 'Referer', value: formatInitiator(initiatorText) });
-    }
-    return { requestHeaders: headers };
-  };
+//     if (initiatorText && doesRequestOriginateFromExtension(initiatorText)) {
+//       headers.push({ name: 'Referer', value: formatInitiator(initiatorText) });
+//     }
+//     return { requestHeaders: headers };
+//   };
 
-  const { name: browserName } = await getBrowserInfo();
+//   const { name: browserName } = await getBrowserInfo();
 
-  const headerTypes = ['requestHeaders', 'blocking', 'extraHeaders'].filter(type =>
-    filterOutExtraHeadersArgumentWhenFirefoxExtension(type, browserName)
-  ) as Browser.WebRequest.OnBeforeSendHeadersOptions[];
+//   const headerTypes = ['requestHeaders', 'blocking', 'extraHeaders'].filter(type =>
+//     filterOutExtraHeadersArgumentWhenFirefoxExtension(type, browserName)
+//   ) as Browser.WebRequest.OnBeforeSendHeadersOptions[];
 
-  browser.webRequest.onBeforeSendHeaders.addListener(
-    handler,
-    {
-      urls: ['https://*.stacks.co/*'],
-    },
-    headerTypes
-  );
-  return () => browser.webRequest.onBeforeSendHeaders.removeListener(handler);
-}
+//   browser.webRequest.onBeforeSendHeaders.addListener(
+//     handler,
+//     {
+//       urls: ['https://*.stacks.co/*'],
+//     },
+//     headerTypes
+//   );
+//   return () => browser.webRequest.onBeforeSendHeaders.removeListener(handler);
+// }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2802480809).<!-- Sticky Header Marker -->

Noticed some instances where the extension crashes when opening popup window. Relates to yesterday's `RESULT_CODE_KILLED_BAD_MESSAGE` issue. Forgot that we also initiate this listening from the popup script.