### PR TITLE
fix: no fallback when no gaia profile found

### DIFF
--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -21,12 +21,17 @@ const deriveWalletWithAccounts = memoize(async (secretKey: string, highestAccoun
   // method. This does the same as the catch case, with the addition that it will
   // also try and fetch usernames associated with an account
   try {
-    return restoreWalletAccounts({ wallet, gaiaHubUrl: gaiaUrl, network: new StacksMainnet() });
+    return await restoreWalletAccounts({
+      wallet,
+      gaiaHubUrl: gaiaUrl,
+      network: new StacksMainnet(),
+    });
   } catch (e) {
     // To generate a new account, the wallet-sdk requires the entire `Wallet` to
     // be supplied so that it can count the `wallet.accounts[]` length, and return
     // a new `Wallet` object with all the accounts. As we want to generate them
     // all, we must set the updated value and read it again in the loop
+    logger.warn('Falling back to manual account generation without Gaia.');
     let walWithAccounts = wallet;
     for (let i = 0; i < highestAccountIndex; i++) {
       walWithAccounts = generateNewAccount(walWithAccounts);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3249140133).<!-- Sticky Header Marker -->

TIL you need to `return await` if you want to hit the catch  block

<img width="848" alt="image" src="https://user-images.githubusercontent.com/1618764/195820602-24b325da-a553-44ca-87e1-abd5c390f705.png">
