### PR TITLE
chore: add window.open lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+const avoidWindowOpenMsg = 'Use `openInNewTab` helper';
+
 module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -23,6 +25,20 @@ module.exports = {
       'error',
       {
         ignoreReadBeforeAssign: false,
+      },
+    ],
+    'no-restricted-globals': ['error', { name: 'open', message: avoidWindowOpenMsg }],
+    'no-restricted-properties': [
+      'error',
+      {
+        object: 'window',
+        property: 'open',
+        message: avoidWindowOpenMsg,
+      },
+      {
+        object: 'globalThis',
+        property: 'open',
+        message: avoidWindowOpenMsg,
       },
     ],
     '@typescript-eslint/no-floating-promises': [1],

--- a/src/app/common/hooks/use-explorer-link.ts
+++ b/src/app/common/hooks/use-explorer-link.ts
@@ -5,6 +5,8 @@ import type { Blockchains } from '@shared/models/blockchain.model';
 import { makeTxExplorerLink } from '@app/common/utils';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
+import { openInNewTab } from '../utils/open-in-new-tab';
+
 interface HandleOpenTxLinkArgs {
   blockchain: Blockchains;
   suffix?: string;
@@ -14,7 +16,7 @@ export function useExplorerLink() {
   const { mode } = useCurrentNetworkState();
   const handleOpenTxLink = useCallback(
     ({ blockchain, suffix, txid }: HandleOpenTxLinkArgs) =>
-      window.open(makeTxExplorerLink({ blockchain, mode, suffix, txid }), '_blank'),
+      openInNewTab(makeTxExplorerLink({ blockchain, mode, suffix, txid })),
     [mode]
   );
 

--- a/src/app/common/utils/open-in-new-tab.ts
+++ b/src/app/common/utils/open-in-new-tab.ts
@@ -3,6 +3,8 @@ import { isValidUrl } from '@shared/utils/validate-url';
 
 export function openInNewTab(url: string) {
   if (!isValidUrl(url)) return;
+  // Only place window.open may be called
+  // eslint-disable-next-line no-restricted-properties
   const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
   if (newWindow) newWindow.opener = null;
 }

--- a/src/app/components/generic-error/generic-error.layout.tsx
+++ b/src/app/components/generic-error/generic-error.layout.tsx
@@ -47,17 +47,7 @@ export function GenericErrorLayout(props: ErrorProps) {
       >
         {helpTextList}
         <Box as="li" mt="base">
-          Still stuck? Reach out to{' '}
-          <Text
-            as="button"
-            color={color('accent')}
-            onClick={() => {
-              window.open('mailto:support@hiro.so');
-              window.close();
-            }}
-          >
-            support@hiro.so
-          </Text>
+          Still stuck? Reach out to support@hiro.so
         </Box>
       </Box>
       <Button fontSize="14px" mt="base-tight" onClick={onClose} p="base" variant="link">

--- a/src/app/features/errors/utils.ts
+++ b/src/app/features/errors/utils.ts
@@ -1,3 +1,5 @@
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+
 function makeStackTraceSection(stackTrace: string | null) {
   if (!stackTrace) return;
   return `
@@ -42,5 +44,5 @@ ${makeStackTraceSection(stackTrace)}
   issueParams.set('labels', issueLabels);
   issueParams.set('body', issueBody);
 
-  window.open(githubUrl.toString(), '_blank');
+  openInNewTab(githubUrl.toString());
 };


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3564883964).<!-- Sticky Header Marker -->

Trying out some lint rules to help communicate use of `window.open`