### PR TITLE
fix(sentry): remove some transaction logs

### DIFF
--- a/src/shared/utils/analytics.ts
+++ b/src/shared/utils/analytics.ts
@@ -40,8 +40,16 @@ export function initSentry() {
 
   Sentry.init({
     dsn: SENTRY_DSN,
-    integrations: [new BrowserTracing()],
-    tracesSampleRate: 1.0,
+    integrations: [
+      new BrowserTracing({
+        traceFetch: false,
+        traceXHR: false,
+        startTransactionOnLocationChange: false,
+        startTransactionOnPageLoad: false,
+        markBackgroundTransactions: false,
+      }),
+    ],
+    tracesSampleRate: 1,
     environment: WALLET_ENVIRONMENT,
     autoSessionTracking: false,
     async beforeSend(event) {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3929165626).<!-- Sticky Header Marker -->

We're hitting the Sentry limit again. Think these settings will reduce the transaction volume, 🤞🏼 