### PR TITLE
fix: btc high fee warning

### DIFF
--- a/src/app/features/high-fee-drawer/components/high-fee-confirmation.tsx
+++ b/src/app/features/high-fee-drawer/components/high-fee-confirmation.tsx
@@ -1,29 +1,32 @@
 import { Button, Stack } from '@stacks/ui';
 import { useFormikContext } from 'formik';
 
-import { StacksSendFormValues, StacksTransactionFormValues } from '@shared/models/form.model';
+import {
+  BitcoinSendFormValues,
+  StacksSendFormValues,
+  StacksTransactionFormValues,
+} from '@shared/models/form.model';
 
 import { useDrawers } from '@app/common/hooks/use-drawers';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { Link } from '@app/components/link';
 import { Caption, Title } from '@app/components/typography';
 
-const url = 'https://hiro.so/questions/fee-estimates';
-
-export function HighFeeConfirmation(): JSX.Element | null {
+export function HighFeeConfirmation(props: { learnMoreUrl: string }) {
+  const { learnMoreUrl } = props;
   const { handleSubmit, values } = useFormikContext<
-    StacksSendFormValues | StacksTransactionFormValues
+    BitcoinSendFormValues | StacksSendFormValues | StacksTransactionFormValues
   >();
   const { setIsShowingHighFeeConfirmation } = useDrawers();
 
   return (
     <Stack px="loose" spacing="loose" pb="extra-loose">
       <Title fontSize="20px" fontWeight={400} lineHeight="28px">
-        Are you sure you want to pay {values.fee} STX in fees for this transaction?
+        Are you sure you want to pay {values.fee} {values.feeCurrency} in fees for this transaction?
       </Title>
       <Caption>
         This action cannot be undone and the fees won't be returned, even if the transaction fails.{' '}
-        <Link fontSize="14px" onClick={() => openInNewTab(url)}>
+        <Link fontSize="14px" onClick={() => openInNewTab(learnMoreUrl)}>
           Learn more
         </Link>
       </Caption>

--- a/src/app/features/high-fee-drawer/high-fee-drawer.tsx
+++ b/src/app/features/high-fee-drawer/high-fee-drawer.tsx
@@ -8,7 +8,8 @@ import { ControlledDrawer } from '@app/components/drawer/controlled-drawer';
 
 import { HighFeeConfirmation } from './components/high-fee-confirmation';
 
-export function HighFeeDrawer(): JSX.Element {
+export function HighFeeDrawer(props: { learnMoreUrl: string }) {
+  const { learnMoreUrl } = props;
   const { isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation } = useDrawers();
 
   useEffect(() => {
@@ -23,7 +24,7 @@ export function HighFeeDrawer(): JSX.Element {
       isShowing={isShowingHighFeeConfirmation}
       onClose={() => setIsShowingHighFeeConfirmation(false)}
     >
-      {isShowingHighFeeConfirmation && <HighFeeConfirmation />}
+      {isShowingHighFeeConfirmation && <HighFeeConfirmation learnMoreUrl={learnMoreUrl} />}
     </ControlledDrawer>
   );
 }

--- a/src/app/pages/send-tokens/send-tokens.tsx
+++ b/src/app/pages/send-tokens/send-tokens.tsx
@@ -5,6 +5,7 @@ import { Outlet, useNavigate } from 'react-router-dom';
 import { StacksTransaction } from '@stacks/transactions';
 import { Formik } from 'formik';
 
+import { HIGH_FEE_WARNING_LEARN_MORE_URL_STX } from '@shared/constants';
 import { logger } from '@shared/logger';
 import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { StacksSendFormValues } from '@shared/models/form.model';
@@ -157,7 +158,7 @@ function SendTokensFormBase() {
                 />
               ),
             })}
-            <HighFeeDrawer />
+            <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
             <Outlet />
           </>
         )}

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
@@ -4,7 +4,7 @@ import { Outlet, useNavigate } from 'react-router-dom';
 import { Form, Formik, FormikHelpers } from 'formik';
 import * as yup from 'yup';
 
-import { HIGH_FEE_AMOUNT_STX } from '@shared/constants';
+import { HIGH_FEE_AMOUNT_STX, HIGH_FEE_WARNING_LEARN_MORE_URL_STX } from '@shared/constants';
 import { logger } from '@shared/logger';
 import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { StacksSendFormValues } from '@shared/models/form.model';
@@ -181,7 +181,7 @@ export function StacksSip10FungibleTokenSendForm({
               onEditNonce={() => navigate(RouteUrls.EditNonce, { state: { contractId } })}
               my={['loose', 'base']}
             />
-            <HighFeeDrawer />
+            <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
             <Outlet />
           </Form>
         </NonceSetter>

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/stx-crypto-currency-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/stx-crypto-currency-send-form.tsx
@@ -4,7 +4,11 @@ import { Outlet, useNavigate } from 'react-router-dom';
 import { Form, Formik, FormikHelpers } from 'formik';
 import * as yup from 'yup';
 
-import { HIGH_FEE_AMOUNT_STX, STX_DECIMALS } from '@shared/constants';
+import {
+  HIGH_FEE_AMOUNT_STX,
+  HIGH_FEE_WARNING_LEARN_MORE_URL_STX,
+  STX_DECIMALS,
+} from '@shared/constants';
 import { logger } from '@shared/logger';
 import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { StacksSendFormValues } from '@shared/models/form.model';
@@ -165,7 +169,7 @@ export function StxCryptoCurrencySendForm() {
               onEditNonce={() => navigate(RouteUrls.EditNonce)}
               my={['loose', 'base']}
             />
-            <HighFeeDrawer />
+            <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
             <Outlet />
           </Form>
         </NonceSetter>

--- a/src/app/pages/transaction-request/transaction-request.tsx
+++ b/src/app/pages/transaction-request/transaction-request.tsx
@@ -6,6 +6,7 @@ import { Formik } from 'formik';
 import get from 'lodash.get';
 import * as yup from 'yup';
 
+import { HIGH_FEE_WARNING_LEARN_MORE_URL_STX } from '@shared/constants';
 import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { StacksTransactionFormValues } from '@shared/models/form.model';
 import { RouteUrls } from '@shared/route-urls';
@@ -100,6 +101,7 @@ function TransactionRequestBase() {
 
   const initialValues: StacksTransactionFormValues = {
     fee: '',
+    feeCurrency: 'STX',
     feeType: FeeTypes[FeeTypes.Middle],
     nonce: nextNonce?.nonce,
   };
@@ -129,7 +131,7 @@ function TransactionRequestBase() {
                 <FeeForm feeEstimations={feeEstimations.estimates} />
                 <SubmitAction />
                 <EditNonceButton onEditNonce={() => navigate(RouteUrls.EditNonce)} />
-                <HighFeeDrawer />
+                <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
               </NonceSetter>
               <Outlet />
             </>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -8,7 +8,10 @@ export const gaiaUrl = 'https://hub.blockstack.org';
 export const POPUP_CENTER_WIDTH = 442;
 export const POPUP_CENTER_HEIGHT = 646;
 
+export const HIGH_FEE_AMOUNT_BTC = 0.001;
 export const HIGH_FEE_AMOUNT_STX = 5;
+export const HIGH_FEE_WARNING_LEARN_MORE_URL_BTC = 'https://bitcoinfees.earn.com/';
+export const HIGH_FEE_WARNING_LEARN_MORE_URL_STX = 'https://hiro.so/questions/fee-estimates';
 
 export const DEFAULT_FEE_RATE = 400;
 

--- a/src/shared/models/form.model.ts
+++ b/src/shared/models/form.model.ts
@@ -1,6 +1,7 @@
 export interface BitcoinSendFormValues {
   amount: number | string;
   fee: number | string;
+  feeCurrency: string;
   feeType: string;
   memo: string;
   recipient: string;
@@ -23,6 +24,7 @@ export interface StacksSendFormValues {
 
 export interface StacksTransactionFormValues {
   fee: number | string;
+  feeCurrency: string;
   feeType: string;
   nonce?: number | string;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4167046558).<!-- Sticky Header Marker -->

This PR adds the high fee warning to btc txs. Once the fee calc is fixed this modal should read correctly so ignore the amount for now. I see the high fee warning to be triggered at `.001` for now and the learn more link goes to:

https://bitcoinfees.earn.com/

Let me know if those two constants should change?

![Screen Shot 2023-02-13 at 1 17 18 PM](https://user-images.githubusercontent.com/6493321/218554011-837b8cce-f73d-46b8-addc-85be46fbf353.png)