### PR TITLE
fix: close other frames when wallet locks

### DIFF
--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect } from 'react';
-import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -44,10 +44,10 @@ import { OnboardingGate } from './onboarding-gate';
 
 function AppRoutesAfterUserHasConsented() {
   const { pathname } = useLocation();
-  const navigate = useNavigate();
+
   const analytics = useAnalytics();
 
-  useOnWalletLock(() => navigate(RouteUrls.Unlock));
+  useOnWalletLock(() => window.close());
   useOnSignOut(() => window.close());
   useEffect(() => void analytics.page('view', `${pathname}`), [analytics, pathname]);
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3619609100).<!-- Sticky Header Marker -->

Fixes wallet locking issue that retains memory in other frames.