### PR TITLE
ci/fix-chrome-publish-issue

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,48 @@
 name: Playwright Tests
-env:
-  CI: true
-  WALLET_ENVIRONMENT: testing
+
 on:
   push:
     branches: [dev, main]
   pull_request:
     branches: [dev, main]
+
+env:
+  CI: true
+  WALLET_ENVIRONMENT: testing
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'yarn'
+
       - name: Install dependencies
         run: yarn
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
+
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: Install Playwright deps
+        run: yarn playwright install chrome
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
       - name: Build extension in test mode
         run: yarn build:test
+
       - name: Run Playwright tests
         # Playwright can only test extensions in headed mode, see
         # https://playwright.dev/docs/chrome-extensions. To run a browser in
@@ -34,6 +55,7 @@ jobs:
         # processes that require a display server to run in environments where
         # one is not available.
         run: xvfb-run yarn playwright test
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -12,6 +12,7 @@ env:
   SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
   TRANSAK_API_KEY: ${{ secrets.TRANSAK_API_KEY }}
   WALLET_ENVIRONMENT: production
+  IS_PUBLISHING: true
 
 jobs:
   pre-run:
@@ -34,9 +35,10 @@ jobs:
         id: extract_version
         uses: Saionaro/extract-package-version@v1.1.1
 
+      - name: Print version
+        run: echo ${{ steps.extract_version.outputs.version }}
+
       - name: Build project
-        env:
-          IS_PUBLISHING: true
         run: yarn build
 
       - uses: actions/upload-artifact@v2
@@ -104,7 +106,6 @@ jobs:
 
       - name: Build project
         env:
-          IS_PUBLISHING: true
           # We only add the sentry auth token for chrome, as we don't want to
           # create a duplicate release during the ff build
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -155,8 +156,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
       - name: Build project
-        env:
-          IS_PUBLISHING: true
+
         run: yarn build
 
       - name: Build extension

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -118,7 +118,7 @@ jobs:
         continue-on-error: true
         id: publish-chrome
         run: |
-          yarn chrome-webstore-upload publish --source stacks-wallet-chromium.zip
+          yarn chrome-webstore-upload upload --auto-publish --source stacks-wallet-chromium.zip
           echo "::set-output name=publish_status::${?}"
         env:
           EXTENSION_ID: ${{ secrets.CHROME_APP_ID }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,37 +1,22 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
-import { devices } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-const config: PlaywrightTestConfig = {
+export default defineConfig({
   testDir: './tests',
-  /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {
-    /**
-     * Maximum time expect() should wait for the condition to be met.
-     * For example in `await expect(locator).toHaveText();`
-     */
     timeout: 5000,
   },
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['html', { open: 'never' }]],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
-
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium',
@@ -40,6 +25,4 @@ const config: PlaywrightTestConfig = {
       },
     },
   ],
-};
-
-export default config;
+});

--- a/src/shared/inpage-types.ts
+++ b/src/shared/inpage-types.ts
@@ -1,5 +1,5 @@
 /**
- * Inpage Script (Stacks Provider) <-> Content Script
+ * Inpage Script (StacksProvider) <-> Content Script
  */
 export enum DomEventName {
   authenticationRequest = 'stacksAuthenticationRequest',


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4104290586).<!-- Sticky Header Marker -->

- Adds logging of package version
- Uses upload & `--auto-publish` flag. This may've been the issue, as publish might not upload the file, even when passed. Let's see.
- More specific playwright installs, caching