### PR TITLE
fix: hide menu in send form

### DIFF
--- a/src/app/pages/send-tokens/send-tokens.tsx
+++ b/src/app/pages/send-tokens/send-tokens.tsx
@@ -52,7 +52,7 @@ function SendTokensFormBase() {
   const { whenWallet } = useWalletType();
   const ledgerNavigate = useLedgerNavigate();
 
-  useRouteHeader(<Header title="Send" onClose={() => navigate(RouteUrls.Home)} />);
+  useRouteHeader(<Header hideActions title="Send" onClose={() => navigate(RouteUrls.Home)} />);
 
   useEffect(() => {
     if (showNetworks) navigate(RouteUrls.Home);

--- a/tests/integration/send-tokens/send-tokens.spec.ts
+++ b/tests/integration/send-tokens/send-tokens.spec.ts
@@ -41,7 +41,8 @@ describe(`Send tokens flow`, () => {
   });
 
   describe('Set max button', () => {
-    it('does not set a fee below zero, when the account balance is 0 STX', async () => {
+    // Skipping while we hide the settings menu on the send form
+    it.skip('does not set a fee below zero, when the account balance is 0 STX', async () => {
       await walletPage.clickSettingsButton();
       await walletPage.page.click(createTestSelector(SettingsSelectors.SwitchAccount));
       await walletPage.page.click(createTestSelector('switch-account-item-1'));


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3175956666).<!-- Sticky Header Marker -->

This PR hides the settings menu on the send form as a temporary solution to prevent switching accounts while on the send form. This will be revisited again when we refactor the send form during bitcoin integration.

cc/ @kyranjamie @fbwoolf
