### PR TITLE
Fix incorrect fiat values

### DIFF
--- a/src/app/common/money/calculate-money.spec.ts
+++ b/src/app/common/money/calculate-money.spec.ts
@@ -22,12 +22,12 @@ describe(baseCurrencyAmountInQuote.name, () => {
 
   test('it converts currency small amounts accurately', () => {
     const result = baseCurrencyAmountInQuote(tenMicroStx, mockAccurateStxMarketData);
-    expect(result.amount.toString()).toEqual('0.000003');
+    expect(result.amount.toString()).toEqual('0.0003');
   });
 
   test('it converts currency amounts accurately', () => {
     const result = baseCurrencyAmountInQuote(tenStx, mockAccurateStxMarketData);
-    expect(result.amount.toString()).toEqual('3');
+    expect(result.amount.toString()).toEqual('300');
   });
 });
 

--- a/src/app/common/money/calculate-money.ts
+++ b/src/app/common/money/calculate-money.ts
@@ -15,7 +15,10 @@ export function baseCurrencyAmountInQuote(quantity: Money, { pair, price }: Mark
     );
 
   return createMoney(
-    convertAmountToBaseUnit(quantity).times(convertAmountToBaseUnit(price)),
+    convertAmountToFractionalUnit(
+      convertAmountToBaseUnit(quantity).times(convertAmountToBaseUnit(price)),
+      price.decimals
+    ),
     pair.quote
   );
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3387420574).<!-- Sticky Header Marker -->

My mistake, creating a money type with the decimal values, rather than the fractional units.  This PR  merges directly to `main` as it's a hotfix,