### PR TITLE
feat: add warning msg for outdated ledger app versions

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -18,7 +18,7 @@ import { Devtools } from '@app/features/devtool/devtools';
 import { AppRoutes } from '@app/routes/app-routes';
 import { persistor, store } from '@app/store';
 
-const reactQueryDevToolsEnabled = process.env.REACT_QUERY_DEVTOOLS_ENABLED;
+const reactQueryDevToolsEnabled = process.env.REACT_QUERY_DEVTOOLS_ENABLED === 'true';
 
 export function App() {
   return (

--- a/src/app/common/utils/create-waitable-action.ts
+++ b/src/app/common/utils/create-waitable-action.ts
@@ -1,0 +1,14 @@
+import { noop } from '@shared/utils';
+
+export function createWaitableAction<T = unknown>() {
+  let resolve = (_value?: unknown) => noop();
+  const promise = new Promise(r => (resolve = r));
+  return {
+    done(value?: T) {
+      resolve(value);
+    },
+    wait() {
+      return promise as Promise<T>;
+    },
+  };
+}

--- a/src/app/features/edit-nonce-drawer/components/edit-nonce-form.tsx
+++ b/src/app/features/edit-nonce-drawer/components/edit-nonce-form.tsx
@@ -11,15 +11,7 @@ function EditNonceFormFallback() {
         <EditNonceField />
       </Stack>
       <Stack isInline>
-        <Button
-          _hover={{
-            boxShadow: 'none',
-          }}
-          boxShadow="none"
-          borderRadius="10px"
-          flexGrow={1}
-          mode="tertiary"
-        >
+        <Button borderRadius="10px" flexGrow={1} mode="tertiary">
           Cancel
         </Button>
         <PrimaryButton isLoading>Apply</PrimaryButton>
@@ -42,16 +34,7 @@ export function EditNonceForm(props: EditNonceFormProps): JSX.Element {
         <EditNonceField onBlur={onBlur} />
       </Stack>
       <Stack isInline>
-        <Button
-          _hover={{
-            boxShadow: 'none',
-          }}
-          boxShadow="none"
-          borderRadius="10px"
-          flexGrow={1}
-          mode="tertiary"
-          onClick={onClose}
-        >
+        <Button flexGrow={1} mode="tertiary" onClick={onClose}>
           Cancel
         </Button>
         <PrimaryButton flexGrow={1} onClick={onSubmit}>

--- a/src/app/features/ledger/flows/tx-signing/ledger-sign-tx.context.ts
+++ b/src/app/features/ledger/flows/tx-signing/ledger-sign-tx.context.ts
@@ -3,10 +3,16 @@ import { StacksTransaction } from '@stacks/transactions';
 
 import { noop } from '@shared/utils';
 import { BaseLedgerOperationContext } from '../../ledger-utils';
+import { createWaitableAction } from '@app/common/utils/create-waitable-action';
+
+export function createWaitForUserToSeeWarningScreen() {
+  return createWaitableAction<'ignored-warning' | 'cancelled-operation'>();
+}
 
 export interface LedgerTxSigningContext extends BaseLedgerOperationContext {
   transaction: StacksTransaction | null;
   signTransaction(): Promise<void> | void;
+  hasUserSkippedBuggyAppWarning: ReturnType<typeof createWaitForUserToSeeWarningScreen>;
 }
 
 export const ledgerTxSigningContext = createContext<LedgerTxSigningContext>({
@@ -14,6 +20,7 @@ export const ledgerTxSigningContext = createContext<LedgerTxSigningContext>({
   latestDeviceResponse: null,
   awaitingDeviceConnection: false,
   signTransaction: noop,
+  hasUserSkippedBuggyAppWarning: createWaitForUserToSeeWarningScreen(),
 });
 
 export const LedgerTxSigningProvider = ledgerTxSigningContext.Provider;

--- a/src/app/features/ledger/flows/tx-signing/ledger-sign-tx.routes.tsx
+++ b/src/app/features/ledger/flows/tx-signing/ledger-sign-tx.routes.tsx
@@ -16,6 +16,7 @@ import {
 import { LedgerSignTxContainer } from './ledger-sign-tx-container';
 import { ConnectLedgerSignTx } from './steps/connect-ledger-sign-tx';
 import { ApproveSignLedgerTx } from './steps/approve-sign-ledger-tx';
+import { ContractPrincipalBugWarning } from './steps/contract-principal-bug-warning';
 
 export const ledgerTxSigningRoutes = (
   <Route element={<LedgerSignTxContainer />}>
@@ -29,5 +30,6 @@ export const ledgerTxSigningRoutes = (
     <Route path={RouteUrls.LedgerOperationRejected} element={<OperationRejected />} />
     <Route path={RouteUrls.LedgerPublicKeyMismatch} element={<LedgerPublicKeyMismatch />} />
     <Route path={RouteUrls.LedgerDevicePayloadInvalid} element={<LedgerDeviceInvalidPayload />} />
+    <Route path={RouteUrls.LedgerOutdatedAppWarning} element={<ContractPrincipalBugWarning />} />
   </Route>
 );

--- a/src/app/features/ledger/flows/tx-signing/steps/contract-principal-bug-warning.tsx
+++ b/src/app/features/ledger/flows/tx-signing/steps/contract-principal-bug-warning.tsx
@@ -1,0 +1,49 @@
+import { LedgerWrapper } from '@app/features/ledger/components/ledger-wrapper';
+import { Box, Button, Stack } from '@stacks/ui';
+import { useContext } from 'react';
+import { ledgerTxSigningContext } from '../ledger-sign-tx.context';
+import GenericErrorImg from '@assets/images/generic-error.png';
+import { LedgerTitle } from '@app/features/ledger/components/ledger-title';
+import { Body } from '@app/components/typography';
+import { useLoading } from '@app/common/hooks/use-loading';
+import { delay } from '@app/common/utils';
+
+export function ContractPrincipalBugWarning() {
+  const { hasUserSkippedBuggyAppWarning } = useContext(ledgerTxSigningContext);
+  const { isLoading, setIsLoading, setIsIdle } = useLoading('temp-spinner-deep-link');
+  return (
+    <LedgerWrapper>
+      <Box mb="tight" mt="tight">
+        <img src={GenericErrorImg} width="106px" />
+      </Box>
+      <LedgerTitle mt="base-loose">Stacks Ledger app is outdated</LedgerTitle>
+      <Body mt="base" mx="tight">
+        Some transactions are not compatible with outdated app versions. Update your app in{' '}
+        <a href="ledgerlive://manager" style={{ textDecoration: 'underline' }}>
+          Ledger Live
+        </a>{' '}
+        and try again.
+      </Body>
+      <Stack isInline mb="loose" mt="extra-loose">
+        <Button
+          as="a"
+          href="ledgerlive://manager"
+          isLoading={isLoading}
+          onClick={async () => {
+            setIsLoading();
+            await delay(300);
+            setIsIdle();
+          }}
+        >
+          Open Ledger Live ↗
+        </Button>
+        <Button
+          mode="tertiary"
+          onClick={() => hasUserSkippedBuggyAppWarning.done('ignored-warning')}
+        >
+          Continue anyway
+        </Button>
+      </Stack>
+    </LedgerWrapper>
+  );
+}

--- a/src/app/features/ledger/generic-steps/ledger-disconnected/ledger-disconnected.layout.tsx
+++ b/src/app/features/ledger/generic-steps/ledger-disconnected/ledger-disconnected.layout.tsx
@@ -20,13 +20,7 @@ export function LedgerDisconnectedLayout(props: LedgerDisconnectedLayoutProps) {
         Your Ledger has disconnected
       </LedgerTitle>
       <Stack isInline mb="loose">
-        <Button
-          _hover={{ boxShadow: 'none' }}
-          borderRadius="10px"
-          boxShadow="none"
-          mode="tertiary"
-          onClick={onClose}
-        >
+        <Button borderRadius="10px" mode="tertiary" onClick={onClose}>
           Close
         </Button>
         <PrimaryButton height="40px" onClick={onConnectAgain}>

--- a/src/app/features/ledger/ledger-utils.ts
+++ b/src/app/features/ledger/ledger-utils.ts
@@ -15,6 +15,11 @@ import { safeAwait } from '@stacks/ui';
 import { useLocation } from 'react-router-dom';
 import { RouteUrls } from '@shared/route-urls';
 
+export interface BaseLedgerOperationContext {
+  latestDeviceResponse: null | Awaited<ReturnType<typeof getAppVersion>>;
+  awaitingDeviceConnection: boolean;
+}
+
 const stxDerivationWithAccount = `m/44'/5757'/0'/0/{account}`;
 
 const identityDerivationWithAccount = `m/888'/0'/{account}'`;
@@ -126,7 +131,16 @@ export function doesLedgerStacksAppVersionSupportJwtAuth(versionInfo: SemVerObje
   );
 }
 
-export interface BaseLedgerOperationContext {
-  latestDeviceResponse: null | Awaited<ReturnType<typeof getAppVersion>>;
-  awaitingDeviceConnection: boolean;
+// https://github.com/Zondax/ledger-stacks/issues/119
+// https://github.com/hirosystems/stacks-wallet-web/issues/2567
+const versionFromWhichContractPrincipalBugIsFixed = '0.23.3';
+
+export function isVersionOfLedgerStacksAppWithContractPrincipalBug(
+  currentDeviceVersion: SemVerObject
+) {
+  return compare(
+    versionObjectToVersionString(currentDeviceVersion),
+    versionFromWhichContractPrincipalBugIsFixed,
+    '<'
+  );
 }

--- a/src/app/pages/receive-tokens/receive-tokens.tsx
+++ b/src/app/pages/receive-tokens/receive-tokens.tsx
@@ -44,15 +44,7 @@ export const ReceiveTokens = () => {
             </Title>
           )}
           <Caption userSelect="none">{truncateMiddle(address, 4)}</Caption>
-          <Button
-            _focus={{ boxShadow: 'none' }}
-            _hover={{ boxShadow: 'none' }}
-            borderRadius="10px"
-            boxShadow="none"
-            height="40px"
-            mode="tertiary"
-            onClick={copyToClipboard}
-          >
+          <Button borderRadius="10px" height="40px" mode="tertiary" onClick={copyToClipboard}>
             <FiCopy />
             <Text ml="tight">Copy address</Text>
           </Button>

--- a/src/app/pages/sign-out-confirm/sign-out-confirm-layout.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm-layout.tsx
@@ -53,10 +53,6 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
           </Flex>
           <Flex mt="loose">
             <Button
-              _hover={{
-                boxShadow: 'none',
-              }}
-              boxShadow="none"
               flex={1}
               type="button"
               onClick={() => onUserSafelyReturnToHomepage()}

--- a/src/app/query/stacks/hiro-config/hiro-config.query.ts
+++ b/src/app/query/stacks/hiro-config/hiro-config.query.ts
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 import { GITHUB_ORG, GITHUB_REPO } from '@shared/constants';
 import { BRANCH_NAME } from '@shared/environment';
 import { isUndefined } from '@shared/utils';
+import get from 'lodash.get';
 
 export interface HiroMessage {
   title: string;
@@ -64,7 +65,7 @@ function useRemoteHiroConfig() {
 
 export function useRemoteHiroMessages(): HiroMessage[] {
   const config = useRemoteHiroConfig();
-  return config?.messages?.global ?? [];
+  return get(config, 'messages.global', []);
 }
 
 export function useActiveFiatProviders() {

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -20,6 +20,7 @@ export enum RouteUrls {
   LedgerPublicKeyMismatch = 'wrong-ledger-device',
   LedgerDevicePayloadInvalid = 'ledger-payload-invalid',
   LedgerUnsupportedBrowser = 'unsupported-browser',
+  LedgerOutdatedAppWarning = 'outdated-app-warning',
 
   TransactionBroadcastError = 'broadcast-error',
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3159223297).<!-- Sticky Header Marker -->

This PR adds a warning flow when a user is signing a transaction if their app is below that of the one where the [contract principal bug](https://github.com/Zondax/ledger-stacks/issues/119) was fixed.

The warning is added as a separate drawer step, and deep links the user to Ledger Live.

I've added a promise helper utility that creates a new promise that simply waits until a resolve is called. This is needed to delay the async method, but not cancel it in case the user wishes to proceed without updating.

https://user-images.githubusercontent.com/1618764/193041676-7f95efea-9154-4234-93e8-80e7ef20a806.mp4

