### PR TITLE
fix: padding on switch acct list, closes #2751

### DIFF
--- a/src/app/features/switch-account-drawer/components/switch-account-list.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list.tsx
@@ -18,11 +18,13 @@ export const SwitchAccountList = memo(
       return (
         <>
           {accounts.map(account => (
-            <SwitchAccountListItem
-              handleClose={handleClose}
-              account={account}
-              key={account.address}
-            />
+            <Box mx="extra-loose">
+              <SwitchAccountListItem
+                handleClose={handleClose}
+                account={account}
+                key={account.address}
+              />
+            </Box>
           ))}
         </>
       );


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3359447252).<!-- Sticky Header Marker -->

<img width="629" alt="image" src="https://user-images.githubusercontent.com/1618764/198955815-1de106b0-df5f-49e2-93bd-2a6ab8b4a9a8.png">

Padding fixed for accounts that have < 10 accounts.