### PR TITLE
feat: add option to easily transfer within same wallet

### DIFF
--- a/src/app/components/account/account-balance-label.tsx
+++ b/src/app/components/account/account-balance-label.tsx
@@ -5,14 +5,14 @@ import {
   AccountBalanceLoading,
 } from '@app/components/account/account-balance-caption';
 import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
-import { useUnanchoredStacksBalances } from '@app/query/stacks/balance/balance.hooks';
+import { useAnchoredStacksAccountBalances } from '@app/query/stacks/balance/balance.hooks';
 
 interface AccountBalanceLabelProps {
   address: string;
 }
 export const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
   const stxMarketData = useStxMarketData();
-  const { data: balances, isLoading } = useUnanchoredStacksBalances(address);
+  const { data: balances, isLoading } = useAnchoredStacksAccountBalances(address);
 
   if (isLoading) return <AccountBalanceLoading />;
 

--- a/src/app/components/account/account-balance-label.tsx
+++ b/src/app/components/account/account-balance-label.tsx
@@ -1,0 +1,27 @@
+import { memo } from 'react';
+
+import {
+  AccountBalanceCaption,
+  AccountBalanceLoading,
+} from '@app/components/account/account-balance-caption';
+import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
+import { useUnanchoredStacksBalances } from '@app/query/stacks/balance/balance.hooks';
+
+interface AccountBalanceLabelProps {
+  address: string;
+}
+export const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
+  const stxMarketData = useStxMarketData();
+  const { data: balances, isLoading } = useUnanchoredStacksBalances(address);
+
+  if (isLoading) return <AccountBalanceLoading />;
+
+  if (!balances) return null;
+
+  return (
+    <AccountBalanceCaption
+      availableBalance={balances.stx.availableStx}
+      marketData={stxMarketData}
+    />
+  );
+});

--- a/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
@@ -3,37 +3,13 @@ import { memo } from 'react';
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { useSwitchAccount } from '@app/common/hooks/account/use-switch-account';
 import { useLoading } from '@app/common/hooks/use-loading';
-import {
-  AccountBalanceCaption,
-  AccountBalanceLoading,
-} from '@app/components/account/account-balance-caption';
 import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
 import { usePressable } from '@app/components/item-hover';
-import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
-import { useAnchoredStacksAccountBalances } from '@app/query/stacks/balance/balance.hooks';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
 
 import { AccountAvatarItem } from './account-avatar';
 import { AccountName } from './account-name';
-
-interface AccountBalanceLabelProps {
-  address: string;
-}
-const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
-  const stxMarketData = useStxMarketData();
-  const { data: balances, isLoading } = useAnchoredStacksAccountBalances(address);
-
-  if (isLoading) return <AccountBalanceLoading />;
-
-  if (!balances) return null;
-
-  return (
-    <AccountBalanceCaption
-      availableBalance={balances.stx.availableStx}
-      marketData={stxMarketData}
-    />
-  );
-});
+import { AccountBalanceLabel } from '@app/components/account/account-balance-label';
 
 interface SwitchAccountListItemProps {
   account: AccountWithAddress;

--- a/src/app/pages/send-tokens/components/recipient-field/recipient-account-drawer.tsx
+++ b/src/app/pages/send-tokens/components/recipient-field/recipient-account-drawer.tsx
@@ -1,0 +1,37 @@
+import { memo } from 'react';
+
+import { Box } from '@stacks/ui';
+
+import { useWalletType } from '@app/common/use-wallet-type';
+import { ControlledDrawer } from '@app/components/drawer/controlled-drawer';
+import { useAccounts } from '@app/store/accounts/account.hooks';
+
+import { RecipientAccountListItem } from './recipient-account-list-item';
+
+interface RecipientAccountDrawerProps {
+  closeAccountsDrawer(): void;
+  isShowing: boolean;
+}
+
+export const RecipientAccountDrawer = memo(
+  ({ isShowing, closeAccountsDrawer }: RecipientAccountDrawerProps) => {
+    const { whenWallet } = useWalletType();
+    const accounts = useAccounts();
+
+    return accounts ? (
+      <ControlledDrawer title="My accounts" isShowing={isShowing} onClose={closeAccountsDrawer}>
+        <Box mb={whenWallet({ ledger: 'base', software: '' })} marginBottom={8}>
+          {accounts.map(item => (
+            <Box mx={['base-loose', 'extra-loose']}>
+              <RecipientAccountListItem
+                handleClose={closeAccountsDrawer}
+                account={item}
+                key={item.address}
+              />
+            </Box>
+          ))}
+        </Box>
+      </ControlledDrawer>
+    ) : null;
+  }
+);

--- a/src/app/pages/send-tokens/components/recipient-field/recipient-account-drawer.tsx
+++ b/src/app/pages/send-tokens/components/recipient-field/recipient-account-drawer.tsx
@@ -1,12 +1,15 @@
 import { memo } from 'react';
+import { Virtuoso } from 'react-virtuoso';
 
 import { Box } from '@stacks/ui';
 
 import { useWalletType } from '@app/common/use-wallet-type';
-import { ControlledDrawer } from '@app/components/drawer/controlled-drawer';
+import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { useAccounts } from '@app/store/accounts/account.hooks';
 
 import { RecipientAccountListItem } from './recipient-account-list-item';
+
+const smallNumberOfAccountsToRenderWholeList = 10;
 
 interface RecipientAccountDrawerProps {
   closeAccountsDrawer(): void;
@@ -18,20 +21,34 @@ export const RecipientAccountDrawer = memo(
     const { whenWallet } = useWalletType();
     const accounts = useAccounts();
 
-    return accounts ? (
-      <ControlledDrawer title="My accounts" isShowing={isShowing} onClose={closeAccountsDrawer}>
-        <Box mb={whenWallet({ ledger: 'base', software: '' })} marginBottom={8}>
-          {accounts.map(item => (
-            <Box mx={['base-loose', 'extra-loose']}>
-              <RecipientAccountListItem
-                handleClose={closeAccountsDrawer}
-                account={item}
-                key={item.address}
-              />
+    return accounts && isShowing ? (
+      <BaseDrawer title="My accounts" isShowing={isShowing} onClose={closeAccountsDrawer}>
+        <Box mx={['base-loose', 'extra-loose']}>
+          {accounts.length <= smallNumberOfAccountsToRenderWholeList ? (
+            <Box mb={whenWallet({ ledger: 'base', software: '' })} marginBottom={8}>
+              {accounts.map(item => (
+                <RecipientAccountListItem
+                  handleClose={closeAccountsDrawer}
+                  account={item}
+                  key={item.address}
+                />
+              ))}
             </Box>
-          ))}
+          ) : (
+            <Virtuoso
+              height="72px"
+              style={{ paddingTop: '24px', height: '70vh' }}
+              totalCount={accounts.length}
+              itemContent={index => (
+                <RecipientAccountListItem
+                  handleClose={closeAccountsDrawer}
+                  account={accounts[index]}
+                />
+              )}
+            />
+          )}
         </Box>
-      </ControlledDrawer>
+      </BaseDrawer>
     ) : null;
   }
 );

--- a/src/app/pages/send-tokens/components/recipient-field/recipient-account-list-item.tsx
+++ b/src/app/pages/send-tokens/components/recipient-field/recipient-account-list-item.tsx
@@ -5,43 +5,20 @@ import { useFormikContext } from 'formik';
 import { SendFormValues } from '@shared/models/form.model';
 
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
-import {
-  AccountBalanceCaption,
-  AccountBalanceLoading,
-} from '@app/components/account/account-balance-caption';
 import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
 import { usePressable } from '@app/components/item-hover';
 import { AccountAvatarItem } from '@app/features/switch-account-drawer/components/account-avatar';
 import { AccountName } from '@app/features/switch-account-drawer/components/account-name';
-import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
-import { useAccountUnanchoredBalances } from '@app/query/stacks/balance/balance.hooks';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
+import { AccountBalanceLabel } from '@app/components/account/account-balance-label';
 
-interface AccountBalanceLabelProps {
-  address: string;
-}
-const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
-  const stxMarketData = useStxMarketData();
-  const { data: balances, isLoading } = useAccountUnanchoredBalances(address);
 
-  if (isLoading) return <AccountBalanceLoading />;
-
-  if (!balances) return null;
-
-  return (
-    <AccountBalanceCaption
-      availableBalance={balances.stx.availableStx}
-      marketData={stxMarketData}
-    />
-  );
-});
-
-interface SwitchAccountListItemProps {
+interface RecipientAccountListItemProps {
   account: AccountWithAddress;
   handleClose(): void;
 }
 export const RecipientAccountListItem = memo(
-  ({ account, handleClose }: SwitchAccountListItemProps) => {
+  ({ account, handleClose }: RecipientAccountListItemProps) => {
     const [component, bind] = usePressable(true);
     const name = useAccountDisplayName(account);
     const { setFieldValue } = useFormikContext<SendFormValues>();

--- a/src/app/pages/send-tokens/components/recipient-field/recipient-account-list-item.tsx
+++ b/src/app/pages/send-tokens/components/recipient-field/recipient-account-list-item.tsx
@@ -1,0 +1,73 @@
+import { memo } from 'react';
+
+import { useFormikContext } from 'formik';
+
+import { SendFormValues } from '@shared/models/form.model';
+
+import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
+import {
+  AccountBalanceCaption,
+  AccountBalanceLoading,
+} from '@app/components/account/account-balance-caption';
+import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
+import { usePressable } from '@app/components/item-hover';
+import { AccountAvatarItem } from '@app/features/switch-account-drawer/components/account-avatar';
+import { AccountName } from '@app/features/switch-account-drawer/components/account-name';
+import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
+import { useAccountUnanchoredBalances } from '@app/query/stacks/balance/balance.hooks';
+import { AccountWithAddress } from '@app/store/accounts/account.models';
+
+interface AccountBalanceLabelProps {
+  address: string;
+}
+const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
+  const stxMarketData = useStxMarketData();
+  const { data: balances, isLoading } = useAccountUnanchoredBalances(address);
+
+  if (isLoading) return <AccountBalanceLoading />;
+
+  if (!balances) return null;
+
+  return (
+    <AccountBalanceCaption
+      availableBalance={balances.stx.availableStx}
+      marketData={stxMarketData}
+    />
+  );
+});
+
+interface SwitchAccountListItemProps {
+  account: AccountWithAddress;
+  handleClose(): void;
+}
+export const RecipientAccountListItem = memo(
+  ({ account, handleClose }: SwitchAccountListItemProps) => {
+    const [component, bind] = usePressable(true);
+    const name = useAccountDisplayName(account);
+    const { setFieldValue } = useFormikContext<SendFormValues>();
+
+    const handleClick = () => {
+      setFieldValue('recipientAddressOrBnsName', account.address);
+      setFieldValue('recipient', account.address);
+      handleClose();
+    };
+
+    return (
+      <AccountListItemLayout
+        account={account}
+        isLoading={false}
+        isActive={false}
+        avatar={
+          <AccountAvatarItem index={account.index} publicKey={account.stxPublicKey} name={name} />
+        }
+        onSelectAccount={handleClick}
+        accountName={<AccountName account={account} />}
+        balanceLabel={<AccountBalanceLabel address={account.address} />}
+        mt="loose"
+        {...bind}
+      >
+        {component}
+      </AccountListItemLayout>
+    );
+  }
+);

--- a/src/app/pages/send-tokens/components/recipient-field/recipient-field.tsx
+++ b/src/app/pages/send-tokens/components/recipient-field/recipient-field.tsx
@@ -11,6 +11,7 @@ import { SendFormValues } from '@shared/models/form.model';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { ErrorLabel } from '@app/components/error-label';
+import { SpaceBetween } from '@app/components/space-between';
 import { Tooltip } from '@app/components/tooltip';
 import { Caption } from '@app/components/typography';
 import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
@@ -53,16 +54,25 @@ function RecipientFieldBase(props: RecipientField) {
   return (
     <Stack width="100%" {...rest}>
       <InputGroup flexDirection="column">
-        <Text
-          as="label"
-          display="block"
-          mb="tight"
-          fontSize={1}
-          fontWeight="500"
-          htmlFor="recipientAddressOrBnsName"
-        >
-          Recipient
-        </Text>
+        <SpaceBetween mb="tight">
+          <Text
+            as="label"
+            display="block"
+            fontSize={1}
+            fontWeight="500"
+            htmlFor="recipientAddressOrBnsName"
+          >
+            Recipient
+          </Text>
+          <Caption
+            as="button"
+            onClick={showAccountsDrawer}
+            _hover={{ cursor: 'pointer', textDecoration: 'underline' }}
+            color={color('brand')}
+          >
+            Choose account
+          </Caption>
+        </SpaceBetween>
         <RecipientAccountDrawer isShowing={isShowing} closeAccountsDrawer={closeAccountsDrawer} />
         <Input
           display="block"
@@ -91,15 +101,6 @@ function RecipientFieldBase(props: RecipientField) {
           data-testid={SendFormSelectors.InputRecipientField}
         />
       </InputGroup>
-      <Caption
-        as="button"
-        textAlign="left"
-        onClick={showAccountsDrawer}
-        _hover={{ cursor: 'pointer', textDecoration: 'underline' }}
-        color={color('brand')}
-      >
-        Transfer between my account
-      </Caption>
       {Boolean(resolvedBnsAddress) && (
         <Stack isInline spacing="tight">
           <Caption display="inline" data-testid={SendFormSelectors.ResolvedBnsAddressPreview}>

--- a/src/app/pages/send-tokens/components/recipient-field/recipient-field.tsx
+++ b/src/app/pages/send-tokens/components/recipient-field/recipient-field.tsx
@@ -91,7 +91,13 @@ function RecipientFieldBase(props: RecipientField) {
           data-testid={SendFormSelectors.InputRecipientField}
         />
       </InputGroup>
-      <Caption cursor="pointer" onClick={showAccountsDrawer}>
+      <Caption
+        as="button"
+        textAlign="left"
+        onClick={showAccountsDrawer}
+        _hover={{ cursor: 'pointer', textDecoration: 'underline' }}
+        color={color('brand')}
+      >
         Transfer between my account
       </Caption>
       {Boolean(resolvedBnsAddress) && (

--- a/src/app/pages/send-tokens/components/recipient-field/recipient-field.tsx
+++ b/src/app/pages/send-tokens/components/recipient-field/recipient-field.tsx
@@ -15,6 +15,8 @@ import { Tooltip } from '@app/components/tooltip';
 import { Caption } from '@app/components/typography';
 import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 
+import { RecipientAccountDrawer } from './recipient-account-drawer';
+
 interface RecipientField extends StackProps {
   error?: string;
   value: string;
@@ -27,7 +29,16 @@ function RecipientFieldBase(props: RecipientField) {
   const client = useStacksClientUnanchored();
   const [resolvedBnsAddress, setResolvedBnsAddress] = useState('');
   const { onCopy, hasCopied } = useClipboard(resolvedBnsAddress);
+  const [isShowing, setIsShowing] = useState(false);
   const analytics = useAnalytics();
+
+  const closeAccountsDrawer = () => {
+    setIsShowing(false);
+  };
+
+  const showAccountsDrawer = () => {
+    setIsShowing(true);
+  };
 
   const copyToClipboard = () => {
     void analytics.track('copy_resolved_address_to_clipboard');
@@ -52,6 +63,7 @@ function RecipientFieldBase(props: RecipientField) {
         >
           Recipient
         </Text>
+        <RecipientAccountDrawer isShowing={isShowing} closeAccountsDrawer={closeAccountsDrawer} />
         <Input
           display="block"
           type="string"
@@ -79,6 +91,9 @@ function RecipientFieldBase(props: RecipientField) {
           data-testid={SendFormSelectors.InputRecipientField}
         />
       </InputGroup>
+      <Caption cursor="pointer" onClick={showAccountsDrawer}>
+        Transfer between my account
+      </Caption>
       {Boolean(resolvedBnsAddress) && (
         <Stack isInline spacing="tight">
           <Caption display="inline" data-testid={SendFormSelectors.ResolvedBnsAddressPreview}>

--- a/src/app/pages/send-tokens/components/send-form-inner.tsx
+++ b/src/app/pages/send-tokens/components/send-form-inner.tsx
@@ -26,9 +26,9 @@ import { ShowEditNonceAction } from '@app/components/show-edit-nonce';
 import { AmountField } from '@app/pages/send-tokens/components/amount-field';
 import { AssetSearch } from '@app/pages/send-tokens/components/asset-search/asset-search';
 import { MemoField } from '@app/pages/send-tokens/components/memo-field';
-import { RecipientField } from '@app/pages/send-tokens/components/recipient-field';
 
 import { SendFormMemoWarning } from './memo-warning';
+import { RecipientField } from './recipient-field/recipient-field';
 
 interface SendFormInnerProps {
   assetError: string | undefined;


### PR DESCRIPTION
feature https://github.com/hirosystems/stacks-wallet-web/issues/2699

### Solution
- User can easily choose from one of the addresses from the wallet
- I took inspiration from `<SwitchAccountDrawer />` and `<AccountListItemLayout />` and created similar components for this feature. Let me know if this is okay or if you prefer to generalize and reuse the components.

## Demo
https://user-images.githubusercontent.com/16448321/202308374-db803e11-2c76-44c7-ba04-e0a07f6eb705.mov




