### PR TITLE
fix: reintroduces usd amounts

### DIFF
--- a/src/app/common/money/calculate-money.spec.ts
+++ b/src/app/common/money/calculate-money.spec.ts
@@ -1,0 +1,40 @@
+import { createMarketData, createMarketPair, MarketData } from '@shared/models/market.model';
+import { createMoney, createMoneyFromDecimal } from '@shared/models/money.model';
+import BigNumber from 'bignumber.js';
+import { baseCurrencyAmountInQuote, convertAmountToFractionalUnit } from './calculate-money';
+
+const tenMicroStx = createMoney(10, 'STX');
+const tenStx = createMoneyFromDecimal(10, 'STX');
+
+const mockWrongMarketData = {
+  pair: createMarketPair('BTC' as any, 'USD'),
+  price: createMoneyFromDecimal(1, 'EUR' as any, 2),
+} as MarketData;
+
+const mockAccurateStxMarketData = createMarketData(
+  createMarketPair('STX', 'USD'),
+  createMoneyFromDecimal(0.3, 'USD')
+);
+
+describe(baseCurrencyAmountInQuote.name, () => {
+  test('it throw when passed mismatching currencies', () =>
+    expect(() => baseCurrencyAmountInQuote(tenMicroStx, mockWrongMarketData)).toThrowError());
+
+  test('it converts currency small amounts accurately', () => {
+    const result = baseCurrencyAmountInQuote(tenMicroStx, mockAccurateStxMarketData);
+    expect(result.amount.toString()).toEqual('0.000003');
+  });
+
+  test('it converts currency amounts accurately', () => {
+    const result = baseCurrencyAmountInQuote(tenStx, mockAccurateStxMarketData);
+    expect(result.amount.toString()).toEqual('3');
+  });
+});
+
+describe(convertAmountToFractionalUnit.name, () => {
+  test('it converts a small decimal amount to a fractional unit', () =>
+    expect(convertAmountToFractionalUnit(new BigNumber(1), 2).toNumber()).toEqual(100));
+
+  test('it converts 99 as decimal amount to a fractional unit', () =>
+    expect(convertAmountToFractionalUnit(new BigNumber(99), 6).toNumber()).toEqual(99000000));
+});

--- a/src/app/common/money/calculate-money.ts
+++ b/src/app/common/money/calculate-money.ts
@@ -1,7 +1,10 @@
-import BigNumber from 'bignumber.js';
+import { BigNumber } from 'bignumber.js';
 
-import { createMoney, formatMoney, Money } from '@shared/models/money.model';
+import { createMoney, Money } from '@shared/models/money.model';
 import { formatMarketPair, MarketData } from '@shared/models/market.model';
+import { formatMoney } from './format-money';
+import { isMoney } from './is-money';
+import { isNumber } from '@shared/utils';
 
 export function baseCurrencyAmountInQuote(quantity: Money, { pair, price }: MarketData) {
   if (quantity.symbol !== pair.base)
@@ -11,5 +14,21 @@ export function baseCurrencyAmountInQuote(quantity: Money, { pair, price }: Mark
       )}`
     );
 
-  return createMoney(new BigNumber(quantity.amount).times(price.amount), pair.quote);
+  return createMoney(
+    convertAmountToBaseUnit(quantity).times(convertAmountToBaseUnit(price)),
+    pair.quote
+  );
+}
+
+export function convertAmountToFractionalUnit(num: Money | BigNumber, decimals?: number) {
+  if (isMoney(num)) return num.amount.shiftedBy(num.decimals);
+  if (!isNumber(decimals)) throw new Error('Must define decimal of given currency');
+  return num.shiftedBy(decimals);
+}
+
+// ts-unused-exports:disable-next-line
+export function convertAmountToBaseUnit(num: Money | BigNumber, decimals?: number) {
+  if (isMoney(num)) return num.amount.shiftedBy(-num.decimals);
+  if (!isNumber(decimals)) throw new Error('Must define decimal of given currency');
+  return num.shiftedBy(-decimals);
 }

--- a/src/app/common/money/format-money.ts
+++ b/src/app/common/money/format-money.ts
@@ -1,0 +1,16 @@
+import { Money } from '@shared/models/money.model';
+
+export function formatMoney({ amount, symbol }: Money) {
+  return `${amount.toString()} ${symbol}`;
+}
+
+export function i18nFormatCurrency(value: Money, locale = 'en-US') {
+  if (value.symbol !== 'USD') throw new Error('Cannot format non-USD amounts');
+  const formatCurrency = new Intl.NumberFormat(locale, { style: 'currency', currency: 'USD' });
+  return formatCurrency.format(value.amount.shiftedBy(-value.decimals).toNumber());
+}
+
+export function formatDustUsdAmounts(value: string) {
+  const thinSpace = ' ';
+  return value.endsWith('0.00') ? '<' + thinSpace + value.replace('0.00', '0.01') : value;
+}

--- a/src/app/common/money/is-money.ts
+++ b/src/app/common/money/is-money.ts
@@ -1,0 +1,7 @@
+import { Money } from '@shared/models/money.model';
+import { isObject } from '@shared/utils';
+
+export function isMoney(val: unknown): val is Money {
+  if (!isObject(val)) return false;
+  return 'amount' in val && 'symbol' in val && 'decimals' in val;
+}

--- a/src/app/components/account/account-active-checkmark.tsx
+++ b/src/app/components/account/account-active-checkmark.tsx
@@ -1,0 +1,18 @@
+import { Box, BoxProps, color } from '@stacks/ui';
+import { FiCheck as IconCheck } from 'react-icons/fi';
+
+interface AccountActiveCheckmarkProps extends BoxProps {
+  index: number;
+}
+export function AccountActiveCheckmark({ index, ...rest }: AccountActiveCheckmarkProps) {
+  return (
+    <Box
+      as={IconCheck}
+      size="18px"
+      color={color('brand')}
+      strokeWidth={2.5}
+      data-testid={`account-checked-${index}`}
+      {...rest}
+    />
+  );
+}

--- a/src/app/components/account/account-balance-caption.tsx
+++ b/src/app/components/account/account-balance-caption.tsx
@@ -1,14 +1,21 @@
 import { useMemo } from 'react';
-import { color } from '@stacks/ui';
+import { color, useMediaQuery } from '@stacks/ui';
 
 import { stacksValue } from '@app/common/stacks-utils';
 import { Caption, Text } from '@app/components/typography';
+import { baseCurrencyAmountInQuote } from '@app/common/money/calculate-money';
 import { Money } from '@shared/models/money.model';
+import { MarketData } from '@shared/models/market.model';
+import { formatDustUsdAmounts, i18nFormatCurrency } from '@app/common/money/format-money';
 
 interface AccountBalanceCaptionProps {
   availableBalance: Money;
+  marketData: MarketData;
 }
-export function AccountBalanceCaption({ availableBalance }: AccountBalanceCaptionProps) {
+export function AccountBalanceCaption({
+  availableBalance,
+  marketData,
+}: AccountBalanceCaptionProps) {
   const balance = useMemo(
     () =>
       stacksValue({
@@ -19,17 +26,29 @@ export function AccountBalanceCaption({ availableBalance }: AccountBalanceCaptio
     [availableBalance]
   );
 
+  const [hasSufficientLayoutWidth] = useMediaQuery('(min-width: 320px)');
+
+  const showFiatConversion =
+    availableBalance.amount.isGreaterThan(0) &&
+    marketData.price.amount.isPositive() &&
+    hasSufficientLayoutWidth;
+
   return (
     <>
       <Text color={color('text-caption')} fontSize="10px">
         •
       </Text>
       <Caption>{balance}</Caption>
-      {availableBalance.amount.isGreaterThan(0) && (
+      {showFiatConversion && hasSufficientLayoutWidth && (
         <>
           <Text color={color('text-caption')} fontSize="10px">
             •
           </Text>
+          <Caption>
+            {formatDustUsdAmounts(
+              i18nFormatCurrency(baseCurrencyAmountInQuote(availableBalance, marketData))
+            )}
+          </Caption>
         </>
       )}
     </>

--- a/src/app/components/account/account-list-item-layout.tsx
+++ b/src/app/components/account/account-list-item-layout.tsx
@@ -1,6 +1,6 @@
+import { AccountActiveCheckmark } from './account-active-checkmark';
 import { truncateMiddle } from '@stacks/ui-utils';
-import { Box, Stack, color, Spinner, StackProps, Flex } from '@stacks/ui';
-import { FiCheck as IconCheck } from 'react-icons/fi';
+import { Stack, color, Spinner, StackProps, Flex, useMediaQuery } from '@stacks/ui';
 
 import { SettingsSelectors } from '@tests/integration/settings.selectors';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
@@ -28,6 +28,8 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
     ...rest
   } = props;
 
+  const [isNarrowViewport] = useMediaQuery('(max-width: 400px)');
+
   return (
     <Flex
       width="100%"
@@ -41,9 +43,14 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
       <Stack isInline alignItems="center" spacing="base">
         {avatar}
         <Stack spacing="base-tight">
-          {accountName}
-          <Stack alignItems="center" spacing="6px" isInline>
-            <Caption>{truncateMiddle(account.address, 4)}</Caption>
+          <Flex>
+            {accountName}
+            {isActive && isNarrowViewport && (
+              <AccountActiveCheckmark index={account.index} ml="tight" />
+            )}
+          </Flex>
+          <Stack alignItems="center" spacing="6px" isInline whiteSpace="nowrap">
+            <Caption>{truncateMiddle(account.address, isNarrowViewport ? 3 : 4)}</Caption>
             {balanceLabel}
           </Stack>
         </Stack>
@@ -51,22 +58,18 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
       {isLoading && (
         <Spinner
           position="absolute"
-          right="12px"
+          right={0}
           top="calc(50% - 8px)"
           color={color('text-caption')}
           size="18px"
         />
       )}
-      {isActive && (
-        <Box
+      {isActive && !isNarrowViewport && (
+        <AccountActiveCheckmark
+          index={account.index}
           position="absolute"
-          right="12px"
+          right={0}
           top="calc(50% - 8px)"
-          as={IconCheck}
-          size="18px"
-          strokeWidth={2.5}
-          color={color('brand')}
-          data-testid={`account-checked-${account.index}`}
         />
       )}
       {children}

--- a/src/app/components/fee-row/components/transaction-fee.tsx
+++ b/src/app/components/fee-row/components/transaction-fee.tsx
@@ -1,7 +1,8 @@
 import { Tooltip } from '@stacks/ui';
 
 import { TransactionSigningSelectors } from '@tests/page-objects/transaction-signing.selectors';
-import { formatDustUsdAmounts, i18nFormatCurrency, Money } from '@shared/models/money.model';
+import { Money } from '@shared/models/money.model';
+import { formatDustUsdAmounts, i18nFormatCurrency } from '@app/common/money/format-money';
 
 interface TransactionFeeProps {
   fee: string | number;

--- a/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
@@ -10,14 +10,20 @@ import { AccountAvatarItem } from './account-avatar';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
 import { usePressable } from '@app/components/item-hover';
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
+import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
 
 interface AccountBalanceLabelProps {
   address: string;
 }
 const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
   const { data: balances } = useAddressBalances(address);
+  const stxMarketData = useStxMarketData();
+
   if (!balances) return null;
-  return <AccountBalanceCaption availableBalance={balances.availableStx} />;
+
+  return (
+    <AccountBalanceCaption availableBalance={balances.availableStx} marketData={stxMarketData} />
+  );
 });
 
 interface SwitchAccountListItemProps {

--- a/src/app/features/switch-account-drawer/components/switch-account-list.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list.tsx
@@ -18,7 +18,7 @@ export const SwitchAccountList = memo(
       return (
         <>
           {accounts.map(account => (
-            <Box mx="extra-loose">
+            <Box mx={['base-loose', 'extra-loose']}>
               <SwitchAccountListItem
                 handleClose={handleClose}
                 account={account}
@@ -37,7 +37,7 @@ export const SwitchAccountList = memo(
         style={{ paddingTop: '24px', height: '70vh' }}
         totalCount={accounts.length}
         itemContent={index => (
-          <Box mx="extra-loose">
+          <Box mx={['base-loose', 'extra-loose']}>
             <SwitchAccountListItem handleClose={handleClose} account={accounts[index]} />
           </Box>
         )}

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -23,6 +23,7 @@ import { AccountWithAddress } from '@app/store/accounts/account.models';
 import { useNavigate } from 'react-router-dom';
 import { RouteUrls } from '@shared/route-urls';
 import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
+import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
 
 const loadingProps = { color: '#A1A7B3' };
 const getLoadingProps = (loading: boolean) => (loading ? loadingProps : {});
@@ -63,7 +64,7 @@ const ChooseAccountItem = memo((props: ChooseAccountItemProps) => {
   const { decodedAuthRequest } = useOnboardingState();
   const name = useAccountDisplayName(account);
   const { data: balances, isLoading: isBalanceLoading } = useAddressBalances(account.address);
-
+  const fiatValue = useStxMarketData();
   const showLoadingProps = !!selectedAddress || !decodedAuthRequest;
 
   const accountSlug = useMemo(() => slugify(`Account ${account?.index + 1}`), [account?.index]);
@@ -95,7 +96,10 @@ const ChooseAccountItem = memo((props: ChooseAccountItemProps) => {
           isBalanceLoading ? (
             <AccountBalanceLoading />
           ) : balances ? (
-            <AccountBalanceCaption availableBalance={balances.availableStx} />
+            <AccountBalanceCaption
+              availableBalance={balances.availableStx}
+              marketData={fiatValue}
+            />
           ) : (
             <></>
           )

--- a/src/app/query/common/market-data/market-data.hooks.ts
+++ b/src/app/query/common/market-data/market-data.hooks.ts
@@ -2,8 +2,9 @@ import { useMemo } from 'react';
 import BigNumber from 'bignumber.js';
 
 import { calculateMeanAverage } from '@app/common/calculate-averages';
-import { createMoney } from '@shared/models/money.model';
+import { createMoney, currencydecimalsMap } from '@shared/models/money.model';
 import { createMarketData, createMarketPair, MarketData } from '@shared/models/market.model';
+import { convertAmountToFractionalUnit } from '@app/common/money/calculate-money';
 
 import {
   selectBinanceUsdPrice,
@@ -26,7 +27,8 @@ function pullPriceDataFromAvailableResponses(responses: MarketDataVendorWithPric
   return responses
     .filter(({ result }) => !!result)
     .map(({ result, selector: priceSelector }) => priceSelector(result))
-    .map(val => new BigNumber(val));
+    .map(val => new BigNumber(val))
+    .map(val => convertAmountToFractionalUnit(val, currencydecimalsMap.USD));
 }
 
 export function useStxMarketData(): MarketData {
@@ -41,6 +43,7 @@ export function useStxMarketData(): MarketData {
       { result: binance, selector: selectBinanceUsdPrice },
     ]);
     const meanStxPrice = calculateMeanAverage(stxPriceData);
-    return createMarketData(createMarketPair('STX', 'USD'), createMoney(meanStxPrice, 'STX'));
+
+    return createMarketData(createMarketPair('STX', 'USD'), createMoney(meanStxPrice, 'USD'));
   }, [binance, coincap, coingecko]);
 }

--- a/src/shared/models/market.model.ts
+++ b/src/shared/models/market.model.ts
@@ -7,7 +7,7 @@ interface MarketPair {
 }
 
 export function createMarketPair(base: CryptoCurrencies, quote: FiatCurrencies): MarketPair {
-  return { base, quote };
+  return Object.freeze({ base, quote });
 }
 
 export function formatMarketPair({ base, quote }: MarketPair) {
@@ -20,5 +20,7 @@ export interface MarketData {
 }
 
 export function createMarketData(pair: MarketPair, price: Money): MarketData {
-  return { pair, price };
+  if (pair.quote !== price.symbol)
+    throw new Error('Cannot create market data when price does not match quote');
+  return Object.freeze({ pair, price });
 }

--- a/src/shared/models/money.model.ts
+++ b/src/shared/models/money.model.ts
@@ -1,28 +1,52 @@
+import { STX_DECIMALS } from '@shared/constants';
+import { isUndefined } from '@shared/utils';
 import BigNumber from 'bignumber.js';
 import { Currencies } from './currencies.model';
+
+type NumType = BigNumber | number;
 
 export interface Money {
   readonly amount: BigNumber;
   readonly symbol: Currencies;
+  readonly decimals: number;
 }
 
-export function createMoney(amount: BigNumber | number, symbol: Currencies): Money {
-  return { amount: new BigNumber(amount), symbol };
+// Units of `Money` should be declared in their smallest unit. Similar to
+// Rosetta, we model currencies with their respective resolution
+export const currencydecimalsMap: Record<Currencies, number> = {
+  STX: STX_DECIMALS,
+  USD: 2,
+};
+
+function throwWhenDecimalUnknown(symbol: Currencies, decimals?: number) {
+  if (isUndefined(decimals) && isUndefined(currencydecimalsMap[symbol]))
+    throw new Error(`Resolution of currency ${symbol} is unknown, must be described`);
 }
 
-export function formatMoney({ amount, symbol }: Money) {
-  return `${amount.toString()} ${symbol}`;
+/**
+ * @param value Amount described in currency's primary unit
+ * @param symbol Identifying letter code, e.g. EUR
+ * @param resolution Optional, required if value not known at build-time
+ */
+export function createMoneyFromDecimal(
+  value: NumType,
+  symbol: Currencies,
+  resolution?: number
+): Money {
+  throwWhenDecimalUnknown(symbol, resolution);
+  const decimals = currencydecimalsMap[symbol] ?? resolution;
+  const amount = new BigNumber(value).shiftedBy(decimals);
+  return Object.freeze({ amount, symbol, decimals });
 }
 
-export function i18nFormatCurrency(value: Money, locale = 'en-US') {
-  if (value.symbol !== 'USD') throw new Error('Cannot format non-USD amounts');
-
-  const formatCurrency = new Intl.NumberFormat(locale, { style: 'currency', currency: 'USD' });
-
-  return formatCurrency.format(value.amount.toNumber());
-}
-
-export function formatDustUsdAmounts(value: string) {
-  const thinSpace = ' ';
-  return value.endsWith('0.00') ? '<' + thinSpace + value.replace('0.00', '0.01') : value;
+/**
+ * @param value Amount described in currency's fractional base unit, e.g. cents for USD amounts
+ * @param symbol Identifying letter code, e.g. EUR
+ * @param resolution Optional, required if value not known at build-time
+ */
+export function createMoney(value: NumType, symbol: Currencies, resolution?: number): Money {
+  throwWhenDecimalUnknown(symbol, resolution);
+  const decimals = currencydecimalsMap[symbol] ?? resolution;
+  const amount = new BigNumber(value);
+  return Object.freeze({ amount, symbol, decimals });
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -14,6 +14,10 @@ export function isFunction(value: unknown): value is Function {
   return typeof value === 'function';
 }
 
+export function isObject(value: unknown): value is object {
+  return typeof value === 'object';
+}
+
 export function isEmpty(value: Object) {
   return Object.keys(value).length === 0;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3376284672).<!-- Sticky Header Marker -->

Reinstates fiat amounts in the list. Also improves handling of narrow viewports. It's not perfect at extremely narrow widths, but not sure we need to optimise for this.

Closes #2756, #2735

https://user-images.githubusercontent.com/1618764/198989372-5ec36b82-1810-4ba5-86b8-d92875a98373.mp4

