### PR TITLE
fix(ledger): failing to broadcast from send form

### DIFF
--- a/src/app/features/ledger/flows/tx-signing/ledger-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/tx-signing/ledger-sign-tx-container.tsx
@@ -22,7 +22,7 @@ import {
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
-import { useTransactionRequestBroadcast } from '@app/store/transactions/transaction.hooks';
+import { useTransactionBroadcast } from '@app/store/transactions/transaction.hooks';
 import { RouteUrls } from '@shared/route-urls';
 import { logger } from '@shared/logger';
 
@@ -37,7 +37,7 @@ export function LedgerSignTxContainer() {
   const ledgerAnalytics = useLedgerAnalytics();
   useScrollLock(true);
   const account = useCurrentAccount();
-  const hwWalletTxBroadcast = useTransactionRequestBroadcast();
+  const hwWalletTxBroadcast = useTransactionBroadcast();
   const canUserCancelAction = useActionCancellableByUser();
   const verifyLedgerPublicKey = useVerifyMatchingLedgerPublicKey();
   const [unsignedTransaction, setUnsignedTransaction] = useState<null | string>(null);

--- a/src/app/store/transactions/transaction.hooks.ts
+++ b/src/app/store/transactions/transaction.hooks.ts
@@ -156,7 +156,7 @@ export function useSignTransactionSoftwareWallet() {
   );
 }
 
-export function useTransactionRequestBroadcast() {
+export function useTransactionBroadcast() {
   const submittedTransactionsActions = useSubmittedTransactionsActions();
   const { tabId } = useDefaultRequestParams();
   const requestToken = useTransactionRequest();
@@ -164,14 +164,6 @@ export function useTransactionRequestBroadcast() {
   const network = useCurrentNetworkState();
 
   return async ({ signedTx }: { signedTx: StacksTransaction }) => {
-    if (!requestToken || !tabId) {
-      logger.error(`Cannot broadcast transaction from transaction request`, {
-        requestToken,
-        tabId,
-      });
-      return;
-    }
-
     try {
       const { isSponsored, serialized, txRaw } = prepareTxDetailsForBroadcast(signedTx);
       const result = await broadcastTransaction({
@@ -181,16 +173,20 @@ export function useTransactionRequestBroadcast() {
         attachment,
         networkUrl: network.url,
       });
+
       if (isString(result.txId)) {
         submittedTransactionsActions.newTransactionSubmitted({
           rawTx: result.txRaw,
           txId: result.txId,
         });
       }
+
       // If there's a request token, this means it's a transaction request
       // In which case we need to return to the app the results of the tx
       // Otherwise, it's a send form tx and we don't want to
-      finalizeTxSignature({ requestPayload: requestToken, tabId, data: result });
+      if (requestToken && tabId) {
+        finalizeTxSignature({ requestPayload: requestToken, tabId, data: result });
+      }
       return Promise.resolve();
     } catch (error) {
       return Promise.reject(error);
@@ -205,7 +201,7 @@ export function useSoftwareWalletTransactionRequestBroadcast() {
   const { tabId } = useDefaultRequestParams();
   const requestToken = useTransactionRequest();
   const account = useCurrentAccount();
-  const txBroadcast = useTransactionRequestBroadcast();
+  const txBroadcast = useTransactionBroadcast();
 
   return async (values: TransactionFormValues) => {
     if (!stacksTxBaseState) return;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3410600821).<!-- Sticky Header Marker -->

User `pankociolek.btc` [reported in Discord](https://discord.com/channels/621759717756370964/745197302255321108/1039128967388610600) transactions failing to broadcast in the wallet from Ledger. This was a bug introduced in https://github.com/hirosystems/stacks-wallet-web/pull/2705.