### PR TITLE
fix: cached data bug in atom with wrong network

### DIFF
--- a/src/app/pages/transaction-request/components/contract-call-details/contract-call-details.tsx
+++ b/src/app/pages/transaction-request/components/contract-call-details/contract-call-details.tsx
@@ -4,14 +4,14 @@ import { Stack, color } from '@stacks/ui';
 import { useExplorerLink } from '@app/common/hooks/use-explorer-link';
 import { Divider } from '@app/components/divider';
 import { Title } from '@app/components/typography';
-import { ContractPreview } from '@app/pages/transaction-request/components/contract-preview';
+import { ContractPreviewLayout } from '@app/pages/transaction-request/components/contract-preview';
 import { AttachmentRow } from '@app/pages/transaction-request/components/attachment-row';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
 
 import { FunctionArgumentsList } from './function-arguments-list';
 import { formatContractId } from '@app/common/utils';
 
-function ContractCallDetailsSuspense(): JSX.Element | null {
+function ContractCallDetailsSuspense() {
   const transactionRequest = useTransactionRequestState();
   const { handleOpenTxLink } = useExplorerLink();
 
@@ -31,7 +31,7 @@ function ContractCallDetailsSuspense(): JSX.Element | null {
         Function and arguments
       </Title>
 
-      <ContractPreview
+      <ContractPreviewLayout
         onClick={() => handleOpenTxLink(formatContractId(contractAddress, contractName))}
         contractAddress={contractAddress}
         contractName={contractName}
@@ -45,7 +45,7 @@ function ContractCallDetailsSuspense(): JSX.Element | null {
   );
 }
 
-export function ContractCallDetails(): JSX.Element {
+export function ContractCallDetails() {
   return (
     <Suspense fallback={<></>}>
       <ContractCallDetailsSuspense />

--- a/src/app/pages/transaction-request/components/contract-deploy-details/contract-deploy-details.tsx
+++ b/src/app/pages/transaction-request/components/contract-deploy-details/contract-deploy-details.tsx
@@ -5,7 +5,7 @@ import { Prism } from '@app/common/clarity-prism';
 import { useWallet } from '@app/common/hooks/use-wallet';
 import { Caption, Title } from '@app/components/typography';
 import { Divider } from '@app/components/divider';
-import { ContractPreview } from '@app/pages/transaction-request/components/contract-preview';
+import { ContractPreviewLayout } from '@app/pages/transaction-request/components/contract-preview';
 import { Row } from '@app/pages/transaction-request/components/row';
 import { AttachmentRow } from '@app/pages/transaction-request/components/attachment-row';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
@@ -95,7 +95,7 @@ export function ContractDeployDetails(): JSX.Element | null {
           <Title as="h2" fontWeight="500">
             Contract deploy details
           </Title>
-          <ContractPreview
+          <ContractPreviewLayout
             contractAddress={currentAccountStxAddress}
             contractName={transactionRequest.contractName}
           />

--- a/src/app/pages/transaction-request/components/contract-preview.tsx
+++ b/src/app/pages/transaction-request/components/contract-preview.tsx
@@ -4,13 +4,13 @@ import { truncateMiddle } from '@stacks/ui-utils';
 import { Caption, Title } from '@app/components/typography';
 import { formatContractId } from '@app/common/utils';
 
-interface ContractPreviewProps extends StackProps {
+interface ContractPreviewLayoutProps extends StackProps {
   contractAddress: string;
   contractName: string;
   functionName?: string;
 }
 
-export function ContractPreview(props: ContractPreviewProps): JSX.Element {
+export function ContractPreviewLayout(props: ContractPreviewLayoutProps) {
   const { contractAddress, contractName, functionName, ...rest } = props;
 
   return (

--- a/src/app/query/contract/contract.hooks.ts
+++ b/src/app/query/contract/contract.hooks.ts
@@ -1,26 +1,18 @@
-import { UseQueryOptions } from 'react-query';
 import type { TransactionPayload } from '@stacks/connect';
 import { ContractInterfaceFunction } from '@stacks/rpc-client';
 
-import { ContractInterfaceResponseWithFunctions } from '@shared/models/contract-types';
 import { useGetContractInterface } from '@app/query/contract/contract.query';
-import { useContractInterfaceState } from '@app/store/contracts/contract.hooks';
+
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
 import { formatContractId } from '@app/common/utils';
 
 export function useContractInterface(transactionRequest: TransactionPayload | null) {
-  const [, setContractInterface] = useContractInterfaceState();
-  const queryOptions: UseQueryOptions<ContractInterfaceResponseWithFunctions> = {
-    onSuccess: (data: ContractInterfaceResponseWithFunctions) => {
-      if (data) setContractInterface(data);
-    },
-  };
-  return useGetContractInterface(transactionRequest, queryOptions);
+  return useGetContractInterface(transactionRequest).data;
 }
 
-export const useContractFunction = () => {
+export function useContractFunction() {
   const transactionRequest = useTransactionRequestState();
-  const [contractInterface] = useContractInterfaceState();
+  const contractInterface = useContractInterface(transactionRequest);
 
   if (!transactionRequest || transactionRequest.txType !== 'contract_call' || !contractInterface)
     return;
@@ -39,4 +31,4 @@ export const useContractFunction = () => {
     );
   }
   return selectedFunction;
-};
+}

--- a/src/app/store/contracts/contract.hooks.ts
+++ b/src/app/store/contracts/contract.hooks.ts
@@ -1,7 +1,0 @@
-import { useAtom } from 'jotai';
-
-import { contractInterfaceState } from '@app/store/contracts/contract';
-
-export function useContractInterfaceState() {
-  return useAtom(contractInterfaceState);
-}

--- a/src/app/store/contracts/contract.ts
+++ b/src/app/store/contracts/contract.ts
@@ -1,9 +1,0 @@
-import { atom } from 'jotai';
-
-import { ContractInterfaceResponseWithFunctions } from '@shared/models/contract-types';
-
-export const contractInterfaceState = atom<ContractInterfaceResponseWithFunctions | undefined>(
-  undefined
-);
-
-contractInterfaceState.debugLabel = 'contractInterfaceState';


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3007548915).<!-- Sticky Header Marker -->

Closes #2645

Not entirely sure what was going on here, but we were using `onSuccess` of react query to populate an atom. As this atom wasn't used by any other atoms, we can remove it entirely, and consume only the hook.  This appears to have solved the problem.

cc/ @radicleart, would you be able to download the build from this PR and ensure it's fixed? This'll help us merge and release this more quickly