### PR TITLE
fix: slow firefox sign in times

### DIFF
--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -2,6 +2,7 @@ import { gaiaUrl } from '@shared/constants';
 import { logger } from '@shared/logger';
 import { InternalMethods } from '@shared/message-types';
 import { BackgroundMessages } from '@shared/messages';
+import { generateEncryptionKey } from '@shared/workers/decryption-worker';
 import { StacksMainnet } from '@stacks/network';
 import { generateNewAccount, generateWallet, restoreWalletAccounts } from '@stacks/wallet-sdk';
 import memoize from 'promise-memoize';
@@ -71,6 +72,13 @@ export async function internalBackgroundMessageHandler(
 
     case InternalMethods.RemoveInMemoryKeys: {
       inMemoryKeys.clear();
+      break;
+    }
+
+    case InternalMethods.StretchKey: {
+      const { payload } = message;
+      const resp = await generateEncryptionKey(payload);
+      sendResponse(resp);
       break;
     }
   }

--- a/src/shared/crypto/generate-encryption-key.ts
+++ b/src/shared/crypto/generate-encryption-key.ts
@@ -1,19 +1,13 @@
-import { createWorker, WorkerScript } from '../workers';
+import { InternalMethods } from '@shared/message-types';
 
 interface GenerateEncryptionKeyArgs {
   password: string;
   salt: string;
 }
-export async function generateEncryptionKey(args: GenerateEncryptionKeyArgs): Promise<string> {
-  const worker = createWorker(WorkerScript.DecryptionWorker);
-
-  return new Promise((resolve, reject) => {
-    worker.addEventListener('message', (e: MessageEvent<string>) => {
-      worker.terminate();
-      resolve(e.data);
+export async function generateEncryptionKey(payload: GenerateEncryptionKeyArgs): Promise<string> {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({ method: InternalMethods.StretchKey, payload }, response => {
+      resolve(response);
     });
-    worker.addEventListener('error', e => reject(e));
-    worker.addEventListener('messageerror', e => reject(e));
-    worker.postMessage(args);
   });
 }

--- a/src/shared/message-types.ts
+++ b/src/shared/message-types.ts
@@ -21,6 +21,7 @@ export enum InternalMethods {
   RequestInMemoryKeys = 'RequestInMemoryKeys',
   RemoveInMemoryKeys = 'RemoveInMemoryKeys',
   OriginatingTabClosed = 'OriginatingTabClosed',
+  StretchKey = 'StretchKey',
 }
 
 export type ExtensionMethods = ExternalMethods | InternalMethods;

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -27,12 +27,15 @@ type OriginatingTabClosed = BackgroundMessage<
   { tabId: number }
 >;
 
+type StretchKey = BackgroundMessage<InternalMethods.StretchKey, { password: string; salt: string }>;
+
 export type BackgroundMessages =
   | RequestDerivedStxAccounts
   | ShareInMemoryKeyToBackground
   | RequestInMemoryKeys
   | RemoveInMemoryKeys
-  | OriginatingTabClosed;
+  | OriginatingTabClosed
+  | StretchKey;
 
 export function sendMessage(message: BackgroundMessages) {
   return chrome.runtime.sendMessage(message);

--- a/src/shared/workers/decryption-worker.ts
+++ b/src/shared/workers/decryption-worker.ts
@@ -1,12 +1,12 @@
 import argon2, { ArgonType } from 'argon2-browser';
 
-const context = self as unknown as Worker;
+// const context = self as unknown as Worker;
 
 interface GenerateEncryptionKeyArgs {
   password: string;
   salt: string;
 }
-async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyArgs) {
+export async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyArgs) {
   const argonHash = await argon2.hash({
     pass: password,
     salt,
@@ -18,9 +18,9 @@ async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyAr
   return argonHash.hashHex;
 }
 
-async function stretchKeyPostMessageHandler(e: MessageEvent<GenerateEncryptionKeyArgs>) {
-  const hex = await generateEncryptionKey(e.data);
-  context.postMessage(hex);
-}
+// async function stretchKeyPostMessageHandler(e: MessageEvent<GenerateEncryptionKeyArgs>) {
+//   const hex = await generateEncryptionKey(e.data);
+//   context.postMessage(hex);
+// }
 
-context.addEventListener('message', stretchKeyPostMessageHandler, false);
+// context.addEventListener('message', stretchKeyPostMessageHandler, false);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3067874907).<!-- Sticky Header Marker -->

**🚧 EXPERIMENTAL**

This PR moves the slow key stretching derivation logic from a Web Worker to the background script. 

Tagging Firefox users from the issue #2014 and others. If you have time to help test this solution and affirm it speeds up unlock times, that'd be very helpful @neorrk @zommuter @friedger @fluidvoice @Hero-Gamer @pors