### PR TITLE
fix: remove localstorage data when migrated

### DIFF
--- a/src/app/store/utils/vault-reducer-migration.spec.ts
+++ b/src/app/store/utils/vault-reducer-migration.spec.ts
@@ -44,8 +44,7 @@ describe(migrateVaultReducerStoreToNewStateStructure.name, () => {
       });
     });
 
-    // This functionality should be re-added, post a successful launch of the wallet refactor
-    test.skip('it removes the existing existing localStorage values', () => {
+    test('it removes the existing localStorage values', () => {
       vi.spyOn(global.localStorage.__proto__, 'removeItem');
       migrateVaultReducerStoreToNewStateStructure({} as any);
       expect(localStorage.removeItem).toHaveBeenCalledWith('stacks-wallet-salt');

--- a/src/app/store/utils/vault-reducer-migration.ts
+++ b/src/app/store/utils/vault-reducer-migration.ts
@@ -26,6 +26,8 @@ export function migrateVaultReducerStoreToNewStateStructure(initialState: typeof
         },
       },
     };
+    localStorage.removeItem(hiroWalletSalt);
+    localStorage.removeItem(hiroWalletEncryptionKey);
     return deepMerge(initialState, migratedState);
   }
   return initialState;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4106179776).<!-- Sticky Header Marker -->

Not to be released yet, but this should be added to tidy up old `localstorage` values.