### PR TITLE
fix: no suspense on market data query

### DIFF
--- a/src/app/query/common/market-data/market-data.query.ts
+++ b/src/app/query/common/market-data/market-data.query.ts
@@ -7,5 +7,4 @@ export const marketDataQueryOptions: UseQueryOptions = {
   refetchOnReconnect: false,
   refetchOnWindowFocus: false,
   refetchIntervalInBackground: false,
-  suspense: true,
 } as const;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3296458175).<!-- Sticky Header Marker -->

Failing API requests causes persistent suspense 