### PR TITLE
feat: fetch BNSx names on mainnet

### DIFF
--- a/src/app/query/stacks/bns/bns.query.ts
+++ b/src/app/query/stacks/bns/bns.query.ts
@@ -1,8 +1,11 @@
+import { BnsNamesOwnByAddressResponse } from '@stacks/stacks-blockchain-api-types';
 import { useQuery } from '@tanstack/react-query';
 
+import { fetcher as fetchApi } from '@app/common/api/wrapped-fetch';
 import { AppUseQueryConfig } from '@app/query/query-config';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
+import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 import { RateLimiter, useHiroApiRateLimiter } from '../rate-limiter';
 
@@ -17,10 +20,34 @@ const bnsQueryOptions = {
   refetchOnReconnect: false,
 } as const;
 
-function getBnsNameFetcherFactory(client: StacksClient, limiter: RateLimiter) {
-  return async (address: string) => {
+// Fetch names owned by address via BNSx API
+// https://docs.bns.xyz/integrate-bnsx/bnsx-api
+async function getBnsxName(address: string): Promise<BnsNamesOwnByAddressResponse> {
+  const url = `https://api.bns.xyz/v1/addresses/stacks/${address}`;
+  const response = await fetchApi(url);
+  if (!response.ok) {
+    throw new Error('Unable to fetch BNSx names');
+  }
+  return response.json();
+}
+
+// Fetch names owned by an address.
+//
+// If `isTestnet` is `false` (aka mainnet), names are fetched from the
+// BNSx API.
+function getBnsNameFetcherFactory(client: StacksClient, limiter: RateLimiter, isTestnet: boolean) {
+  const baseFetcher = async (address: string) => {
     await limiter.removeTokens(1);
     return client.namesApi.getNamesOwnedByAddress({ address, blockchain: 'stacks' });
+  };
+  if (isTestnet) {
+    return baseFetcher;
+  }
+  // Fetch from BNSx API, and fallback to vanilla API in case
+  // of error.
+  return async (address: string) => {
+    const bnsxFetch = getBnsxName(address);
+    return bnsxFetch.catch(() => baseFetcher(address));
   };
 }
 
@@ -31,11 +58,12 @@ export function useGetBnsNamesOwnedByAddress<T extends unknown = BnsNameFetcherR
   options?: AppUseQueryConfig<BnsNameFetcherResp, T>
 ) {
   const client = useStacksClientUnanchored();
+  const { isTestnet } = useCurrentNetworkState();
   const limiter = useHiroApiRateLimiter();
   return useQuery({
     enabled: address !== '',
     queryKey: ['bns-names-by-address', address],
-    queryFn: () => getBnsNameFetcherFactory(client, limiter)(address),
+    queryFn: () => getBnsNameFetcherFactory(client, limiter, isTestnet)(address),
     ...bnsQueryOptions,
     ...options,
   });


### PR DESCRIPTION
This PR updates the logic for fetching the BNS name that the current account owns. On mainnet, if the user owns a BNSx name, their BNSx primary name will be shown. Otherwise, their BNS name is shown. The reason this change is helpful is because using BNSx requires wrapping your BNS name, which involves transferring it to an external contract. This provides a better UX for users who still own their (wrapped) name and want it to display in their wallet.

For background on BNSx (a protocol I'm building), check out our [docs](https://docs.bns.xyz). Specifically for this PR, the [API docs](https://docs.bns.xyz/integrate-bnsx/bnsx-api) are helpful.

The BNSx API provides a backwards compatible endpoint at `/v1/addresses/stacks/:principal`, which is the API you use in the wallet to fetch a name. Our API provides the same basic interface (`{ names: string[] }`), along with additional metadata ([example](https://api.bns.xyz/v1/addresses/stacks/SP1JTCR202ECC6333N7ZXD7MK7E3ZTEEE1MJ73C60)). This API will always behave the same for users who don't use BNSx (it'll show their BNS name), but it will also work for users who use BNSx.

The logic for this PR is (when fetching the current account's name):

- If we're not in mainnet, use the same behavior
- Fetch the "names owned by address" endpoint on the BNSx API
  - If this result is `ok`, return `names[0]` (even if empty)
- If this fetch fails (due to server error etc), then fallback to the current API implementation. This helps to ensure the BNSx API doesn't cause any degradation in the wallet

_Why should this PR get implemented?_

This PR isn't trying to give precedence to BNSx in trying to force users to switch - it only makes the wallet work better for users who opt in to BNSx. If users don't want to use BNSx, the wallet will behave the same as before.

_How can I test this?_

I'm not sure if you have any mechanisms for "spoofing" the account address during development, but if you can, try an address like `SP1JTCR202ECC6333N7ZXD7MK7E3ZTEEE1MJ73C60`. We'll be releasing our web app soon, but in the meantime I'm happy to send devs on the wallet team a BNSx name for testing (feel free to dm your address).

Thanks!