### PR TITLE
fix: tooltip label

### DIFF
--- a/src/app/pages/home/components/account-area.tsx
+++ b/src/app/pages/home/components/account-area.tsx
@@ -27,7 +27,7 @@ const AccountBnsAddress = memo(() => {
   return (
     <>
       <Caption>{bnsName}</Caption>
-      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy BNS address'}>
+      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy BNS name'}>
         <Stack>
           <Box
             _hover={{ cursor: 'pointer' }}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3339091877).<!-- Sticky Header Marker -->

Updates to tooltip text to reflect that what is being copied is a name, not an address.