### PR TITLE
refactor: fees component for bitcoin

### DIFF
--- a/src/app/common/hooks/use-convert-to-fiat-amount.ts
+++ b/src/app/common/hooks/use-convert-to-fiat-amount.ts
@@ -1,15 +1,16 @@
 import { useCallback } from 'react';
 
+import { CryptoCurrencies } from '@shared/models/currencies.model';
 import type { Money } from '@shared/models/money.model';
 
-import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
+import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
 
 import { baseCurrencyAmountInQuote } from '../money/calculate-money';
 
-export function useConvertStxToFiatAmount() {
-  const stxMarketData = useStxMarketData();
+export function useConvertCryptoCurrencyToFiatAmount(currency: CryptoCurrencies) {
+  const cryptoCurrencyMarketData = useCryptoCurrencyMarketData(currency);
   return useCallback(
-    (value: Money) => baseCurrencyAmountInQuote(value, stxMarketData),
-    [stxMarketData]
+    (value: Money) => baseCurrencyAmountInQuote(value, cryptoCurrencyMarketData),
+    [cryptoCurrencyMarketData]
   );
 }

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -272,6 +272,10 @@ export function formatContractId(address: string, name: string) {
   return `${address}.${name}`;
 }
 
+/**
+ * Refactored with new send form; remove with legacy send form.
+ * @deprecated
+ */
 export function getFullyQualifiedStacksAssetName(
   assetBalance: StacksCryptoCurrencyAssetBalance | StacksFungibleTokenAssetBalance
 ) {

--- a/src/app/components/account/account-balance-label.tsx
+++ b/src/app/components/account/account-balance-label.tsx
@@ -4,14 +4,14 @@ import {
   AccountBalanceCaption,
   AccountBalanceLoading,
 } from '@app/components/account/account-balance-caption';
-import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
+import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
 import { useAnchoredStacksAccountBalances } from '@app/query/stacks/balance/balance.hooks';
 
 interface AccountBalanceLabelProps {
   address: string;
 }
 export const AccountBalanceLabel = memo(({ address }: AccountBalanceLabelProps) => {
-  const stxMarketData = useStxMarketData();
+  const stxMarketData = useCryptoCurrencyMarketData('STX');
   const { data: balances, isLoading } = useAnchoredStacksAccountBalances(address);
 
   if (isLoading) return <AccountBalanceLoading />;

--- a/src/app/components/fee-row/components/fee-estimate-select.tsx
+++ b/src/app/components/fee-row/components/fee-estimate-select.tsx
@@ -3,15 +3,15 @@ import { Dispatch, SetStateAction, useRef } from 'react';
 import { Fade, Stack, color } from '@stacks/ui';
 import { SendFormSelectors } from '@tests-legacy/page-objects/send-form.selectors';
 
+import { StacksFeeEstimateLegacy } from '@shared/models/fees/_fees-legacy.model';
 import { FeeTypes } from '@shared/models/fees/_fees.model';
-import { StacksFeeEstimate } from '@shared/models/fees/stacks-fees.model';
 
 import { useOnClickOutside } from '@app/common/hooks/use-onclickoutside';
 
 import { FeeEstimateItem } from './fee-estimate-item';
 
 interface FeeEstimateSelectProps {
-  items: StacksFeeEstimate[];
+  items: StacksFeeEstimateLegacy[];
   onClick: (index: number) => void;
   selected: number;
   setIsOpen: Dispatch<SetStateAction<boolean>>;

--- a/src/app/components/fee-row/fee-row.tsx
+++ b/src/app/components/fee-row/fee-row.tsx
@@ -6,12 +6,12 @@ import { SendFormSelectors } from '@tests-legacy/page-objects/send-form.selector
 import BigNumber from 'bignumber.js';
 import { useField } from 'formik';
 
+import { StacksFeeEstimateLegacy } from '@shared/models/fees/_fees-legacy.model';
 import { FeeTypes } from '@shared/models/fees/_fees.model';
-import { StacksFeeEstimate } from '@shared/models/fees/stacks-fees.model';
 import { createMoney } from '@shared/models/money.model';
 import { isNumber, isString } from '@shared/utils';
 
-import { useConvertStxToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
+import { useConvertCryptoCurrencyToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
 import { microStxToStx } from '@app/common/money/unit-conversion';
 import { stacksValue } from '@app/common/stacks-utils';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
@@ -32,11 +32,15 @@ const feesInfo =
 const url = 'https://hiro.so/questions/fee-estimates';
 
 interface FeeRowProps {
-  feeEstimations: StacksFeeEstimate[];
+  feeEstimations: StacksFeeEstimateLegacy[];
   feeFieldName: string;
   feeTypeFieldName: string;
   isSponsored: boolean;
 }
+/**
+ * Refactored with new send form; remove with legacy send form.
+ * @deprecated
+ */
 export function FeeRow(props: FeeRowProps): JSX.Element {
   const { feeEstimations, feeFieldName, isSponsored, feeTypeFieldName } = props;
   const [feeInput, feeMeta, feeHelper] = useField(feeFieldName);
@@ -46,7 +50,7 @@ export function FeeRow(props: FeeRowProps): JSX.Element {
   const [selected, setSelected] = useState(FeeTypes.Middle);
   const [isCustom, setIsCustom] = useState(false);
 
-  const convertStxToUsd = useConvertStxToFiatAmount();
+  const convertStxToUsd = useConvertCryptoCurrencyToFiatAmount('STX');
 
   const feeInUsd = useMemo(() => {
     if (!isNumber(feeInput.value) && !isString(feeInput.value)) return null;

--- a/src/app/components/fees-row/components/custom-fee-field.tsx
+++ b/src/app/components/fees-row/components/custom-fee-field.tsx
@@ -1,30 +1,28 @@
-import { Dispatch, FormEvent, SetStateAction, useCallback } from 'react';
+import { FormEvent, useCallback } from 'react';
 
 import { Input, InputGroup, Stack, StackProps, color } from '@stacks/ui';
 import { SendFormSelectors } from '@tests-legacy/page-objects/send-form.selectors';
-import BigNumber from 'bignumber.js';
 import { useField } from 'formik';
 
-import { StacksFeeEstimateLegacy } from '@shared/models/fees/_fees-legacy.model';
+import { StacksFeeEstimate } from '@shared/models/fees/stacks-fees.model';
 
 import { stxToMicroStx } from '@app/common/money/unit-conversion';
 import { SendFormWarningMessages } from '@app/common/warning-messages';
 import { Caption } from '@app/components/typography';
 
 interface CustomFeeFieldProps extends StackProps {
-  fieldName: string;
-  lowFeeEstimate: StacksFeeEstimateLegacy;
-  setFieldWarning: Dispatch<SetStateAction<string | undefined>>;
+  lowFeeEstimate: StacksFeeEstimate;
+  setFieldWarning(value: string): void;
 }
 export function CustomFeeField(props: CustomFeeFieldProps) {
-  const { fieldName, lowFeeEstimate, setFieldWarning, ...rest } = props;
-  const [input, meta, helpers] = useField(fieldName);
+  const { lowFeeEstimate, setFieldWarning, ...rest } = props;
+  const [input, meta, helpers] = useField('fee');
 
   const checkFieldWarning = useCallback(
     (value: string) => {
       if (meta.error) return setFieldWarning('');
       const fee = stxToMicroStx(value);
-      if (new BigNumber(lowFeeEstimate.fee).isGreaterThan(fee)) {
+      if (lowFeeEstimate.fee.amount.isGreaterThan(fee)) {
         return setFieldWarning(SendFormWarningMessages.AdjustedFeeBelowLowestEstimate);
       }
       return setFieldWarning('');

--- a/src/app/components/fees-row/components/fee-error.tsx
+++ b/src/app/components/fees-row/components/fee-error.tsx
@@ -1,0 +1,21 @@
+import { Text } from '@stacks/ui';
+import { SendFormSelectors } from '@tests-legacy/page-objects/send-form.selectors';
+import { useField } from 'formik';
+
+import { ErrorLabel } from '@app/components/error-label';
+
+export function FeeError() {
+  const [, meta] = useField('fee');
+
+  return (
+    <ErrorLabel data-testid={SendFormSelectors.InputCustomFeeFieldErrorLabel}>
+      <Text
+        data-testid={SendFormSelectors.InputCustomFeeFieldError}
+        lineHeight="18px"
+        textStyle="caption"
+      >
+        {meta.error}
+      </Text>
+    </ErrorLabel>
+  );
+}

--- a/src/app/components/fees-row/components/fee-estimate-item.tsx
+++ b/src/app/components/fees-row/components/fee-estimate-item.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { FiCheck, FiChevronDown } from 'react-icons/fi';
+
+import { Stack, color } from '@stacks/ui';
+
+import { SpaceBetween } from '@app/components/space-between';
+import { Caption } from '@app/components/typography';
+
+const labels = ['Low', 'Standard', 'High', 'Custom'];
+const testLabels = labels.map(label => label.toLowerCase());
+
+interface FeeEstimateItemProps {
+  index: number;
+  isVisible?: boolean;
+  onSelectItem(index: number): void;
+  selectedItem: number;
+}
+export function FeeEstimateItem(props: FeeEstimateItemProps) {
+  const { index, isVisible, onSelectItem, selectedItem } = props;
+
+  const selectedIcon = useMemo(() => {
+    const isSelected = index === selectedItem;
+    return isSelected ? <FiCheck color={color('accent')} size="14px" /> : <></>;
+  }, [index, selectedItem]);
+
+  return (
+    <Stack
+      alignItems="center"
+      border={isVisible ? 'none' : '1px solid #EFEFF2'}
+      borderRadius={isVisible ? '0px' : '10px'}
+      bg={color('bg')}
+      data-testid={`${testLabels[index]}-fee`}
+      _hover={{ bg: isVisible ? color('bg-alt') : 'none', borderRadius: '8px' }}
+      height="32px"
+      isInline
+      mb="0px !important"
+      minWidth="100px"
+      onClick={() => onSelectItem(index)}
+      p="tight"
+    >
+      <SpaceBetween flexGrow={1}>
+        <Caption ml="2px">{labels[index]}</Caption>
+        {isVisible ? selectedIcon : <FiChevronDown />}
+      </SpaceBetween>
+    </Stack>
+  );
+}

--- a/src/app/components/fees-row/components/fee-estimate-select.layout.tsx
+++ b/src/app/components/fees-row/components/fee-estimate-select.layout.tsx
@@ -1,0 +1,81 @@
+import { ReactNode, useRef } from 'react';
+import { FiInfo } from 'react-icons/fi';
+
+import { Box, Fade, Stack, Tooltip, color } from '@stacks/ui';
+import { SendFormSelectors } from '@tests-legacy/page-objects/send-form.selectors';
+
+import { FeeTypes } from '@shared/models/fees/_fees.model';
+
+import { useOnClickOutside } from '@app/common/hooks/use-onclickoutside';
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+
+import { FeeEstimateItem } from './fee-estimate-item';
+
+const feesInfo =
+  'Higher fees increase the likelihood of your transaction getting confirmed before others. Click to learn more.';
+const url = 'https://hiro.so/questions/fee-estimates';
+
+interface FeeEstimateSelectLayoutProps {
+  children: ReactNode;
+  isVisible: boolean;
+  onSelectItem(index: number): void;
+  onSetIsSelectVisible(value: boolean): void;
+  selectedItem: number;
+}
+export function FeeEstimateSelectLayout(props: FeeEstimateSelectLayoutProps) {
+  const { children, isVisible, onSelectItem, onSetIsSelectVisible, selectedItem } = props;
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useOnClickOutside(ref, () => onSetIsSelectVisible(false));
+
+  return (
+    <>
+      <Stack _hover={{ cursor: 'pointer' }}>
+        <FeeEstimateItem
+          index={selectedItem}
+          onSelectItem={() => onSetIsSelectVisible(true)}
+          selectedItem={FeeTypes.Middle}
+        />
+        <Fade in={isVisible}>
+          {styles => (
+            <Stack
+              bg={color('bg')}
+              borderRadius="8px"
+              boxShadow="high"
+              data-testid={SendFormSelectors.FeeEstimateSelect}
+              flexDirection="column"
+              minHeight="96px"
+              minWidth="100px"
+              overflow="hidden"
+              p="extra-tight"
+              position="absolute"
+              ref={ref}
+              style={styles}
+              top="-100px"
+              zIndex={9999}
+            >
+              {children}
+              <FeeEstimateItem
+                index={FeeTypes.Custom}
+                isVisible={isVisible}
+                onSelectItem={onSelectItem}
+                selectedItem={selectedItem}
+              />
+            </Stack>
+          )}
+        </Fade>
+      </Stack>
+      <Tooltip label={feesInfo} placement="bottom">
+        <Stack>
+          <Box
+            _hover={{ cursor: 'pointer' }}
+            as={FiInfo}
+            color={color('text-caption')}
+            onClick={() => openInNewTab(url)}
+            size="14px"
+          />
+        </Stack>
+      </Tooltip>
+    </>
+  );
+}

--- a/src/app/components/fees-row/components/fee-estimate-select.tsx
+++ b/src/app/components/fees-row/components/fee-estimate-select.tsx
@@ -1,0 +1,35 @@
+import { BitcoinFeeEstimate } from '@shared/models/fees/bitcoin-fees.model';
+import { StacksFeeEstimate } from '@shared/models/fees/stacks-fees.model';
+
+import { FeeEstimateItem } from './fee-estimate-item';
+import { FeeEstimateSelectLayout } from './fee-estimate-select.layout';
+
+interface FeeEstimateSelectProps {
+  isVisible: boolean;
+  items: BitcoinFeeEstimate[] | StacksFeeEstimate[];
+  onSelectItem(index: number): void;
+  onSetIsSelectVisible(value: boolean): void;
+  selectedItem: number;
+}
+export function FeeEstimateSelect(props: FeeEstimateSelectProps) {
+  const { isVisible, items, onSelectItem, onSetIsSelectVisible, selectedItem } = props;
+
+  return (
+    <FeeEstimateSelectLayout
+      isVisible={isVisible}
+      onSelectItem={onSelectItem}
+      onSetIsSelectVisible={onSetIsSelectVisible}
+      selectedItem={selectedItem}
+    >
+      {items.map((item, index) => (
+        <FeeEstimateItem
+          index={index}
+          isVisible={isVisible}
+          key={item.fee.amount.toNumber()}
+          onSelectItem={onSelectItem}
+          selectedItem={selectedItem}
+        />
+      ))}
+    </FeeEstimateSelectLayout>
+  );
+}

--- a/src/app/components/fees-row/components/fees-row.layout.tsx
+++ b/src/app/components/fees-row/components/fees-row.layout.tsx
@@ -1,0 +1,35 @@
+import { Stack, StackProps } from '@stacks/ui';
+import { useField } from 'formik';
+
+import { SpaceBetween } from '@app/components/space-between';
+import { SponsoredLabel } from '@app/components/sponsored-label';
+import { Caption } from '@app/components/typography';
+import { WarningLabel } from '@app/components/warning-label';
+
+import { FeeError } from './fee-error';
+
+interface FeesRowLayoutProps extends StackProps {
+  feeField: JSX.Element;
+  fieldWarning?: string;
+  isSponsored: boolean;
+  selectInput: JSX.Element;
+}
+export function FeesRowLayout(props: FeesRowLayoutProps) {
+  const { feeField, fieldWarning, isSponsored, selectInput, ...rest } = props;
+  const [_, meta] = useField('fee');
+
+  return (
+    <Stack spacing="base" {...rest}>
+      <SpaceBetween position="relative">
+        <Stack alignItems="center" isInline>
+          <Caption>Fees</Caption>
+          {!isSponsored ? selectInput : null}
+        </Stack>
+        {feeField}
+      </SpaceBetween>
+      {meta.error && <FeeError />}
+      {isSponsored && <SponsoredLabel />}
+      {!meta.error && fieldWarning && <WarningLabel>{fieldWarning}</WarningLabel>}
+    </Stack>
+  );
+}

--- a/src/app/components/fees-row/components/transaction-fee.tsx
+++ b/src/app/components/fees-row/components/transaction-fee.tsx
@@ -1,0 +1,23 @@
+import { Tooltip } from '@stacks/ui';
+import { TransactionSigningSelectors } from '@tests-legacy/page-objects/transaction-signing.selectors';
+
+import { CryptoCurrencies } from '@shared/models/currencies.model';
+import { Money } from '@shared/models/money.model';
+
+import { formatDustUsdAmounts, i18nFormatCurrency } from '@app/common/money/format-money';
+import { Caption } from '@app/components/typography';
+
+interface TransactionFeeProps {
+  fee: string | number;
+  feeCurrencySymbol: CryptoCurrencies;
+  usdAmount: Money | null;
+}
+export function TransactionFee({ fee, feeCurrencySymbol, usdAmount }: TransactionFeeProps) {
+  const feeLabel = (
+    <Caption data-testid={TransactionSigningSelectors.FeeToBePaidLabel}>
+      {fee} {feeCurrencySymbol}
+    </Caption>
+  );
+  if (!usdAmount || usdAmount.amount.isNaN()) return feeLabel;
+  return <Tooltip label={formatDustUsdAmounts(i18nFormatCurrency(usdAmount))}>{feeLabel}</Tooltip>;
+}

--- a/src/app/components/fees-row/fees-row.tsx
+++ b/src/app/components/fees-row/fees-row.tsx
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { StackProps } from '@stacks/ui';
+import BigNumber from 'bignumber.js';
+import { useField } from 'formik';
+
+import { CryptoCurrencies } from '@shared/models/currencies.model';
+import { FeeTypes, Fees } from '@shared/models/fees/_fees.model';
+import { createMoney } from '@shared/models/money.model';
+import { isNumber, isString } from '@shared/utils';
+
+import { useConvertCryptoCurrencyToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
+import { convertAmountToBaseUnit } from '@app/common/money/calculate-money';
+import { LoadingRectangle } from '@app/components/loading-rectangle';
+
+import { CustomFeeField } from './components/custom-fee-field';
+import { FeeEstimateSelect } from './components/fee-estimate-select';
+import { FeesRowLayout } from './components/fees-row.layout';
+import { TransactionFee } from './components/transaction-fee';
+
+interface FeeRowProps extends StackProps {
+  fees?: Fees;
+  isSponsored: boolean;
+}
+export function FeesRow(props: FeeRowProps): JSX.Element {
+  const { fees, isSponsored, ...rest } = props;
+  const [feeField, _, feeHelper] = useField('fee');
+  const [feeTypeField, __, feeTypeHelper] = useField('feeType');
+  const [fieldWarning, setFieldWarning] = useState<string | undefined>(undefined);
+  const [isSelectVisible, setIsSelectVisible] = useState(false);
+
+  const isCustom = feeTypeField.value === FeeTypes[FeeTypes.Custom];
+  const selectedItem = Number(FeeTypes[feeTypeField.value]);
+
+  const hasFeeEstimates = fees?.estimates.length;
+  const feeCurrencySymbol = fees?.estimates[0].fee.symbol as CryptoCurrencies;
+  const convertCryptoCurrencyToUsd = useConvertCryptoCurrencyToFiatAmount(feeCurrencySymbol);
+
+  const feeInUsd = useMemo(() => {
+    if ((!isNumber(feeField.value) && !isString(feeField.value)) || !feeCurrencySymbol) return null;
+    const feeAsMoney = createMoney(new BigNumber(feeField.value), feeCurrencySymbol);
+    return convertCryptoCurrencyToUsd(feeAsMoney);
+  }, [convertCryptoCurrencyToUsd, feeCurrencySymbol, feeField.value]);
+
+  useEffect(() => {
+    if (hasFeeEstimates && !feeField.value && !isCustom) {
+      feeHelper.setValue(convertAmountToBaseUnit(fees.estimates[FeeTypes.Middle].fee).toNumber());
+      feeTypeHelper.setValue(FeeTypes[FeeTypes.Middle]);
+    }
+    if (isSponsored) {
+      feeHelper.setValue(0);
+    }
+  }, [
+    feeField.value,
+    feeHelper,
+    feeTypeHelper,
+    fees?.estimates,
+    hasFeeEstimates,
+    isCustom,
+    isSponsored,
+  ]);
+
+  const handleSelectFeeEstimateOrCustomField = useCallback(
+    (index: number) => {
+      feeTypeHelper.setValue(FeeTypes[index]);
+      if (index === FeeTypes.Custom) feeHelper.setValue('');
+      else
+        fees && feeHelper.setValue(convertAmountToBaseUnit(fees.estimates[index].fee).toNumber());
+      setFieldWarning('');
+      setIsSelectVisible(false);
+    },
+    [feeTypeHelper, feeHelper, fees]
+  );
+
+  if (!hasFeeEstimates) return <LoadingRectangle height="32px" width="100%" {...rest} />;
+
+  return (
+    <FeesRowLayout
+      feeField={
+        isCustom ? (
+          <CustomFeeField
+            lowFeeEstimate={fees.estimates[FeeTypes.Low]}
+            setFieldWarning={(value: string) => setFieldWarning(value)}
+          />
+        ) : (
+          <TransactionFee
+            fee={feeField.value}
+            feeCurrencySymbol={feeCurrencySymbol}
+            usdAmount={feeInUsd}
+          />
+        )
+      }
+      fieldWarning={fieldWarning}
+      isSponsored={isSponsored}
+      selectInput={
+        <FeeEstimateSelect
+          isVisible={isSelectVisible}
+          items={fees.estimates}
+          onSelectItem={handleSelectFeeEstimateOrCustomField}
+          onSetIsSelectVisible={(value: boolean) => setIsSelectVisible(value)}
+          selectedItem={selectedItem}
+        />
+      }
+      {...rest}
+    />
+  );
+}

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -21,7 +21,7 @@ import {
 import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
 import { usePressable } from '@app/components/item-hover';
 import { Title } from '@app/components/typography';
-import { useStxMarketData } from '@app/query/common/market-data/market-data.hooks';
+import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
 import { useAnchoredStacksAccountBalances } from '@app/query/stacks/balance/balance.hooks';
 import { useAccounts, useHasCreatedAccount } from '@app/store/accounts/account.hooks';
 import { AccountWithAddress } from '@app/store/accounts/account.models';
@@ -67,7 +67,7 @@ const ChooseAccountItem = memo((props: ChooseAccountItemProps) => {
   const { data: balances, isLoading: isBalanceLoading } = useAnchoredStacksAccountBalances(
     account.address
   );
-  const stxMarketData = useStxMarketData();
+  const stxMarketData = useCryptoCurrencyMarketData('STX');
 
   const showLoadingProps = !!selectedAddress || !decodedAuthRequest;
 

--- a/src/app/pages/send-crypto-asset/forms/btc/btc-crypto-currency-send-form.tsx
+++ b/src/app/pages/send-crypto-asset/forms/btc/btc-crypto-currency-send-form.tsx
@@ -4,12 +4,14 @@ import { Form, Formik } from 'formik';
 import * as yup from 'yup';
 
 import { logger } from '@shared/logger';
+import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { RouteUrls } from '@shared/route-urls';
 
 import { btcAmountSchema } from '@app/common/validation/currency-schema';
+import { FeesRow } from '@app/components/fees-row/fees-row';
 import { BtcIcon } from '@app/components/icons/btc-icon';
 import { useBitcoinCryptoCurrencyAssetBalance } from '@app/query/bitcoin/address/address.hooks';
-import { useBitcoinFeeEstimations } from '@app/query/bitcoin/fees/fee-estimates.hooks';
+import { useBitcoinFees } from '@app/query/bitcoin/fees/fee-estimates.hooks';
 import { useCurrentAccountBtcAddressState } from '@app/store/accounts/account.hooks';
 
 import { AmountField } from '../../components/amount-field';
@@ -25,19 +27,20 @@ import { btcAddressValidator } from '../../validators/recipient-validators';
 
 interface BitcoinCryptoCurrencySendFormProps {}
 export function BitcoinCryptoCurrencySendForm({}: BitcoinCryptoCurrencySendFormProps) {
+  const navigate = useNavigate();
   const currentAccountBtcAddress = useCurrentAccountBtcAddressState();
   const btcCryptoCurrencyAssetBalance =
     useBitcoinCryptoCurrencyAssetBalance(currentAccountBtcAddress);
   // TODO: Replace hardcoded number here (200) with the tx byte length
-  const { data: btcFeeEstimations } = useBitcoinFeeEstimations(200);
-  const navigate = useNavigate();
+  const { data: btcFees } = useBitcoinFees(200);
 
   logger.debug('btc balance', btcCryptoCurrencyAssetBalance);
-  logger.debug('btc fees', btcFeeEstimations);
+  logger.debug('btc fees', btcFees);
 
   const initialValues = createDefaultInitialFormValues({
     memo: '',
-    fee: null,
+    fee: 0,
+    feeType: FeeTypes.Unknown,
   });
 
   function onSubmit() {
@@ -63,6 +66,7 @@ export function BitcoinCryptoCurrencySendForm({}: BitcoinCryptoCurrencySendFormP
           <RecipientField />
           <MemoField lastChild />
         </FormFieldsLayout>
+        <FeesRow fees={btcFees} isSponsored={false} mt="base" />
         <FormErrors />
         <PreviewButton />
       </Form>

--- a/src/app/pages/send-crypto-asset/forms/stx-sip10/stacks-fungible-token-send-form.tsx
+++ b/src/app/pages/send-crypto-asset/forms/stx-sip10/stacks-fungible-token-send-form.tsx
@@ -4,12 +4,16 @@ import { Form, Formik } from 'formik';
 import * as yup from 'yup';
 
 import { logger } from '@shared/logger';
+import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useFungibleTokenAmountSchema } from '@app/common/hooks/use-send-form-validation';
 import { pullContractIdFromIdentity } from '@app/common/utils';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
+import { FeesRow } from '@app/components/fees-row/fees-row';
+import { useCalculateStacksTxFees } from '@app/query/stacks/fees/fees.hooks';
 import { useGetFungibleTokenMetadataQuery } from '@app/query/stacks/fungible-tokens/fungible-token-metadata.query';
+import { useFtTokenTransferUnsignedTx } from '@app/store/transactions/token-transfer.hooks';
 
 import { AmountField } from '../../components/amount-field';
 import { FormErrors } from '../../components/form-errors';
@@ -32,10 +36,13 @@ export function StacksFungibleTokenSendForm({ symbol }: StacksFungibleTokenSendF
     pullContractIdFromIdentity(contractId)
   );
   const ftAmountSchema = useFungibleTokenAmountSchema(contractId);
+  const unsignedTx = useFtTokenTransferUnsignedTx(contractId);
+  const { data: stacksFtFees } = useCalculateStacksTxFees(unsignedTx);
 
   const initialValues = createDefaultInitialFormValues({
     symbol: '',
-    fee: null,
+    fee: 0,
+    feeType: FeeTypes.Unknown,
   });
 
   function onSubmit(values: any) {
@@ -64,6 +71,7 @@ export function StacksFungibleTokenSendForm({ symbol }: StacksFungibleTokenSendF
             <RecipientField />
             <MemoField />
           </FormFieldsLayout>
+          <FeesRow fees={stacksFtFees} isSponsored={false} mt="base" />
           <FormErrors />
           <PreviewButton />
           <pre>{JSON.stringify(form, null, 2)}</pre>

--- a/src/app/pages/send-crypto-asset/forms/stx/stx-crypto-currency-send-form.tsx
+++ b/src/app/pages/send-crypto-asset/forms/stx/stx-crypto-currency-send-form.tsx
@@ -4,10 +4,14 @@ import { Form, Formik } from 'formik';
 import * as yup from 'yup';
 
 import { logger } from '@shared/logger';
+import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { RouteUrls } from '@shared/route-urls';
 
 import { stxAmountSchema } from '@app/common/validation/currency-schema';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
+import { FeesRow } from '@app/components/fees-row/fees-row';
+import { useCalculateStacksTxFees } from '@app/query/stacks/fees/fees.hooks';
+import { useStxTokenTransferUnsignedTxState } from '@app/store/transactions/token-transfer.hooks';
 
 import { FormErrors } from '../../components/form-errors';
 import { FormFieldsLayout } from '../../components/form-fields.layout';
@@ -20,8 +24,13 @@ import { createDefaultInitialFormValues } from '../../form-utils';
 interface StacksCryptoCurrencySendFormProps {}
 export function StacksCryptoCurrencySendForm({}: StacksCryptoCurrencySendFormProps) {
   const navigate = useNavigate();
+  const unsignedTx = useStxTokenTransferUnsignedTxState();
+  const { data: stxFees } = useCalculateStacksTxFees(unsignedTx);
 
-  const initialValues = createDefaultInitialFormValues({ fee: null });
+  const initialValues = createDefaultInitialFormValues({
+    fee: 0,
+    feeType: FeeTypes.Unknown,
+  });
 
   const validationSchema = yup.object({
     amount: stxAmountSchema('test error msg'),
@@ -46,6 +55,7 @@ export function StacksCryptoCurrencySendForm({}: StacksCryptoCurrencySendFormPro
             <RecipientField />
             <MemoField lastChild />
           </FormFieldsLayout>
+          <FeesRow fees={stxFees} isSponsored={false} mt="base" />
           <FormErrors />
           <PreviewButton />
           <pre>{JSON.stringify(form, null, 2)}</pre>

--- a/src/app/pages/send-tokens/components/send-form-inner.tsx
+++ b/src/app/pages/send-tokens/components/send-form-inner.tsx
@@ -9,7 +9,7 @@ import type {
   StacksCryptoCurrencyAssetBalance,
   StacksFungibleTokenAssetBalance,
 } from '@shared/models/crypto-asset-balance.model';
-import { StacksFeeEstimate } from '@shared/models/fees/stacks-fees.model';
+import { StacksFeeEstimateLegacy } from '@shared/models/fees/_fees-legacy.model';
 import type { SendFormValues } from '@shared/models/form.model';
 import { isEmpty, isUndefined } from '@shared/utils';
 
@@ -32,7 +32,7 @@ import { RecipientField } from './recipient-field/recipient-field';
 
 interface SendFormInnerProps {
   assetError: string | undefined;
-  feeEstimations: StacksFeeEstimate[];
+  feeEstimations: StacksFeeEstimateLegacy[];
   onAssetIdSelected(assetId: string): void;
   nonce: number | undefined;
 }

--- a/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
+++ b/src/app/pages/send-tokens/components/send-tokens-confirm-drawer/send-tokens-confirm-drawer.tsx
@@ -9,7 +9,7 @@ import { SendFormValues } from '@shared/models/form.model';
 import { createMoney } from '@shared/models/money.model';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
-import { useConvertStxToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
+import { useConvertCryptoCurrencyToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
 import { useDrawers } from '@app/common/hooks/use-drawers';
 import { microStxToStx } from '@app/common/money/unit-conversion';
 import { BaseDrawer, BaseDrawerProps } from '@app/components/drawer/base-drawer';
@@ -37,7 +37,7 @@ export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirm
   const analytics = useAnalytics();
   const { isShowingEditNonce } = useDrawers();
 
-  const convertStxToUsd = useConvertStxToFiatAmount();
+  const convertStxToUsd = useConvertCryptoCurrencyToFiatAmount('STX');
 
   const feeInUsd = useMemo(
     () => convertStxToUsd(getFeeWithDefaultOfZero(unsignedTransaction)),
@@ -65,7 +65,7 @@ export function SendTokensSoftwareConfirmDrawer(props: SendTokensSoftwareConfirm
           recipient={values.recipient}
         />
         <SpaceBetween>
-          <Caption>Fees</Caption>
+          <Caption>Fee</Caption>
           <Caption>
             <TransactionFee
               fee={getFeeWithDefaultOfZero(unsignedTransaction).amount.toString()}

--- a/src/app/pages/send-tokens/send-tokens.tsx
+++ b/src/app/pages/send-tokens/send-tokens.tsx
@@ -22,7 +22,7 @@ import { Header } from '@app/components/header';
 import { EditNonceDrawer } from '@app/features/edit-nonce-drawer/edit-nonce-drawer';
 import { HighFeeDrawer } from '@app/features/high-fee-drawer/high-fee-drawer';
 import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
-import { useStacksFeeEstimations } from '@app/query/stacks/fees/fees.hooks';
+import { useStacksFeeEstimations } from '@app/query/stacks/fees/fees-legacy';
 import { useNextNonce } from '@app/query/stacks/nonce/account-nonces.hooks';
 import {
   useGenerateSendFormUnsignedTx,

--- a/src/app/pages/transaction-request/components/fee-form.tsx
+++ b/src/app/pages/transaction-request/components/fee-form.tsx
@@ -1,7 +1,7 @@
 import { useFormikContext } from 'formik';
 
-import { StacksFeeEstimate } from '@shared/models/fees/stacks-fees.model';
-import { SendFormValues, TransactionFormValues } from '@shared/models/form.model';
+import { StacksFeeEstimateLegacy } from '@shared/models/fees/_fees-legacy.model';
+import { TransactionFormValues } from '@shared/models/form.model';
 
 import { isTxSponsored } from '@app/common/transactions/stacks/transaction.utils';
 import { FeeRow } from '@app/components/fee-row/fee-row';
@@ -10,12 +10,13 @@ import { MinimalErrorMessage } from '@app/pages/transaction-request/components/m
 import { useUnsignedPrepareTransactionDetails } from '@app/store/transactions/transaction.hooks';
 
 interface FeeFormProps {
-  feeEstimations: StacksFeeEstimate[];
+  feeEstimations: StacksFeeEstimateLegacy[];
 }
+// TODO: The new FeesRow component should be used here when the legacy
+// send form, and the legacy fee row, are removed.
 export function FeeForm({ feeEstimations }: FeeFormProps) {
-  const { values } = useFormikContext<SendFormValues | TransactionFormValues>();
-  const assetId = 'assetId' in values ? values.assetId : '';
-  const transaction = useUnsignedPrepareTransactionDetails(assetId, values);
+  const { values } = useFormikContext<TransactionFormValues>();
+  const transaction = useUnsignedPrepareTransactionDetails(values);
 
   const isSponsored = transaction ? isTxSponsored(transaction) : false;
 

--- a/src/app/pages/transaction-request/transaction-request.tsx
+++ b/src/app/pages/transaction-request/transaction-request.tsx
@@ -29,7 +29,7 @@ import { PostConditionModeWarning } from '@app/pages/transaction-request/compone
 import { PostConditions } from '@app/pages/transaction-request/components/post-conditions/post-conditions';
 import { StxTransferDetails } from '@app/pages/transaction-request/components/stx-transfer-details/stx-transfer-details';
 import { TransactionError } from '@app/pages/transaction-request/components/transaction-error/transaction-error';
-import { useStacksFeeEstimations } from '@app/query/stacks/fees/fees.hooks';
+import { useStacksFeeEstimations } from '@app/query/stacks/fees/fees-legacy';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
 import {
   useGenerateUnsignedStacksTransaction,

--- a/src/app/query/bitcoin/fees/fee-estimates.hooks.ts
+++ b/src/app/query/bitcoin/fees/fee-estimates.hooks.ts
@@ -1,33 +1,47 @@
-import { FeeCalculationTypes, FeeEstimations } from '@shared/models/fees/_fees.model';
-import { BitcoinFeeEstimates } from '@shared/models/fees/bitcoin-fees.model';
+import BigNumber from 'bignumber.js';
 
-import { satToBtc } from '@app/common/money/unit-conversion';
+import { logger } from '@shared/logger';
+import { FeeCalculationTypes, Fees } from '@shared/models/fees/_fees.model';
+import { BitcoinFeeEstimates } from '@shared/models/fees/bitcoin-fees.model';
+import { createMoney } from '@shared/models/money.model';
 
 import { useGetBitcoinFeeEstimatesQuery } from './fee-estimates.query';
+
+// TODO: What should we return as default fee values for bitcoin?
+// const defaultBitcoinFeeEstimates: BitcoinFeeEstimate[] = [
+//   { fee: createMoney(new BigNumber(0), 'BTC'), feeRate: 0 },
+//   { fee: createMoney(new BigNumber(0), 'BTC'), feeRate: 0 },
+//   { fee: createMoney(new BigNumber(0), 'BTC'), feeRate: 0 },
+// ];
+
+// export const defaultBitcoinFees: Fees = {
+//   blockchain: 'bitcoin',
+//   estimates: defaultBitcoinFeeEstimates,
+//   calculation: FeeCalculationTypes.Default,
+// };
 
 interface ParseBitcoinFeeEstimatesResponseArgs {
   feeEstimates: BitcoinFeeEstimates;
   txByteLength: number;
 }
-
 function parseBitcoinFeeEstimatesResponse({
   feeEstimates,
   txByteLength,
-}: ParseBitcoinFeeEstimatesResponseArgs): FeeEstimations {
+}: ParseBitcoinFeeEstimatesResponseArgs): Fees {
   // TODO: What block confirmations do we want to target here for low, middle, and high?
   return {
     blockchain: 'bitcoin',
     estimates: [
       {
-        fee: satToBtc(feeEstimates['1']).multipliedBy(txByteLength).toNumber(),
+        fee: createMoney(new BigNumber(feeEstimates['1']).multipliedBy(txByteLength), 'BTC'),
         feeRate: feeEstimates['1'],
       },
       {
-        fee: satToBtc(feeEstimates['5']).multipliedBy(txByteLength).toNumber(),
+        fee: createMoney(new BigNumber(feeEstimates['5']).multipliedBy(txByteLength), 'BTC'),
         feeRate: feeEstimates['5'],
       },
       {
-        fee: satToBtc(feeEstimates['10']).multipliedBy(txByteLength).toNumber(),
+        fee: createMoney(new BigNumber(feeEstimates['10']).multipliedBy(txByteLength), 'BTC'),
         feeRate: feeEstimates['10'],
       },
     ],
@@ -35,8 +49,9 @@ function parseBitcoinFeeEstimatesResponse({
   };
 }
 
-export function useBitcoinFeeEstimations(txByteLength: number) {
+export function useBitcoinFees(txByteLength: number) {
   return useGetBitcoinFeeEstimatesQuery({
+    onError: err => logger.error('Error getting bitcoin fee estimates', { err }),
     select: resp => parseBitcoinFeeEstimatesResponse({ feeEstimates: resp, txByteLength }),
   });
 }

--- a/src/app/query/common/hiro-config/hiro-config.query.ts
+++ b/src/app/query/common/hiro-config/hiro-config.query.ts
@@ -3,6 +3,7 @@ import get from 'lodash.get';
 
 import { GITHUB_ORG, GITHUB_REPO } from '@shared/constants';
 import { BRANCH_NAME } from '@shared/environment';
+import { createMoney } from '@shared/models/money.model';
 import { isUndefined } from '@shared/utils';
 
 export interface HiroMessage {
@@ -52,7 +53,7 @@ async function fetchHiroMessages(): Promise<HiroConfig> {
   return fetch(githubWalletConfigRawUrl).then(msg => msg.json());
 }
 
-function useRemoteHiroConfig() {
+export function useRemoteHiroConfig() {
   const { data } = useQuery(['walletConfig'], fetchHiroMessages, {
     // As we're fetching from Github, a third-party, we want
     // to avoid any unnecessary stress on their services, so
@@ -96,7 +97,7 @@ export function useConfigFeeEstimationsMaxValues() {
   if (typeof config?.feeEstimationsMinMax === 'undefined') return;
   if (!config.feeEstimationsMinMax.maxValues) return;
   if (!Array.isArray(config.feeEstimationsMinMax.maxValues)) return;
-  return config.feeEstimationsMinMax.maxValues;
+  return config.feeEstimationsMinMax.maxValues.map(value => createMoney(value, 'STX'));
 }
 
 export function useConfigFeeEstimationsMinEnabled() {
@@ -110,5 +111,5 @@ export function useConfigFeeEstimationsMinValues() {
   if (typeof config?.feeEstimationsMinMax === 'undefined') return;
   if (!config.feeEstimationsMinMax.minValues) return;
   if (!Array.isArray(config.feeEstimationsMinMax.minValues)) return;
-  return config.feeEstimationsMinMax.minValues;
+  return config.feeEstimationsMinMax.minValues.map(value => createMoney(value, 'STX'));
 }

--- a/src/app/query/common/market-data/market-data.hooks.ts
+++ b/src/app/query/common/market-data/market-data.hooks.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
+import { CryptoCurrencies } from '@shared/models/currencies.model';
 import { MarketData, createMarketData, createMarketPair } from '@shared/models/market.model';
 import { createMoney, currencydecimalsMap } from '@shared/models/money.model';
 
@@ -33,10 +34,10 @@ function pullPriceDataFromAvailableResponses(responses: MarketDataVendorWithPric
     .map(val => convertAmountToFractionalUnit(val, currencydecimalsMap.USD));
 }
 
-export function useStxMarketData(): MarketData {
-  const { data: coingecko } = useCoinGeckoMarketDataQuery('STX');
-  const { data: coincap } = useCoincapMarketDataQuery('STX');
-  const { data: binance } = useBinanceMarketDataQuery('STX');
+export function useCryptoCurrencyMarketData(currency: CryptoCurrencies): MarketData {
+  const { data: coingecko } = useCoinGeckoMarketDataQuery(currency);
+  const { data: coincap } = useCoincapMarketDataQuery(currency);
+  const { data: binance } = useBinanceMarketDataQuery(currency);
 
   return useMemo(() => {
     const stxPriceData = pullPriceDataFromAvailableResponses([
@@ -46,6 +47,6 @@ export function useStxMarketData(): MarketData {
     ]);
     const meanStxPrice = calculateMeanAverage(stxPriceData);
 
-    return createMarketData(createMarketPair('STX', 'USD'), createMoney(meanStxPrice, 'USD'));
-  }, [binance, coincap, coingecko]);
+    return createMarketData(createMarketPair(currency, 'USD'), createMoney(meanStxPrice, 'USD'));
+  }, [binance, coincap, coingecko, currency]);
 }

--- a/src/app/query/stacks/balance/crypto-asset-balances.utils.ts
+++ b/src/app/query/stacks/balance/crypto-asset-balances.utils.ts
@@ -103,7 +103,11 @@ export function addQueriedMetadataToInitializedStacksFungibleTokenAssetBalance(
 ) {
   return {
     ...assetBalance,
-    balance: createMoney(assetBalance.balance.amount, metadata.symbol ?? '', metadata.decimals),
+    balance: createMoney(
+      assetBalance.balance.amount,
+      metadata.symbol ?? '',
+      metadata.decimals ?? 0
+    ),
     asset: {
       ...assetBalance.asset,
       canTransfer: isTransferableStacksFungibleTokenAsset(assetBalance.asset),

--- a/src/app/query/stacks/fees/fees-legacy.ts
+++ b/src/app/query/stacks/fees/fees-legacy.ts
@@ -1,0 +1,205 @@
+/*
+  This file is being kept to handle the legacy send form (pre-bitcoin).
+  It should be removed with the legacy send form.
+*/
+import { useMemo } from 'react';
+
+import { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import { BigNumber } from 'bignumber.js';
+
+import { DEFAULT_FEE_RATE } from '@shared/constants';
+import {
+  FeesLegacy,
+  StacksFeeEstimateLegacy,
+  StacksTxFeeEstimationLegacy,
+} from '@shared/models/fees/_fees-legacy.model';
+import { FeeCalculationTypes } from '@shared/models/fees/_fees.model';
+
+import { fetcher } from '@app/common/api/wrapped-fetch';
+import {
+  useConfigFeeEstimationsMaxEnabled,
+  useConfigFeeEstimationsMinEnabled,
+  useRemoteHiroConfig,
+} from '@app/query/common/hiro-config/hiro-config.query';
+import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
+
+const staleTime = 5 * 60 * 1000; // 5 min
+
+const feeEstimationsQueryOptions = {
+  staleTime,
+} as const;
+
+function useGetTransactionFeeEstimationQuery(
+  estimatedLen: number | null,
+  transactionPayload: string
+) {
+  const currentNetwork = useCurrentNetworkState();
+
+  const fetchTransactionFeeEstimation = async () => {
+    const response = await fetcher(currentNetwork.chain.stacks.url + '/v2/fees/transaction', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        transaction_payload: transactionPayload,
+        estimated_len: estimatedLen,
+      }),
+    });
+    const data = await response.json();
+    return data as StacksTxFeeEstimationLegacy;
+  };
+
+  return useQuery({
+    queryKey: ['transaction-fee-estimation', transactionPayload],
+    queryFn: fetchTransactionFeeEstimation,
+    enabled: transactionPayload !== '',
+    ...feeEstimationsQueryOptions,
+  }) as UseQueryResult<StacksTxFeeEstimationLegacy>;
+}
+
+const defaultFeesMaxValues = [500000, 750000, 2000000];
+const defaultFeesMinValues = [2500, 3000, 3500];
+
+const defaultFeeEstimations: StacksFeeEstimateLegacy[] = [
+  { fee: defaultFeesMinValues[0], feeRate: 0 },
+  { fee: defaultFeesMinValues[1], feeRate: 0 },
+  { fee: defaultFeesMinValues[2], feeRate: 0 },
+];
+
+function getFeeEstimationsWithCappedValues(
+  feeEstimations: StacksFeeEstimateLegacy[],
+  feeEstimationsMaxValues: number[] | undefined,
+  feeEstimationsMinValues: number[] | undefined
+) {
+  return feeEstimations.map((feeEstimation, index) => {
+    if (
+      feeEstimationsMaxValues &&
+      new BigNumber(feeEstimation.fee).isGreaterThan(feeEstimationsMaxValues[index])
+    ) {
+      return { fee: feeEstimationsMaxValues[index], feeRate: 0 };
+    } else if (
+      feeEstimationsMinValues &&
+      new BigNumber(feeEstimation.fee).isLessThan(feeEstimationsMinValues[index])
+    ) {
+      return { fee: feeEstimationsMinValues[index], feeRate: 0 };
+    } else {
+      return feeEstimation;
+    }
+  });
+}
+
+function calculateFeeFromFeeRate(txBytes: number, feeRate: number) {
+  return new BigNumber(txBytes).multipliedBy(feeRate);
+}
+
+const marginFromDefaultFeeDecimalPercent = 0.1;
+
+function getDefaultSimulatedFeeEstimations(estimatedByteLength: number): StacksFeeEstimateLegacy[] {
+  const fee = calculateFeeFromFeeRate(estimatedByteLength, DEFAULT_FEE_RATE);
+  return [
+    { fee: fee.multipliedBy(1 - marginFromDefaultFeeDecimalPercent).toNumber(), feeRate: 0 },
+    { fee: fee.toNumber(), feeRate: 0 },
+    { fee: fee.multipliedBy(1 + marginFromDefaultFeeDecimalPercent).toNumber(), feeRate: 0 },
+  ];
+}
+
+function useTransactionFeeEstimation(
+  estimatedLen: number | null,
+  transactionPayload: string
+): UseQueryResult<StacksTxFeeEstimationLegacy> {
+  return useGetTransactionFeeEstimationQuery(estimatedLen, transactionPayload);
+}
+
+function useConfigFeeEstimationsMaxValues() {
+  const config = useRemoteHiroConfig();
+  if (typeof config?.feeEstimationsMinMax === 'undefined') return;
+  if (!config.feeEstimationsMinMax.maxValues) return;
+  if (!Array.isArray(config.feeEstimationsMinMax.maxValues)) return;
+  return config.feeEstimationsMinMax.maxValues;
+}
+
+function useFeeEstimationsMaxValues() {
+  const configFeeEstimationsMaxEnabled = useConfigFeeEstimationsMaxEnabled();
+  const configFeeEstimationsMaxValues = useConfigFeeEstimationsMaxValues();
+
+  if (configFeeEstimationsMaxEnabled === false) return;
+  return configFeeEstimationsMaxValues || defaultFeesMaxValues;
+}
+
+function useConfigFeeEstimationsMinValues() {
+  const config = useRemoteHiroConfig();
+  if (typeof config?.feeEstimationsMinMax === 'undefined') return;
+  if (!config.feeEstimationsMinMax.minValues) return;
+  if (!Array.isArray(config.feeEstimationsMinMax.minValues)) return;
+  return config.feeEstimationsMinMax.minValues;
+}
+
+function useFeeEstimationsMinValues() {
+  const configFeeEstimationsMinEnabled = useConfigFeeEstimationsMinEnabled();
+  const configFeeEstimationsMinValues = useConfigFeeEstimationsMinValues();
+
+  if (configFeeEstimationsMinEnabled === false) return;
+  return configFeeEstimationsMinValues || defaultFeesMinValues;
+}
+
+function feeEstimationQueryFailedSilently(
+  feeEstimationResult: UseQueryResult<StacksTxFeeEstimationLegacy>
+) {
+  return !!(
+    feeEstimationResult.data &&
+    !feeEstimationResult.isLoading &&
+    (!!feeEstimationResult?.error || !feeEstimationResult.data.estimations?.length)
+  );
+}
+
+export function useStacksFeeEstimations(txByteLength: number | null, txPayload: string) {
+  const feeEstimationsMaxValues = useFeeEstimationsMaxValues();
+  const feeEstimationsMinValues = useFeeEstimationsMinValues();
+  const result = useTransactionFeeEstimation(txByteLength, txPayload);
+  const { data: txFeeEstimation, isError, isLoading } = result;
+
+  return useMemo<FeesLegacy>(() => {
+    const feeEstimations = txFeeEstimation?.estimations;
+
+    if ((!isLoading && isError) || txFeeEstimation?.error) {
+      return {
+        blockchain: 'stacks',
+        estimates: defaultFeeEstimations,
+        calculation: FeeCalculationTypes.Default,
+      };
+    }
+    if (txByteLength && feeEstimationQueryFailedSilently(result)) {
+      return {
+        blockchain: 'stacks',
+        estimates: getDefaultSimulatedFeeEstimations(txByteLength),
+        calculation: FeeCalculationTypes.DefaultSimulated,
+      };
+    }
+    if (feeEstimations?.length) {
+      const feeEstimationsWithCappedValues = getFeeEstimationsWithCappedValues(
+        feeEstimations,
+        feeEstimationsMaxValues,
+        feeEstimationsMinValues
+      );
+      return {
+        blockchain: 'stacks',
+        estimates: feeEstimationsWithCappedValues,
+        calculation: FeeCalculationTypes.FeesCapped,
+      };
+    }
+    return {
+      blockchain: 'stacks',
+      estimates: feeEstimations ?? [],
+      calculation: FeeCalculationTypes.Api,
+    };
+  }, [
+    feeEstimationsMaxValues,
+    feeEstimationsMinValues,
+    isError,
+    isLoading,
+    result,
+    txByteLength,
+    txFeeEstimation?.error,
+    txFeeEstimation?.estimations,
+  ]);
+}

--- a/src/app/query/stacks/fees/fees.hooks.ts
+++ b/src/app/query/stacks/fees/fees.hooks.ts
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
 
-import { UseQueryResult } from '@tanstack/react-query';
+import { StacksTransaction } from '@stacks/transactions';
 
-import { FeeCalculationTypes, FeeEstimations } from '@shared/models/fees/_fees.model';
+import { logger } from '@shared/logger';
+import { FeeCalculationTypes, Fees } from '@shared/models/fees/_fees.model';
 import { StacksFeeEstimate, StacksTxFeeEstimation } from '@shared/models/fees/stacks-fees.model';
+import { Money, createMoney } from '@shared/models/money.model';
 
 import {
   useConfigFeeEstimationsMaxEnabled,
@@ -11,24 +13,40 @@ import {
   useConfigFeeEstimationsMinEnabled,
   useConfigFeeEstimationsMinValues,
 } from '@app/query/common/hiro-config/hiro-config.query';
-import { useGetTransactionFeeEstimationQuery } from '@app/query/stacks/fees/fees.query';
+import { useGetStacksTransactionFeeEstimationQuery } from '@app/query/stacks/fees/fees.query';
 
-import { getDefaultSimulatedFeeEstimations, getFeeEstimationsWithCappedValues } from './fees.utils';
+import {
+  getDefaultSimulatedFeeEstimations,
+  getEstimatedUnsignedStacksTxByteLength,
+  getFeeEstimationsWithCappedValues,
+  getSerializedUnsignedStacksTxPayload,
+} from './fees.utils';
 
-const defaultFeesMaxValues = [500000, 750000, 2000000];
-const defaultFeesMinValues = [2500, 3000, 3500];
+const defaultFeesMaxValues = [
+  createMoney(500000, 'STX'),
+  createMoney(750000, 'STX'),
+  createMoney(2000000, 'STX'),
+];
+const defaultFeesMinValues = [
+  createMoney(2500, 'STX'),
+  createMoney(3000, 'STX'),
+  createMoney(3500, 'STX'),
+];
 
-const defaultFeeEstimations: StacksFeeEstimate[] = [
+const defaultStacksFeeEstimates: StacksFeeEstimate[] = [
   { fee: defaultFeesMinValues[0], feeRate: 0 },
   { fee: defaultFeesMinValues[1], feeRate: 0 },
   { fee: defaultFeesMinValues[2], feeRate: 0 },
 ];
 
-function useTransactionFeeEstimation(
-  estimatedLen: number | null,
-  transactionPayload: string
-): UseQueryResult<StacksTxFeeEstimation> {
-  return useGetTransactionFeeEstimationQuery(estimatedLen, transactionPayload);
+const defaultStacksFees: Fees = {
+  blockchain: 'stacks',
+  estimates: defaultStacksFeeEstimates,
+  calculation: FeeCalculationTypes.Default,
+};
+
+function feeEstimationQueryFailedSilently(feeEstimation: StacksTxFeeEstimation) {
+  return !!(feeEstimation && (!!feeEstimation.error || !feeEstimation.estimations.length));
 }
 
 function useFeeEstimationsMaxValues() {
@@ -47,63 +65,74 @@ function useFeeEstimationsMinValues() {
   return configFeeEstimationsMinValues || defaultFeesMinValues;
 }
 
-function feeEstimationQueryFailedSilently(
-  feeEstimationResult: UseQueryResult<StacksTxFeeEstimation>
-) {
-  return !!(
-    feeEstimationResult.data &&
-    !feeEstimationResult.isLoading &&
-    (!!feeEstimationResult?.error || !feeEstimationResult.data.estimations?.length)
-  );
+interface ParseStacksTxFeeEstimationResponseArgs {
+  feeEstimation: StacksTxFeeEstimation;
+  maxValues?: Money[];
+  minValues?: Money[];
+  txByteLength: number | null;
 }
-
-export function useStacksFeeEstimations(txByteLength: number | null, txPayload: string) {
-  const feeEstimationsMaxValues = useFeeEstimationsMaxValues();
-  const feeEstimationsMinValues = useFeeEstimationsMinValues();
-  const result = useTransactionFeeEstimation(txByteLength, txPayload);
-  const { data: txFeeEstimation, isError, isLoading } = result;
-
-  return useMemo<FeeEstimations>(() => {
-    const feeEstimations = txFeeEstimation?.estimations;
-
-    if (!isLoading && isError) {
-      return {
-        blockchain: 'stacks',
-        estimates: defaultFeeEstimations,
-        calculation: FeeCalculationTypes.Default,
-      };
-    }
-    if (txByteLength && feeEstimationQueryFailedSilently(result)) {
-      return {
-        blockchain: 'stacks',
-        estimates: getDefaultSimulatedFeeEstimations(txByteLength),
-        calculation: FeeCalculationTypes.DefaultSimulated,
-      };
-    }
-    if (feeEstimations?.length) {
-      const feeEstimationsWithCappedValues = getFeeEstimationsWithCappedValues(
-        feeEstimations,
-        feeEstimationsMaxValues,
-        feeEstimationsMinValues
-      );
-      return {
-        blockchain: 'stacks',
-        estimates: feeEstimationsWithCappedValues,
-        calculation: FeeCalculationTypes.FeesCapped,
-      };
-    }
+function parseStacksTxFeeEstimationResponse({
+  feeEstimation,
+  maxValues,
+  minValues,
+  txByteLength,
+}: ParseStacksTxFeeEstimationResponseArgs): Fees {
+  if (!!feeEstimation.error) defaultStacksFees;
+  if (txByteLength && feeEstimationQueryFailedSilently(feeEstimation)) {
     return {
       blockchain: 'stacks',
-      estimates: feeEstimations ?? [],
-      calculation: FeeCalculationTypes.Api,
+      estimates: getDefaultSimulatedFeeEstimations(txByteLength),
+      calculation: FeeCalculationTypes.DefaultSimulated,
     };
-  }, [
-    feeEstimationsMaxValues,
-    feeEstimationsMinValues,
-    isError,
-    isLoading,
-    result,
-    txByteLength,
-    txFeeEstimation?.estimations,
-  ]);
+  }
+
+  const stacksFeeEstimates: StacksFeeEstimate[] = feeEstimation.estimations.map(estimate => {
+    return {
+      fee: createMoney(estimate.fee, 'STX'),
+      feeRate: estimate.fee_rate,
+    };
+  });
+
+  if (feeEstimation.estimations && feeEstimation.estimations.length) {
+    const feeEstimationsWithCappedValues = getFeeEstimationsWithCappedValues(
+      stacksFeeEstimates,
+      maxValues,
+      minValues
+    );
+    return {
+      blockchain: 'stacks',
+      estimates: feeEstimationsWithCappedValues,
+      calculation: FeeCalculationTypes.FeesCapped,
+    };
+  }
+  return {
+    blockchain: 'stacks',
+    estimates: stacksFeeEstimates ?? [],
+    calculation: FeeCalculationTypes.Api,
+  };
+}
+
+export function useCalculateStacksTxFees(unsignedTx?: StacksTransaction) {
+  const feeEstimationsMaxValues = useFeeEstimationsMaxValues();
+  const feeEstimationsMinValues = useFeeEstimationsMinValues();
+
+  const { txByteLength, txPayload } = useMemo(() => {
+    if (!unsignedTx) return { txByteLength: null, txPayload: '' };
+
+    return {
+      txByteLength: getEstimatedUnsignedStacksTxByteLength(unsignedTx),
+      txPayload: getSerializedUnsignedStacksTxPayload(unsignedTx),
+    };
+  }, [unsignedTx]);
+
+  return useGetStacksTransactionFeeEstimationQuery(txByteLength, txPayload, {
+    onError: err => logger.error('Error getting stacks tx fee estimation', { err }),
+    select: resp =>
+      parseStacksTxFeeEstimationResponse({
+        feeEstimation: resp,
+        maxValues: feeEstimationsMaxValues,
+        minValues: feeEstimationsMinValues,
+        txByteLength,
+      }),
+  });
 }

--- a/src/app/store/transactions/token-transfer.hooks.ts
+++ b/src/app/store/transactions/token-transfer.hooks.ts
@@ -182,6 +182,7 @@ export function useGenerateFtTokenTransferUnsignedTx(selectedAssetId: string) {
   );
 }
 
+// TODO: Refactor when remove legacy send form?
 export function useFtTokenTransferUnsignedTx(selectedAssetId: string, values?: SendFormValues) {
   const generateTx = useGenerateFtTokenTransferUnsignedTx(selectedAssetId);
   const account = useCurrentAccount();

--- a/src/app/store/transactions/transaction.hooks.ts
+++ b/src/app/store/transactions/transaction.hooks.ts
@@ -94,21 +94,15 @@ function useUnsignedStacksTransactionBaseState() {
   }, [account, options, payload, stxAddress, transaction]);
 }
 
-export function useUnsignedPrepareTransactionDetails(
-  selectedAssetId: string,
-  values: SendFormValues | TransactionFormValues
-) {
+export function useUnsignedPrepareTransactionDetails(values: TransactionFormValues) {
   const unsignedStacksTransaction = useUnsignedStacksTransaction(values);
-  const sendFormUnsignedTx = useSendFormUnsignedTxPreviewState(
-    selectedAssetId,
-    values as SendFormValues
-  );
-  return useMemo(
-    () => unsignedStacksTransaction || sendFormUnsignedTx,
-    [sendFormUnsignedTx, unsignedStacksTransaction]
-  );
+  return useMemo(() => unsignedStacksTransaction, [unsignedStacksTransaction]);
 }
 
+/**
+ * Refactored with new send form; remove with legacy send form.
+ * @deprecated
+ */
 export function useSendFormSerializedUnsignedTxPayloadState(
   selectedAssetId: string,
   values?: SendFormValues
@@ -118,6 +112,10 @@ export function useSendFormSerializedUnsignedTxPayloadState(
   return bytesToHex(serializePayload(transaction.payload));
 }
 
+/**
+ * Refactored with new send form; remove with legacy send form.
+ * @deprecated
+ */
 export function useSendFormEstimatedUnsignedTxByteLengthState(
   selectedAssetId: string,
   values?: SendFormValues
@@ -127,12 +125,20 @@ export function useSendFormEstimatedUnsignedTxByteLengthState(
   return transaction.serialize().byteLength;
 }
 
+/**
+ * Refactor and remove with new fees row component.
+ * @deprecated
+ */
 export function useTxRequestSerializedUnsignedTxPayloadState() {
   const { transaction } = useUnsignedStacksTransactionBaseState();
   if (!transaction) return '';
   return bytesToHex(serializePayload(transaction.payload));
 }
 
+/**
+ * Refactor and remove with new fees row component.
+ * @deprecated
+ */
 export function useTxRequestEstimatedUnsignedTxByteLengthState() {
   const { transaction } = useUnsignedStacksTransactionBaseState();
   if (!transaction) return null;
@@ -291,6 +297,10 @@ export function useGenerateSendFormUnsignedTx(selectedAssetId: string) {
   );
 }
 
+/**
+ * Refactored with new send form; remove with legacy send form.
+ * @deprecated
+ */
 export function useSendFormUnsignedTxPreviewState(
   selectedAssetId: string,
   values?: SendFormValues

--- a/src/shared/models/fees/_fees-legacy.model.ts
+++ b/src/shared/models/fees/_fees-legacy.model.ts
@@ -1,0 +1,25 @@
+/*
+  This file is being kept to handle the legacy send form (pre-bitcoin).
+  It should be removed with the legacy send form.
+*/
+import { Blockchains } from '../blockchain.model';
+import { FeeCalculationTypes } from './_fees.model';
+
+export interface StacksFeeEstimateLegacy {
+  fee: number;
+  feeRate: number;
+}
+
+export interface StacksTxFeeEstimationLegacy {
+  cost_scalar_change_by_byte: number;
+  estimated_cost: Object;
+  estimated_cost_scalar: number;
+  estimations: StacksFeeEstimateLegacy[];
+  error: string;
+}
+
+export interface FeesLegacy {
+  blockchain: Blockchains;
+  estimates: StacksFeeEstimateLegacy[];
+  calculation: FeeCalculationTypes;
+}

--- a/src/shared/models/fees/_fees.model.ts
+++ b/src/shared/models/fees/_fees.model.ts
@@ -7,6 +7,7 @@ export enum FeeTypes {
   Middle,
   High,
   Custom,
+  Unknown,
 }
 
 export enum FeeCalculationTypes {
@@ -16,7 +17,7 @@ export enum FeeCalculationTypes {
   FeesCapped = 'fees-capped',
 }
 
-export interface FeeEstimations {
+export interface Fees {
   blockchain: Blockchains;
   estimates: BitcoinFeeEstimate[] | StacksFeeEstimate[];
   calculation: FeeCalculationTypes;

--- a/src/shared/models/fees/bitcoin-fees.model.ts
+++ b/src/shared/models/fees/bitcoin-fees.model.ts
@@ -1,4 +1,6 @@
 // Source: https://github.com/Blockstream/esplora/blob/master/API.md#fee-estimates
+import { Money } from '../money.model';
+
 // Returned as fee rates
 export interface BitcoinFeeEstimates {
   '1': number;
@@ -32,6 +34,6 @@ export interface BitcoinFeeEstimates {
 }
 
 export interface BitcoinFeeEstimate {
-  fee: number;
+  fee: Money;
   feeRate: number;
 }

--- a/src/shared/models/fees/stacks-fees.model.ts
+++ b/src/shared/models/fees/stacks-fees.model.ts
@@ -1,12 +1,19 @@
+import { Money } from '../money.model';
+
 export interface StacksFeeEstimate {
-  fee: number;
+  fee: Money;
   feeRate: number;
+}
+
+interface Estimation {
+  fee: number;
+  fee_rate: number;
 }
 
 export interface StacksTxFeeEstimation {
   cost_scalar_change_by_byte: number;
   estimated_cost: Object;
   estimated_cost_scalar: number;
-  estimations: StacksFeeEstimate[];
-  error: string; // Returned if bad request
+  estimations: Estimation[];
+  error: string;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3678208371).<!-- Sticky Header Marker -->

This PR refactors/adds a new `FeesRow` component for the new send form. It temporarily leaves the old (singular) `FeeRow` used in the legacy send form. There are two files here that use `-legacy` to mark files to remove with the old send form. ~~In order to make this work now, I did switch the transaction request form to use the new fees component so that should be tested bc will be live when released.~~ EDIT: I did not end up doing this now bc I didn't want to release any live changes here. The tx request fee form should be refactored to use the new fees row when the legacy send form is removed.

In addition, effort was made here to use the new `Money` type with fees and to refactor the stacks fees query to use the new react-query select pattern. 