### PR TITLE
feat: strengthen signout message

### DIFF
--- a/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import { Box, Button, Flex, color } from '@stacks/ui';
+import { Box, Button, Flex, Text, color } from '@stacks/ui';
 import { SettingsSelectors } from '@tests/integration/settings.selectors';
 import { useFormik } from 'formik';
 
@@ -29,11 +29,20 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
       <Box mx="loose" mb="extra-loose">
         <form onChange={form.handleChange} onSubmit={form.handleSubmit}>
           <Body>
-            When you sign out,
-            {whenWallet({
-              software: ` you'll need your Secret Key to sign back in. Only sign out if you've backed up your Secret Key.`,
-              ledger: ` you'll need to reconnect your Ledger to sign back into your wallet.`,
-            })}
+            <p>
+              When you sign out,
+              {whenWallet({
+                software: ` you'll need your Secret Key to sign back in. Only sign out if you've backed up your Secret Key.`,
+                ledger: ` you'll need to reconnect your Ledger to sign back into your wallet.`,
+              })}
+            </p>
+            <Text as="p" mt="loose" fontWeight="bold">
+              {whenWallet({
+                software:
+                  "⚠️ If you haven't backed up your Secret Key, you will loose all your funds.",
+                ledger: '',
+              })}
+            </Text>
           </Body>
 
           <Flex

--- a/src/app/pages/sign-out-confirm/sign-out-confirm.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.tsx
@@ -4,7 +4,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 
-import { SignOutConfirmLayout } from './sign-out-confirm-layout';
+import { SignOutConfirmLayout } from './sign-out-confirm.layout';
 
 export function SignOutConfirmDrawer() {
   const { signOut } = useKeyActions();


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3426790823).<!-- Sticky Header Marker -->

Closes #2748 

Provides a bit of a stronger message to emphasize the importance of having stored the secret key before signing out.