### PR TITLE
feat: add sign out warning and check (Closes #3037)

### DIFF
--- a/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
@@ -18,7 +18,10 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
   const { whenWallet, walletType } = useWalletType();
 
   const form = useFormik({
-    initialValues: { confirmBackup: whenWallet({ ledger: true, software: false }) },
+    initialValues: {
+      confirmBackup: whenWallet({ ledger: true, software: false }),
+      confirmPasswordDisable: whenWallet({ ledger: true, software: false }),
+    },
     onSubmit() {
       onUserDeleteWallet();
     },
@@ -43,6 +46,14 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
                 ledger: '',
               })}
             </Text>
+
+            <Text as="p" mt="tight" fontWeight="bold">
+              {whenWallet({
+                software:
+                  '⚠️ After signing out, your current password can no longer be used to unlock the wallet. You get to set a new password when you recreate your wallet with the original seed.',
+                ledger: '',
+              })}
+            </Text>
           </Body>
 
           <Flex
@@ -61,6 +72,24 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
             </Box>
             <Caption userSelect="none">I've backed up my Secret Key</Caption>
           </Flex>
+          <Flex
+            as="label"
+            alignItems="center"
+            mt="tight"
+            display={walletType === 'software' ? 'flex' : 'none'}
+          >
+            <Box mr="tight">
+              <input
+                type="checkbox"
+                name="confirmPasswordDisable"
+                defaultChecked={form.values.confirmPasswordDisable}
+                data-testid={SettingsSelectors.SignOutConfirmHasBackupCheckbox}
+              />
+            </Box>
+            <Caption userSelect="none">
+              I understand that after signing out my current password can no longer be used to unlock the wallet
+            </Caption>
+          </Flex>
           <Flex mt="loose">
             <Button
               flex={1}
@@ -78,7 +107,7 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
               mode="primary"
               background={color('feedback-error')}
               _hover={{ background: color('feedback-error') }}
-              isDisabled={!form.values.confirmBackup}
+              isDisabled={!(form.values.confirmBackup && form.values.confirmPasswordDisable)}
               data-testid={SettingsSelectors.BtnSignOutActuallyDeleteWallet}
             >
               Sign out

--- a/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
@@ -46,14 +46,6 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
                 ledger: '',
               })}
             </Text>
-
-            <Text as="p" mt="tight" fontWeight="bold">
-              {whenWallet({
-                software:
-                  '⚠️ After signing out, your current password can no longer be used to unlock the wallet. You get to set a new password when you recreate your wallet with the original seed.',
-                ledger: '',
-              })}
-            </Text>
           </Body>
 
           <Flex
@@ -87,8 +79,7 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
               />
             </Box>
             <Caption userSelect="none">
-              I understand and confirm that after signing out my current password can no longer be
-              used to unlock the wallet
+              I understand my password will no longer work for accessing my wallet upon signing out
             </Caption>
           </Flex>
           <Flex mt="loose">

--- a/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
@@ -87,7 +87,8 @@ export const SignOutConfirmLayout: FC<SignOutConfirmLayoutProps> = props => {
               />
             </Box>
             <Caption userSelect="none">
-              I understand that after signing out my current password can no longer be used to unlock the wallet
+              I understand and confirm that after signing out my current password can no longer be
+              used to unlock the wallet
             </Caption>
           </Flex>
           <Flex mt="loose">


### PR DESCRIPTION
This pr closes https://github.com/hirosystems/stacks-wallet-web/issues/3037

I decided to go further and add one more checkbox, as this is very critical flow and mistake here may lead to loosing funds.
Actually, we can even remove this second warning and keep checkbox.

<img width="495" alt="Screenshot 2023-02-13 at 22 36 36" src="https://user-images.githubusercontent.com/46521087/218545144-cba64994-7d6b-44c1-ac52-d51f138b5ac6.png">
