### PR TITLE
fix: padding on switch account modal

### DIFF
--- a/src/app/components/account/account-list-item-layout.tsx
+++ b/src/app/components/account/account-list-item-layout.tsx
@@ -30,12 +30,14 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
 
   return (
     <Flex
-      width="100%"
       key={`account-${account.index}`}
       data-testid={SettingsSelectors.AccountIndex.replace('[index]', `${account.index}`)}
       cursor="pointer"
       position="relative"
       onClick={onSelectAccount}
+      marginLeft="24px"
+      marginRight="24px"
+      marginBottom="24px"
       {...rest}
     >
       <Stack isInline alignItems="center" spacing="base">
@@ -51,7 +53,7 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
       {isLoading && (
         <Spinner
           position="absolute"
-          right="12px"
+          right="0px"
           top="calc(50% - 8px)"
           color={color('text-caption')}
           size="18px"
@@ -60,7 +62,7 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
       {isActive && (
         <Box
           position="absolute"
-          right="12px"
+          right="0px"
           top="calc(50% - 8px)"
           as={IconCheck}
           size="18px"

--- a/src/app/features/switch-account-drawer/components/switch-account-list.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list.tsx
@@ -3,7 +3,6 @@ import { Virtuoso } from 'react-virtuoso';
 
 import { AccountWithAddress } from '@app/store/accounts/account.models';
 import { SwitchAccountListItem } from './switch-account-list-item';
-import { Box } from '@stacks/ui';
 
 const smallNumberOfAccountsToRenderWholeList = 10;
 
@@ -32,12 +31,10 @@ export const SwitchAccountList = memo(
       <Virtuoso
         initialTopMostItemIndex={currentAccountIndex}
         height="72px"
-        style={{ paddingTop: '24px', height: '70vh' }}
+        style={{ height: '70vh' }}
         totalCount={accounts.length}
         itemContent={index => (
-          <Box mx="extra-loose">
-            <SwitchAccountListItem handleClose={handleClose} account={accounts[index]} />
-          </Box>
+          <SwitchAccountListItem handleClose={handleClose} account={accounts[index]} />
         )}
       />
     );


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3330111615).<!-- Sticky Header Marker -->

Items are padded nicely, both when the user has a few and many accounts.

Fixes https://github.com/hirosystems/stacks-wallet-web/issues/2751