### PR TITLE
fix: firefox not opening popups, missing `origin` in firefox

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -47,7 +47,10 @@ chrome.runtime.onConnect.addListener(port =>
       if (!port.sender?.tab?.id)
         return logger.error('Message reached background script without a corresponding tab');
 
-      if (!port.sender?.origin)
+      // Chromium/Firefox discrepancy
+      const originUrl = port.sender?.origin ?? port.sender?.url;
+
+      if (!originUrl)
         return logger.error('Message reached background script without a corresponding origin');
 
       if (inferLegacyMessage(message)) {

--- a/src/background/legacy-external-message-handler.ts
+++ b/src/background/legacy-external-message-handler.ts
@@ -34,6 +34,7 @@ function getTabIdFromPort(port: chrome.runtime.Port) {
 }
 
 function getOriginFromPort(port: chrome.runtime.Port) {
+  if (port.sender?.url) return new URL(port.sender.url).origin;
   return port.sender?.origin;
 }
 

--- a/src/shared/crypto/generate-encryption-key.ts
+++ b/src/shared/crypto/generate-encryption-key.ts
@@ -7,11 +7,13 @@ interface GenerateEncryptionKeyArgs {
 export async function generateEncryptionKey(args: GenerateEncryptionKeyArgs): Promise<string> {
   const worker = createWorker(WorkerScript.DecryptionWorker);
 
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     worker.addEventListener('message', (e: MessageEvent<string>) => {
       worker.terminate();
       resolve(e.data);
     });
+    worker.addEventListener('error', e => reject(e));
+    worker.addEventListener('messageerror', e => reject(e));
     worker.postMessage(args);
   });
 }

--- a/src/shared/workers/index.ts
+++ b/src/shared/workers/index.ts
@@ -1,7 +1,14 @@
+import { analytics } from '@shared/utils/analytics';
+
 export enum WorkerScript {
   DecryptionWorker = 'decryption-worker.js',
 }
 
 export function createWorker(scriptName: WorkerScript) {
-  return new Worker(scriptName);
+  const worker = new Worker(scriptName);
+  worker.addEventListener(
+    'error',
+    error => void analytics.track(`worker_error_thrown_${scriptName}`, { error })
+  );
+  return worker;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2873846859).<!-- Sticky Header Marker -->

Firefox doesn't return an `origin`, only a `url`. This PR checks for both when performing validation logic.

cc/ @friedger 