### PR TITLE
Remove successful key entry toast (Closes #3074)

### DIFF
--- a/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
+++ b/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
@@ -79,7 +79,7 @@ export function useSignIn() {
       }
 
       await simulateShortDelayToAvoidImmediateNavigation();
-      toast.success('Secret Key valid');
+
       dispatch(inMemoryKeyActions.saveUsersSecretKeyToBeRestored(parsedKeyInput));
       dispatch(onboardingActions.hideSuggestedFirstSteps(true));
       void analytics.track('submit_valid_secret_key');


### PR DESCRIPTION
This pr closes https://github.com/hirosystems/stacks-wallet-web/issues/3074
It seems to me that it is better to just remove the toast, because successful key entry is rather evident and you don't need to notify user about it