### PR TITLE
fix: removed create account button from settings dropdown

### DIFF
--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -36,7 +36,6 @@ export function SettingsDropdown() {
   const hasGeneratedWallet = !!useCurrentStacksAccount();
   const wallet = useStacksWallet();
   const { lockWallet } = useKeyActions();
-  const createAccount = useCreateAccount();
   const [hasCreatedAccount, setHasCreatedAccount] = useHasCreatedAccount();
   const { setIsShowingSettings, isShowingSettings, setIsShowingSwitchAccountsState } = useDrawers();
   const currentNetworkId = useCurrentNetworkId();

--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -8,7 +8,6 @@ import { SettingsMenuSelectors } from '@tests/selectors/settings.selectors';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useCreateAccount } from '@app/common/hooks/account/use-create-account';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useDrawers } from '@app/common/hooks/use-drawers';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
@@ -81,15 +80,6 @@ export function SettingsDropdown() {
             )}
             {hasGeneratedWallet && walletType === 'software' && (
               <>
-                <MenuItem
-                  data-testid={SettingsSelectors.CreateAccountBtn}
-                  onClick={wrappedCloseCallback(() => {
-                    void createAccount();
-                    setHasCreatedAccount(true);
-                  })}
-                >
-                  Create an account
-                </MenuItem>
                 <MenuItem
                   data-testid={SettingsSelectors.ViewSecretKeyListItem}
                   onClick={wrappedCloseCallback(() => {


### PR DESCRIPTION
## Description

Removed create account button from settings dropdown so now the only way to create accounts is through the "Switch Accounts" modal.

Fixes #2843 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes