### PR TITLE
fix: recipient choose account

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/account-list-item.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/account-list-item.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 
 import { useFormikContext } from 'formik';
 
-import { StacksSendFormValues } from '@shared/models/form.model';
+import { BitcoinSendFormValues, StacksSendFormValues } from '@shared/models/form.model';
 
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { AccountAvatarItem } from '@app/components/account/account-avatar';
@@ -18,15 +18,18 @@ interface AccountListItemProps {
   onClose(): void;
 }
 export const AccountListItem = memo(({ account, onClose }: AccountListItemProps) => {
-  const { setFieldValue } = useFormikContext<StacksSendFormValues>();
+  const { setFieldValue, values } = useFormikContext<
+    BitcoinSendFormValues | StacksSendFormValues
+  >();
   const [component, bind] = usePressable(true);
   const name = useAccountDisplayName(account);
 
   const btcAddress = useBtcAccountIndexAddressIndexZero(account.index);
 
   const onSelectAccount = () => {
-    setFieldValue('recipient', account.address);
-    setFieldValue('recipientAddressOrBnsName', account.address);
+    const isBitcoin = values.symbol === 'BTC';
+    setFieldValue('recipient', isBitcoin ? btcAddress : account.address);
+    !isBitcoin && setFieldValue('recipientAddressOrBnsName', account.address);
     onClose();
   };
 

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/recipient-accounts-drawer.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/recipient-accounts-drawer.tsx
@@ -20,7 +20,7 @@ export const RecipientAccountsDrawer = memo(() => {
   const navigate = useNavigate();
 
   const onGoBack = useCallback(
-    () => navigate('..', { state: { contractId } }),
+    () => navigate('..', { replace: true, state: { contractId } }),
     [contractId, navigate]
   );
 

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-field.tsx
@@ -3,26 +3,27 @@ import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { TextInputField } from './text-input-field';
 
 interface RecipientFieldProps {
+  labelAction: string;
   name: string;
   onBlur?(): void;
   onClickLabelAction?(): void;
   topInputOverlay?: JSX.Element;
 }
 export function RecipientField({
+  labelAction,
   name,
   onBlur,
-  // TODO: Removed until it works for Bitcoin
-  // onClickLabelAction,
+  onClickLabelAction,
   topInputOverlay,
 }: RecipientFieldProps) {
   return (
     <TextInputField
       dataTestId={SendCryptoAssetSelectors.RecipientFieldInput}
       label="To"
-      // labelAction="Choose account"
+      labelAction={labelAction}
       name={name}
       onBlur={onBlur}
-      // onClickLabelAction={onClickLabelAction}
+      onClickLabelAction={onClickLabelAction}
       placeholder="Address or name"
       topInputOverlay={topInputOverlay}
     />

--- a/src/app/pages/send/send-crypto-asset-form/family/stacks/components/stacks-recipient-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/stacks/components/stacks-recipient-field.tsx
@@ -13,10 +13,13 @@ export function StacksRecipientField(props: { contractId?: string }) {
 
   return (
     <RecipientField
+      labelAction="Choose account"
       name="recipientAddressOrBnsName"
       onBlur={getBnsAddress}
       onClickLabelAction={() =>
-        navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts, { state: { contractId } })
+        navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts, {
+          state: { contractId },
+        })
       }
       topInputOverlay={
         !!bnsAddress ? <RecipientFieldBnsAddress bnsAddress={bnsAddress} /> : undefined

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-crypto-currency-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-crypto-currency-send-form.tsx
@@ -137,6 +137,7 @@ export function BtcCryptoCurrencySendForm() {
               symbol="BTC"
             />
             <RecipientField
+              labelAction="Choose account"
               name="recipient"
               onClickLabelAction={() => navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts)}
             />

--- a/src/app/pages/send/send-crypto-asset-form/hooks/use-send-form-navigate.ts
+++ b/src/app/pages/send/send-crypto-asset-form/hooks/use-send-form-navigate.ts
@@ -26,6 +26,7 @@ export function useSendFormNavigate() {
     () => ({
       toConfirmAndSignBtcTransaction(tx: string, recipient: string, fee: number) {
         return navigate(`${RouteUrls.SendCryptoAsset}/btc/confirmation`, {
+          replace: true,
           state: {
             tx,
             recipient,
@@ -35,6 +36,7 @@ export function useSendFormNavigate() {
       },
       toConfirmAndSignStxTransaction(tx: StacksTransaction) {
         return navigate(`${RouteUrls.SendCryptoAsset}/stx/confirmation`, {
+          replace: true,
           state: {
             tx: bytesToHex(tx.serialize()),
           } as ConfirmationRouteState,
@@ -47,6 +49,7 @@ export function useSendFormNavigate() {
         tx,
       }: ConfirmationRouteStacksSip10Args) {
         return navigate(`${RouteUrls.SendCryptoAsset}/${symbol}/confirmation`, {
+          replace: true,
           state: {
             decimals,
             token: name,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4176810748).<!-- Sticky Header Marker -->

This fixes applying the wrong address in the btc form when using the choose account drawer.