### PR TITLE
fix: name spoofing detection from metadata

### DIFF
--- a/src/app/common/token-utils.ts
+++ b/src/app/common/token-utils.ts
@@ -28,7 +28,7 @@ export function isFtNameLikeStx(name: string) {
 export function imageCanonicalUriFromFtMetadata(meta: FtMeta | undefined) {
   return meta?.image_canonical_uri &&
     isIconUrl(meta.image_canonical_uri) &&
-    !isFtNameLikeStx(meta.image_canonical_uri)
+    !isFtNameLikeStx(meta.name)
     ? meta.image_canonical_uri
     : undefined;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2838998331).<!-- Sticky Header Marker -->

While working on https://github.com/hirosystems/explorer/pull/812 I found a mistake in detecting token impersonating STX, we should use the meta.name instead of the url.

I tested non-regression on the QA wallet
<img width="927" alt="wallet-token" src="https://user-images.githubusercontent.com/1501454/184110674-8b3366a8-9f27-43c9-a2e8-8251cbe79bde.png">


cc: @kyranjamie @fbwoolf 