### PR TITLE
fix: account header addresses

### DIFF
--- a/src/app/components/tooltip.tsx
+++ b/src/app/components/tooltip.tsx
@@ -4,22 +4,25 @@ import { Box, BoxProps } from '@stacks/ui';
 import Tippy, { TippyProps } from '@tippyjs/react';
 
 interface TooltipProps extends TippyProps {
+  hideOnClick?: boolean;
   label?: TippyProps['content'];
   labelProps?: BoxProps;
 }
-export const Tooltip = memo(({ label, labelProps = {}, children, ...rest }: TooltipProps) => {
-  const content = useMemo(
-    () => (
-      <Box as="span" display="block" fontSize={0} {...labelProps}>
-        {label}
-      </Box>
-    ),
-    [labelProps, label]
-  );
-  if (!label) return <>{children}</>;
-  return (
-    <Tippy content={content} trigger="mouseenter" hideOnClick={undefined} {...rest}>
-      {children}
-    </Tippy>
-  );
-});
+export const Tooltip = memo(
+  ({ children, hideOnClick, label, labelProps = {}, ...rest }: TooltipProps) => {
+    const content = useMemo(
+      () => (
+        <Box as="span" display="block" fontSize={0} {...labelProps}>
+          {label}
+        </Box>
+      ),
+      [labelProps, label]
+    );
+    if (!label) return <>{children}</>;
+    return (
+      <Tippy content={content} hideOnClick={hideOnClick} trigger="mouseenter" {...rest}>
+        {children}
+      </Tippy>
+    );
+  }
+);

--- a/src/app/pages/home/components/account-area.tsx
+++ b/src/app/pages/home/components/account-area.tsx
@@ -14,6 +14,7 @@ import { useCurrentAccountNamesQuery } from '@app/query/stacks/bns/bns.hooks';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
 import { useCurrentAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+import { useBitcoinFeature } from '@app/store/feature-flags/feature-flags.slice';
 
 const AccountBnsAddress = memo(() => {
   const currentAccountNamesQuery = useCurrentAccountNamesQuery();
@@ -31,7 +32,11 @@ const AccountBnsAddress = memo(() => {
   return (
     <>
       <Caption>{bnsName}</Caption>
-      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy BNS name'}>
+      <Tooltip
+        hideOnClick={false}
+        label={hasCopied ? 'Copied!' : 'Copy BNS name'}
+        placement="right"
+      >
         <Stack>
           <Box
             _hover={{ cursor: 'pointer' }}
@@ -53,6 +58,7 @@ const AccountAddress = memo((props: StackProps) => {
   const btcAddress = useBtcAccountIndexAddressIndexZero(accountIndex);
   const { onCopy, hasCopied } = useClipboard(currentAccount?.address || '');
   const analytics = useAnalytics();
+  const isBitcoinEnabled = useBitcoinFeature();
 
   const copyToClipboard = () => {
     void analytics.track('copy_address_to_clipboard');
@@ -62,7 +68,11 @@ const AccountAddress = memo((props: StackProps) => {
   return currentAccount ? (
     <Stack isInline {...props}>
       <Caption>{truncateMiddle(currentAccount.address, 4)}</Caption>
-      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy Stacks address'}>
+      <Tooltip
+        hideOnClick={false}
+        label={hasCopied ? 'Copied!' : 'Copy Stacks address'}
+        placement="right"
+      >
         <Stack>
           <Box
             _hover={{ cursor: 'pointer' }}
@@ -74,22 +84,31 @@ const AccountAddress = memo((props: StackProps) => {
           />
         </Stack>
       </Tooltip>
-      <Caption>{truncateMiddle(btcAddress, 4)}</Caption>
-      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy Bitcoin address'}>
-        <Stack>
-          <Box
-            _hover={{ cursor: 'pointer' }}
-            onClick={copyToClipboard}
-            size="12px"
-            color={color('text-caption')}
-            data-testid={UserAreaSelectors.AccountCopyAddress}
-            as={FiCopy}
-          />
-        </Stack>
-      </Tooltip>
+      {isBitcoinEnabled ? (
+        <>
+          <Caption>{truncateMiddle(btcAddress, 4)}</Caption>
+          <Tooltip
+            hideOnClick={false}
+            label={hasCopied ? 'Copied!' : 'Copy Bitcoin address'}
+            placement="right"
+          >
+            <Stack>
+              <Box
+                _hover={{ cursor: 'pointer' }}
+                onClick={copyToClipboard}
+                size="12px"
+                color={color('text-caption')}
+                data-testid={UserAreaSelectors.AccountCopyAddress}
+                as={FiCopy}
+              />
+            </Stack>
+          </Tooltip>
+        </>
+      ) : null}
     </Stack>
   ) : null;
 });
+
 export const CurrentAccount = memo((props: StackProps) => {
   const currentAccount = useCurrentAccount();
   if (!currentAccount) return null;

--- a/src/app/pages/home/components/account-area.tsx
+++ b/src/app/pages/home/components/account-area.tsx
@@ -11,6 +11,8 @@ import { Caption } from '@app/components/typography';
 import { CurrentAccountAvatar } from '@app/features/current-account/current-account-avatar';
 import { CurrentAccountName } from '@app/features/current-account/current-account-name';
 import { useCurrentAccountNamesQuery } from '@app/query/stacks/bns/bns.hooks';
+import { useCurrentAccountIndex } from '@app/store/accounts/account';
+import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
 import { useCurrentAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 const AccountBnsAddress = memo(() => {
@@ -47,8 +49,11 @@ const AccountBnsAddress = memo(() => {
 
 const AccountAddress = memo((props: StackProps) => {
   const currentAccount = useCurrentAccount();
+  const accountIndex = useCurrentAccountIndex();
+  const btcAddress = useBtcAccountIndexAddressIndexZero(accountIndex);
   const { onCopy, hasCopied } = useClipboard(currentAccount?.address || '');
   const analytics = useAnalytics();
+
   const copyToClipboard = () => {
     void analytics.track('copy_address_to_clipboard');
     onCopy();
@@ -57,7 +62,20 @@ const AccountAddress = memo((props: StackProps) => {
   return currentAccount ? (
     <Stack isInline {...props}>
       <Caption>{truncateMiddle(currentAccount.address, 4)}</Caption>
-      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy address'}>
+      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy Stacks address'}>
+        <Stack>
+          <Box
+            _hover={{ cursor: 'pointer' }}
+            onClick={copyToClipboard}
+            size="12px"
+            color={color('text-caption')}
+            data-testid={UserAreaSelectors.AccountCopyAddress}
+            as={FiCopy}
+          />
+        </Stack>
+      </Tooltip>
+      <Caption>{truncateMiddle(btcAddress, 4)}</Caption>
+      <Tooltip placement="right" label={hasCopied ? 'Copied!' : 'Copy Bitcoin address'}>
         <Stack>
           <Box
             _hover={{ cursor: 'pointer' }}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4178678031).<!-- Sticky Header Marker -->

This PR adds the bitcoin address to the account area. I also cherry picked commits from this PR by @alter-eggo so the `Copied!` text appears on click: https://github.com/hirosystems/stacks-wallet-web/pull/3069

![Screen Shot 2023-02-14 at 4 21 14 PM](https://user-images.githubusercontent.com/6493321/218878101-5802d0e7-dc82-4e38-86e7-2e4327c6b39c.png)

![Screen Shot 2023-02-14 at 4 21 19 PM](https://user-images.githubusercontent.com/6493321/218878139-421a5716-28f6-4545-aeb5-b311b3cc0087.png)
