### PR TITLE
fix: edit nonce to zero

### DIFF
--- a/src/app/components/drawer/controlled-drawer.tsx
+++ b/src/app/components/drawer/controlled-drawer.tsx
@@ -3,16 +3,17 @@ import { ReactNode } from 'react';
 import { BaseDrawer } from './base-drawer';
 
 interface ControlledDrawerProps {
+  children?: ReactNode;
   enableGoBack?: boolean;
   icon?: JSX.Element;
-  children?: ReactNode;
   isShowing: boolean;
   onClose(): void;
+  pauseOnClickOutside?: boolean;
   title?: string;
 }
 // The visibility of this drawer is controlled by an atom
 export function ControlledDrawer(props: ControlledDrawerProps) {
-  const { enableGoBack, children, icon, isShowing, onClose, title } = props;
+  const { children, enableGoBack, icon, isShowing, onClose, pauseOnClickOutside, title } = props;
 
   return (
     <BaseDrawer
@@ -20,6 +21,7 @@ export function ControlledDrawer(props: ControlledDrawerProps) {
       icon={icon}
       isShowing={isShowing}
       onClose={onClose}
+      pauseOnClickOutside={pauseOnClickOutside}
       title={title}
     >
       {children}

--- a/src/app/features/edit-nonce-drawer/edit-nonce-drawer.tsx
+++ b/src/app/features/edit-nonce-drawer/edit-nonce-drawer.tsx
@@ -63,7 +63,12 @@ export function EditNonceDrawer() {
   }, [customNonce, setFieldError, setFieldValue, setShowEditNonce, values.nonce]);
 
   return (
-    <ControlledDrawer title="Edit nonce" isShowing={!!showEditNonce} onClose={onClose}>
+    <ControlledDrawer
+      isShowing={!!showEditNonce}
+      onClose={onClose}
+      pauseOnClickOutside
+      title="Edit nonce"
+    >
       <Stack px="loose" spacing="loose" pb="extra-loose">
         <CustomFeeMessaging />
         {showEditNonce && <EditNonceForm onBlur={onBlur} onClose={onClose} onSubmit={onSubmit} />}

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-details.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-details.tsx
@@ -10,11 +10,10 @@ import { SendFormSelectors } from '@tests/page-objects/send-form.selectors';
 interface SendTokensConfirmDetailsProps extends StackProps {
   amount: number | string;
   assetId: string;
-  nonce?: number;
   recipient: string;
 }
 export function SendTokensConfirmDetails(props: SendTokensConfirmDetailsProps): JSX.Element {
-  const { amount, assetId, nonce, recipient, ...rest } = props;
+  const { amount, assetId, recipient, ...rest } = props;
   const { selectedAsset, ticker } = useSelectedAsset(assetId);
   const currentAccount = useCurrentAccount();
   const icon = iconStringForAsset(selectedAsset);

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
@@ -15,6 +15,7 @@ import { SendTokensConfirmDetails } from './send-tokens-confirm-details';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { SendFormValues } from '@app/common/transactions/transaction-utils';
 import { StacksTransaction } from '@stacks/transactions';
+import { microStxToStx } from '@stacks/ui-utils';
 
 interface SendTokensSoftwareConfirmDrawerProps extends BaseDrawerProps {
   onUserSelectBroadcastTransaction(tx: StacksTransaction | undefined): void;
@@ -22,7 +23,7 @@ interface SendTokensSoftwareConfirmDrawerProps extends BaseDrawerProps {
 export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirmDrawerProps) {
   const { isShowing, onClose, onUserSelectBroadcastTransaction } = props;
   const { values } = useFormikContext<SendFormValues>();
-  const transaction = useSendFormUnsignedTxPreviewState(values.assetId, values);
+  const unsignedTransaction = useSendFormUnsignedTxPreviewState(values.assetId, values);
   const analytics = useAnalytics();
   const { showEditNonce } = useDrawers();
 
@@ -31,7 +32,7 @@ export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirm
     void analytics.track('view_transaction_signing');
   }, [isShowing, analytics]);
 
-  if (!isShowing || !transaction || !values) return null;
+  if (!isShowing || !unsignedTransaction || !values) return null;
 
   return (
     <BaseDrawer
@@ -40,22 +41,27 @@ export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirm
       onClose={onClose}
       pauseOnClickOutside={showEditNonce}
     >
-      <Stack pb="extra-loose" px="loose" spacing="loose">
+      <Stack pb="extra-loose" px="loose" spacing="base">
         <SendTokensConfirmDetails
           amount={values.amount}
           assetId={values.assetId}
           recipient={values.recipient}
-          nonce={Number(transaction?.auth.spendingCondition?.nonce)}
         />
         <SpaceBetween>
           <Caption>Fees</Caption>
           <Caption>
-            <TransactionFee fee={values.fee} />
+            <TransactionFee
+              fee={microStxToStx(Number(unsignedTransaction.auth.spendingCondition.fee))}
+            />
           </Caption>
         </SpaceBetween>
+        <SpaceBetween>
+          <Caption>Nonce</Caption>
+          <Caption>{Number(unsignedTransaction.auth.spendingCondition.nonce)}</Caption>
+        </SpaceBetween>
         <SendTokensConfirmActions
-          transaction={transaction}
-          onUserConfirmBroadcast={() => onUserSelectBroadcastTransaction(transaction)}
+          transaction={unsignedTransaction}
+          onUserConfirmBroadcast={() => onUserSelectBroadcastTransaction(unsignedTransaction)}
         />
       </Stack>
     </BaseDrawer>

--- a/src/app/store/transactions/token-transfer.hooks.ts
+++ b/src/app/store/transactions/token-transfer.hooks.ts
@@ -59,7 +59,7 @@ export function useGenerateStxTokenTransferUnsignedTx() {
 
       const options: GenerateUnsignedTransactionOptions = {
         publicKey: account.stxPublicKey,
-        nonce: Number(values?.nonce) || nonce,
+        nonce: Number(values?.nonce) ?? nonce,
         fee: stxToMicroStx(values?.fee || 0).toNumber(),
         txData: {
           txType: TransactionTypes.STXTransfer,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3160675560).<!-- Sticky Header Marker -->

This PR fixes an edge case where a user skips the zero nonce tx and tries to go back and edit the nonce to zero. There was a bug happening when generating the unsigned tx the next suggested nonce was replacing the input value. Also, a nonce detail was added to the confirmation modal so the user can see the nonce they are signing.

![Screen Shot 2022-09-29 at 7 10 55 PM](https://user-images.githubusercontent.com/6493321/193165271-65f39144-63a6-4804-8284-6bab2d85b7d8.png)

EDIT: Maybe nonce should be listed here first? @markmhx 

cc/ @kyranjamie @fbwoolf
