### PR TITLE
fix: bitcoin send all

### DIFF
--- a/src/app/features/activity-list/activity-list.tsx
+++ b/src/app/features/activity-list/activity-list.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { LoadingSpinner } from '@app/components/loading-spinner';
+import { useBitcoinPendingTransactions } from '@app/query/bitcoin/address/transactions-by-address.hooks';
 import { useGetBitcoinTransactionsByAddressQuery } from '@app/query/bitcoin/address/transactions-by-address.query';
 import { useStacksPendingTransactions } from '@app/query/stacks/mempool/mempool.hooks';
 import { useGetAccountTransactionsWithTransfersQuery } from '@app/query/stacks/transactions/transactions-with-transfers.query';
@@ -17,6 +18,7 @@ export function ActivityList() {
   const bitcoinAddress = useCurrentBtcAccountAddressIndexZero();
   const { isInitialLoading: isInitialLoadingBitcoinTransactions, data: bitcoinTransactions } =
     useGetBitcoinTransactionsByAddressQuery(bitcoinAddress);
+  const bitcoinPendingTxs = useBitcoinPendingTransactions();
   const {
     isInitialLoading: isInitialLoadingStacksTransactions,
     data: stacksTransactionsWithTransfers,
@@ -32,10 +34,6 @@ export function ActivityList() {
     isInitialLoadingStacksTransactions ||
     isInitialLoadingStacksPendingTransactions;
 
-  const bitcoinPendingTxs = useMemo(
-    () => (bitcoinTransactions ?? []).filter(tx => !tx.status.confirmed),
-    [bitcoinTransactions]
-  );
   const transactionListBitcoinTxs = useMemo(
     () => convertBitcoinTxsToListType(bitcoinTransactions),
     [bitcoinTransactions]

--- a/src/app/pages/send-tokens/hooks/use-send-form.ts
+++ b/src/app/pages/send-tokens/hooks/use-send-form.ts
@@ -22,7 +22,7 @@ export function useSendAmountFieldActions() {
       if (!selectedAssetBalance) return;
       if (isStx && fee) {
         const stx = microStxToStx(
-          stacksBalances?.stx.availableStx.amount.minus(pendingTxsBalance) || 0
+          stacksBalances?.stx.availableStx.amount.minus(pendingTxsBalance.amount) || 0
         ).minus(fee);
         if (stx.isLessThanOrEqualTo(0)) return;
         return setFieldValue('amount', stx.toNumber());

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/coinselect/coinselect.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/coinselect/coinselect.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import coinselection from 'coinselect';
 
+// ts-unused-exports:disable-next-line
 export interface Input {
   txid: string;
   vout: number;
@@ -13,6 +14,7 @@ export interface Input {
   value: number;
 }
 
+// ts-unused-exports:disable-next-line
 export interface Output {
   address?: string;
   value: number;

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/stx-crypto-currency-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/stx-crypto-currency-send-form.tsx
@@ -4,7 +4,7 @@ import { Outlet, useNavigate } from 'react-router-dom';
 import { Form, Formik, FormikHelpers } from 'formik';
 import * as yup from 'yup';
 
-import { HIGH_FEE_AMOUNT_STX } from '@shared/constants';
+import { HIGH_FEE_AMOUNT_STX, STX_DECIMALS } from '@shared/constants';
 import { logger } from '@shared/logger';
 import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { StacksSendFormValues } from '@shared/models/form.model';
@@ -71,7 +71,11 @@ export function StxCryptoCurrencySendForm() {
 
   const availableStxBalance = balances?.stx.availableStx ?? createMoney(0, 'STX');
   const sendAllBalance = useMemo(
-    () => convertAmountToBaseUnit(availableStxBalance).minus(pendingTxsBalance),
+    () =>
+      convertAmountToBaseUnit(
+        availableStxBalance.amount.minus(pendingTxsBalance.amount),
+        STX_DECIMALS
+      ),
     [availableStxBalance, pendingTxsBalance]
   );
 

--- a/src/app/query/bitcoin/address/transactions-by-address.hooks.ts
+++ b/src/app/query/bitcoin/address/transactions-by-address.hooks.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+
+import { createMoney } from '@shared/models/money.model';
+
+import { sumNumbers } from '@app/common/utils';
+import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+
+import { useGetBitcoinTransactionsByAddressQuery } from './transactions-by-address.query';
+
+export function useBitcoinPendingTransactions() {
+  const bitcoinAddress = useCurrentBtcAccountAddressIndexZero();
+  const { data: bitcoinTransactions } = useGetBitcoinTransactionsByAddressQuery(bitcoinAddress);
+  return useMemo(
+    () => (bitcoinTransactions ?? []).filter(tx => !tx.status.confirmed),
+    [bitcoinTransactions]
+  );
+}
+
+export function useBitcoinPendingTransactionsBalance() {
+  const bitcoinAddress = useCurrentBtcAccountAddressIndexZero();
+  const pendingTransactions = useBitcoinPendingTransactions();
+
+  return useMemo(
+    () =>
+      createMoney(
+        sumNumbers(
+          pendingTransactions
+            .flatMap(tx => tx.vout.filter(output => output.scriptpubkey_address === bitcoinAddress))
+            .map(vout => vout.value)
+        ),
+        'BTC'
+      ),
+    [bitcoinAddress, pendingTransactions]
+  );
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4164936495).<!-- Sticky Header Marker -->

Addressing: https://github.com/hirosystems/stacks-wallet-web/pull/3068#issuecomment-1422541911

This fixes `subtracting` pending txs balance from the `Send all` button for both STX and BTC. The current functionality was broken in that it never checked for if the account address was sending or receiving, but it always subtracted out the balance. I think STX txs moved so quickly from pending to microblocks that we never noticed.

cc @markmhx I don't think we ever intended to add incoming pending txs to the balance, did we? We never have with STX. Currently, txs in a mircoblock show an increased `subBalance` as a caption in the balance list but it doesn't add to the send max balance value in the send form.

I can change that here if we want to?