### PR TITLE
fix(analytics): track switching account

### DIFF
--- a/src/app/common/hooks/analytics/use-track-switch-account.ts
+++ b/src/app/common/hooks/analytics/use-track-switch-account.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+
+import { parseBalanceResponse } from '@app/query/stacks/balance/balance.hooks';
+import { useStacksClientAnchored } from '@app/store/common/api-clients.hooks';
+
+import { useAnalytics } from './use-analytics';
+
+export function useTrackSwitchAccount() {
+  const analytics = useAnalytics();
+  const client = useStacksClientAnchored();
+
+  return useCallback(
+    async (address: string, index: number) => {
+      const balancesResp = await client.accountsApi.getAccountBalance({ principal: address });
+      const balances = parseBalanceResponse(balancesResp as any);
+      const hasStxBalance = !!balances?.stx.availableStx.amount.isGreaterThan(0);
+      void analytics.track('switch_account', { index, hasStxBalance });
+    },
+    [analytics, client.accountsApi]
+  );
+}

--- a/src/app/common/hooks/analytics/use-track-switch-account.ts
+++ b/src/app/common/hooks/analytics/use-track-switch-account.ts
@@ -1,21 +1,27 @@
 import { useCallback } from 'react';
 
+import { queryClient } from '@app/common/persistence';
 import { parseBalanceResponse } from '@app/query/stacks/balance/balance.hooks';
-import { useStacksClientAnchored } from '@app/store/common/api-clients.hooks';
 
 import { useAnalytics } from './use-analytics';
 
 export function useTrackSwitchAccount() {
   const analytics = useAnalytics();
-  const client = useStacksClientAnchored();
 
   return useCallback(
     async (address: string, index: number) => {
-      const balancesResp = await client.accountsApi.getAccountBalance({ principal: address });
-      const balances = parseBalanceResponse(balancesResp as any);
-      const hasStxBalance = !!balances?.stx.availableStx.amount.isGreaterThan(0);
-      void analytics.track('switch_account', { index, hasStxBalance });
+      const accountBalanceCache = queryClient.getQueryData([
+        'get-address-anchored-stx-balance',
+        address,
+      ]);
+      if (!accountBalanceCache) return;
+      try {
+        const balances = parseBalanceResponse(accountBalanceCache as any);
+        const hasStxBalance = !!balances?.stx.availableStx.amount.isGreaterThan(0);
+        void analytics.track('switch_account', { index, hasStxBalance });
+      } finally {
+      }
     },
-    [analytics, client.accountsApi]
+    [analytics]
   );
 }

--- a/src/app/common/hooks/use-key-actions.ts
+++ b/src/app/common/hooks/use-key-actions.ts
@@ -38,6 +38,7 @@ export function useKeyActions() {
       },
 
       switchAccount(index: number) {
+        void analytics.track('switch_account', { index });
         return dispatch(stxChainActions.switchAccount(index));
       },
 

--- a/src/app/common/hooks/use-key-actions.ts
+++ b/src/app/common/hooks/use-key-actions.ts
@@ -38,7 +38,6 @@ export function useKeyActions() {
       },
 
       switchAccount(index: number) {
-        void analytics.track('switch_account', { index });
         return dispatch(stxChainActions.switchAccount(index));
       },
 

--- a/src/app/features/switch-account-drawer/components/switch-account-list.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list.tsx
@@ -20,12 +20,8 @@ export const SwitchAccountList = memo(
       return (
         <>
           {accounts.map(account => (
-            <Box mx={['base-loose', 'extra-loose']}>
-              <SwitchAccountListItem
-                handleClose={handleClose}
-                account={account}
-                key={account.address}
-              />
+            <Box key={account.address} mx={['base-loose', 'extra-loose']}>
+              <SwitchAccountListItem handleClose={handleClose} account={account} />
             </Box>
           ))}
         </>
@@ -39,7 +35,7 @@ export const SwitchAccountList = memo(
         style={{ paddingTop: '24px', height: '70vh' }}
         totalCount={accounts.length}
         itemContent={index => (
-          <Box mx={['base-loose', 'extra-loose']}>
+          <Box mx={['base-loose', 'extra-loose']} key={accounts[index].address}>
             <SwitchAccountListItem handleClose={handleClose} account={accounts[index]} />
           </Box>
         )}

--- a/src/app/features/switch-account-drawer/switch-account-drawer.tsx
+++ b/src/app/features/switch-account-drawer/switch-account-drawer.tsx
@@ -3,7 +3,6 @@ import { memo } from 'react';
 import { Box } from '@stacks/ui';
 
 import { useCreateAccount } from '@app/common/hooks/account/use-create-account';
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useWalletType } from '@app/common/use-wallet-type';
 import { ControlledDrawer } from '@app/components/drawer/controlled-drawer';
 import {
@@ -21,7 +20,6 @@ export const SwitchAccountDrawer = memo(() => {
   const [isShowing, setShowSwitchAccountsState] = useShowSwitchAccountsState();
   const accounts = useAccounts();
   const currentAccountIndex = useCurrentAccountIndex();
-  const analytics = useAnalytics();
   const createAccount = useCreateAccount();
   const [, setHasCreatedAccount] = useHasCreatedAccount();
   const { whenWallet } = useWalletType();
@@ -29,7 +27,6 @@ export const SwitchAccountDrawer = memo(() => {
   const onClose = () => setShowSwitchAccountsState(false);
 
   const onCreateAccount = () => {
-    void analytics.track('choose_to_create_account');
     void createAccount();
     setHasCreatedAccount(true);
     setShowSwitchAccountsState(false);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3910345564).<!-- Sticky Header Marker -->

Closes #2994

New analytics event `switch_account`, including metadata of account index.