### PR TITLE
fix: simulated fee estimations

### DIFF
--- a/src/app/query/stacks/fees/fees.hooks.ts
+++ b/src/app/query/stacks/fees/fees.hooks.ts
@@ -49,6 +49,16 @@ function useFeeEstimationsMinValues() {
   return configFeeEstimationsMinValues || defaultFeesMinValues;
 }
 
+function feeEstimationQueryFailedSilently(
+  feeEstimationResult: UseQueryResult<TransactionFeeEstimation, Error>
+) {
+  return !!(
+    feeEstimationResult.data &&
+    !feeEstimationResult.isLoading &&
+    (!!feeEstimationResult?.error || !feeEstimationResult.data.estimations?.length)
+  );
+}
+
 export function useFeeEstimations(txByteLength: number | null, txPayload: string) {
   const feeEstimationsMaxValues = useFeeEstimationsMaxValues();
   const feeEstimationsMinValues = useFeeEstimationsMinValues();
@@ -61,7 +71,7 @@ export function useFeeEstimations(txByteLength: number | null, txPayload: string
     if (!isLoading && isError) {
       return { estimates: defaultFeeEstimations, calculation: FeeCalculationType.Default };
     }
-    if (!isLoading && (!!txFeeEstimation?.error || !feeEstimations?.length) && txByteLength) {
+    if (txByteLength && feeEstimationQueryFailedSilently(result)) {
       return {
         estimates: getDefaultSimulatedFeeEstimations(txByteLength),
         calculation: FeeCalculationType.DefaultSimulated,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3250446325).<!-- Sticky Header Marker -->

This PR fixes the simulated fees loading in the UI before the capped api fee estimations.