### PR TITLE
refactor: select asset

### DIFF
--- a/src/app/common/transactions/transaction-utils.ts
+++ b/src/app/common/transactions/transaction-utils.ts
@@ -26,6 +26,7 @@ import { stacksValue } from '@app/common/stacks-utils';
 type Tx = MempoolTransaction | Transaction;
 
 export interface TransactionFormValues {
+  assetId: string;
   amount: number | string;
   fee: number | string;
   feeType: string;

--- a/src/app/pages/send-tokens/components/amount-field.tsx
+++ b/src/app/pages/send-tokens/components/amount-field.tsx
@@ -23,14 +23,12 @@ interface AmountFieldProps extends StackProps {
 // TODO: this should use a new "Field" component (with inline label like in figma)
 function AmountFieldBase(props: AmountFieldProps) {
   const { error, value, ...rest } = props;
-  const { setFieldValue, handleChange, values } = useFormikContext<TransactionFormValues>();
+  const { handleChange, values } = useFormikContext<TransactionFormValues>();
   const analytics = useAnalytics();
   const assets = useBaseAssetsUnanchored();
   const balances = useCurrentAccountUnanchoredBalances();
-  const { selectedAsset, placeholder } = useSelectedAsset();
-  const { handleOnKeyDown, handleSetSendMax } = useSendAmountFieldActions({
-    setFieldValue,
-  });
+  const { selectedAsset, placeholder } = useSelectedAsset(values.assetId);
+  const { handleOnKeyDown, handleSetSendMax } = useSendAmountFieldActions();
 
   const handleSetSendMaxTracked = () => {
     void analytics.track('select_maximum_amount_for_send');

--- a/src/app/pages/send-tokens/components/asset-search/asset-search.tsx
+++ b/src/app/pages/send-tokens/components/asset-search/asset-search.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useState } from 'react';
+import { useField } from 'formik';
 import { Box, color, Stack } from '@stacks/ui';
 
 import { AssetWithMeta } from '@app/common/asset-types';
@@ -15,19 +16,20 @@ function principalHasOnlyOneAsset(assets: AssetWithMeta[]) {
 
 interface AssetSearchProps {
   autoFocus?: boolean;
-  onSelectAssetResetForm(): void;
+  onSelectAsset(asset: AssetWithMeta): void;
 }
 export const AssetSearch: React.FC<AssetSearchProps> = memo(
-  ({ autoFocus, onSelectAssetResetForm, ...rest }) => {
+  ({ autoFocus, onSelectAsset, ...rest }) => {
+    const [field, _, helpers] = useField('assetId');
     const assets = useTransferableAssets();
     const availableStxBalance = useCurrentAccountAvailableStxBalance();
-    const { selectedAsset, updateSelectedAsset } = useSelectedAsset();
+    const { selectedAsset } = useSelectedAsset(field.value);
     const [searchInput, setSearchInput] = useState<string>('');
     const [assetItems, setAssetItems] = useState(assets);
 
     useEffect(() => {
       if (principalHasOnlyOneAsset(assets ?? [])) {
-        updateSelectedAsset(assets[0]);
+        onSelectAsset(assets[0]);
       }
       return () => onClearSearch();
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -35,7 +37,8 @@ export const AssetSearch: React.FC<AssetSearchProps> = memo(
 
     const onClearSearch = () => {
       setSearchInput('');
-      updateSelectedAsset(undefined);
+      setAssetItems(assets);
+      helpers.setValue('');
     };
 
     const onInputValueChange = (value: string | undefined) => {
@@ -47,11 +50,6 @@ export const AssetSearch: React.FC<AssetSearchProps> = memo(
       setAssetItems(assets.filter(asset => asset.name.toLowerCase().includes(value.toLowerCase())));
     };
 
-    const onSelectedItemChange = (item: any) => {
-      updateSelectedAsset(item || undefined);
-      onSelectAssetResetForm();
-    };
-
     if (!assets) {
       return (
         <Stack spacing="tight" {...rest}>
@@ -61,7 +59,7 @@ export const AssetSearch: React.FC<AssetSearchProps> = memo(
       );
     }
 
-    if (selectedAsset) {
+    if (field.value) {
       return (
         <SelectedAsset
           hideArrow={principalHasOnlyOneAsset(assets ?? [])}
@@ -77,7 +75,7 @@ export const AssetSearch: React.FC<AssetSearchProps> = memo(
         autoFocus={autoFocus}
         hasStxBalance={!!availableStxBalance}
         onInputValueChange={onInputValueChange}
-        onSelectedItemChange={onSelectedItemChange}
+        onSelectedItemChange={onSelectAsset}
         searchInput={searchInput}
         selectedAsset={selectedAsset}
         {...rest}

--- a/src/app/pages/send-tokens/components/asset-search/selected-asset-item.tsx
+++ b/src/app/pages/send-tokens/components/asset-search/selected-asset-item.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { useField } from 'formik';
 import { Box, ChevronIcon, Text, color, Stack, BoxProps } from '@stacks/ui';
 
 import { AssetAvatar } from '@app/components/stx-avatar';
@@ -12,8 +13,8 @@ interface SelectedAssetItemProps extends BoxProps {
 }
 export const SelectedAssetItem = memo(
   ({ hideArrow, onClearSearch, ...rest }: SelectedAssetItemProps) => {
-    const { name, selectedAsset, ticker } = useSelectedAsset();
-
+    const [field] = useField('assetId');
+    const { name, selectedAsset, ticker } = useSelectedAsset(field.value);
     if (!selectedAsset) return null;
     const isStx = name === 'Stacks Token';
     const gradientString = gradientStringForAsset(selectedAsset);

--- a/src/app/pages/send-tokens/components/asset-search/selected-asset.tsx
+++ b/src/app/pages/send-tokens/components/asset-search/selected-asset.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { useField } from 'formik';
 import { Text, Stack, StackProps } from '@stacks/ui';
 
 import { Caption } from '@app/components/typography';
@@ -11,7 +12,8 @@ interface SelectedAssetProps extends StackProps {
   onClearSearch(): void;
 }
 export const SelectedAsset = memo(({ hideArrow, onClearSearch, ...rest }: SelectedAssetProps) => {
-  const { balance, selectedAsset, ticker } = useSelectedAsset();
+  const [field] = useField('assetId');
+  const { balance, selectedAsset, ticker } = useSelectedAsset(field.value);
 
   if (!selectedAsset) return null;
 

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-details.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-details.tsx
@@ -9,15 +9,14 @@ import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 
 interface SendTokensConfirmDetailsProps extends StackProps {
   amount: number | string;
+  assetId: string;
   nonce?: number;
   recipient: string;
 }
-
 export function SendTokensConfirmDetails(props: SendTokensConfirmDetailsProps): JSX.Element {
-  const { amount, nonce, recipient, ...rest } = props;
-  const { ticker } = useSelectedAsset();
+  const { amount, assetId, nonce, recipient, ...rest } = props;
+  const { selectedAsset, ticker } = useSelectedAsset(assetId);
   const currentAccount = useCurrentAccount();
-  const { selectedAsset } = useSelectedAsset();
   const icon = iconStringForAsset(selectedAsset);
 
   return (

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
@@ -22,7 +22,7 @@ interface SendTokensSoftwareConfirmDrawerProps extends BaseDrawerProps {
 export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirmDrawerProps) {
   const { isShowing, onClose, onUserSelectBroadcastTransaction } = props;
   const { values } = useFormikContext<TransactionFormValues>();
-  const transaction = useSendFormUnsignedTxPreviewState(values);
+  const transaction = useSendFormUnsignedTxPreviewState(values.assetId, values);
   const analytics = useAnalytics();
   const { showEditNonce } = useDrawers();
 
@@ -43,6 +43,7 @@ export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirm
       <Stack pb="extra-loose" px="loose" spacing="loose">
         <SendTokensConfirmDetails
           amount={values.amount}
+          assetId={values.assetId}
           recipient={values.recipient}
           nonce={Number(transaction?.auth.spendingCondition?.nonce)}
         />

--- a/src/app/pages/send-tokens/hooks/use-selected-asset.ts
+++ b/src/app/pages/send-tokens/hooks/use-selected-asset.ts
@@ -1,26 +1,14 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import BigNumber from 'bignumber.js';
 
-import { AssetWithMeta } from '@app/common/asset-types';
-import { getFullyQualifiedAssetName, getTicker, initBigNumber } from '@app/common/utils';
+import { getTicker, initBigNumber } from '@app/common/utils';
 import { ftDecimals, stacksValue } from '@app/common/stacks-utils';
 import { useCurrentAccountAvailableStxBalance } from '@app/query/balance/balance.hooks';
-import { useSelectedAssetItem, useUpdateSelectedAsset } from '@app/store/assets/asset.hooks';
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useSelectedAssetMetadata } from '@app/store/assets/asset.hooks';
 
-export function useSelectedAsset() {
-  const selectedAsset = useSelectedAssetItem();
-  const setSelectedAsset = useUpdateSelectedAsset();
+export function useSelectedAsset(assetId: string) {
+  const selectedAsset = useSelectedAssetMetadata(assetId);
   const availableStxBalance = useCurrentAccountAvailableStxBalance();
-  const analytics = useAnalytics();
-
-  const updateSelectedAsset = useCallback(
-    (asset: AssetWithMeta | undefined) => {
-      setSelectedAsset(getFullyQualifiedAssetName(asset) || undefined);
-      void analytics.track('select_asset_for_send');
-    },
-    [analytics, setSelectedAsset]
-  );
 
   const name = selectedAsset?.meta?.name || selectedAsset?.name;
   const isStx = selectedAsset?.name === 'Stacks Token';
@@ -53,6 +41,5 @@ export function useSelectedAsset() {
     placeholder,
     selectedAsset,
     ticker,
-    updateSelectedAsset,
   };
 }

--- a/src/app/pages/send-tokens/hooks/use-send-form-validation.ts
+++ b/src/app/pages/send-tokens/hooks/use-send-form-validation.ts
@@ -1,5 +1,5 @@
-import * as yup from 'yup';
 import BigNumber from 'bignumber.js';
+import * as yup from 'yup';
 import { stxToMicroStx } from '@stacks/ui-utils';
 
 import { useWallet } from '@app/common/hooks/use-wallet';
@@ -22,12 +22,16 @@ import { nonceSchema } from '@app/common/validation/nonce-schema';
 import { isNumber } from '@shared/utils';
 
 interface UseSendFormValidationArgs {
+  selectedAssetId: string;
   setAssetError(error: string | undefined): void;
 }
-export const useSendFormValidation = ({ setAssetError }: UseSendFormValidationArgs) => {
+export const useSendFormValidation = ({
+  selectedAssetId,
+  setAssetError,
+}: UseSendFormValidationArgs) => {
   const { currentNetwork, currentAccountStxAddress } = useWallet();
   const availableStxBalance = useCurrentAccountAvailableStxBalance();
-  const { selectedAsset, balanceBigNumber } = useSelectedAsset();
+  const { selectedAsset, balanceBigNumber } = useSelectedAsset(selectedAssetId);
   const feeSchema = useFeeSchema();
   const isSendingStx = selectedAsset?.type === 'stx';
 

--- a/src/app/pages/send-tokens/hooks/use-send-form.ts
+++ b/src/app/pages/send-tokens/hooks/use-send-form.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import * as React from 'react';
-import { FormikProps } from 'formik';
+import { useFormikContext } from 'formik';
 
 import { microStxToStx } from '@app/common/stacks-utils';
 import { removeCommas } from '@app/common/token-utils';
@@ -9,12 +9,11 @@ import { useSelectedAsset } from '@app/pages/send-tokens/hooks/use-selected-asse
 import { useCurrentAccountAvailableStxBalance } from '@app/query/balance/balance.hooks';
 import { useCurrentAccountMempoolTransactionsBalance } from '@app/query/mempool/mempool.hooks';
 
-export function useSendAmountFieldActions({
-  setFieldValue,
-}: Pick<FormikProps<TransactionFormValues>, 'setFieldValue'>) {
+export function useSendAmountFieldActions() {
+  const { setFieldValue, values } = useFormikContext<TransactionFormValues>();
   const availableStxBalance = useCurrentAccountAvailableStxBalance();
   const pendingTxsBalance = useCurrentAccountMempoolTransactionsBalance();
-  const { selectedAsset, balance } = useSelectedAsset();
+  const { selectedAsset, balance } = useSelectedAsset(values.assetId);
   const isStx = selectedAsset?.type === 'stx';
 
   const handleSetSendMax = useCallback(

--- a/src/app/pages/transaction-request/components/fee-form.tsx
+++ b/src/app/pages/transaction-request/components/fee-form.tsx
@@ -12,7 +12,7 @@ interface FeeFormProps {
 }
 export function FeeForm({ feeEstimations }: FeeFormProps) {
   const { values } = useFormikContext<TransactionFormValues>();
-  const transaction = useUnsignedPrepareTransactionDetails(values);
+  const transaction = useUnsignedPrepareTransactionDetails(values.assetId, values);
 
   const isSponsored = transaction ? isTxSponsored(transaction) : false;
 

--- a/src/app/store/assets/asset-search.ts
+++ b/src/app/store/assets/asset-search.ts
@@ -1,3 +1,0 @@
-import { atom } from 'jotai';
-
-export const selectedAssetIdState = atom<string | undefined>(undefined);

--- a/src/app/store/assets/asset.hooks.ts
+++ b/src/app/store/assets/asset.hooks.ts
@@ -1,8 +1,6 @@
 import { useMemo } from 'react';
-import { useAtomValue, useUpdateAtom } from 'jotai/utils';
 import { mergeAssetBalances } from '@app/store/assets/tokens';
 import type { Asset, AssetWithMeta } from '@app/common/asset-types';
-import { selectedAssetIdState } from './asset-search';
 import {
   useAddressAnchoredAvailableStxBalance,
   useAddressBalances,
@@ -34,8 +32,7 @@ export function useAssetWithMetadata(asset: Asset) {
   return asset as AssetWithMeta;
 }
 
-export function useSelectedAssetItem() {
-  const selectedAssetId = useAtomValue(selectedAssetIdState);
+export function useSelectedAssetMetadata(selectedAssetId?: string) {
   const assetsWithMetadata = useAssetsWithMetadata();
 
   return useMemo(
@@ -47,10 +44,6 @@ export function useSelectedAssetItem() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedAssetId]
   );
-}
-
-export function useUpdateSelectedAsset() {
-  return useUpdateAtom(selectedAssetIdState);
 }
 
 export function useStxTokenState(address: string) {

--- a/src/app/store/transactions/utils.ts
+++ b/src/app/store/transactions/utils.ts
@@ -5,3 +5,7 @@ export function getPayloadFromToken(requestToken: string) {
   const token = decodeToken(requestToken);
   return token.payload as unknown as TransactionPayload;
 }
+
+export function isSendingFormSendingStx(assetId?: string) {
+  return assetId === '.::Stacks Token';
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3015443935).<!-- Sticky Header Marker -->

This PR removes `useUpdateSelectedAsset` and the atoms/hooks associated to it. Proposing here to use an `assetId` in the form state to keep track of the selected asset instead.

cc/ @kyranjamie @fbwoolf
