### PR TITLE
fix: querying fee endpoint empty payload

### DIFF
--- a/src/app/pages/send-tokens/send-tokens.tsx
+++ b/src/app/pages/send-tokens/send-tokens.tsx
@@ -55,9 +55,7 @@ function SendTokensFormBase() {
   useRouteHeader(<Header title="Send" onClose={() => navigate(RouteUrls.Home)} />);
 
   useEffect(() => {
-    if (showNetworks) {
-      navigate(RouteUrls.Home);
-    }
+    if (showNetworks) navigate(RouteUrls.Home);
   }, [navigate, showNetworks]);
 
   const handleConfirmDrawerOnClose = useCallback(() => {

--- a/src/app/query/fees/fees.query.ts
+++ b/src/app/query/fees/fees.query.ts
@@ -36,6 +36,7 @@ export function useGetTransactionFeeEstimationQuery(
   return useQuery({
     queryKey: ['transaction-fee-estimation', transactionPayload],
     queryFn: fetchTransactionFeeEstimation,
+    enabled: transactionPayload !== '',
     ...feeEstimationsQueryOptions,
   }) as UseQueryResult<TransactionFeeEstimation, Error>;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3043297180).<!-- Sticky Header Marker -->

Closes #2653

Disable fee query when given payload equals `""`

cc/ @aulneau @kantai