### PR TITLE
fix: menu items casing

### DIFF
--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -77,7 +77,7 @@ export function SettingsDropdown() {
                     setHasCreatedAccount(true);
                   })}
                 >
-                  Create an Account
+                  Create an account
                 </MenuItem>
                 <MenuItem
                   data-testid={SettingsSelectors.ViewSecretKeyListItem}
@@ -98,7 +98,7 @@ export function SettingsDropdown() {
               })}
             >
               <Flex width="100%" alignItems="center" justifyContent="space-between">
-                <Box>Change Network</Box>
+                <Box>Change network</Box>
                 <Caption data-testid={SettingsSelectors.CurrentNetwork}>{currentNetworkId}</Caption>
               </Flex>
             </MenuItem>
@@ -123,7 +123,7 @@ export function SettingsDropdown() {
               })}
               data-testid="settings-sign-out"
             >
-              Sign Out
+              Sign out
             </MenuItem>
           </MenuWrapper>
         )}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3274875022).<!-- Sticky Header Marker -->

Sets the menu items to sentence case.

Fixes https://github.com/hirosystems/stacks-wallet-web/issues/2698

![image](https://user-images.githubusercontent.com/116000646/196479417-50d95ea7-92b9-4203-8a0d-f082c115febb.png)
