### PR TITLE
fix: send max, closes #2922

### DIFF
--- a/src/app/common/crypto-assets/stacks-crypto-asset.utils.ts
+++ b/src/app/common/crypto-assets/stacks-crypto-asset.utils.ts
@@ -6,7 +6,7 @@ import { abbreviateNumber } from '@app/common/utils';
 
 import { convertUnicodeToAscii } from '../string-utils';
 
-export function removeCommas(amountWithCommas: string) {
+function removeCommas(amountWithCommas: string) {
   return amountWithCommas.replace(/,/g, '');
 }
 

--- a/src/app/common/hooks/use-selected-asset-balance.ts
+++ b/src/app/common/hooks/use-selected-asset-balance.ts
@@ -33,7 +33,7 @@ export function useSelectedAssetBalance(assetId: string) {
     } ${ticker}`;
 
     return {
-      balance: formattedSelectedAssetBalance || ftBalance,
+      balanceFormatted: formattedSelectedAssetBalance || ftBalance,
       isStx,
       name: selectedAssetBalance?.asset.name,
       placeholder,

--- a/src/app/pages/send-tokens/components/asset-search/selected-asset.tsx
+++ b/src/app/pages/send-tokens/components/asset-search/selected-asset.tsx
@@ -14,7 +14,7 @@ interface SelectedAssetProps extends StackProps {
 }
 export const SelectedAsset = memo(({ hideArrow, onClearSearch, ...rest }: SelectedAssetProps) => {
   const [field] = useField('assetId');
-  const { balance } = useSelectedAssetBalance(field.value);
+  const { balanceFormatted: balance } = useSelectedAssetBalance(field.value);
 
   return (
     <Stack spacing="base-loose" flexDirection="column" {...rest}>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3695313058).<!-- Sticky Header Marker -->

`removeCommas` 🥲

This PR changes send max to use the raw balance value and manipulate it to the format we want (rather trying to work backwards from a formatted number to an accurate decimal number).