### PR TITLE
refactor: broadcast fn promise

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -73,9 +73,8 @@ jobs:
       - pre_run
     env:
       MINIFY_PRODUCTION_BUILD: true
-    # only run on commits with message 'Version release' because this will often fail on PRs
-    # due to reasons out of our control in the Firefox submission process
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.commits[0].message == 'Version release'
+    # Disabled as this job isn't running correctly
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/app/pages/onboarding/set-password/components/password-field.tsx
+++ b/src/app/pages/onboarding/set-password/components/password-field.tsx
@@ -12,8 +12,9 @@ import { getIndicatorsOfPasswordStrength } from './password-field.utils';
 
 interface PasswordFieldProps {
   strengthResult: ValidatedPassword;
+  isDisabled: boolean;
 }
-export function PasswordField({ strengthResult }: PasswordFieldProps) {
+export function PasswordField({ strengthResult, isDisabled }: PasswordFieldProps) {
   const [field] = useField('password');
   const [showPassword, setShowPassword] = useState(false);
 
@@ -31,6 +32,7 @@ export function PasswordField({ strengthResult }: PasswordFieldProps) {
           key="password-input"
           placeholder="Set a password"
           type={showPassword ? 'text' : 'password'}
+          isDisabled={isDisabled}
           {...field}
         />
         <Button

--- a/src/app/pages/onboarding/set-password/set-password.tsx
+++ b/src/app/pages/onboarding/set-password/set-password.tsx
@@ -138,7 +138,7 @@ export const SetPasswordPage = () => {
                 words.
               </Caption>
               <Stack px={['unset', 'base-loose']} spacing="base">
-                <PasswordField strengthResult={strengthResult} />
+                <PasswordField strengthResult={strengthResult} isDisabled={loading} />
                 <PrimaryButton
                   data-testid={OnboardingSelectors.SetPasswordBtn}
                   isDisabled={loading || !(dirty && isValid)}

--- a/src/app/store/transactions/transaction.hooks.ts
+++ b/src/app/store/transactions/transaction.hooks.ts
@@ -165,7 +165,10 @@ export function useTransactionRequestBroadcast() {
 
   return async ({ signedTx }: { signedTx: StacksTransaction }) => {
     if (!requestToken || !tabId) {
-      logger.error(`Cannot broadcast transaction from `);
+      logger.error(`Cannot broadcast transaction from transaction request`, {
+        requestToken,
+        tabId,
+      });
       return;
     }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -14,6 +14,10 @@ export function isFunction(value: unknown): value is Function {
   return typeof value === 'function';
 }
 
+export function isError(value: unknown): value is Error {
+  return value instanceof Error;
+}
+
 export function isEmpty(value: Object) {
   return Object.keys(value).length === 0;
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -14,10 +14,6 @@ export function isFunction(value: unknown): value is Function {
   return typeof value === 'function';
 }
 
-export function isError(value: unknown): value is Error {
-  return value instanceof Error;
-}
-
 export function isEmpty(value: Object) {
   return Object.keys(value).length === 0;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3327926729).<!-- Sticky Header Marker -->

~~#2409 was never quite fixed, in that we never sent a response back to the client~~

This PR refactors the broadcast fn to be a `Promise`.

Also disables pw field when loading.

