### PR TITLE
fix: missing address chars, closes #2860

### DIFF
--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -89,7 +89,7 @@ export function truncateString(str: string, maxLength: number) {
   return str.slice(0, maxLength) + '...';
 }
 
-export function isMultipleOf(multiple: number) {
+function isMultipleOf(multiple: number) {
   return (num: number) => num % multiple === 0;
 }
 

--- a/src/app/components/address-displayer/address-displayer.tsx
+++ b/src/app/components/address-displayer/address-displayer.tsx
@@ -1,22 +1,15 @@
-import { isEven, isMultipleOf } from '@app/common/utils';
+import { isEven } from '@app/common/utils';
 
 import { AddressDisplayerLayout } from './address-displayer.layout';
 
-const isMultipleOfFour = isMultipleOf(4);
-
 function groupByFour(text: string) {
-  const initialValue = { result: [] as string[][], tmp: [] as string[] };
+  const result = [];
 
-  const textGrouper = ({ result, tmp }: typeof initialValue, letter: string, index: number) => {
-    tmp.push(letter);
-    if (isMultipleOfFour(index + 1)) {
-      result.push(tmp);
-      tmp = [];
-    }
-    return { result, tmp };
-  };
+  for (let i = 0; i < text.length; i += 4) {
+    result.push(text.slice(i, i + 4));
+  }
 
-  return [...text].reduce(textGrouper, initialValue).result;
+  return result;
 }
 
 interface AddressDisplayerProps {
@@ -27,7 +20,7 @@ export function AddressDisplayer({ address }: AddressDisplayerProps) {
     <>
       {groupByFour(address).map((letterGroup, index) => (
         <AddressDisplayerLayout key={index} isEven={isEven(index + 1)}>
-          {letterGroup.join('')}
+          {letterGroup}
         </AddressDisplayerLayout>
       ))}
     </>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3475072844).<!-- Sticky Header Marker -->

Not all address chars of an address were being displayed due to the logic breaking up the address in groups of four not using any remaining chars after the division.

This PR fixes and simplifies the dividing logic.

closes #2860 