### PR TITLE
refactor: home page with facade pattern

### DIFF
--- a/src/app/features/balances-list/balances-list.tsx
+++ b/src/app/features/balances-list/balances-list.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Box, Stack, StackProps } from '@stacks/ui';
+import { HomePageSelectors } from '@tests/page-objects/home.selectors';
 
 import { BITCOIN_TEST_ADDRESS } from '@shared/constants';
 import { RouteUrls } from '@shared/route-urls';
@@ -44,7 +45,12 @@ export const BalancesList = ({ address, ...props }: BalancesListProps) => {
   if (noAssets) return <FundAccount onFundAccount={handleFundAccount} {...props} />;
 
   return (
-    <Stack pb="extra-loose" spacing="extra-loose" {...props}>
+    <Stack
+      pb="extra-loose"
+      spacing="extra-loose"
+      data-testid={HomePageSelectors.BalancesList}
+      {...props}
+    >
       {btcAssetBalance.balance.amount.isGreaterThan(0) && (
         <CryptoCurrencyAssetItem assetBalance={btcAssetBalance} icon={<Box as={BtcIcon} />} />
       )}

--- a/src/app/pages/home/components/home.layout.tsx
+++ b/src/app/pages/home/components/home.layout.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { Flex, Stack } from '@stacks/ui';
+import { HomePageSelectors } from '@tests/page-objects/home.selectors';
+
+import { HOME_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
+
+type HomeLayoutProps = Record<
+  'suggestedFirstSteps' | 'currentAccount' | 'actions' | 'children',
+  React.ReactNode
+>;
+export function HomeLayout(props: HomeLayoutProps) {
+  const { suggestedFirstSteps, currentAccount, actions, children } = props;
+  return (
+    <Stack alignItems="center" width="100%" spacing="extra-tight">
+      {suggestedFirstSteps}
+      <Stack
+        data-testid={HomePageSelectors.HomePageContainer}
+        maxWidth={['unset', HOME_FULL_PAGE_MAX_WIDTH]}
+        mt="extra-loose"
+        px={['base-loose', 'base-loose', 'base-loose', 'unset']}
+        spacing="loose"
+        width="100%"
+      >
+        <Flex
+          flexDirection={['column', 'column', 'unset']}
+          alignItems={['start', 'start', 'center']}
+          justifyContent={['unset', 'space-between']}
+        >
+          {currentAccount}
+          {actions}
+        </Flex>
+        {children}
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/app/pages/home/home.container.tsx
+++ b/src/app/pages/home/home.container.tsx
@@ -1,0 +1,12 @@
+import { FullPageLoadingSpinner } from '@app/components/loading-spinner';
+import { useCurrentAccount } from '@app/store/accounts/account.hooks';
+import { AccountWithAddress } from '@app/store/accounts/account.models';
+
+interface HomeContainerProps {
+  children(data: AccountWithAddress): JSX.Element;
+}
+export function HomeContainer({ children }: HomeContainerProps) {
+  const currentAccount = useCurrentAccount();
+  if (!currentAccount) return <FullPageLoadingSpinner />;
+  return children(currentAccount);
+}

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -1,31 +1,26 @@
 import { useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
-import { Flex, Stack } from '@stacks/ui';
-import { HomePageSelectors } from '@tests/page-objects/home.selectors';
-
 import { RouteUrls } from '@shared/route-urls';
 
 import { useTrackFirstDeposit } from '@app/common/hooks/analytics/transactions-analytics.hooks';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
-import { HOME_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
 import { Header } from '@app/components/header';
-import { FullPageLoadingSpinner } from '@app/components/loading-spinner';
 import { ActivityList } from '@app/features/activity-list/activity-list';
 import { BalancesList } from '@app/features/balances-list/balances-list';
 import { HiroMessages } from '@app/features/hiro-messages/hiro-messages';
 import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggested-first-steps';
 import { HomeActions } from '@app/pages/home/components/home-actions';
-import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 
 import { CurrentAccount } from './components/account-area';
 import { HomeTabs } from './components/home-tabs';
+import { HomeLayout } from './components/home.layout';
+import { HomeContainer } from './home.container';
 
 export function Home() {
   const { decodedAuthRequest } = useOnboardingState();
   const navigate = useNavigate();
-  const account = useCurrentAccount();
   useTrackFirstDeposit();
 
   useRouteHeader(
@@ -40,44 +35,21 @@ export function Home() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (!account) return <FullPageLoadingSpinner />;
-
   return (
-    <>
-      <Stack alignItems="center" width="100%" spacing="extra-tight">
-        <SuggestedFirstSteps />
-        <Stack
-          data-testid={HomePageSelectors.HomePageContainer}
-          maxWidth={['unset', HOME_FULL_PAGE_MAX_WIDTH]}
-          mt="extra-loose"
-          px={['base-loose', 'base-loose', 'base-loose', 'unset']}
-          spacing="loose"
-          width="100%"
+    <HomeContainer>
+      {account => (
+        <HomeLayout
+          suggestedFirstSteps={<SuggestedFirstSteps />}
+          currentAccount={<CurrentAccount />}
+          actions={<HomeActions />}
         >
-          {account ? (
-            <>
-              <Flex
-                flexDirection={['column', 'column', 'unset']}
-                alignItems={['start', 'start', 'center']}
-                justifyContent={['unset', 'space-between']}
-              >
-                <CurrentAccount />
-                <HomeActions />
-              </Flex>
-              <HomeTabs
-                balances={
-                  <BalancesList
-                    address={account?.address}
-                    data-testid={HomePageSelectors.BalancesList}
-                  />
-                }
-                activity={<ActivityList />}
-              />
-            </>
-          ) : null}
-        </Stack>
-      </Stack>
-      <Outlet />
-    </>
+          <HomeTabs
+            balances={<BalancesList address={account.address} />}
+            activity={<ActivityList />}
+          />
+          <Outlet />
+        </HomeLayout>
+      )}
+    </HomeContainer>
   );
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3481359227).<!-- Sticky Header Marker -->

This PR demonstrates pattern discussed in our discord. It makes a couple of improvements:

- `<Home />` is no longer concerned with data "preparation" or loading state. It does not need to know that `account` may sometimes be `undefined`
- A layout component further moves style-related content/logic to it's own component, leaving the next developer who needs to touch the home page focusing on the business logic of the page's root

<img width="664" alt="image" src="https://user-images.githubusercontent.com/1618764/202245077-2fd6fa5f-cfe3-4d6f-a16d-7baef71ee065.png">
