### PR TITLE
fix(ledger): mismatching public key

### DIFF
--- a/src/app/features/ledger/flows/message-signing/ledger-sign-msg-container.tsx
+++ b/src/app/features/ledger/flows/message-signing/ledger-sign-msg-container.tsx
@@ -23,6 +23,7 @@ import { finalizeMessageSignature } from '@shared/actions/finalize-message-signa
 import { useLedgerNavigate } from '../../hooks/use-ledger-navigate';
 import { useLedgerAnalytics } from '../../hooks/use-ledger-analytics.hook';
 import { LedgerMessageSigningContext, LedgerMsgSigningProvider } from './ledger-sign-msg.context';
+import { useVerifyMatchingLedgerPublicKey } from '../../hooks/use-verify-matching-public-key';
 
 export function LedgerSignMsgContainer() {
   useScrollLock(true);
@@ -33,6 +34,7 @@ export function LedgerSignMsgContainer() {
   const ledgerAnalytics = useLedgerAnalytics();
   const message = useLocationStateWithCache('message');
   const account = useCurrentAccount();
+  const verifyLedgerPublicKey = useVerifyMatchingLedgerPublicKey();
   const { tabId, requestToken } = useSignatureRequestSearchParams();
 
   const [latestDeviceResponse, setLatestDeviceResponse] = useLedgerResponseState();
@@ -62,8 +64,8 @@ export function LedgerSignMsgContainer() {
       return;
     }
 
-    ledgerNavigate.toDeviceBusyStep(`Sending message to Ledger`);
-    await delay(1000);
+    ledgerNavigate.toDeviceBusyStep(`Verifying public key on Ledger…`);
+    await verifyLedgerPublicKey(stacksApp);
 
     try {
       ledgerNavigate.toConnectionSuccessStep();

--- a/src/app/features/ledger/flows/request-keys/request-keys.utils.ts
+++ b/src/app/features/ledger/flows/request-keys/request-keys.utils.ts
@@ -1,24 +1,13 @@
 import { delay } from '@app/common/utils';
 import * as secp from '@noble/secp256k1';
 import { logger } from '@shared/logger';
-import { AddressVersion } from '@stacks/transactions';
 import StacksApp from '@zondax/ledger-stacks';
 
 import {
   getIdentityDerivationPath,
-  getStxDerivationPath,
+  requestPublicKeyForStxAccount,
   StxAndIdentityPublicKeys,
 } from '../../ledger-utils';
-
-function requestPublicKeyForStxAccount(app: StacksApp) {
-  return async (index: number) =>
-    app.getAddressAndPubKey(
-      getStxDerivationPath(index),
-      // We pass mainnet as it expects something, however this is so it can return a formatted address
-      // We only need the public key, and can derive the address later in any network format
-      AddressVersion.MainnetSingleSig
-    );
-}
 
 function requestPublicKeyForIdentityAccount(app: StacksApp) {
   return async (index: number) => app.getIdentityPubKey(getIdentityDerivationPath(index));

--- a/src/app/features/ledger/flows/tx-signing/ledger-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/tx-signing/ledger-sign-tx-container.tsx
@@ -28,6 +28,7 @@ import { logger } from '@shared/logger';
 
 import { useLedgerNavigate } from '../../hooks/use-ledger-navigate';
 import { useLedgerAnalytics } from '../../hooks/use-ledger-analytics.hook';
+import { useVerifyMatchingLedgerPublicKey } from '../../hooks/use-verify-matching-public-key';
 
 export function LedgerSignTxContainer() {
   const location = useLocation();
@@ -38,7 +39,7 @@ export function LedgerSignTxContainer() {
   const account = useCurrentAccount();
   const hwWalletTxBroadcast = useBroadcastTransaction();
   const canUserCancelAction = useActionCancellableByUser();
-
+  const verifyLedgerPublicKey = useVerifyMatchingLedgerPublicKey();
   const [unsignedTransaction, setUnsignedTransaction] = useState<null | string>(null);
 
   const hasUserSkippedBuggyAppWarning = useMemo(() => createWaitForUserToSeeWarningScreen(), []);
@@ -88,8 +89,8 @@ export function LedgerSignTxContainer() {
       }
     }
 
-    ledgerNavigate.toDeviceBusyStep('Verifying public key from Ledger…');
-    await delay(1000);
+    ledgerNavigate.toDeviceBusyStep('Verifying public key on Ledger…');
+    await verifyLedgerPublicKey(stacksApp);
 
     try {
       ledgerNavigate.toConnectionSuccessStep();

--- a/src/app/features/ledger/hooks/use-verify-matching-public-key.ts
+++ b/src/app/features/ledger/hooks/use-verify-matching-public-key.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import StacksApp from '@zondax/ledger-stacks';
+
+import { useCurrentAccount } from '@app/store/accounts/account.hooks';
+import { requestPublicKeyForStxAccount } from '../ledger-utils';
+import { useLedgerNavigate } from './use-ledger-navigate';
+
+export function useVerifyMatchingLedgerPublicKey() {
+  const account = useCurrentAccount();
+  const ledgerNavigate = useLedgerNavigate();
+
+  return useCallback(
+    async (stacksApp: StacksApp) => {
+      if (!account) return;
+      const { publicKey } = await requestPublicKeyForStxAccount(stacksApp)(account.index);
+      if (publicKey.toString('hex') !== account.stxPublicKey) {
+        ledgerNavigate.toPublicKeyMismatchStep();
+        throw new Error('Mismatching public keys');
+      }
+    },
+    [account, ledgerNavigate]
+  );
+}

--- a/src/app/features/ledger/ledger-utils.ts
+++ b/src/app/features/ledger/ledger-utils.ts
@@ -4,6 +4,7 @@ import StacksApp, { LedgerError, ResponseVersion } from '@zondax/ledger-stacks';
 import { compare } from 'compare-versions';
 
 import {
+  AddressVersion,
   createMessageSignature,
   deserializeTransaction,
   SingleSigSpendingCondition,
@@ -28,12 +29,21 @@ function getAccountIndexFromDerivationPathFactory(derivationPath: string) {
   return (account: number) => derivationPath.replace('{account}', account.toString());
 }
 
-export const getStxDerivationPath =
-  getAccountIndexFromDerivationPathFactory(stxDerivationWithAccount);
+const getStxDerivationPath = getAccountIndexFromDerivationPathFactory(stxDerivationWithAccount);
 
 export const getIdentityDerivationPath = getAccountIndexFromDerivationPathFactory(
   identityDerivationWithAccount
 );
+
+export function requestPublicKeyForStxAccount(app: StacksApp) {
+  return async (index: number) =>
+    app.getAddressAndPubKey(
+      getStxDerivationPath(index),
+      // We pass mainnet as it expects something, however this is so it can return a formatted address
+      // We only need the public key, and can derive the address later in any network format
+      AddressVersion.MainnetSingleSig
+    );
+}
 
 export interface StxAndIdentityPublicKeys {
   stxPublicKey: string;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3180303011).<!-- Sticky Header Marker -->

This fixes issue where we don't drive the user to the public key mismatch error. The page exists, but we never route there.

Previously, the implementation reacted on an error msg stating the keys mismatched. Now, we proactively check.