### PR TITLE
Chore/track analytics consent screen view and selection rates #2784

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@reach/utils": "0.15.3",
     "@reach/visually-hidden": "0.15.2",
     "@reduxjs/toolkit": "1.8.4",
-    "@segment/analytics-next": "1.31.1",
+    "@segment/analytics-next": "1.46.0",
     "@sentry/react": "6.16.1",
     "@sentry/tracing": "6.16.1",
     "@stacks/auth": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -256,7 +256,6 @@
     "@types/react-test-renderer": "17.0.1",
     "@types/redux-persist": "4.3.1",
     "@types/remote-redux-devtools": "0.5.5",
-    "@types/segment-analytics": "0.0.34",
     "@types/styled-system__theme-get": "5.0.2",
     "@types/valid-url": "1.0.3",
     "@types/webextension-polyfill": "0.9.0",

--- a/src/app/common/hooks/analytics/use-analytics.ts
+++ b/src/app/common/hooks/analytics/use-analytics.ts
@@ -1,7 +1,10 @@
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { EventParams, PageParams } from '@segment/analytics-next/dist/pkg/core/arguments-resolver';
+import {
+  EventParams,
+  PageParams,
+} from '@segment/analytics-next/dist/types/core/arguments-resolver';
 
 import { IS_TEST_ENV } from '@shared/environment';
 import { logger } from '@shared/logger';
@@ -9,6 +12,7 @@ import { analytics } from '@shared/utils/analytics';
 
 import { useWalletType } from '@app/common/use-wallet-type';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
+import { useHasUserExplicitlyDeclinedAnalytics } from '@app/store/settings/settings.selectors';
 
 const IGNORED_PATH_REGEXPS = [/^\/$/];
 
@@ -24,6 +28,8 @@ export function useAnalytics() {
   const currentNetwork = useCurrentNetworkState();
   const location = useLocation();
   const { walletType } = useWalletType();
+
+  const hasDeclined = useHasUserExplicitlyDeclinedAnalytics();
 
   return useMemo(() => {
     const defaultProperties = {
@@ -45,8 +51,11 @@ export function useAnalytics() {
         const opts = { ...defaultOptions, ...options };
         logger.info(`Analytics page view: ${name}`, properties);
 
-        if (!analytics || IS_TEST_ENV) return;
+        if (!analytics) return;
+        if (hasDeclined) return;
+        if (IS_TEST_ENV) return;
         if (typeof name === 'string' && isIgnoredPath(name)) return;
+
         return analytics.page(category, name, prop, opts, ...rest).catch(logger.error);
       },
       async track(...args: EventParams) {
@@ -55,9 +64,18 @@ export function useAnalytics() {
         const opts = { ...defaultOptions, ...options };
         logger.info(`Analytics event: ${eventName}`, properties);
 
-        if (!analytics || IS_TEST_ENV) return;
+        if (!analytics) return;
+        if (hasDeclined) return;
+        if (IS_TEST_ENV) return;
+
         return analytics.track(eventName, prop, opts, ...rest).catch(logger.error);
       },
     };
-  }, [currentNetwork.chain.stacks.url, currentNetwork.name, location.pathname, walletType]);
+  }, [
+    currentNetwork.chain.stacks.url,
+    currentNetwork.name,
+    location.pathname,
+    walletType,
+    hasDeclined,
+  ]);
 }

--- a/src/app/common/store-utils.ts
+++ b/src/app/common/store-utils.ts
@@ -1,8 +1,6 @@
 import { QueryKey, hashQueryKey } from '@tanstack/react-query';
 import hash from 'object-hash';
 
-import { userHasAllowedDiagnosticsKey } from '@shared/utils/storage';
-
 export function textToBytes(content: string) {
   return new TextEncoder().encode(content);
 }
@@ -16,7 +14,7 @@ export function makeLocalDataKey(params: QueryKey): string {
 }
 
 // LocalStorage keys kept across sign-in/signout sessions
-const PERSISTENT_LOCAL_DATA: string[] = [userHasAllowedDiagnosticsKey];
+const PERSISTENT_LOCAL_DATA: string[] = [];
 
 export function partiallyClearLocalStorage() {
   const backup = PERSISTENT_LOCAL_DATA.map((key: string) => [key, localStorage.getItem(key)]);

--- a/src/app/common/theme-provider.tsx
+++ b/src/app/common/theme-provider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 
 import { store } from '@app/store';
-import { userSelectedThemeActions } from '@app/store/settings/settings.actions';
+import { settingsActions } from '@app/store/settings/settings.actions';
 import { useUserSelectedTheme } from '@app/store/settings/settings.selectors';
 
 export const themeLabelMap = {
@@ -38,7 +38,7 @@ function getComputedTheme(userSelectedTheme: UserSelectedTheme): ComputedTheme {
 }
 
 function setUserSelectedTheme(theme: UserSelectedTheme) {
-  store.dispatch(userSelectedThemeActions.setUserSelectedTheme(theme));
+  store.dispatch(settingsActions.setUserSelectedTheme(theme));
 }
 
 interface ThemeSwitcherProviderProps {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 
 import { InternalMethods } from '@shared/message-types';
-import { initSegment, initSentry } from '@shared/utils/analytics';
+import { initSentry } from '@shared/utils/analytics';
 import { warnUsersAboutDevToolsDangers } from '@shared/utils/dev-tools-warning-log';
 
 import { persistAndRenderApp } from '@app/common/persistence';
@@ -11,7 +11,6 @@ import { store } from './store';
 import { inMemoryKeyActions } from './store/in-memory-key/in-memory-key.actions';
 
 initSentry();
-void initSegment();
 warnUsersAboutDevToolsDangers();
 
 declare global {

--- a/src/app/pages/allow-diagnostics/allow-diagnostics-layout.tsx
+++ b/src/app/pages/allow-diagnostics/allow-diagnostics-layout.tsx
@@ -26,11 +26,10 @@ const ReasonToAllowDiagnostics: FC<ReasonToAllowDiagnosticsProps> = ({ text }) =
 
 interface AllowDiagnosticsLayoutProps {
   onUserAllowDiagnostics(): void;
-  onUserDenyDiagnosticsPermissions(): void;
+  onUserDenyDiagnostics(): void;
 }
 export function AllowDiagnosticsLayout(props: AllowDiagnosticsLayoutProps) {
-  const { onUserAllowDiagnostics, onUserDenyDiagnosticsPermissions } = props;
-
+  const { onUserAllowDiagnostics, onUserDenyDiagnostics } = props;
   return (
     <CenteredPageContainer>
       <Stack
@@ -67,7 +66,7 @@ export function AllowDiagnosticsLayout(props: AllowDiagnosticsLayoutProps) {
             fontSize="14px"
             mode="tertiary"
             ml="base"
-            onClick={() => onUserDenyDiagnosticsPermissions()}
+            onClick={() => onUserDenyDiagnostics()}
             type="button"
             variant="link"
             data-testid={OnboardingSelectors.AnalyticsDenyBtn}

--- a/src/app/pages/allow-diagnostics/allow-diagnostics.tsx
+++ b/src/app/pages/allow-diagnostics/allow-diagnostics.tsx
@@ -1,38 +1,49 @@
-import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
-import { initSegment, initSentry } from '@shared/utils/analytics';
 
+import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { Header } from '@app/components/header';
-import { useHasAllowedDiagnostics } from '@app/store/onboarding/onboarding.hooks';
+import { settingsActions } from '@app/store/settings/settings.actions';
 
 import { AllowDiagnosticsLayout } from './allow-diagnostics-layout';
 
 export const AllowDiagnosticsPage = () => {
   const navigate = useNavigate();
-  const [, setHasAllowedDiagnostics] = useHasAllowedDiagnostics();
+  const dispatch = useDispatch();
+  const analytics = useAnalytics();
+  const { pathname } = useLocation();
+
+  useEffect(() => void analytics.page('view', `${pathname}`), [analytics, pathname]);
 
   useRouteHeader(<Header hideActions />);
 
-  const goToOnboardingAndSetDiagnosticsPermissionTo = useCallback(
-    (areDiagnosticsAllowed: boolean | undefined) => {
-      if (typeof areDiagnosticsAllowed === undefined) return;
-      setHasAllowedDiagnostics(areDiagnosticsAllowed);
-      if (areDiagnosticsAllowed) {
-        initSentry();
-        void initSegment();
-      }
+  const setDiagnosticsPermissionsAndGoToOnboarding = useCallback(
+    (areDiagnosticsAllowed: boolean) => {
+      dispatch(settingsActions.setHasAllowedAnalytics(areDiagnosticsAllowed));
+
       navigate(RouteUrls.Onboarding);
     },
-    [navigate, setHasAllowedDiagnostics]
+    [navigate, dispatch]
   );
 
   return (
     <AllowDiagnosticsLayout
-      onUserDenyDiagnosticsPermissions={() => goToOnboardingAndSetDiagnosticsPermissionTo(false)}
-      onUserAllowDiagnostics={() => goToOnboardingAndSetDiagnosticsPermissionTo(true)}
+      onUserDenyDiagnostics={() => {
+        void analytics.track('respond_diagnostics_consent', {
+          areDiagnosticsAllowed: false,
+        });
+        setDiagnosticsPermissionsAndGoToOnboarding(false);
+      }}
+      onUserAllowDiagnostics={() => {
+        void analytics.track('respond_diagnostics_consent', {
+          areDiagnosticsAllowed: true,
+        });
+        setDiagnosticsPermissionsAndGoToOnboarding(true);
+      }}
     />
   );
 };

--- a/src/app/pages/onboarding/welcome/welcome.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.tsx
@@ -10,12 +10,12 @@ import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { doesBrowserSupportWebUsbApi, whenPageMode } from '@app/common/utils';
 import { openIndexPageInNewTab } from '@app/common/utils/open-in-new-tab';
 import { Header } from '@app/components/header';
-import { useHasAllowedDiagnostics } from '@app/store/onboarding/onboarding.hooks';
+import { useHasUserRespondedToAnalyticsConsent } from '@app/store/settings/settings.selectors';
 
 import { WelcomeLayout } from './welcome.layout';
 
 export const WelcomePage = memo(() => {
-  const [hasAllowedDiagnostics] = useHasAllowedDiagnostics();
+  const hasResponded = useHasUserRespondedToAnalyticsConsent();
   const navigate = useNavigate();
   const { decodedAuthRequest } = useOnboardingState();
   const analytics = useAnalytics();
@@ -36,7 +36,7 @@ export const WelcomePage = memo(() => {
   }, [keyActions, analytics, decodedAuthRequest, navigate]);
 
   useEffect(() => {
-    if (hasAllowedDiagnostics === undefined) navigate(RouteUrls.RequestDiagnostics);
+    if (!hasResponded) navigate(RouteUrls.RequestDiagnostics);
 
     return () => setIsGeneratingWallet(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -35,23 +35,20 @@ import { Unlock } from '@app/pages/unlock';
 import { ViewSecretKey } from '@app/pages/view-secret-key/view-secret-key';
 import { AccountGate } from '@app/routes/account-gate';
 import { useHasStateRehydrated } from '@app/store';
+import { useHasUserRespondedToAnalyticsConsent } from '@app/store/settings/settings.selectors';
 
 import { useOnSignOut } from './hooks/use-on-sign-out';
 import { useOnWalletLock } from './hooks/use-on-wallet-lock';
 import { OnboardingGate } from './onboarding-gate';
 
-export function AppRoutes() {
+function AppRoutesAfterUserHasConsented() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const analytics = useAnalytics();
 
   useOnWalletLock(() => navigate(RouteUrls.Unlock));
   useOnSignOut(() => window.close());
-
   useEffect(() => void analytics.page('view', `${pathname}`), [analytics, pathname]);
-
-  const hasStateRehydrated = useHasStateRehydrated();
-  if (!hasStateRehydrated) return <LoadingSpinner />;
 
   const settingsModalRoutes = (
     <>
@@ -200,4 +197,24 @@ export function AppRoutes() {
       </Route>
     </Routes>
   );
+}
+
+function AppRoutesBeforeUserHasConsented() {
+  return (
+    <Routes>
+      <Route path={RouteUrls.RequestDiagnostics} element={<AllowDiagnosticsPage />} />
+      <Route path="*" element={<Navigate replace to={RouteUrls.RequestDiagnostics} />} />
+    </Routes>
+  );
+}
+
+export function AppRoutes() {
+  const hasStateRehydrated = useHasStateRehydrated();
+  const hasResponded = useHasUserRespondedToAnalyticsConsent();
+
+  if (!hasStateRehydrated) return <LoadingSpinner />;
+
+  if (!hasResponded) return <AppRoutesBeforeUserHasConsented />;
+
+  return <AppRoutesAfterUserHasConsented />;
 }

--- a/src/app/store/onboarding/onboarding.hooks.ts
+++ b/src/app/store/onboarding/onboarding.hooks.ts
@@ -1,7 +1,7 @@
 import { useAtom } from 'jotai';
 import { useAtomValue } from 'jotai/utils';
 
-import { hasAllowedDiagnosticsState, secretKeyState, seedInputErrorState } from './onboarding';
+import { secretKeyState, seedInputErrorState } from './onboarding';
 
 export function useSeedInputErrorState() {
   return useAtom(seedInputErrorState);
@@ -9,8 +9,4 @@ export function useSeedInputErrorState() {
 
 export function useSecretKeyState() {
   return useAtomValue(secretKeyState);
-}
-
-export function useHasAllowedDiagnostics() {
-  return useAtom(hasAllowedDiagnosticsState);
 }

--- a/src/app/store/onboarding/onboarding.ts
+++ b/src/app/store/onboarding/onboarding.ts
@@ -1,12 +1,4 @@
 import { atom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
-
-import { userHasAllowedDiagnosticsKey } from '@shared/utils/storage';
 
 export const seedInputErrorState = atom<string | undefined>(undefined);
 export const secretKeyState = atom(null);
-
-export const hasAllowedDiagnosticsState = atomWithStorage<boolean | undefined>(
-  userHasAllowedDiagnosticsKey,
-  undefined
-);

--- a/src/app/store/settings/settings.actions.ts
+++ b/src/app/store/settings/settings.actions.ts
@@ -1,3 +1,3 @@
 import { settingsSlice } from './settings.slice';
 
-export const userSelectedThemeActions = settingsSlice.actions;
+export const settingsActions = settingsSlice.actions;

--- a/src/app/store/settings/settings.selectors.ts
+++ b/src/app/store/settings/settings.selectors.ts
@@ -7,7 +7,21 @@ import { RootState } from '@app/store';
 const selectSettings = (state: RootState) => state.settings;
 
 const selectUserSelectedTheme = createSelector(selectSettings, state => state.userSelectedTheme);
-
 export function useUserSelectedTheme() {
   return useSelector(selectUserSelectedTheme);
+}
+
+const selectHasUserExplicitlyDeclinedAnalytics = createSelector(
+  selectSettings,
+  state => state.hasAllowedAnalytics === false
+);
+export function useHasUserExplicitlyDeclinedAnalytics() {
+  return useSelector(selectHasUserExplicitlyDeclinedAnalytics);
+}
+const selectHasUserRespondedToAnalyticsConsent = createSelector(
+  selectSettings,
+  state => state.hasAllowedAnalytics !== null
+);
+export function useHasUserRespondedToAnalyticsConsent() {
+  return useSelector(selectHasUserRespondedToAnalyticsConsent);
 }

--- a/src/app/store/settings/settings.slice.ts
+++ b/src/app/store/settings/settings.slice.ts
@@ -2,12 +2,15 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { UserSelectedTheme } from '@app/common/theme-provider';
 
+type HasAcceptedAnalytics = null | boolean;
 interface InitialState {
   userSelectedTheme: UserSelectedTheme;
+  hasAllowedAnalytics: HasAcceptedAnalytics;
 }
 
 const initialState: InitialState = {
   userSelectedTheme: 'system',
+  hasAllowedAnalytics: null,
 };
 
 export const settingsSlice = createSlice({
@@ -16,6 +19,9 @@ export const settingsSlice = createSlice({
   reducers: {
     setUserSelectedTheme(state, action: PayloadAction<UserSelectedTheme>) {
       state.userSelectedTheme = action.payload;
+    },
+    setHasAllowedAnalytics(state, action: PayloadAction<boolean>) {
+      state.hasAllowedAnalytics = action.payload;
     },
   },
 });

--- a/src/shared/actions/finalize-auth-response.ts
+++ b/src/shared/actions/finalize-auth-response.ts
@@ -56,7 +56,7 @@ export function finalizeAuthResponse({
   const origin = new URL(requestingOrigin);
 
   if (redirectUri.hostname !== origin.hostname) {
-    void analytics.track('auth_response_with_illegal_redirect_uri');
+    analytics?.track('auth_response_with_illegal_redirect_uri');
     throw new Error('Cannot redirect to a different domain than the one requesting');
   }
 

--- a/src/shared/actions/finalize-tx-signature.ts
+++ b/src/shared/actions/finalize-tx-signature.ts
@@ -40,7 +40,7 @@ export function finalizeTxSignature({ requestPayload, data, tabId }: FinalizeTxS
     // My own testing shows that `sendMessage` doesn't throw yet users have
     // reported these errors. Tracking here to see if we are able to detect this
     // happening.
-    void analytics.track('finalize_tx_signature_error_thrown', { data: e });
+    analytics?.track('finalize_tx_signature_error_thrown', { data: e });
     logger.error('Error in finalising tx signature', e);
   }
 }

--- a/src/shared/environment.ts
+++ b/src/shared/environment.ts
@@ -4,10 +4,7 @@ export const BRANCH_NAME = process.env.GITHUB_HEAD_REF;
 export const COINBASE_APP_ID = process.env.COINBASE_APP_ID ?? '';
 export const COMMIT_SHA = process.env.GITHUB_SHA;
 export const IS_DEV_ENV = process.env.WALLET_ENVIRONMENT === 'development';
-export const IS_PROD_ENV =
-  process.env.WALLET_ENVIRONMENT === 'production' || process.env.WALLET_ENVIRONMENT === 'preview';
 export const MOONPAY_API_KEY = process.env.MOONPAY_API_KEY ?? '';
 export const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 export const SEGMENT_WRITE_KEY = process.env.SEGMENT_WRITE_KEY ?? '';
-export const SENTRY_DSN = process.env.SENTRY_DSN ?? '';
 export const TRANSAK_API_KEY = process.env.TRANSAK_API_KEY ?? '';

--- a/src/shared/utils/storage.ts
+++ b/src/shared/utils/storage.ts
@@ -1,5 +1,3 @@
-export const userHasAllowedDiagnosticsKey = 'stacks-wallet-has-allowed-diagnostics';
-
 export function setToLocalstorageIfDefined(storageKey: string, value?: string) {
   if (value) {
     localStorage.setItem(storageKey, value);

--- a/src/shared/workers/index.ts
+++ b/src/shared/workers/index.ts
@@ -7,7 +7,8 @@ export enum WorkerScript {
 export function createWorker(scriptName: WorkerScript) {
   const worker = new Worker(scriptName);
   worker.addEventListener('error', error => {
-    void analytics.track(`worker_error_thrown_${scriptName}`, { error });
+    analytics?.track(`worker_error_thrown_${scriptName}`, { error });
   });
+
   return worker;
 }

--- a/tests/integration/onboarding/onboarding.spec.ts
+++ b/tests/integration/onboarding/onboarding.spec.ts
@@ -57,7 +57,7 @@ describe(`Onboarding integration tests`, () => {
     await wallet.page.click('text=Sign Out');
     await wallet.page.click(wallet.$signOutConfirmHasBackupCheckbox);
     await wallet.page.click(wallet.$signOutDeleteWalletBtn);
-    await wallet.waitForWelcomePage();
+    await wallet.page.waitForSelector(wallet.$analyticsDenyButton);
   });
 
   it('should route to unlock page if the wallet is locked', async () => {

--- a/tests/integration/settings/settings.spec.ts
+++ b/tests/integration/settings/settings.spec.ts
@@ -89,6 +89,7 @@ describe(`Settings integration tests`, () => {
     await wallet.page.click(createTestSelector(SettingsSelectors.SignOutListItem));
     await wallet.page.click(wallet.$signOutConfirmHasBackupCheckbox);
     await wallet.page.click(wallet.$signOutDeleteWalletBtn);
+    await wallet.clickDenyAnalytics();
     await wallet.clickSignIn();
     await wallet.enterSecretKey(secretKey);
     const password = randomString(15);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6355,11 +6355,6 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/segment-analytics@0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@types/segment-analytics/-/segment-analytics-0.0.34.tgz#e88fd5286e27eefafbc1b98c8c7e143b9aab5fb5"
-  integrity sha512-fiOyEgyqJY2Mv9k72WG4XoY4fVE31byiSUrEFcNh+MgHcH3HuJmoz2J7ktO3YizBrN6/RuaH1tY5J/5I5BJHJQ==
-
 "@types/serve-index@*", "@types/serve-index@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3948,18 +3948,30 @@
     "@noble/hashes" "~1.1.1"
     "@scure/base" "~1.1.0"
 
-"@segment/analytics-next@1.31.1":
-  version "1.31.1"
-  resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.31.1.tgz#f5d38f3dc120ba0def3b1b7c0ddaedfc9925ac65"
-  integrity sha512-IJIO4K+kcaidGLLcQfwitPYdpS5eqqtrPvq4hIRA5VZL7B/qFwzBHW4j1CyKxHKx1tNgEtOZGiW9TbRmZkhWgw==
+"@segment/analytics-core@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-core/-/analytics-core-1.1.1.tgz#34a583d12fd42c82f3a55173dcaf121e03e27228"
+  integrity sha512-rnxhw5sBGfV0R79SI/C4nKw3OFjhhWQMo7lOwRv2GuL/JbnOcA6DxP1RMs1Vc7TaS/fjeSJrfpP84k3A5xPzHw==
   dependencies:
     "@lukeed/uuid" "^2.0.0"
+    dset "^3.1.2"
+    tslib "^2.4.0"
+
+"@segment/analytics-next@1.46.0":
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.46.0.tgz#4bfa48200b8073d8d99b1a8e528122d149a74a9b"
+  integrity sha512-5QgBk2bQIgYmElY2Dk2hrruHrKlNZ0yyUOG+WWsz/6ca+jDdNHjMZLiKIGARg6Das8MLrmHbrXy67TXp3Ch82A==
+  dependencies:
+    "@lukeed/uuid" "^2.0.0"
+    "@segment/analytics-core" "1.1.1"
     "@segment/analytics.js-video-plugins" "^0.2.1"
-    "@segment/facade" "3.4.7"
-    "@segment/tsub" "^0.1.9"
-    dset "^3.0.0"
-    js-cookie "^2.2.1"
+    "@segment/facade" "^3.4.9"
+    "@segment/tsub" "^0.2.0"
+    dset "^3.1.2"
+    js-cookie "3.0.1"
+    node-fetch "^2.6.7"
     spark-md5 "^3.0.1"
+    tslib "^2.4.0"
     unfetch "^4.1.0"
 
 "@segment/analytics.js-video-plugins@^0.2.1":
@@ -3969,14 +3981,13 @@
   dependencies:
     unfetch "^3.1.1"
 
-"@segment/facade@3.4.7":
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/@segment/facade/-/facade-3.4.7.tgz#27e469189d45d5a2806d16571722e6b00d81429a"
-  integrity sha512-Tj4aJsdmR9cl7xm7BT0NF9kYOnbIJ/3DdC1yOiLnjQRbHcnOq7WWkMDug/JCSEPF2loxGhG/oTeZybR3hpG3MA==
+"@segment/facade@^3.4.9":
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/@segment/facade/-/facade-3.4.9.tgz#07e614073fa873910035c085e69bccd27df088a6"
+  integrity sha512-0RTLB0g4HiJASc6pTD2/Tru+Qz+VPGL1W+/EvkBGhY6WYk00cZhTjLsMJ8X5BO6iPqLb3vsxtfjVM/RREG5oQQ==
   dependencies:
     "@segment/isodate-traverse" "^1.1.1"
     inherits "^2.0.4"
-    klona "^2.0.5"
     new-date "^1.0.3"
     obj-case "0.2.1"
 
@@ -3992,10 +4003,10 @@
   resolved "https://registry.yarnpkg.com/@segment/isodate/-/isodate-1.0.3.tgz#f44e8202d5edd277ce822785239474b2c9411d4a"
   integrity sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==
 
-"@segment/tsub@^0.1.9":
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/@segment/tsub/-/tsub-0.1.12.tgz#1c301a8b81e5dbda54eb0435ae808fbe65553f23"
-  integrity sha512-35JB0+HuMZrn7mus/s4yOHAcuid+MzaOYxV8YAogTR4Z7AsHwn/Zn/y9XdoHp2kKdn54s6jO4IaO826v0j7qmw==
+"@segment/tsub@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@segment/tsub/-/tsub-0.2.0.tgz#456345ad04bca81f6c3fefacac722fd9eb4923ce"
+  integrity sha512-DThHEnZ+1PlSjj59Q7Ns/ESevjfztDV4PtKMcoVp1PWSWaaPcaktWGdTeDgi8ucsJO91qtY9N4aM2cbfGr/yWA==
   dependencies:
     "@stdlib/math-base-special-ldexp" "^0.0.5"
     dlv "^1.1.3"
@@ -9812,7 +9823,7 @@ dragula@3.7.2:
     contra "1.9.4"
     crossvent "1.5.4"
 
-dset@^3.0.0, dset@^3.1.1:
+dset@^3.1.1, dset@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.2.tgz#89c436ca6450398396dc6538ea00abc0c54cd45a"
   integrity sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==
@@ -13633,10 +13644,10 @@ joycon@^3.0.1:
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
-js-cookie@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+js-cookie@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 js-levenshtein@^1.1.6:
   version "1.1.6"
@@ -14095,11 +14106,6 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
-
-klona@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
-  integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
 knex@^0.95.15:
   version "0.95.15"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3463152717).<!-- Sticky Header Marker -->

**Segment is always on**. Segment can only be turned on, it can’t be turned off once it’s turned on. Therefore, in order to be able to capture the analytics acceptance rate (and then nothing else should the user opt out of analytics), Segment needs to be turned on as soon as the app loads. The user’s consent response is respected by modifying the behavior of the methods we use to interact with Segment: if the user accepts, they work as expected and capture analytics, otherwise, they’re converted into no-ops and calling those functions won’t capture any analytics.

**Segment only captures consent page load and consent response by default**. These are the only two analytics that Segment will capture by default. Should the user opt out of analytics, Segment will not capture anything further.

**Users can’t manually navigate to pages other than the consent screen without having provided their consent response**. Users may try to navigate to any part of the app by typing the address in the URL bar. However, given Segment is on by default, until they provide a response to the analytics consent, they will always be redirected to the consent page and aren’t allowed to view other pages or interact with the app in any way (and therefore avoid data collection).

Sentry code has been commented removed given it was disabled to avoid interfering with this PR, will be taken care of as part of #2822.

FYI @fbwoolf, using settings slice as recommended in [comment](https://github.com/hirosystems/stacks-wallet-web/pull/2791#discussion_r1013301989).

Closes https://github.com/hirosystems/stacks-wallet-web/issues/2784