### PR TITLE
refactor: remove capsize library

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "bitcoinjs-lib": "5.2.0",
     "bn.js": "5.2.0",
     "c32check": "1.1.3",
-    "capsize": "2.0.0",
     "chroma-js": "2.1.2",
     "compare-versions": "4.1.3",
     "dayjs": "1.10.7",

--- a/src/app/components/typography.tsx
+++ b/src/app/components/typography.tsx
@@ -1,6 +1,5 @@
 import { Text as BaseText, BoxProps, color } from '@stacks/ui';
 import { forwardRefWithAs } from '@stacks/ui-core';
-import capsize from 'capsize';
 
 const interMetrics = {
   capHeight: 2048,
@@ -17,54 +16,54 @@ const openSauceMetrics = {
   unitsPerEm: 2048,
 };
 
-const h1 = capsize({
+const h1 = {
   fontMetrics: openSauceMetrics,
   fontSize: 24,
   leading: 32,
-});
+};
 
 // B2
-const h2 = capsize({
+const h2 = {
   fontMetrics: openSauceMetrics,
   fontSize: 18,
   leading: 28,
-});
+};
 // B3
-const h3 = capsize({
+const h3 = {
   fontMetrics: openSauceMetrics,
   fontSize: 16,
   leading: 24,
-});
+};
 // C1
-const h4 = capsize({
+const h4 = {
   fontMetrics: openSauceMetrics,
   fontSize: 14,
   leading: 20,
-});
+};
 // C2
-const h5 = capsize({
+const h5 = {
   fontMetrics: openSauceMetrics,
   fontSize: 12,
   leading: 16,
-});
+};
 
-const c1 = capsize({
+const c1 = {
   fontMetrics: interMetrics,
   fontSize: 14,
   leading: 20,
-});
+};
 
-const c2 = capsize({
+const c2 = {
   fontMetrics: interMetrics,
   fontSize: 12,
   leading: 16,
-});
+};
 
-const c3 = capsize({
+const c3 = {
   fontMetrics: interMetrics,
   fontSize: 10,
   leading: 16,
-});
+};
 
 const captionStyles = (variant?: 'c1' | 'c2' | 'c3') => {
   switch (variant) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8356,11 +8356,6 @@ caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001400:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz#30f67d55a865da43e0aeec003f073ea8764d5d7c"
   integrity sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==
 
-capsize@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/capsize/-/capsize-2.0.0.tgz#09c440000d6c6c9da2c22b419b6ced1b74a1b29d"
-  integrity sha512-/xluZJe+SnuByQjws/B6QkrMzo9OqE9sd+k6paTxYoVVZLrwZoPdsCRasPiCIUQMy8UD11xgo5QZ/gtcNMlGlQ==
-
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3420414927).<!-- Sticky Header Marker -->

Quick test. Removes `capsize`. Some alignments/line heights are different now, and will need adjustments.

I reckon removing the library and making fixes without it, is a better approach than adding new code to fix problems introduced by it.

| Before 	| After 	|
|--------	|-------	|
| <img width="1392" alt="image" src="https://user-images.githubusercontent.com/1618764/200279905-7076be68-2bc3-47ee-a9be-166504a0e349.png"> | <img width="1392" alt="image" src="https://user-images.githubusercontent.com/1618764/200280146-690bad99-e8f6-4a42-b649-6735e169148b.png"> |
| <img width="1392" alt="image" src="https://user-images.githubusercontent.com/1618764/200279971-4037e850-6847-49f7-affd-1d8841145b63.png"> | <img width="1392" alt="image" src="https://user-images.githubusercontent.com/1618764/200280198-8b14be26-1380-4238-8fc8-6b71ce612783.png">|
| <img width="554" alt="image" src="https://user-images.githubusercontent.com/1618764/200280050-515decf4-f556-44ee-a7ea-56079362ad18.png"> | <img width="554" alt="image" src="https://user-images.githubusercontent.com/1618764/200280286-2b0746fe-da2f-4cb0-915b-df1fcf5b2c56.png">|


