### PR TITLE
Revert "refactor: remove coreApiUrl getter"

### DIFF
--- a/src/background/legacy-external-message-handler.ts
+++ b/src/background/legacy-external-message-handler.ts
@@ -10,7 +10,7 @@ import {
 } from '@shared/message-types';
 import { sendMessage } from '@shared/messages';
 import { RouteUrls } from '@shared/route-urls';
-import { getPayloadFromToken } from '@shared/utils/requests';
+import { getCoreApiUrl, getPayloadFromToken } from '@shared/utils/requests';
 
 import { popupCenter } from './popup-center';
 
@@ -87,8 +87,9 @@ async function triggerRequestWindowOpen(path: RouteUrls, urlParams: URLSearchPar
 function getNetworkParamsFromPayload(payload: string): [string, string][] {
   const { network } = getPayloadFromToken(payload);
   if (!network) return [];
+  const developerDefinedApiUrl = getCoreApiUrl(network);
   return [
-    ['coreApiUrl', network.coreApiUrl],
+    ['coreApiUrl', developerDefinedApiUrl],
     ['networkChainId', network.chainId.toString()],
   ];
 }

--- a/src/shared/utils/requests.ts
+++ b/src/shared/utils/requests.ts
@@ -1,5 +1,21 @@
 import { TransactionPayload } from '@stacks/connect';
+import { StacksNetwork } from '@stacks/network';
 import { decodeToken } from 'jsontokens';
+
+// We need this function because the latest changes
+// to `@stacks/network` had some undesired consequence.
+// As `StacksNetwork` is a class instance, this is auto
+// serialized when being passed across `postMessage`,
+// from the developer's app, to the Hiro Wallet.
+// `coreApiUrl` now uses a getter, rather than a prop,
+// and `_coreApiUrl` is a private value.
+// To support both `@stacks/network` versions a dev may be using
+// we look for both possible networks defined
+export function getCoreApiUrl(network: Pick<StacksNetwork, 'coreApiUrl'>): string {
+  if (network.coreApiUrl) return network.coreApiUrl;
+  if ((network as any)._coreApiUrl) return (network as any)._coreApiUrl;
+  return '';
+}
 
 export function getPayloadFromToken(requestToken: string) {
   const token = decodeToken(requestToken);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4083036668).<!-- Sticky Header Marker -->

This reverts commit 001dad382a965859e326a05a152f98217eaac60d.