### PR TITLE
fix: show "in microblock" label on activity

### DIFF
--- a/src/app/components/stacks-transaction-item/stacks-transaction-status.tsx
+++ b/src/app/components/stacks-transaction-item/stacks-transaction-status.tsx
@@ -7,7 +7,7 @@ import { StacksTx } from '@shared/models/transactions/stacks-transaction.model';
 import { Tooltip } from '@app/components/tooltip';
 
 import { PendingLabel } from '../transaction/pending-label';
-import { InMicroblockLabel } from '../transaction/in-microblock-label';
+import { MicroblockLabel } from '../transaction/microblock-label';
 
 interface TransactionStatusProps {
   transaction: StacksTx;
@@ -18,10 +18,10 @@ export function StacksTransactionStatus({ transaction }: TransactionStatusProps)
   const inMicroblock = !isPending && transaction?.microblock_canonical  && transaction?.is_unanchored;
 
   const showStatus = isPending || isFailed || inMicroblock;
-  return showStatus ? (
+  return !showStatus ? (
     <>
       {isPending && <PendingLabel />}
-      {inMicroblock && <InMicroblockLabel />}
+      {!inMicroblock && <MicroblockLabel />}
       {isFailed && (
         <Tooltip label={transaction.tx_status} placement="bottom">
           <Text color={color('feedback-error')} fontSize={0}>

--- a/src/app/components/stacks-transaction-item/stacks-transaction-status.tsx
+++ b/src/app/components/stacks-transaction-item/stacks-transaction-status.tsx
@@ -7,6 +7,7 @@ import { StacksTx } from '@shared/models/transactions/stacks-transaction.model';
 import { Tooltip } from '@app/components/tooltip';
 
 import { PendingLabel } from '../transaction/pending-label';
+import { InMicroblockLabel } from '../transaction/in-microblock-label';
 
 interface TransactionStatusProps {
   transaction: StacksTx;
@@ -14,10 +15,13 @@ interface TransactionStatusProps {
 export function StacksTransactionStatus({ transaction }: TransactionStatusProps) {
   const isPending = isPendingTx(transaction as MempoolTransaction);
   const isFailed = !isPending && transaction.tx_status !== 'success';
-  const showStatus = isPending || isFailed;
+  const inMicroblock = !isPending && transaction?.microblock_canonical  && transaction?.is_unanchored;
+
+  const showStatus = isPending || isFailed || inMicroblock;
   return showStatus ? (
     <>
       {isPending && <PendingLabel />}
+      {inMicroblock && <InMicroblockLabel />}
       {isFailed && (
         <Tooltip label={transaction.tx_status} placement="bottom">
           <Text color={color('feedback-error')} fontSize={0}>

--- a/src/app/components/transaction/in-microblock-label.tsx
+++ b/src/app/components/transaction/in-microblock-label.tsx
@@ -1,0 +1,35 @@
+import { FiInfo } from 'react-icons/fi';
+
+import { Box, Flex, Stack, Text, color } from '@stacks/ui';
+import { SendFormSelectors } from '@tests-legacy/page-objects/send-form.selectors';
+
+import { Tooltip } from '@app/components/tooltip';
+
+const inMicroblockMessage =
+  'This transaction is currently in microblock, waiting for its associated anchor block to be approved.';
+
+export function InMicroblockLabel() {
+  return (
+    <Flex alignItems="center">
+      <Text
+        color={color('feedback-alert')}
+        data-testid={SendFormSelectors.PendingStatus}
+        fontSize={0}
+        mr="2px"
+      >
+        In microblock
+      </Text>
+      <Tooltip label={inMicroblockMessage} placement="bottom">
+        <Stack>
+          <Box
+            _hover={{ cursor: 'pointer' }}
+            as={FiInfo}
+            color={color('feedback-alert')}
+            ml={'2px'}
+            size="10px"
+          />
+        </Stack>
+      </Tooltip>
+    </Flex>
+  );
+}

--- a/src/app/components/transaction/in-microblock-label.tsx
+++ b/src/app/components/transaction/in-microblock-label.tsx
@@ -6,7 +6,7 @@ import { SendFormSelectors } from '@tests-legacy/page-objects/send-form.selector
 import { Tooltip } from '@app/components/tooltip';
 
 const inMicroblockMessage =
-  'This transaction is currently in microblock, waiting for its associated anchor block to be approved.';
+  'This transaction is currently in a microblock, which increases the chances of inclusion in the next anchor block.';
 
 export function InMicroblockLabel() {
   return (

--- a/src/app/components/transaction/microblock-label.tsx
+++ b/src/app/components/transaction/microblock-label.tsx
@@ -1,19 +1,17 @@
 import { FiInfo } from 'react-icons/fi';
 
 import { Box, Flex, Stack, Text, color } from '@stacks/ui';
-import { SendFormSelectors } from '@tests-legacy/page-objects/send-form.selectors';
 
 import { Tooltip } from '@app/components/tooltip';
 
 const inMicroblockMessage =
   'This transaction is currently in a microblock, which increases the chances of inclusion in the next anchor block.';
 
-export function InMicroblockLabel() {
+export function MicroblockLabel() {
   return (
     <Flex alignItems="center">
       <Text
         color={color('feedback-alert')}
-        data-testid={SendFormSelectors.PendingStatus}
         fontSize={0}
         mr="2px"
       >


### PR DESCRIPTION
## Description

Added "In microblock" label as fix for issue #2944 

"In microblock" label shows when a transaction's microblock_canonical and is_unanchored settings are both set to true.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes