### PR TITLE
chore: rename vars, closes #2779

### DIFF
--- a/src/app/common/hooks/use-drawers.ts
+++ b/src/app/common/hooks/use-drawers.ts
@@ -7,24 +7,25 @@ import {
 } from '@app/store/ui/ui.hooks';
 
 export function useDrawers() {
-  const [showAccounts, setShowSwitchAccountsState] = useShowSwitchAccountsState();
-  const [showHighFeeConfirmation, setShowHighFeeConfirmation] = useShowHighFeeConfirmationState();
+  const [isShowingAccounts, setIsShowingSwitchAccountsState] = useShowSwitchAccountsState();
+  const [isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation] =
+    useShowHighFeeConfirmationState();
 
-  const [showSettings, setShowSettings] = useShowSettingsStore();
-  const [showEditNonce, setShowEditNonce] = useShowEditNonceState();
-  const [showTxSettingsCallback, setShowTxSettingsCallback] = useShowTxSettingsCallback();
+  const [isShowingSettings, setIsShowingSettings] = useShowSettingsStore();
+  const [isShowingEditNonce, setIsShowingEditNonce] = useShowEditNonceState();
+  const [isShowingTxSettingsCallback, setIsShowingTxSettingsCallback] = useShowTxSettingsCallback();
 
   return {
-    showAccounts,
-    setShowSwitchAccountsState,
-    showHighFeeConfirmation,
-    setShowHighFeeConfirmation,
+    isShowingAccounts,
+    setIsShowingSwitchAccountsState,
+    isShowingHighFeeConfirmation,
+    setIsShowingHighFeeConfirmation,
 
-    showSettings,
-    setShowSettings,
-    showEditNonce,
-    setShowEditNonce,
-    showTxSettingsCallback,
-    setShowTxSettingsCallback,
+    isShowingSettings,
+    setIsShowingSettings,
+    isShowingEditNonce,
+    setIsShowingEditNonce,
+    isShowingTxSettingsCallback,
+    setIsShowingTxSettingsCallback,
   };
 }

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -21,7 +21,7 @@ interface HeaderProps extends FlexProps {
 }
 export const Header: React.FC<HeaderProps> = memo(props => {
   const { actionButton, hideActions, onClose, title, ...rest } = props;
-  const { showSettings, setShowSettings } = useDrawers();
+  const { isShowingSettings, setIsShowingSettings } = useDrawers();
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
@@ -112,8 +112,8 @@ export const Header: React.FC<HeaderProps> = memo(props => {
             data-testid={SettingsSelectors.MenuBtn}
             iconSize="16px"
             icon={FiMoreHorizontal}
-            onMouseUp={showSettings ? undefined : () => setShowSettings(true)}
-            pointerEvents={showSettings ? 'none' : 'all'}
+            onMouseUp={isShowingSettings ? undefined : () => setIsShowingSettings(true)}
+            pointerEvents={isShowingSettings ? 'none' : 'all'}
           />
         )}
         {actionButton ? actionButton : null}

--- a/src/app/components/show-edit-nonce.tsx
+++ b/src/app/components/show-edit-nonce.tsx
@@ -7,14 +7,14 @@ import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 export function ShowEditNonceAction() {
   const { isTestnet, name } = useCurrentNetworkState();
-  const { showEditNonce, setShowEditNonce } = useDrawers();
+  const { isShowingEditNonce, setIsShowingEditNonce } = useDrawers();
 
   return (
     <SpaceBetween>
       <Caption
         _hover={{ cursor: 'pointer', textDecoration: 'underline' }}
         color={color('brand')}
-        onClick={() => setShowEditNonce(!showEditNonce)}
+        onClick={() => setIsShowingEditNonce(!isShowingEditNonce)}
       >
         Edit nonce
       </Caption>

--- a/src/app/features/current-account/current-account-avatar.tsx
+++ b/src/app/features/current-account/current-account-avatar.tsx
@@ -8,11 +8,11 @@ import { useCurrentAccountDisplayName } from '@app/common/hooks/account/use-acco
 export const CurrentAccountAvatar = memo((props: BoxProps) => {
   const currentAccount = useCurrentAccount();
   const name = useCurrentAccountDisplayName();
-  const { setShowSwitchAccountsState } = useDrawers();
+  const { setIsShowingSwitchAccountsState } = useDrawers();
   if (!currentAccount) return null;
   return (
     <AccountAvatar
-      onClick={() => setShowSwitchAccountsState(true)}
+      onClick={() => setIsShowingSwitchAccountsState(true)}
       cursor="pointer"
       name={name}
       publicKey={currentAccount.stxPublicKey}

--- a/src/app/features/edit-nonce-drawer/edit-nonce-drawer.tsx
+++ b/src/app/features/edit-nonce-drawer/edit-nonce-drawer.tsx
@@ -32,13 +32,13 @@ export function EditNonceDrawer() {
     useFormikContext<TransactionFormValues>();
   const [customNonce, setCustomNonce] = useState<number | string>();
   const { nonce } = useNextNonce();
-  const { showEditNonce, setShowEditNonce } = useDrawers();
+  const { isShowingEditNonce, setIsShowingEditNonce } = useDrawers();
   useShowEditNonceCleanupEffect();
 
   useEffect(() => {
-    if (showEditNonce) setCustomNonce(values.nonce);
+    if (isShowingEditNonce) setCustomNonce(values.nonce);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showEditNonce]);
+  }, [isShowingEditNonce]);
 
   useEffect(() => {
     if (isUndefined(values.nonce)) setFieldValue('nonce', nonce);
@@ -51,27 +51,29 @@ export function EditNonceDrawer() {
   const onSubmit = useCallback(async () => {
     validateField('nonce');
     if (!errors.nonce) {
-      setShowEditNonce(false);
+      setIsShowingEditNonce(false);
     }
-  }, [errors.nonce, setShowEditNonce, validateField]);
+  }, [errors.nonce, setIsShowingEditNonce, validateField]);
 
   const onClose = useCallback(() => {
     if (!values.nonce) setFieldValue('nonce', undefined);
     setFieldError('nonce', '');
     setFieldValue('nonce', customNonce);
-    setShowEditNonce(false);
-  }, [customNonce, setFieldError, setFieldValue, setShowEditNonce, values.nonce]);
+    setIsShowingEditNonce(false);
+  }, [customNonce, setFieldError, setFieldValue, setIsShowingEditNonce, values.nonce]);
 
   return (
     <ControlledDrawer
-      isShowing={!!showEditNonce}
+      isShowing={!!isShowingEditNonce}
       onClose={onClose}
       pauseOnClickOutside
       title="Edit nonce"
     >
       <Stack px="loose" spacing="loose" pb="extra-loose">
         <CustomFeeMessaging />
-        {showEditNonce && <EditNonceForm onBlur={onBlur} onClose={onClose} onSubmit={onSubmit} />}
+        {isShowingEditNonce && (
+          <EditNonceForm onBlur={onBlur} onClose={onClose} onSubmit={onSubmit} />
+        )}
       </Stack>
     </ControlledDrawer>
   );

--- a/src/app/features/high-fee-drawer/components/high-fee-confirmation.tsx
+++ b/src/app/features/high-fee-drawer/components/high-fee-confirmation.tsx
@@ -11,7 +11,7 @@ const url = 'https://hiro.so/questions/fee-estimates';
 
 export function HighFeeConfirmation(): JSX.Element | null {
   const { handleSubmit, values } = useFormikContext<TransactionFormValues>();
-  const { showHighFeeConfirmation, setShowHighFeeConfirmation } = useDrawers();
+  const { isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation } = useDrawers();
 
   return (
     <Stack px="loose" spacing="loose" pb="extra-loose">
@@ -28,7 +28,7 @@ export function HighFeeConfirmation(): JSX.Element | null {
         <Button
           borderRadius="10px"
           mode="tertiary"
-          onClick={() => setShowHighFeeConfirmation(!showHighFeeConfirmation)}
+          onClick={() => setIsShowingHighFeeConfirmation(!isShowingHighFeeConfirmation)}
           width="50%"
         >
           Edit fee
@@ -36,7 +36,7 @@ export function HighFeeConfirmation(): JSX.Element | null {
         <Button
           borderRadius="10px"
           onClick={() => {
-            setShowHighFeeConfirmation(!showHighFeeConfirmation);
+            setIsShowingHighFeeConfirmation(!isShowingHighFeeConfirmation);
             handleSubmit();
           }}
           width="50%"

--- a/src/app/features/high-fee-drawer/high-fee-drawer.tsx
+++ b/src/app/features/high-fee-drawer/high-fee-drawer.tsx
@@ -8,21 +8,21 @@ import { ControlledDrawer } from '@app/components/drawer/controlled-drawer';
 import { HighFeeConfirmation } from './components/high-fee-confirmation';
 
 export function HighFeeDrawer(): JSX.Element {
-  const { showHighFeeConfirmation, setShowHighFeeConfirmation } = useDrawers();
+  const { isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation } = useDrawers();
 
   useEffect(() => {
     return () => {
-      if (showHighFeeConfirmation) setShowHighFeeConfirmation(false);
+      if (isShowingHighFeeConfirmation) setIsShowingHighFeeConfirmation(false);
     };
-  }, [showHighFeeConfirmation, setShowHighFeeConfirmation]);
+  }, [isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation]);
 
   return (
     <ControlledDrawer
       icon={<Box as={FiAlertTriangle} color={color('feedback-error')} size="36px" />}
-      isShowing={!!showHighFeeConfirmation}
-      onClose={() => setShowHighFeeConfirmation(false)}
+      isShowing={!!isShowingHighFeeConfirmation}
+      onClose={() => setIsShowingHighFeeConfirmation(false)}
     >
-      {showHighFeeConfirmation && <HighFeeConfirmation />}
+      {isShowingHighFeeConfirmation && <HighFeeConfirmation />}
     </ControlledDrawer>
   );
 }

--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -28,7 +28,7 @@ export function SettingsDropdown() {
   const { lockWallet, hasGeneratedWallet, wallet } = useWallet();
   const createAccount = useCreateAccount();
   const [hasCreatedAccount, setHasCreatedAccount] = useHasCreatedAccount();
-  const { setShowSettings, showSettings, setShowSwitchAccountsState } = useDrawers();
+  const { setIsShowingSettings, isShowingSettings, setIsShowingSwitchAccountsState } = useDrawers();
   const currentNetworkId = useCurrentNetworkId();
   const navigate = useNavigate();
   const analytics = useAnalytics();
@@ -36,7 +36,7 @@ export function SettingsDropdown() {
   const key = useCurrentKeyDetails();
   const { isPressed: showAdvancedMenuOptions } = useModifierKey('alt', 120);
 
-  const handleClose = useCallback(() => setShowSettings(false), [setShowSettings]);
+  const handleClose = useCallback(() => setIsShowingSettings(false), [setIsShowingSettings]);
 
   const wrappedCloseCallback = useCallback(
     (callback: () => void) => () => {
@@ -46,7 +46,7 @@ export function SettingsDropdown() {
     [handleClose]
   );
 
-  const isShowing = showSettings;
+  const isShowing = isShowingSettings;
 
   useOnClickOutside(ref, isShowing ? handleClose : null);
 
@@ -63,7 +63,7 @@ export function SettingsDropdown() {
             {wallet && wallet?.accounts?.length > 1 && (
               <MenuItem
                 data-testid={SettingsSelectors.SwitchAccount}
-                onClick={wrappedCloseCallback(() => setShowSwitchAccountsState(true))}
+                onClick={wrappedCloseCallback(() => setIsShowingSwitchAccountsState(true))}
               >
                 Switch account
               </MenuItem>
@@ -114,7 +114,10 @@ export function SettingsDropdown() {
 
             <Divider />
             {showAdvancedMenuOptions && (
-              <AdvancedMenuItems closeHandler={wrappedCloseCallback} settingsShown={showSettings} />
+              <AdvancedMenuItems
+                closeHandler={wrappedCloseCallback}
+                settingsShown={isShowingSettings}
+              />
             )}
             {hasGeneratedWallet && walletType === 'software' && (
               <MenuItem

--- a/src/app/pages/send-tokens/components/send-form-inner.tsx
+++ b/src/app/pages/send-tokens/components/send-form-inner.tsx
@@ -39,7 +39,7 @@ export function SendFormInner(props: SendFormInnerProps) {
   const { handleSubmit, values, setValues, errors, setFieldError, validateForm } =
     useFormikContext<SendFormValues>();
 
-  const { showHighFeeConfirmation, setShowHighFeeConfirmation } = useDrawers();
+  const { isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation } = useDrawers();
   const { selectedAssetBalance } = useSelectedAssetBalance(values.assetId);
   const analytics = useAnalytics();
 
@@ -48,15 +48,15 @@ export function SendFormInner(props: SendFormInnerProps) {
       // We need to check for errors here before we show the high fee confirmation
       const formErrors = await validateForm();
       if (isEmpty(formErrors) && values.fee > HIGH_FEE_AMOUNT_STX) {
-        return setShowHighFeeConfirmation(!showHighFeeConfirmation);
+        return setIsShowingHighFeeConfirmation(!isShowingHighFeeConfirmation);
       }
       handleSubmit();
     }
   }, [
     handleSubmit,
     selectedAssetBalance,
-    setShowHighFeeConfirmation,
-    showHighFeeConfirmation,
+    setIsShowingHighFeeConfirmation,
+    isShowingHighFeeConfirmation,
     validateForm,
     values.amount,
     values.fee,

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
@@ -33,7 +33,7 @@ export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirm
   const { values } = useFormikContext<SendFormValues>();
   const unsignedTransaction = useSendFormUnsignedTxPreviewState(values.assetId, values);
   const analytics = useAnalytics();
-  const { showEditNonce } = useDrawers();
+  const { isShowingEditNonce } = useDrawers();
 
   const convertStxToUsd = useConvertStxToFiatAmount();
 
@@ -54,7 +54,7 @@ export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirm
       title="Confirm transfer"
       isShowing={isShowing}
       onClose={onClose}
-      pauseOnClickOutside={showEditNonce}
+      pauseOnClickOutside={isShowingEditNonce}
     >
       <Stack pb="extra-loose" px="loose" spacing="base">
         <SendTokensConfirmDetails

--- a/src/app/pages/send-tokens/send-tokens.tsx
+++ b/src/app/pages/send-tokens/send-tokens.tsx
@@ -34,7 +34,7 @@ import { SendTokensSoftwareConfirmDrawer } from './components/send-tokens-confir
 
 function SendTokensFormBase() {
   const navigate = useNavigate();
-  const { showEditNonce } = useDrawers();
+  const { isShowingEditNonce } = useDrawers();
   const [isShowing, setShowing] = useState(false);
   const [assetError, setAssetError] = useState<string | undefined>(undefined);
   const [selectedAssetId, setSelectedAssetId] = useState<string>('');
@@ -134,7 +134,7 @@ function SendTokensFormBase() {
               ledger: <></>,
               software: (
                 <SendTokensSoftwareConfirmDrawer
-                  isShowing={isShowing && !showEditNonce}
+                  isShowing={isShowing && !isShowingEditNonce}
                   onClose={() => handleConfirmDrawerOnClose()}
                   onUserSelectBroadcastTransaction={async (
                     transaction: StacksTransaction | undefined

--- a/src/app/pages/transaction-request/components/submit-action.tsx
+++ b/src/app/pages/transaction-request/components/submit-action.tsx
@@ -21,7 +21,7 @@ function BaseConfirmButton(props: ButtonProps): JSX.Element {
 
 export function SubmitAction() {
   const { handleSubmit, values, validateForm } = useFormikContext<TransactionFormValues>();
-  const { showHighFeeConfirmation, setShowHighFeeConfirmation } = useDrawers();
+  const { isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation } = useDrawers();
   const { isLoading } = useLoading(LoadingKeys.SUBMIT_TRANSACTION);
   const error = useTransactionError();
 
@@ -31,7 +31,7 @@ export function SubmitAction() {
     // Check for errors before showing the high fee confirmation
     const formErrors = await validateForm();
     if (isEmpty(formErrors) && values.fee > HIGH_FEE_AMOUNT_STX) {
-      return setShowHighFeeConfirmation(!showHighFeeConfirmation);
+      return setIsShowingHighFeeConfirmation(!isShowingHighFeeConfirmation);
     }
     handleSubmit();
   };

--- a/src/app/pages/transaction-request/components/transaction-error/error-messages.tsx
+++ b/src/app/pages/transaction-request/components/transaction-error/error-messages.tsx
@@ -23,7 +23,7 @@ interface InsufficientFundsActionButtonsProps {
 }
 function InsufficientFundsActionButtons({ eventName }: InsufficientFundsActionButtonsProps) {
   const analytics = useAnalytics();
-  const { setShowSwitchAccountsState } = useDrawers();
+  const { setIsShowingSwitchAccountsState } = useDrawers();
 
   const onGetStx = () => {
     void analytics.track(eventName);
@@ -34,7 +34,7 @@ function InsufficientFundsActionButtons({ eventName }: InsufficientFundsActionBu
   return (
     <>
       <PrimaryButton onClick={onGetStx}>Get STX</PrimaryButton>
-      <SecondaryButton onClick={() => setShowSwitchAccountsState(true)}>
+      <SecondaryButton onClick={() => setIsShowingSwitchAccountsState(true)}>
         Switch account
       </SecondaryButton>
     </>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3394296576).<!-- Sticky Header Marker -->

Renames boolean vars with `is*` prefix.

closes #2779