### PR TITLE
chore: prevent vercel msgs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3311502037).<!-- Sticky Header Marker -->

Silences github comment from Vercel. Anyone object to this? We seldom make changes to the test app, which it deploys. I get spammed with useless vercel gh notifications. 

https://vercel.com/guides/how-to-prevent-vercel-github-comments