### PR TITLE
fix(packaging): prevent unresolvable sourcemap logs

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -42,7 +42,7 @@ const manifest = {
   },
   content_scripts: [
     {
-      js: ['browser-polyfill.js', 'content-script.js'],
+      js: ['content-script.js'],
       matches: ['*://*/*'],
       all_frames: true,
     },


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3885417782).<!-- Sticky Header Marker -->

 Closes #2964

Webpack configuration to the rescue. This PR configures the source map bundling of the production build.

The previous config used the webpack preset to create source maps for all entry points. However, both the `inpage` and `content-script` bundles run in all webpage contexts, which cannot access extension files (those under `chrome-extension://*`). With sourcemaps enabled for these files, the browser attempts to load them, throwing an error when it fails. This configuration disables source maps only for these files. Further, it removes the browser polyfill from the content script which isn't needed.

cc/ @getify