### PR TITLE
test: fix unreliable account creation test

### DIFF
--- a/tests/integration/settings/settings.spec.ts
+++ b/tests/integration/settings/settings.spec.ts
@@ -32,12 +32,13 @@ describe(`Settings integration tests`, () => {
     await wallet.waitForSettingsButton();
     await wallet.clickSettingsButton();
     await wallet.page.click(createTestSelector(SettingsSelectors.CreateAccountBtn));
-    await delay(500);
-    await wallet.waitForHomePage();
+
+    const expectedText = 'Account 2';
+    await wallet.page.waitForSelector(`text=${expectedText}`);
     const displayName = await wallet.page.textContent(
       createTestSelector(SettingsSelectors.CurrentAccountDisplayName)
     );
-    expect(displayName).toEqual('Account 2');
+    expect(displayName).toEqual(expectedText);
   });
 
   it(`should be able to create ${numOfAccountsToTest} new accounts then switch between them`, async () => {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3044236030).<!-- Sticky Header Marker -->

Closes #2656

The issue here was the use of a fixed sleep operation, that in some conditions, would mean the operation hadn't fully completed, and thus the account was unchanged.

Now, we use the `waitForSelector` element, and then test the result. If it never appears, the test will timeout and fail.