### PR TITLE
fix: slow firefox sign in times, persistent worker

### DIFF
--- a/src/shared/crypto/generate-encryption-key.ts
+++ b/src/shared/crypto/generate-encryption-key.ts
@@ -1,19 +1,14 @@
 import { createWorker, WorkerScript } from '../workers';
 
+const worker = createWorker(WorkerScript.DecryptionWorker);
 interface GenerateEncryptionKeyArgs {
   password: string;
   salt: string;
 }
 export async function generateEncryptionKey(args: GenerateEncryptionKeyArgs): Promise<string> {
-  const worker = createWorker(WorkerScript.DecryptionWorker);
-
-  return new Promise((resolve, reject) => {
-    worker.addEventListener('message', (e: MessageEvent<string>) => {
-      worker.terminate();
-      resolve(e.data);
-    });
-    worker.addEventListener('error', e => reject(e));
-    worker.addEventListener('messageerror', e => reject(e));
+  return new Promise(resolve => {
+    const handler = (e: MessageEvent<string>) => resolve(e.data);
+    worker.addEventListener('message', handler);
     worker.postMessage(args);
   });
 }

--- a/src/shared/workers/decryption-worker.ts
+++ b/src/shared/workers/decryption-worker.ts
@@ -1,3 +1,4 @@
+import { logger } from '@shared/logger';
 import argon2, { ArgonType } from 'argon2-browser';
 
 const context = self as unknown as Worker;
@@ -7,6 +8,7 @@ interface GenerateEncryptionKeyArgs {
   salt: string;
 }
 async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyArgs) {
+  const x = performance.now();
   const argonHash = await argon2.hash({
     pass: password,
     salt,
@@ -15,6 +17,8 @@ async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyAr
     mem: 1024 * 32,
     type: ArgonType.Argon2id,
   });
+  const y = performance.now();
+  logger.info({ keyStretchDuration: (y - x) / 1000 + ' seconds' });
   return argonHash.hashHex;
 }
 
@@ -23,4 +27,4 @@ async function stretchKeyPostMessageHandler(e: MessageEvent<GenerateEncryptionKe
   context.postMessage(hex);
 }
 
-context.addEventListener('message', stretchKeyPostMessageHandler, false);
+context.addEventListener('message', stretchKeyPostMessageHandler);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3068410882).<!-- Sticky Header Marker -->

https://github.com/hirosystems/stacks-wallet-web/pull/2665 attempts to do the key stretching in the background script. This increases speed I reckon, though in Chrome it seems to block the popup script's thread (despite supposedly being a separate context).

This attempt keeps the worker open for the duration of the session, rather than initialising it and terminating it on every request. As far as I can tell this also increases the speed.

cc/ @neorrk @zommuter @friedger @fluidvoice @Hero-Gamer @pors if you're able to try the build