### PR TITLE
chore: audit tx request errors

### DIFF
--- a/src/app/query/stacks/transactions/transactions-with-transfers.query.ts
+++ b/src/app/query/stacks/transactions/transactions-with-transfers.query.ts
@@ -6,10 +6,6 @@ import { DEFAULT_LIST_LIMIT, QueryRefreshRates } from '@shared/constants';
 import { useStacksClient } from '@app/store/common/api-clients.hooks';
 import { AddressTransactionsWithTransfersListResponse } from '@stacks/stacks-blockchain-api-types';
 
-enum AccountClientKeys {
-  TransactionsWithTransfersClient = 'account/TransactionsWithTransfersClient',
-}
-
 const queryOptions = {
   refetchInterval: QueryRefreshRates.MEDIUM,
   refetchOnMount: 'always',
@@ -30,9 +26,9 @@ export function useGetAccountTransactionsWithTransfersQuery() {
   };
 
   return useQuery({
-    queryKey: [AccountClientKeys.TransactionsWithTransfersClient, principal, networkUrl],
+    queryKey: ['account-txs-with-transfers', principal, networkUrl],
     queryFn: fetch,
-    enabled: !!principal || !!networkUrl,
+    enabled: !!principal && !!networkUrl,
     ...queryOptions,
   }) as UseQueryResult<AddressTransactionsWithTransfersListResponse, Error>;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3396302797).<!-- Sticky Header Marker -->

While auditing the tx request errors I fixed this minor error showing up in the tx-request popup...

There was no principal but we had an `or` conditional to enable the query instead of an `and`.

![Screen Shot 2022-11-03 at 2 58 59 PM](https://user-images.githubusercontent.com/6493321/200051675-7decd041-af12-4095-b101-98d8db69bb4d.png)
