### PR TITLE
fix: delayed home loading

### DIFF
--- a/src/app/pages/home/home.loader.tsx
+++ b/src/app/pages/home/home.loader.tsx
@@ -2,10 +2,10 @@ import { FullPageLoadingSpinner } from '@app/components/loading-spinner';
 import { useCurrentAccount } from '@app/store/accounts/account.hooks';
 import { WalletAccount } from '@app/store/accounts/account.models';
 
-interface HomeContainerProps {
+interface HomeLoaderProps {
   children(data: WalletAccount): JSX.Element;
 }
-export function HomeContainer({ children }: HomeContainerProps) {
+export function HomeLoader({ children }: HomeLoaderProps) {
   const currentAccount = useCurrentAccount();
   if (!currentAccount) return <FullPageLoadingSpinner />;
   return children(currentAccount);

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -12,13 +12,21 @@ import { BalancesList } from '@app/features/balances-list/balances-list';
 import { HiroMessages } from '@app/features/hiro-messages/hiro-messages';
 import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggested-first-steps';
 import { HomeActions } from '@app/pages/home/components/home-actions';
+import { WalletAccount } from '@app/store/accounts/account.models';
 
 import { CurrentAccount } from './components/account-area';
 import { HomeTabs } from './components/home-tabs';
 import { HomeLayout } from './components/home.layout';
-import { HomeContainer } from './home.container';
+import { HomeLoader } from './home.loader';
 
 export function Home() {
+  return <HomeLoader>{account => <HomeContainer account={account} />}</HomeLoader>;
+}
+
+interface HomeContainerProps {
+  account: WalletAccount;
+}
+function HomeContainer({ account }: HomeContainerProps) {
   const { decodedAuthRequest } = useOnboardingState();
   const navigate = useNavigate();
   useTrackFirstDeposit();
@@ -36,20 +44,13 @@ export function Home() {
   }, []);
 
   return (
-    <HomeContainer>
-      {account => (
-        <HomeLayout
-          suggestedFirstSteps={<SuggestedFirstSteps />}
-          currentAccount={<CurrentAccount />}
-          actions={<HomeActions />}
-        >
-          <HomeTabs
-            balances={<BalancesList address={account.address} />}
-            activity={<ActivityList />}
-          />
-          <Outlet />
-        </HomeLayout>
-      )}
-    </HomeContainer>
+    <HomeLayout
+      suggestedFirstSteps={<SuggestedFirstSteps />}
+      currentAccount={<CurrentAccount />}
+      actions={<HomeActions />}
+    >
+      <HomeTabs balances={<BalancesList address={account.address} />} activity={<ActivityList />} />
+      <Outlet />
+    </HomeLayout>
   );
 }

--- a/src/app/query/stacks/balance/balance.query.ts
+++ b/src/app/query/stacks/balance/balance.query.ts
@@ -38,6 +38,7 @@ export function useUnanchoredStacksAccountBalanceQuery<T extends unknown = Fetch
   const limiter = useHiroApiRateLimiter();
 
   return useQuery({
+    enabled: !!address,
     queryKey: ['get-address-stx-balance', address],
     queryFn: () => fetchAccountBalance(client, limiter)(address),
     ...balanceQueryOptions,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4106105984).<!-- Sticky Header Marker -->

Adjusted the "component loader" pattern a little bit here. By creating the separate component, we make sure none of the hooks are called prior to the address being ready.

`<HomeLoader />` is responsible for loading state
`<HomeContainer />` is responsible for home, once data ready

Not sure if this will fix the infinite loader issue, as I can't replicate locally, but will at least prevent 404 requests and eliminate one possible cause.