### PR TITLE
refactor: improve when fn types

### DIFF
--- a/src/app/features/ledger/flows/message-signing/ledger-sign-msg-container.tsx
+++ b/src/app/features/ledger/flows/message-signing/ledger-sign-msg-container.tsx
@@ -3,7 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 
 import { bytesToHex, signatureVrsToRsv } from '@stacks/common';
 import { serializeCV } from '@stacks/transactions';
-import { LedgerError, ResponseSign } from '@zondax/ledger-stacks';
+import { LedgerError } from '@zondax/ledger-stacks';
 import get from 'lodash.get';
 
 import { finalizeMessageSignature } from '@shared/actions/finalize-message-signature';
@@ -89,7 +89,7 @@ function LedgerSignMsg({ account, unsignedMessage }: LedgerSignMsgProps) {
       await delay(1000);
       ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: false });
 
-      const resp = await whenSignedMessageOfType<ResponseSign>(unsignedMessage)({
+      const resp = await whenSignedMessageOfType(unsignedMessage)({
         async utf8(msg) {
           return signLedgerUtf8Message(stacksApp)(msg, account.index);
         },

--- a/src/app/features/ledger/flows/message-signing/steps/sign-ledger-message.tsx
+++ b/src/app/features/ledger/flows/message-signing/steps/sign-ledger-message.tsx
@@ -46,5 +46,5 @@ export function SignLedgerMessage() {
         />
       );
     },
-  }) as JSX.Element;
+  });
 }

--- a/src/shared/signature/signature-types.ts
+++ b/src/shared/signature/signature-types.ts
@@ -39,12 +39,12 @@ export function isSignedMessageType(messageType: unknown): messageType is Signed
   return typeof messageType === 'string' && ['utf8', 'structured'].includes(messageType);
 }
 
-interface WhenSigningMessageArgs<T> {
-  utf8(message: string): Promise<T> | T;
-  structured(domain: StructuredMessageDataDomain, message: ClarityValue): Promise<T> | T;
+interface WhenSignedMessageOfType<T> {
+  utf8(message: string): T;
+  structured(domain: StructuredMessageDataDomain, message: ClarityValue): T;
 }
-export function whenSignedMessageOfType<T>(msg: SignedMessage) {
-  return ({ utf8, structured }: WhenSigningMessageArgs<T | Promise<T>>) => {
+export function whenSignedMessageOfType(msg: SignedMessage) {
+  return <T>({ utf8, structured }: WhenSignedMessageOfType<T>) => {
     if (msg.messageType === 'utf8') return utf8(msg.message);
     if (msg.messageType === 'structured') return structured(msg.domain, msg.message);
     throw new Error('Message can only be either `utf8` or `structured`');


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3658982054).<!-- Sticky Header Marker -->

Wanted to figure out how to type properly the when-style fns so they automatically infer whether the value of a prop. In this instance I had the generic type argument in the wrong place, and the compiler does a good job of inferring the result without needing conditional types or the `infer` keyword.