### PR TITLE
fix(balances): query correct balance endpoint, show microblock balance

### DIFF
--- a/src/app/common/hooks/use-send-form-validation.ts
+++ b/src/app/common/hooks/use-send-form-validation.ts
@@ -22,7 +22,7 @@ import {
 import { useFeeSchema } from '@app/common/validation/use-fee-schema';
 import { transactionMemoSchema } from '@app/common/validation/validate-memo';
 import { useCurrentStacksAccountAnchoredBalances } from '@app/query/stacks/balance/balance.hooks';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 
 export function useFungibleTokenAmountSchema(selectedAssetId: string) {
   const { selectedAssetBalance } = useSelectedAssetBalance(selectedAssetId);
@@ -45,7 +45,7 @@ export const useStacksSendFormValidation = ({
   const { isStx, selectedAssetBalance } = useSelectedAssetBalance(selectedAssetId);
   const fungibleTokenSchema = useFungibleTokenAmountSchema(selectedAssetId);
   const feeSchema = useFeeSchema();
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
 
   // TODO: Can this be removed?
   const selectedAssetSchema = useCallback(

--- a/src/app/components/balance.tsx
+++ b/src/app/components/balance.tsx
@@ -2,14 +2,14 @@ import { useMemo } from 'react';
 
 import { stacksValue } from '@app/common/stacks-utils';
 import { Caption } from '@app/components/typography';
-import { useUnanchoredStacksBalances } from '@app/query/stacks/balance/balance.hooks';
+import { useAnchoredStacksAccountBalances } from '@app/query/stacks/balance/balance.hooks';
 
 interface BalanceProps {
   address: string;
 }
 export function Balance(props: BalanceProps) {
   const { address } = props;
-  const { data: balances } = useUnanchoredStacksBalances(address);
+  const { data: balances } = useAnchoredStacksAccountBalances(address);
 
   const balance = useMemo(
     () =>

--- a/src/app/features/balances-list/balances-list.tsx
+++ b/src/app/features/balances-list/balances-list.tsx
@@ -15,6 +15,7 @@ import {
   useStacksAnchoredCryptoCurrencyAssetBalance,
   useStacksFungibleTokenAssetBalancesAnchoredWithMetadata,
   useStacksNonFungibleTokenAssetsUnanchored,
+  useStacksUnanchoredCryptoCurrencyAssetBalance,
 } from '@app/query/stacks/balance/crypto-asset-balances.hooks';
 
 import { FundAccount } from './components/fund-account';
@@ -26,6 +27,7 @@ interface BalancesListProps extends StackProps {
 }
 export const BalancesList = ({ address, ...props }: BalancesListProps) => {
   const { data: stxAssetBalance } = useStacksAnchoredCryptoCurrencyAssetBalance(address);
+  const { data: stxUnachoredAssetBalance } = useStacksUnanchoredCryptoCurrencyAssetBalance(address);
   const btcAssetBalance = useBitcoinCryptoCurrencyAssetBalance(BITCOIN_TEST_ADDRESS);
   const stacksFtAssetBalances = useStacksFungibleTokenAssetBalancesAnchoredWithMetadata(address);
   const { data: stacksNftAssetBalances = [] } = useStacksNonFungibleTokenAssetsUnanchored();
@@ -34,11 +36,12 @@ export const BalancesList = ({ address, ...props }: BalancesListProps) => {
   const handleFundAccount = useCallback(() => navigate(RouteUrls.Fund), [navigate]);
 
   // Better handle loading state
-  if (!stxAssetBalance) return null;
+  if (!stxAssetBalance || !stxUnachoredAssetBalance) return null;
 
   const noAssets =
     btcAssetBalance.balance.amount.isEqualTo(0) &&
     stxAssetBalance.balance.amount.isEqualTo(0) &&
+    stxUnachoredAssetBalance.balance.amount.isEqualTo(0) &&
     stacksFtAssetBalances.length === 0 &&
     stacksNftAssetBalances.length === 0;
 
@@ -54,8 +57,13 @@ export const BalancesList = ({ address, ...props }: BalancesListProps) => {
       {btcAssetBalance.balance.amount.isGreaterThan(0) && (
         <CryptoCurrencyAssetItem assetBalance={btcAssetBalance} icon={<Box as={BtcIcon} />} />
       )}
-      {stxAssetBalance.balance.amount.isGreaterThan(0) && (
-        <CryptoCurrencyAssetItem assetBalance={stxAssetBalance} icon={<StxAvatar {...props} />} />
+      {(stxAssetBalance.balance.amount.isGreaterThan(0) ||
+        stxUnachoredAssetBalance.balance.amount.isGreaterThan(0)) && (
+        <CryptoCurrencyAssetItem
+          assetBalance={stxAssetBalance}
+          assetSubBalance={stxUnachoredAssetBalance}
+          icon={<StxAvatar {...props} />}
+        />
       )}
       <StacksFungibleTokenAssetList assetBalances={stacksFtAssetBalances} />
       <StacksNonFungibleTokenAssetList assetBalances={stacksNftAssetBalances} />

--- a/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
@@ -10,7 +10,7 @@ import {
 import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
 import { usePressable } from '@app/components/item-hover';
 import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
-import { useUnanchoredStacksBalances } from '@app/query/stacks/balance/balance.hooks';
+import { useAnchoredStacksAccountBalances } from '@app/query/stacks/balance/balance.hooks';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
 
 import { AccountAvatarItem } from './account-avatar';
@@ -21,7 +21,7 @@ interface AccountBalanceLabelProps {
 }
 const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
   const stxMarketData = useStxMarketData();
-  const { data: balances, isLoading } = useUnanchoredStacksBalances(address);
+  const { data: balances, isLoading } = useAnchoredStacksAccountBalances(address);
 
   if (isLoading) return <AccountBalanceLoading />;
 

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -22,7 +22,7 @@ import { AccountListItemLayout } from '@app/components/account/account-list-item
 import { usePressable } from '@app/components/item-hover';
 import { Title } from '@app/components/typography';
 import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
-import { useUnanchoredStacksBalances } from '@app/query/stacks/balance/balance.hooks';
+import { useAnchoredStacksAccountBalances } from '@app/query/stacks/balance/balance.hooks';
 import { useAccounts, useHasCreatedAccount } from '@app/store/accounts/account.hooks';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
 
@@ -64,7 +64,7 @@ const ChooseAccountItem = memo((props: ChooseAccountItemProps) => {
   const [component, bind] = usePressable(true);
   const { decodedAuthRequest } = useOnboardingState();
   const name = useAccountDisplayName(account);
-  const { data: balances, isLoading: isBalanceLoading } = useUnanchoredStacksBalances(
+  const { data: balances, isLoading: isBalanceLoading } = useAnchoredStacksAccountBalances(
     account.address
   );
   const stxMarketData = useStxMarketData();

--- a/src/app/pages/send-tokens/components/recipient-field.tsx
+++ b/src/app/pages/send-tokens/components/recipient-field.tsx
@@ -13,7 +13,7 @@ import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { ErrorLabel } from '@app/components/error-label';
 import { Tooltip } from '@app/components/tooltip';
 import { Caption } from '@app/components/typography';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 
 interface RecipientField extends StackProps {
   error?: string;
@@ -24,7 +24,7 @@ interface RecipientField extends StackProps {
 function RecipientFieldBase(props: RecipientField) {
   const { error, value, ...rest } = props;
   const { handleChange, values, setFieldValue } = useFormikContext<SendFormValues>();
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   const [resolvedBnsAddress, setResolvedBnsAddress] = useState('');
   const { onCopy, hasCopied } = useClipboard(resolvedBnsAddress);
   const analytics = useAnalytics();

--- a/src/app/query/stacks/balance/balance.hooks.ts
+++ b/src/app/query/stacks/balance/balance.hooks.ts
@@ -31,7 +31,7 @@ export function parseBalanceResponse(balances: AddressBalanceResponse) {
   return { ...balances, stx };
 }
 
-export function useUnanchoredStacksBalances(address: string) {
+function useUnanchoredStacksBalances(address: string) {
   return useUnanchoredStacksAccountBalanceQuery(address, {
     select: resp => parseBalanceResponse(resp),
   });
@@ -41,7 +41,7 @@ export function useCurrentStacksAccountUnanchoredBalances() {
   return useUnanchoredStacksBalances(account?.address ?? '');
 }
 
-function useAnchoredStacksAccountBalances(address: string) {
+export function useAnchoredStacksAccountBalances(address: string) {
   return useAnchoredStacksAccountBalanceQuery(address, {
     select: resp => parseBalanceResponse(resp),
   });

--- a/src/app/query/stacks/balance/balance.query.ts
+++ b/src/app/query/stacks/balance/balance.query.ts
@@ -5,17 +5,17 @@ import { AddressBalanceResponse } from '@shared/models/account.model';
 import { AppUseQueryConfig } from '@app/query/query-config';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import type { AccountWithAddress } from '@app/store/accounts/account.models';
-import { useStacksClient, useStacksClientAnchored } from '@app/store/common/api-clients.hooks';
+import {
+  useStacksClientAnchored,
+  useStacksClientUnanchored,
+} from '@app/store/common/api-clients.hooks';
 
-const staleTime = 15 * 60 * 1000; // 15 min
+const staleTime = 1 * 60 * 1000; // 1min
 
 const balanceQueryOptions = {
-  keepPreviousData: false,
   staleTime,
-  cacheTime: 0,
+  keepPreviousData: false,
   refetchOnMount: true,
-  refetchInterval: false,
-  refetchOnReconnect: false,
 } as const;
 
 function fetchAccountBalance(client: StacksClient) {
@@ -33,11 +33,12 @@ export function useUnanchoredStacksAccountBalanceQuery<T extends unknown = Fetch
   address: string,
   options?: AppUseQueryConfig<FetchAccountBalanceResp, T>
 ) {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   return useQuery({
     enabled: !!address,
     queryKey: ['get-address-stx-balance', address],
     queryFn: () => fetchAccountBalance(client)(address),
+    ...balanceQueryOptions,
     ...options,
   });
 }
@@ -47,18 +48,19 @@ export function useAnchoredStacksAccountBalanceQuery<T extends unknown = FetchAc
   options?: AppUseQueryConfig<FetchAccountBalanceResp, T>
 ) {
   const client = useStacksClientAnchored();
+
   return useQuery({
     enabled: !!address,
     queryKey: ['get-address-anchored-stx-balance', address],
     queryFn: () => fetchAccountBalance(client)(address),
-    retryOnMount: true,
+
     ...balanceQueryOptions,
     ...options,
   });
 }
 
 export function useAnchoredAccountBalanceListQuery(accounts?: AccountWithAddress[]) {
-  const client = useStacksClient();
+  const client = useStacksClientAnchored();
 
   return useQueries({
     queries: (accounts ?? []).map(account => ({

--- a/src/app/query/stacks/balance/crypto-asset-balances.hooks.ts
+++ b/src/app/query/stacks/balance/crypto-asset-balances.hooks.ts
@@ -26,6 +26,14 @@ export function useStacksAnchoredCryptoCurrencyAssetBalance(address: string) {
       ),
   });
 }
+export function useStacksUnanchoredCryptoCurrencyAssetBalance(address: string) {
+  return useUnanchoredStacksAccountBalanceQuery(address, {
+    select: resp =>
+      createStacksCryptoCurrencyAssetTypeWrapper(
+        parseBalanceResponse(resp).stx.availableStx.amount
+      ),
+  });
+}
 
 function useStacksFungibleTokenAssetBalancesAnchored(address: string) {
   return useAnchoredStacksAccountBalanceQuery(address, {

--- a/src/app/query/stacks/bns/bns.query.ts
+++ b/src/app/query/stacks/bns/bns.query.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { AppUseQueryConfig } from '@app/query/query-config';
 import { StacksClient } from '@app/query/stacks/stacks-client';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 
 const staleTime = 15 * 60 * 1000; // 15 min
 
@@ -26,7 +26,7 @@ export function useGetBnsNamesOwnedByAddress<T extends unknown = BnsNameFetcherR
   address: string,
   options?: AppUseQueryConfig<BnsNameFetcherResp, T>
 ) {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   return useQuery({
     enabled: address !== '',
     queryKey: ['bns-names-by-address', address],

--- a/src/app/query/stacks/contract/contract.query.ts
+++ b/src/app/query/stacks/contract/contract.query.ts
@@ -3,10 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { ContractInterfaceResponseWithFunctions } from '@shared/models/contract-types';
 
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 
 export function useGetContractInterface(transactionRequest: ContractCallPayload | null) {
-  const { smartContractsApi } = useStacksClient();
+  const { smartContractsApi } = useStacksClientUnanchored();
 
   const fetchContractInterface = () => {
     if (!transactionRequest || transactionRequest?.txType !== TransactionTypes.ContractCall) return;

--- a/src/app/query/stacks/fungible-tokens/fungible-token-metadata.query.ts
+++ b/src/app/query/stacks/fungible-tokens/fungible-token-metadata.query.ts
@@ -4,7 +4,7 @@ import { RateLimiter } from 'limiter';
 
 import { isResponseCode } from '@app/common/network/is-response-code';
 import { StacksClient } from '@app/query/stacks/stacks-client';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 const limiter = new RateLimiter({ tokensPerInterval: 1, interval: 250 });
@@ -36,7 +36,7 @@ function fetchUnanchoredAccountInfo(client: StacksClient) {
 export function useGetFungibleTokenMetadataQuery(
   contractId: string
 ): UseQueryResult<FungibleTokenMetadata> {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   const network = useCurrentNetworkState();
 
   return useQuery({
@@ -49,7 +49,7 @@ export function useGetFungibleTokenMetadataQuery(
 export function useGetFungibleTokenMetadataListQuery(
   contractIds: string[]
 ): UseQueryResult<FungibleTokenMetadata>[] {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   const network = useCurrentNetworkState();
 
   return useQueries({

--- a/src/app/query/stacks/mempool/mempool.query.ts
+++ b/src/app/query/stacks/mempool/mempool.query.ts
@@ -2,12 +2,12 @@ import { MempoolTransaction } from '@stacks/stacks-blockchain-api-types';
 import { useQuery } from '@tanstack/react-query';
 
 import { safelyFormatHexTxid } from '@app/common/utils/safe-handle-txid';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 import { useSubmittedTransactionsActions } from '@app/store/submitted-transactions/submitted-transactions.hooks';
 import { useSubmittedTransactions } from '@app/store/submitted-transactions/submitted-transactions.selectors';
 
 export function useAccountMempoolQuery(address: string) {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   const submittedTransactions = useSubmittedTransactions();
   const submittedTransactionsActions = useSubmittedTransactionsActions();
 

--- a/src/app/query/stacks/non-fungible-tokens/non-fungible-token-holdings.query.ts
+++ b/src/app/query/stacks/non-fungible-tokens/non-fungible-token-holdings.query.ts
@@ -3,7 +3,7 @@ import { useQueries, useQuery } from '@tanstack/react-query';
 import { AppUseQueryConfig } from '@app/query/query-config';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 const staleTime = 15 * 60 * 1000; // 15 min
@@ -27,7 +27,7 @@ type FetchNonFungibleTokenHoldingsResp = Awaited<
 export function useGetNonFungibleTokenHoldingsQuery<
   T extends unknown = FetchNonFungibleTokenHoldingsResp
 >(address?: string, options?: AppUseQueryConfig<FetchNonFungibleTokenHoldingsResp, T>) {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   const network = useCurrentNetworkState();
 
   return useQuery({
@@ -44,7 +44,7 @@ export function useGetNonFungibleTokenHoldingsListQuery<
   accounts?: AccountWithAddress[],
   options?: AppUseQueryConfig<FetchNonFungibleTokenHoldingsResp, T>
 ) {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   const network = useCurrentNetworkState();
 
   return useQueries({

--- a/src/app/query/stacks/nonce/account-nonces.query.ts
+++ b/src/app/query/stacks/nonce/account-nonces.query.ts
@@ -2,7 +2,7 @@ import type { AddressNonces } from '@stacks/blockchain-api-client/lib/generated'
 import { UseQueryOptions, UseQueryResult, useQuery } from '@tanstack/react-query';
 
 import { useCurrentAccountStxAddressState } from '@app/store/accounts/account.hooks';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 const accountNoncesQueryOptions: UseQueryOptions = {
@@ -14,7 +14,7 @@ const accountNoncesQueryOptions: UseQueryOptions = {
 export function useGetAccountNonces() {
   const principal = useCurrentAccountStxAddressState();
   const network = useCurrentNetworkState();
-  const { accountsApi } = useStacksClient();
+  const { accountsApi } = useStacksClientUnanchored();
 
   const fetchAccountNonces = () => {
     if (!principal) return;

--- a/src/app/query/stacks/transactions/transactions-by-id.query.ts
+++ b/src/app/query/stacks/transactions/transactions-by-id.query.ts
@@ -1,10 +1,10 @@
 import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types/generated';
 import { useQueries, useQuery } from '@tanstack/react-query';
 
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 
 export function useTransactionsById(txids: string[]) {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
 
   function transactionByIdFetcher(txId: string) {
     return client.transactionsApi.getTransactionById({ txId }) as unknown as MempoolTransaction;
@@ -21,7 +21,7 @@ export function useTransactionsById(txids: string[]) {
 }
 
 export function useTransactionById(txid: string) {
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
 
   function transactionByIdFetcher(txId: string) {
     return client.transactionsApi.getTransactionById({ txId }) as unknown as

--- a/src/app/query/stacks/transactions/transactions-with-transfers.query.ts
+++ b/src/app/query/stacks/transactions/transactions-with-transfers.query.ts
@@ -4,7 +4,7 @@ import { UseQueryOptions, UseQueryResult, useQuery } from '@tanstack/react-query
 import { DEFAULT_LIST_LIMIT, QueryRefreshRates } from '@shared/constants';
 
 import { useCurrentAccountStxAddressState } from '@app/store/accounts/account.hooks';
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 const queryOptions = {
@@ -17,7 +17,7 @@ const queryOptions = {
 export function useGetAccountTransactionsWithTransfersQuery() {
   const principal = useCurrentAccountStxAddressState();
   const { chain } = useCurrentNetworkState();
-  const client = useStacksClient();
+  const client = useStacksClientUnanchored();
   const fetch = () => {
     if (!principal) return;
     return client.accountsApi.getAccountTransactionsWithTransfers({

--- a/src/app/store/common/api-clients.hooks.ts
+++ b/src/app/store/common/api-clients.hooks.ts
@@ -23,7 +23,7 @@ export function useBitcoinClient() {
 }
 
 // Unanchored by default (microblocks)
-export function useStacksClient() {
+export function useStacksClientUnanchored() {
   const network = useCurrentNetworkState();
 
   return useMemo(() => {

--- a/src/app/store/transactions/raw.hooks.ts
+++ b/src/app/store/transactions/raw.hooks.ts
@@ -4,7 +4,7 @@ import { useAsync } from 'react-async-hook';
 import { deserializeTransaction } from '@stacks/transactions';
 import { useAtom } from 'jotai';
 
-import { useStacksClient } from '@app/store/common/api-clients.hooks';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 import { rawTxIdState } from '@app/store/transactions/raw';
 
 export function useRawTxIdState() {
@@ -15,7 +15,7 @@ const rawTxCache = new Map();
 
 function useRawTxState() {
   const [txId] = useRawTxIdState();
-  const { transactionsApi } = useStacksClient();
+  const { transactionsApi } = useStacksClientUnanchored();
 
   return useAsync(async () => {
     if (!txId) return;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3525782388).<!-- Sticky Header Marker -->

- Fixes endpoint named anchored but querying unanchored balance
- Fixes microblock balance not showing on homepage
- Displays anchored balance in transaction request header
- Displays anchored balance in choose/switch account preview
- Increasing query time for balance endpoint, was far too slow

cc/ @314159265359879