### PR TITLE
fix: case where current account index higher than highest

### DIFF
--- a/src/app/store/wallet/wallet.ts
+++ b/src/app/store/wallet/wallet.ts
@@ -2,6 +2,8 @@ import { createSelector } from '@reduxjs/toolkit';
 import { Account, Wallet } from '@stacks/wallet-sdk';
 import { atom } from 'jotai';
 
+import { analytics } from '@shared/utils/analytics';
+
 import { textToBytes } from '@app/common/store-utils';
 
 import { storeAtom } from '..';
@@ -37,7 +39,15 @@ export const softwareStacksWalletState = atom(async get => {
   const defaultInMemoryKey = store.inMemoryKeys.keys[defaultKeyId];
   if (!defaultInMemoryKey || !defaultKey) return;
   if (defaultKey.type !== 'software') return;
-  return deriveWalletWithAccounts(defaultInMemoryKey, store.chains.stx.default.highestAccountIndex);
+  const { highestAccountIndex, currentAccountIndex } = store.chains.stx.default;
+  const accountsToRender = Math.max(
+    store.chains.stx.default.highestAccountIndex,
+    store.chains.stx.default.currentAccountIndex
+  );
+  if (currentAccountIndex > highestAccountIndex) {
+    void analytics?.track('illegal_wallet_state_current_index_higher_than_highest');
+  }
+  return deriveWalletWithAccounts(defaultInMemoryKey, accountsToRender);
 });
 
 //


### PR DESCRIPTION
There was a possible state where the current account index persisted was higher than the persisted highest account index. I think this would happen for accounts that hadn't made a new account since the migration to using `chrome.storage.local` instead of `localStorage`, over a year ago.

In moving away from Gaia, and generating accounts locally, some wallet's found themselves in an illegal state where we'd look for an account index of a non-generated account. This PR makes sure that we always generate the max of either the highest or current account index.

cc/ @fbwoolf would you be able to help QA this? Replicating issue by setting current account index higher than highest, then with this PR, that should fix the issue.