### PR TITLE
ci: fix coverage summary

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
         run: yarn build
 
       - name: Run jest
-        run: yarn test:unit
+        run: yarn test:unit --coverage
 
       - name: Make badge maker
         run: npx make-coverage-badge


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4005203924).<!-- Sticky Header Marker -->

Fixes CI not generating coverage report