### PR TITLE
fix: send form loading ui

### DIFF
--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -97,7 +97,6 @@ export const Header: React.FC<HeaderProps> = memo(props => {
           fontSize="16px"
           fontWeight={500}
           lineHeight="24px"
-          pr={hideActions ? '36px' : 'unset'}
           textAlign="center"
           {...rest}
         >

--- a/src/app/components/loading-spinner.tsx
+++ b/src/app/components/loading-spinner.tsx
@@ -13,7 +13,15 @@ export function LoadingSpinner(props: FlexProps) {
 
 export function FullPageLoadingSpinner(props: FlexProps) {
   return (
-    <Flex height="100vh" {...props}>
+    <Flex height="100vh" width="100%" {...props}>
+      <LoadingSpinner />
+    </Flex>
+  );
+}
+
+export function FullPageWithHeaderLoadingSpinner(props: FlexProps) {
+  return (
+    <Flex height="calc(100vh - 68px)" width="100%" {...props}>
       <LoadingSpinner />
     </Flex>
   );

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -4,7 +4,7 @@ import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-
 import { RouteUrls } from '@shared/route-urls';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { Container } from '@app/features/container/container';
-import { LoadingSpinner } from '@app/components/loading-spinner';
+import { FullPageWithHeaderLoadingSpinner, LoadingSpinner } from '@app/components/loading-spinner';
 import { MagicRecoveryCode } from '@app/pages/onboarding/magic-recovery-code/magic-recovery-code';
 import { ChooseAccount } from '@app/pages/choose-account/choose-account';
 import { TransactionRequest } from '@app/pages/transaction-request/transaction-request';
@@ -137,7 +137,7 @@ export function AppRoutes() {
           path={RouteUrls.Send}
           element={
             <AccountGate>
-              <Suspense fallback={<LoadingSpinner />}>
+              <Suspense fallback={<FullPageWithHeaderLoadingSpinner />}>
                 <SendTokensForm />
               </Suspense>
             </AccountGate>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3292362827).<!-- Sticky Header Marker -->

Noticed the loading spinner on our send form was rendering high on the page and the header title was off-center. Also, no width had been applied to our full page spinner so in our popup it rendered to the left side.

This PR fixes the title being off-center and adds a full page spinner for pages that have our header.

![Screen Shot 2022-10-20 at 2 05 46 PM](https://user-images.githubusercontent.com/6493321/197040006-fcfd0ddb-82bc-427f-9c38-fabc560a1ea3.png)

![Screen Shot 2022-10-20 at 2 05 54 PM](https://user-images.githubusercontent.com/6493321/197040017-1c9e24f3-c0fd-4508-9039-c7e968ace500.png)
