### PR TITLE
fix: temp disable bitcoin for ledger

### DIFF
--- a/src/app/pages/home/components/receive-button.tsx
+++ b/src/app/pages/home/components/receive-button.tsx
@@ -13,7 +13,7 @@ import { HomeActionButton } from './tx-button';
 
 export function ReceiveButton(props: ButtonProps) {
   const navigate = useNavigate();
-  const bitcoinFeature = useBitcoinFeature();
+  const isBitcoinEnabled = useBitcoinFeature();
 
   return (
     <HomeActionButton
@@ -21,7 +21,7 @@ export function ReceiveButton(props: ButtonProps) {
       data-testid={HomePageSelectors.ReceiveCryptoAssetBtn}
       icon={QrCodeIcon}
       label="Receive"
-      onClick={() => navigate(bitcoinFeature ? RouteUrls.Receive : RouteUrls.ReceiveStx)}
+      onClick={() => navigate(isBitcoinEnabled ? RouteUrls.Receive : RouteUrls.ReceiveStx)}
       {...props}
     />
   );

--- a/src/app/pages/home/components/send-button.tsx
+++ b/src/app/pages/home/components/send-button.tsx
@@ -40,6 +40,7 @@ function SendButtonSuspense() {
   const ftAssets = useTransferableStacksFungibleTokenAssetBalances(account?.address ?? '');
   const isDisabled = !stxAssetBalance && ftAssets?.length === 0;
   const isBitcoinEnabled = useBitcoinFeature();
+
   return (
     <SendTxButton
       onClick={() =>

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-account.models.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-account.models.ts
@@ -5,7 +5,7 @@ export interface SoftwareBitcoinAccount {
 }
 
 // TODO: complete with bitcoin ledger support
-interface HardwareBitcoinAccount {
+export interface HardwareBitcoinAccount {
   type: 'ledger';
   path: string;
   index: number;

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
@@ -4,13 +4,16 @@ import { deriveNativeSegWitAccountFromHdKey } from '@shared/crypto/bitcoin/p2wpk
 
 import { mnemonicToRootNode } from '@app/common/keychain/keychain';
 import { selectInMemoryKey } from '@app/store/in-memory-key/in-memory-key.selectors';
+import { selectCurrentKey } from '@app/store/keys/key.selectors';
 import { defaultKeyId } from '@app/store/keys/key.slice';
 import { selectCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 export const selectSoftwareBitcoinNativeSegWitKeychain = createSelector(
+  selectCurrentKey,
   selectInMemoryKey,
   selectCurrentNetwork,
-  (inMemKey, network) => {
+  (currentKey, inMemKey, network) => {
+    if (currentKey?.type !== 'software') return;
     if (!inMemKey.keys[defaultKeyId]) throw new Error('No in-memory key found');
     return deriveNativeSegWitAccountFromHdKey(
       mnemonicToRootNode(inMemKey.keys.default),

--- a/src/app/store/feature-flags/feature-flags.slice.ts
+++ b/src/app/store/feature-flags/feature-flags.slice.ts
@@ -5,6 +5,7 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { BITCOIN_ENABLED } from '@shared/environment';
 
+import { useWalletType } from '@app/common/use-wallet-type';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { RootState } from '..';
@@ -61,7 +62,12 @@ function useFeatureFlags() {
 }
 
 export function useBitcoinFeature() {
+  const { whenWallet } = useWalletType();
   const network = useCurrentNetwork();
   const featureFlags = useFeatureFlags();
-  return network.chain.bitcoin.network === 'testnet' || featureFlags.bitcoin.isEnabled();
+
+  return whenWallet({
+    ledger: false,
+    software: network.chain.bitcoin.network === 'testnet' || featureFlags.bitcoin.isEnabled(),
+  });
 }

--- a/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
@@ -23,6 +23,7 @@ export function deriveNativeSegWitAccountFromHdKey(keychain: HDKey, network: Net
 }
 
 export function deriveBip32KeychainFromExtendedPublicKey(xpub: string) {
+  if (!xpub) return;
   return HDKey.fromExtendedKey(xpub);
 }
 
@@ -36,9 +37,10 @@ function deriveNativeSegWitReceiveAddressIndexKeychain({
   index,
   network,
 }: DeriveNativeSegWitReceiveAddressIndexKeychainArgs) {
+  if (!xpub) return;
   const keychain = deriveBip32KeychainFromExtendedPublicKey(xpub);
-  const zeroAddressIndex = keychain.deriveChild(0).deriveChild(index);
-  return btc.p2wpkh(zeroAddressIndex.publicKey!, getBtcSignerLibNetworkByMode(network));
+  const zeroAddressIndex = keychain?.deriveChild(0).deriveChild(index);
+  return btc.p2wpkh(zeroAddressIndex?.publicKey!, getBtcSignerLibNetworkByMode(network));
 }
 
 interface DeriveNativeSegWitReceiveAddressIndexAddressArgs {
@@ -51,5 +53,6 @@ export function deriveNativeSegWitReceiveAddressIndexAddress({
   index,
   network,
 }: DeriveNativeSegWitReceiveAddressIndexAddressArgs) {
-  return deriveNativeSegWitReceiveAddressIndexKeychain({ xpub, index, network }).address;
+  if (!xpub) return;
+  return deriveNativeSegWitReceiveAddressIndexKeychain({ xpub, index, network })?.address;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4178290835).<!-- Sticky Header Marker -->

This PR disables bitcoin on ledger temporarily.

@kyranjamie not sure if this is the best solution for this, but the code was getting stuck on `useCurrentBtcAccountAddressIndexZero()` and a chain of hooks leading to `selectSoftwareBitcoinNativeSegWitKeychain` where it throws an error. If there is a better way, let me know or feel free to make a commit tomorrow.