### PR TITLE
fix(query): reuse of query key

### DIFF
--- a/src/app/pages/transaction-request/hooks/use-transaction-error.ts
+++ b/src/app/pages/transaction-request/hooks/use-transaction-error.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import { microStxToStx, validateStacksAddress } from '@app/common/stacks-utils';
 import { TransactionErrorReason } from '@app/pages/transaction-request/components/transaction-error/transaction-error';
 import { useContractInterface } from '@app/query/contract/contract.hooks';
-import { TransactionTypes } from '@stacks/connect';
+import { ContractCallPayload, TransactionTypes } from '@stacks/connect';
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { useCurrentAccountAvailableStxBalance } from '@app/query/balance/balance.hooks';
 
@@ -13,7 +13,7 @@ import { useDefaultRequestParams } from '@app/common/hooks/use-default-request-s
 
 export function useTransactionError() {
   const transactionRequest = useTransactionRequestState();
-  const contractInterface = useContractInterface(transactionRequest);
+  const contractInterface = useContractInterface(transactionRequest as ContractCallPayload);
   const { origin } = useDefaultRequestParams();
 
   const currentAccount = useCurrentAccount();

--- a/src/app/query/contract/contract.hooks.ts
+++ b/src/app/query/contract/contract.hooks.ts
@@ -1,17 +1,18 @@
-import type { TransactionPayload } from '@stacks/connect';
-import { ContractInterfaceFunction } from '@stacks/rpc-client';
+import type { ContractCallPayload } from '@stacks/connect';
+import type { ContractInterfaceFunction } from '@stacks/rpc-client';
 
+import { logger } from '@shared/logger';
 import { useGetContractInterface } from '@app/query/contract/contract.query';
-
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
+import { formatContractId } from '@app/common/utils';
 
-export function useContractInterface(transactionRequest: TransactionPayload | null) {
+export function useContractInterface(transactionRequest: ContractCallPayload | null) {
   return useGetContractInterface(transactionRequest).data;
 }
 
 export function useContractFunction() {
   const transactionRequest = useTransactionRequestState();
-  const contractInterface = useContractInterface(transactionRequest);
+  const contractInterface = useContractInterface(transactionRequest as ContractCallPayload);
 
   if (!transactionRequest || transactionRequest.txType !== 'contract_call' || !contractInterface)
     return;
@@ -19,6 +20,16 @@ export function useContractFunction() {
   const selectedFunction = contractInterface.functions.find((func: ContractInterfaceFunction) => {
     return func.name === transactionRequest.functionName;
   });
+
+  if (!selectedFunction) {
+    logger.error(
+      `Attempting to call a function (\`${transactionRequest.functionName}\`) that ` +
+        `does not exist on contract ${formatContractId(
+          transactionRequest.contractAddress,
+          transactionRequest.contractName
+        )}`
+    );
+  }
 
   return selectedFunction;
 }

--- a/src/app/query/contract/contract.query.ts
+++ b/src/app/query/contract/contract.query.ts
@@ -1,13 +1,10 @@
-import { useQuery, UseQueryOptions } from 'react-query';
-import { TransactionPayload, TransactionTypes } from '@stacks/connect';
+import { useQuery } from 'react-query';
+import { ContractCallPayload, TransactionTypes } from '@stacks/connect';
 
 import { ContractInterfaceResponseWithFunctions } from '@shared/models/contract-types';
 import { useApi } from '@app/store/common/api-clients.hooks';
 
-export function useGetContractInterface(
-  transactionRequest: TransactionPayload | null,
-  reactQueryOptions: UseQueryOptions<any> = {}
-) {
+export function useGetContractInterface(transactionRequest: ContractCallPayload | null) {
   const { smartContractsApi } = useApi();
 
   const fetchContractInterface = () => {
@@ -22,8 +19,12 @@ export function useGetContractInterface(
   };
 
   return useQuery({
-    queryKey: ['contract-interface', transactionRequest?.publicKey],
+    enabled: !!transactionRequest,
+    queryKey: [
+      'contract-interface',
+      transactionRequest?.contractName,
+      transactionRequest?.contractAddress,
+    ],
     queryFn: fetchContractInterface,
-    ...reactQueryOptions,
   });
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3067399299).<!-- Sticky Header Marker -->

This fixes the underlying issue of the white screens in release `v3.17.0`, which revealed a preexisting issue in the hook's implementation (815407ec3ba20e667efab6d5208504ebae162984) that hadn't noticeably surfaced, whereby a `queryKey` that wasn't unique to each contract would be reused, resulting the cache logic restoring incorrect contract details.
