### PR TITLE
fix: tooltip dissapearing after click (Closes #2963)

### DIFF
--- a/src/app/components/tooltip.tsx
+++ b/src/app/components/tooltip.tsx
@@ -18,7 +18,7 @@ export const Tooltip = memo(({ label, labelProps = {}, children, ...rest }: Tool
   );
   if (!label) return <>{children}</>;
   return (
-    <Tippy content={content} trigger="mouseenter" hideOnClick={undefined} {...rest}>
+    <Tippy content={content} trigger="mouseenter" hideOnClick={false} {...rest}>
       {children}
     </Tippy>
   );

--- a/src/app/components/tooltip.tsx
+++ b/src/app/components/tooltip.tsx
@@ -6,8 +6,9 @@ import Tippy, { TippyProps } from '@tippyjs/react';
 interface TooltipProps extends TippyProps {
   label?: TippyProps['content'];
   labelProps?: BoxProps;
+  hideOnClick?: boolean;
 }
-export const Tooltip = memo(({ label, labelProps = {}, children, ...rest }: TooltipProps) => {
+export const Tooltip = memo(({ label, labelProps = {}, hideOnClick, children, ...rest }: TooltipProps) => {
   const content = useMemo(
     () => (
       <Box as="span" display="block" fontSize={0} {...labelProps}>
@@ -18,7 +19,7 @@ export const Tooltip = memo(({ label, labelProps = {}, children, ...rest }: Tool
   );
   if (!label) return <>{children}</>;
   return (
-    <Tippy content={content} trigger="mouseenter" hideOnClick={false} {...rest}>
+    <Tippy content={content} trigger="mouseenter" hideOnClick={hideOnClick} {...rest}>
       {children}
     </Tippy>
   );

--- a/src/app/pages/home/components/account-area.tsx
+++ b/src/app/pages/home/components/account-area.tsx
@@ -29,7 +29,11 @@ const AccountBnsAddress = memo(() => {
   return (
     <>
       <Caption>{bnsName}</Caption>
-      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy BNS name'}>
+      <Tooltip
+        placement="right"
+        hideOnClick={false}
+        label={hasCopied ? 'Copied!' : 'Copy BNS name'}
+      >
         <Stack>
           <Box
             _hover={{ cursor: 'pointer' }}
@@ -57,7 +61,7 @@ const AccountAddress = memo((props: StackProps) => {
   return currentAccount ? (
     <Stack isInline {...props}>
       <Caption>{truncateMiddle(currentAccount.address, 4)}</Caption>
-      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy address'}>
+      <Tooltip placement="right" hideOnClick={false} label={hasCopied ? 'Copied!' : 'Copy address'}>
         <Stack>
           <Box
             _hover={{ cursor: 'pointer' }}


### PR DESCRIPTION
This pr fixes https://github.com/hirosystems/stacks-wallet-web/issues/2963

`hideOnClick` value was `undefined`, and I set it as default, but `false` is probably better