### PR TITLE
fix: throw on http error response

### DIFF
--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -12,6 +12,7 @@ import { DefaultNetworkModes, KEBAB_REGEX, NetworkModes } from '@shared/constant
 import { WalletBlockchains, WalletChainTypes } from '@shared/models/blockchain.model';
 
 import { AssetWithMeta } from './asset-types';
+import { logger } from '@shared/logger';
 
 function kebabCase(str: string) {
   return str.replace(KEBAB_REGEX, match => '-' + match.toLowerCase());
@@ -302,6 +303,7 @@ export function sumNumbers(nums: number[]) {
   return nums.reduce((acc, num) => acc.plus(num), new BigNumber(0));
 }
 
-export async function fetchJson(request: RequestInfo | URL) {
-  return fetch(request).then(resp => resp.json());
+export function logAndThrow(msg: string, args: any[] = []) {
+  logger.error(msg, ...args);
+  throw new Error(msg);
 }

--- a/src/app/components/fee-row/components/transaction-fee.tsx
+++ b/src/app/components/fee-row/components/transaction-fee.tsx
@@ -11,6 +11,6 @@ export function TransactionFee({ fee, usdAmount }: TransactionFeeProps) {
   const feeLabel = (
     <span data-testid={TransactionSigningSelectors.FeeToBePaidLabel}>{fee} STX</span>
   );
-  if (!usdAmount) return feeLabel;
+  if (!usdAmount || usdAmount.amount.isNaN()) return feeLabel;
   return <Tooltip label={formatDustUsdAmounts(i18nFormatCurrency(usdAmount))}>{feeLabel}</Tooltip>;
 }

--- a/src/app/query/common/market-data/vendors/binance-market-data.query.ts
+++ b/src/app/query/common/market-data/vendors/binance-market-data.query.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { logAndThrow } from '@app/common/utils';
 import { CryptoCurrencies } from '@shared/models/currencies.model';
-import { fetchJson } from '@app/common/utils';
 import { marketDataQueryOptions } from '../market-data.query';
 
-function fetchBinanceMarketData(currency: CryptoCurrencies) {
-  return fetchJson(`https://api1.binance.com/api/v3/ticker/price?symbol=${currency}USDT`);
+async function fetchBinanceMarketData(currency: CryptoCurrencies) {
+  const resp = await fetch(`https://api1.binance.com/api/v3/ticker/price?symbol=${currency}USDT`);
+  if (!resp.ok) logAndThrow('Cannot load binance data');
+  return resp.json();
 }
 
 export function selectBinanceUsdPrice(resp: any) {

--- a/src/app/query/common/market-data/vendors/coincap-market-data.query.ts
+++ b/src/app/query/common/market-data/vendors/coincap-market-data.query.ts
@@ -1,15 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchJson } from '@app/common/utils';
 import { CryptoCurrencies } from '@shared/models/currencies.model';
 import { marketDataQueryOptions } from '../market-data.query';
+import { logAndThrow } from '@app/common/utils';
 
 const currencyNameMap: Record<CryptoCurrencies, string> = {
   STX: 'stacks',
 };
 
-function fetchCoincapMarketData(currency: CryptoCurrencies) {
-  return fetchJson(`https://api.coincap.io/v2/assets/${currencyNameMap[currency]}`);
+async function fetchCoincapMarketData(currency: CryptoCurrencies) {
+  const resp = await fetch(`https://api.coincap.io/v2/assets/${currencyNameMap[currency]}`);
+  if (!resp.ok) logAndThrow('Cannot load coincap data');
+  return resp.json();
 }
 
 export function selectCoincapUsdPrice(resp: any) {

--- a/src/app/query/common/market-data/vendors/coingecko-market-data.query.ts
+++ b/src/app/query/common/market-data/vendors/coingecko-market-data.query.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchJson } from '@app/common/utils';
+import { logAndThrow } from '@app/common/utils';
 import { CryptoCurrencies } from '@shared/models/currencies.model';
 import { marketDataQueryOptions } from '../market-data.query';
 
@@ -8,10 +8,12 @@ const currencyNameMap: Record<CryptoCurrencies, string> = {
   STX: 'blockstack',
 };
 
-function fetchCoingeckoMarketData(currency: CryptoCurrencies) {
-  return fetchJson(
+async function fetchCoingeckoMarketData(currency: CryptoCurrencies) {
+  const resp = await fetch(
     `https://api.coingecko.com/api/v3/simple/price?ids=${currencyNameMap[currency]}&vs_currencies=usd`
   );
+  if (!resp.ok) logAndThrow('Cannot load coingecko data');
+  return resp.json();
 }
 
 export function selectCoingeckoUsdPrice(resp: any) {

--- a/src/shared/workers/decryption-worker.ts
+++ b/src/shared/workers/decryption-worker.ts
@@ -18,7 +18,7 @@ async function generateEncryptionKey({ password, salt }: GenerateEncryptionKeyAr
     type: ArgonType.Argon2id,
   });
   const y = performance.now();
-  logger.info({ keyStretchDuration: (y - x) / 1000 + ' seconds' });
+  logger.info('keyStretchDuration', (y - x) / 1000 + ' seconds');
   return argonHash.hashHex;
 }
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3311436547).<!-- Sticky Header Marker -->

Better `NaN` handing for fiat conversions. Explicit error handling for failed market data responses.