### PR TITLE
fix: path url trailing slash

### DIFF
--- a/src/app/common/url-join.ts
+++ b/src/app/common/url-join.ts
@@ -1,0 +1,3 @@
+export function removeTrailingSlash(path: string) {
+  return path.replace(/\/+$/, '');
+}

--- a/src/app/pages/add-network/add-network.tsx
+++ b/src/app/pages/add-network/add-network.tsx
@@ -19,6 +19,7 @@ import {
   useCurrentStacksNetworkState,
   useNetworksActions,
 } from '@app/store/networks/networks.hooks';
+import { removeTrailingSlash } from '@app/common/url-join';
 
 interface AddNetworkFormValues {
   key: string;
@@ -49,7 +50,7 @@ export const AddNetwork = () => {
           setLoading(true);
           setError('');
           try {
-            const path = new URL(url).href;
+            const path = removeTrailingSlash(new URL(url).href);
             const response = await network.fetchFn(`${path}/v2/info`);
             const chainInfo = await response.json();
             const networkId = chainInfo?.network_id && parseInt(chainInfo?.network_id);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3191187938).<!-- Sticky Header Marker -->

This PR fixes a `//` in the url path when creating a new network.

cc/ @kyranjamie @fbwoolf
