### PR TITLE
refactor: remove coreApiUrl getter

### DIFF
--- a/src/background/legacy-external-message-handler.ts
+++ b/src/background/legacy-external-message-handler.ts
@@ -10,7 +10,7 @@ import {
 } from '@shared/message-types';
 import { sendMessage } from '@shared/messages';
 import { RouteUrls } from '@shared/route-urls';
-import { getCoreApiUrl, getPayloadFromToken } from '@shared/utils/requests';
+import { getPayloadFromToken } from '@shared/utils/requests';
 
 import { popupCenter } from './popup-center';
 
@@ -87,9 +87,8 @@ async function triggerRequestWindowOpen(path: RouteUrls, urlParams: URLSearchPar
 function getNetworkParamsFromPayload(payload: string): [string, string][] {
   const { network } = getPayloadFromToken(payload);
   if (!network) return [];
-  const developerDefinedApiUrl = getCoreApiUrl(network);
   return [
-    ['coreApiUrl', developerDefinedApiUrl],
+    ['coreApiUrl', network.coreApiUrl],
     ['networkChainId', network.chainId.toString()],
   ];
 }

--- a/src/shared/utils/requests.ts
+++ b/src/shared/utils/requests.ts
@@ -1,21 +1,5 @@
 import { TransactionPayload } from '@stacks/connect';
-import { StacksNetwork } from '@stacks/network';
 import { decodeToken } from 'jsontokens';
-
-// We need this function because the latest changes
-// to `@stacks/network` had some undesired consequence.
-// As `StacksNetwork` is a class instance, this is auto
-// serialized when being passed across `postMessage`,
-// from the developer's app, to the Hiro Wallet.
-// `coreApiUrl` now uses a getter, rather than a prop,
-// and `_coreApiUrl` is a private value.
-// To support both `@stacks/network` versions a dev may be using
-// we look for both possible networks defined
-export function getCoreApiUrl(network: Pick<StacksNetwork, 'coreApiUrl'>): string {
-  if (network.coreApiUrl) return network.coreApiUrl;
-  if ((network as any)._coreApiUrl) return (network as any)._coreApiUrl;
-  return '';
-}
 
 export function getPayloadFromToken(requestToken: string) {
   const token = decodeToken(requestToken);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3877848911).<!-- Sticky Header Marker -->

I believe the `@stacks/network` package has matured since this code was written, and is now no longer necessary. From what I tested, transaction calls work as expected with these changes in place.

The `@stacks/network` library is now using a key rather than an accessor,

https://github.com/hirosystems/stacks.js/blob/0e1f9f19dfa45788236c9e481f9a476d9948d86d/packages/network/src/network.ts#L30
