### PR TITLE
fix: send form routing

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/components/confirmation/send-form-confirmation-container.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/confirmation/send-form-confirmation-container.tsx
@@ -1,7 +1,5 @@
 import { Outlet, useNavigate } from 'react-router-dom';
 
-import { RouteUrls } from '@shared/route-urls';
-
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { Header } from '@app/components/header';
 
@@ -10,9 +8,7 @@ import { SendFormConfirmationLayout } from './components/send-form-confirmation.
 export function SendFormConfirmationContainer() {
   const navigate = useNavigate();
 
-  useRouteHeader(
-    <Header hideActions onClose={() => navigate(RouteUrls.SendCryptoAsset)} title="You'll send" />
-  );
+  useRouteHeader(<Header hideActions onClose={() => navigate(-1)} title="You'll send" />);
 
   return (
     <SendFormConfirmationLayout>

--- a/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.tsx
@@ -15,9 +15,7 @@ export function SendCryptoAssetForm() {
   const { symbol } = useParams();
   const navigate = useNavigate();
 
-  useRouteHeader(
-    <Header hideActions onClose={() => navigate(RouteUrls.SendCryptoAsset)} title="Send" />
-  );
+  useRouteHeader(<Header hideActions onClose={() => navigate(-1)} title="Send" />);
 
   if (!isString(symbol)) {
     return <Navigate to={RouteUrls.SendCryptoAsset} />;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4167902891).<!-- Sticky Header Marker -->

This fixes the new send form routing using the back arrow from the send form preview. It should go back to the right send form now, and from there go back to the page to choose an asset, and from there back to the home page.