### PR TITLE
chore(tooling): add decrypt mnemonic page

### DIFF
--- a/public/html/debug.html
+++ b/public/html/debug.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="mode__full-page light">
+  <head>
+    <meta charset="UTF-8" />
+    <title><%= htmlWebpackPlugin.options.title %></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="/assets/connect-logo/Stacks128w.png" />
+    <link href="/assets/base.css" rel="stylesheet" />
+  </head>
+  <body style="padding: 50px">
+    <form class="decrypt-mnemonic-form">
+      <fieldset>
+        <legend>Decrypt Hiro Wallet mnemonic</legend>
+        <p>
+          <label
+            >Encrypted Secret Key<br />
+            <input name="encryptedSecretKey" type="text"
+          /></label>
+        </p>
+
+        <p>
+          <label>
+            Salt<br />
+            <input name="salt" type="text" />
+          </label>
+        </p>
+        <p>
+          <label>
+            Password<br />
+            <input name="password" type="text" />
+          </label>
+        </p>
+        <button>Decrypt</button>
+      </fieldset>
+    </form>
+    <script src="browser-polyfill.js"></script>
+  </body>
+</html>

--- a/scripts/debug.js
+++ b/scripts/debug.js
@@ -1,0 +1,35 @@
+const mnemonicCrypto = require('../src/shared/crypto/mnemonic-encryption');
+
+function main() {
+  const mnemonicForm = document.querySelector('.decrypt-mnemonic-form');
+  const submitButton = document.querySelector('.decrypt-mnemonic-form button');
+
+  const originalBtnText = submitButton.textContent;
+
+  function setPending() {
+    submitButton.disabled = true;
+    submitButton.textContent = 'Wait';
+  }
+  function setComplete() {
+    submitButton.disabled = false;
+    submitButton.textContent = originalBtnText;
+  }
+
+  mnemonicForm.addEventListener('submit', async event => {
+    event.preventDefault();
+
+    setPending();
+
+    const formData = Object.fromEntries(new FormData(event.target).entries());
+
+    try {
+      const result = await mnemonicCrypto.decryptMnemonic(formData);
+      console.log(result);
+      alert(result.secretKey);
+    } finally {
+      setComplete();
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => main());

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -84,6 +84,7 @@ const config = {
     'content-script': path.join(SRC_ROOT_PATH, 'content-scripts', 'content-script.ts'),
     index: path.join(SRC_ROOT_PATH, 'app', 'index.tsx'),
     'decryption-worker': path.join(SRC_ROOT_PATH, 'shared/workers/decryption-worker.ts'),
+    debug: path.join(SRC_ROOT_PATH, '../scripts/debug.js'),
   },
   output: {
     path: DIST_ROOT_PATH,
@@ -181,6 +182,12 @@ const config = {
       template: path.join(SRC_ROOT_PATH, '../', 'public', 'html', 'popup-center.html'),
       filename: 'popup-center.html',
       ...HTML_PROD_OPTIONS,
+    }),
+    new HtmlWebpackPlugin({
+      template: path.join(SRC_ROOT_PATH, '../', 'public', 'html', 'debug.html'),
+      filename: 'debug.html',
+      title: 'Hiro Wallet—Debugger',
+      chunks: ['debug'],
     }),
     new GenerateJsonPlugin(
       'manifest.json',


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3412664021).<!-- Sticky Header Marker -->

Very simple form accepting 3 inputs: encrypted secret key, salt, and user password. This tool is intended to be used to support users who've forgotten their secret key only.

(N.b. weird html formatting is automatic and related to prettier formatting it)