### PR TITLE
fix: chrome rejections, unused permissions

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -16,7 +16,7 @@ const manifest = {
   author: 'Hiro PBC',
   description:
     'Hiro Wallet is a safe way to manage your STX, sign into apps, and protect your funds while interacting with Clarity smart contracts.',
-  permissions: ['contextMenus', 'storage', 'webRequest', 'webRequestBlocking', '*://*/*'],
+  permissions: ['contextMenus', 'storage', '*://*/*'],
   manifest_version: 2,
   background: {
     scripts: ['browser-polyfill.js', 'background.js'],


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/2955117786).<!-- Sticky Header Marker -->

Removes permissions that are unused, and caused Chrome store rejection