### PR TITLE
refactor: make error currency agnostic

### DIFF
--- a/src/app/common/hooks/use-send-form-validation-legacy.ts
+++ b/src/app/common/hooks/use-send-form-validation-legacy.ts
@@ -20,7 +20,7 @@ import { nonceValidator } from '@app/common/validation/nonce-validators';
 import { useCurrentStacksAccountAnchoredBalances } from '@app/query/stacks/balance/balance.hooks';
 import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 
-import { stxToMicroStx } from '../money/unit-conversion';
+import { microStxToStx, stxToMicroStx } from '../money/unit-conversion';
 import { stacksFungibleTokenValidator } from '../validation/forms/amount-validators';
 import { stxFeeValidator } from '../validation/forms/fee-validators';
 
@@ -66,7 +66,9 @@ export const useStacksSendFormValidationLegacy = ({
   const stxAmountFormSchema = useCallback(
     () =>
       stxAmountValidator(formatPrecisionError(availableStxBalance)).test({
-        message: formatInsufficientBalanceError(availableStxBalance),
+        message: formatInsufficientBalanceError(availableStxBalance, sum =>
+          microStxToStx(sum.amount).toString()
+        ),
         test(value: unknown) {
           const fee = stxToMicroStx(this.parent.fee);
           if (!stacksBalances || !isNumber(value)) return false;

--- a/src/app/common/money/unit-conversion.ts
+++ b/src/app/common/money/unit-conversion.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import { BTC_DECIMALS, STX_DECIMALS } from '@shared/constants';
+import { Money } from '@shared/models/money.model';
 
 import { initBigNumber } from '../utils';
 
@@ -23,3 +24,7 @@ export const btcToSat = unitToFractionalUnit(BTC_DECIMALS);
 
 export const microStxToStx = fractionalUnitToUnit(STX_DECIMALS);
 export const stxToMicroStx = unitToFractionalUnit(STX_DECIMALS);
+
+export function moneyToBaseUnit(sum: Money) {
+  return fractionalUnitToUnit(sum.decimals)(sum.amount);
+}

--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -4,6 +4,8 @@ import * as yup from 'yup';
 import { Money } from '@shared/models/money.model';
 import { isNumber } from '@shared/utils';
 
+import { microStxToStx } from '@app/common/money/unit-conversion';
+
 import { formatInsufficientBalanceError, formatPrecisionError } from '../../error-formatters';
 import { FormErrorMessages } from '../../error-messages';
 import { countDecimals } from '../../utils';
@@ -24,7 +26,7 @@ export function stacksFungibleTokenValidator(balance: Money) {
       return true;
     })
     .test({
-      message: formatInsufficientBalanceError(balance),
+      message: formatInsufficientBalanceError(balance, sum => microStxToStx(sum.amount).toString()),
       test(value) {
         if (!isNumber(value) || !amount) return false;
         return new BigNumber(value).isLessThanOrEqualTo(amount);

--- a/src/app/common/validation/forms/fee-validators.ts
+++ b/src/app/common/validation/forms/fee-validators.ts
@@ -11,7 +11,7 @@ import {
   stxAmountValidator,
 } from '@app/common/validation/forms/currency-validators';
 
-import { btcToSat, stxToMicroStx } from '../../money/unit-conversion';
+import { btcToSat, moneyToBaseUnit, stxToMicroStx } from '../../money/unit-conversion';
 
 interface FeeValidatorFactoryArgs {
   availableBalance?: Money;
@@ -24,7 +24,9 @@ function feeValidatorFactory({
   validator,
 }: FeeValidatorFactoryArgs) {
   return validator(formatPrecisionError(availableBalance)).test({
-    message: formatInsufficientBalanceError(availableBalance),
+    message: formatInsufficientBalanceError(availableBalance, sum =>
+      moneyToBaseUnit(sum).toString()
+    ),
     test(fee: unknown) {
       if (!availableBalance || !isNumber(fee)) return false;
       return availableBalance.amount.isGreaterThanOrEqualTo(unitConverter(fee));


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/3997856318).<!-- Sticky Header Marker -->

This PR makes the `formatInsufficientBalanceError` agnostic of any currency specific details.