### PR TITLE
refactor: use onMount hook

### DIFF
--- a/src/app/common/hooks/use-on-mount.ts
+++ b/src/app/common/hooks/use-on-mount.ts
@@ -1,0 +1,10 @@
+import { isFunction } from '@shared/utils';
+import { useEffect } from 'react';
+
+export function useOnMount(effect: () => void | (() => void)) {
+  useEffect(() => {
+    const fn = effect();
+    return () => (isFunction(fn) ? fn() : undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/app/features/container/container.tsx
+++ b/src/app/features/container/container.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
 import { Outlet, useSearchParams } from 'react-router-dom';
 
 import { useRouteHeaderState } from '@app/store/ui/ui.hooks';
+import { useOnMount } from '@app/common/hooks/use-on-mount';
 
 import { ContainerLayout } from './container.layout';
 import { useSetInitialRouteSearchParams } from '@app/store/common/initial-route-search-params.hooks';
@@ -10,11 +10,7 @@ function useCacheInitialRouteSearchParams() {
   const [searchParams] = useSearchParams();
   const setParams = useSetInitialRouteSearchParams();
 
-  useEffect(() => {
-    setParams(searchParams);
-    // We only want to set the initial searchParams, not all subsequent updates
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useOnMount(() => setParams(searchParams));
 }
 
 export function Container() {

--- a/src/app/routes/hooks/use-on-sign-out.ts
+++ b/src/app/routes/hooks/use-on-sign-out.ts
@@ -1,12 +1,10 @@
-import { useEffect } from 'react';
-
 import { keyActions } from '@app/store/keys/key.actions';
+import { useOnMount } from '@app/common/hooks/use-on-mount';
 
 export function useOnSignOut(handler: () => void) {
-  useEffect(() => {
+  useOnMount(() => {
     chrome.runtime.onMessage.addListener(message => {
       if (message?.method === keyActions.signOut.type) handler();
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  });
 }

--- a/src/app/routes/hooks/use-on-wallet-lock.ts
+++ b/src/app/routes/hooks/use-on-wallet-lock.ts
@@ -1,12 +1,10 @@
-import { useEffect } from 'react';
-
 import { inMemoryKeyActions } from '@app/store/in-memory-key/in-memory-key.actions';
+import { useOnMount } from '@app/common/hooks/use-on-mount';
 
 export function useOnWalletLock(handler: () => void) {
-  useEffect(() => {
+  useOnMount(() => {
     chrome.runtime.onMessage.addListener(message => {
       if (message?.method === inMemoryKeyActions.lockWallet.type) handler();
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  });
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -10,6 +10,10 @@ export function isUndefined(value: unknown): value is undefined {
   return typeof value === 'undefined';
 }
 
+export function isFunction(value: unknown): value is Function {
+  return typeof value === 'function';
+}
+
 export function isEmpty(value: Object) {
   return Object.keys(value).length === 0;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3052585781).<!-- Sticky Header Marker -->

Hooks don't have an exact replica of `componentDidMount()`, yet oftentimes there's code we legitimately want to run when the component mounts, and dismounts. 

We _don't_ always want to run hooks whenever a dependency changes, which has lead to wide spread use of `// eslint-disable-next-line react-hooks/exhaustive-deps` in our codebase.

Some implementations of a hook like this use a `useRef` to keep track of whether the callback passed has been fired, though here, to use a returning dismount fn, requires the function be pre-usecallback'd.

Open to being convinced we shouldn't do this, stale closure issues etc, but in testing this works just fine...