### PR TITLE
fix: clipped label

### DIFF
--- a/src/app/features/current-account/current-account-name.tsx
+++ b/src/app/features/current-account/current-account-name.tsx
@@ -18,7 +18,6 @@ function AccountNameTitle(props: BoxProps) {
       data-testid={SettingsSelectors.CurrentAccountDisplayName}
       fontSize={4}
       fontWeight={500}
-      lineHeight="1rem"
       {...props}
     />
   );


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3440839363).<!-- Sticky Header Marker -->

As a result of #2833, the title was being clipped,

![image](https://user-images.githubusercontent.com/116000646/201216507-06c5a0a7-f03f-4a33-8aed-ef021d16fbba.png)

Fixed,

![image](https://user-images.githubusercontent.com/116000646/201216584-c42dccab-82e8-4f28-bcb3-d99c471e8f34.png)

Tried to reduce the margin on the header, but was unable to, there's a style with higher specificity and I don't know where it's coming from (in the screenshot I set my value to 33px just to exaggerate the difference should it have worked),

![image](https://user-images.githubusercontent.com/116000646/201217337-807f55d0-6388-4ca4-b627-b5c85ae41192.png)
