### PR TITLE
fix: bad error catching

### DIFF
--- a/src/app/common/network/is-response-code.ts
+++ b/src/app/common/network/is-response-code.ts
@@ -1,3 +1,0 @@
-export function isResponseCode(responseCode: number) {
-  return (response: any) => 'status' in response && response.status === responseCode;
-}

--- a/src/app/query/stacks/balance/crypto-asset-balances.utils.ts
+++ b/src/app/query/stacks/balance/crypto-asset-balances.utils.ts
@@ -103,11 +103,7 @@ export function addQueriedMetadataToInitializedStacksFungibleTokenAssetBalance(
 ) {
   return {
     ...assetBalance,
-    balance: createMoney(
-      assetBalance.balance.amount,
-      metadata.symbol ?? '',
-      metadata.decimals ?? undefined
-    ),
+    balance: createMoney(assetBalance.balance.amount, metadata.symbol ?? '', metadata.decimals),
     asset: {
       ...assetBalance.asset,
       canTransfer: isTransferableStacksFungibleTokenAsset(assetBalance.asset),

--- a/src/app/query/stacks/fungible-tokens/fungible-token-metadata.query.ts
+++ b/src/app/query/stacks/fungible-tokens/fungible-token-metadata.query.ts
@@ -1,7 +1,6 @@
 import { FungibleTokenMetadata } from '@stacks/stacks-blockchain-api-types';
 import { UseQueryResult, useQueries, useQuery } from '@tanstack/react-query';
 
-import { isResponseCode } from '@app/common/network/is-response-code';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
@@ -21,14 +20,10 @@ const queryOptions = {
   retryDelay: 2 * 60 * 1000,
 } as const;
 
-const is404 = isResponseCode(404);
-
 function fetchUnanchoredAccountInfo(client: StacksClient, limiter: RateLimiter) {
   return (contractId: string) => async () => {
     await limiter.removeTokens(1);
-    return client.fungibleTokensApi
-      .getContractFtMetadata({ contractId })
-      .catch(error => (is404(error) ? null : error));
+    return client.fungibleTokensApi.getContractFtMetadata({ contractId });
   };
 }
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3674758120).<!-- Sticky Header Marker -->

Closes #2931
Closes #2935
The API has started throwing 500 errors when it hits rate limiting (previously used 429). Some error handling for this request didn't work properly, so was passing the failed response through as a successful one, and the necessary metadata was missing, throwing an error.


cc/ @314159265359879 @friedger 