### PR TITLE
Feat: fetch BNSx state directly from on-chain contract

### DIFF
--- a/src/app/common/validation/forms/recipient-validators.ts
+++ b/src/app/common/validation/forms/recipient-validators.ts
@@ -1,3 +1,4 @@
+import { ChainID } from '@stacks/transactions';
 import * as yup from 'yup';
 
 import { NetworkConfiguration } from '@shared/constants';
@@ -5,6 +6,7 @@ import { NetworkConfiguration } from '@shared/constants';
 import { FormErrorMessages } from '@app/common/error-messages';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 
+import { fetchNameOwner } from '../../../query/stacks/bns/bns.utils';
 import {
   notCurrentAddressValidator,
   stxAddressNetworkValidatorFactory,
@@ -41,9 +43,9 @@ export function stxRecipientAddressOrBnsNameValidator({
         return true;
       } catch (e) {}
       try {
-        const res = await client.namesApi.getNameInfo({ name: value ?? '' });
-        if (typeof res.address !== 'string' || res.address.length === 0) return false;
-        return true;
+        const isTestnet = currentNetwork.chain.stacks.chainId === ChainID.Testnet;
+        const owner = await fetchNameOwner(client, value ?? '', isTestnet);
+        return owner !== null;
       } catch (e) {
         return false;
       }

--- a/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-recipient-bns-name.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-recipient-bns-name.tsx
@@ -2,23 +2,28 @@ import { useCallback, useState } from 'react';
 
 import { useField } from 'formik';
 
+import { fetchNameOwner } from '@app/query/stacks/bns/bns.utils';
 import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
+import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 export function useStacksRecipientBnsName() {
   const [, _, recipientFieldHelpers] = useField('recipient');
   const [recipientAddressOrBnsNameField] = useField('recipientAddressOrBnsName');
   const [bnsAddress, setBnsAddress] = useState('');
   const client = useStacksClientUnanchored();
+  const { isTestnet } = useCurrentNetworkState();
 
   const getBnsAddress = useCallback(async () => {
     setBnsAddress('');
     try {
-      const res = await client.namesApi.getNameInfo({
-        name: recipientAddressOrBnsNameField.value ?? '',
-      });
-      if (res.address) {
-        recipientFieldHelpers.setValue(res.address);
-        setBnsAddress(res.address);
+      const owner = await fetchNameOwner(
+        client,
+        recipientAddressOrBnsNameField.value ?? '',
+        isTestnet
+      );
+      if (owner) {
+        recipientFieldHelpers.setValue(owner);
+        setBnsAddress(owner);
       } else {
         recipientFieldHelpers.setValue(recipientAddressOrBnsNameField.value);
       }
@@ -26,7 +31,7 @@ export function useStacksRecipientBnsName() {
     } catch {
       recipientFieldHelpers.setValue(recipientAddressOrBnsNameField.value);
     }
-  }, [client.namesApi, recipientAddressOrBnsNameField.value, recipientFieldHelpers]);
+  }, [recipientAddressOrBnsNameField.value, recipientFieldHelpers, isTestnet, client]);
 
   return { getBnsAddress, bnsAddress };
 }

--- a/src/app/query/stacks/bns/bns.utils.ts
+++ b/src/app/query/stacks/bns/bns.utils.ts
@@ -126,8 +126,11 @@ export async function fetchNamesForAddress(
 
   // Return BNSx name if available, otherwise return names from API.
   const [bnsxName, bnsNames] = await Promise.all([fetchBnsxName(client, address), fetchFromApi()]);
-  if (bnsxName !== null) return { names: [bnsxName] };
-  return bnsNames;
+  const bnsName = 'names' in bnsNames ? bnsNames.names[0] : null;
+  const names: string[] = [];
+  if (bnsName) names.push(bnsName);
+  if (bnsxName) names.push(bnsxName);
+  return { names };
 }
 
 // Fetch the owner of a name.

--- a/src/app/query/stacks/bns/bns.utils.ts
+++ b/src/app/query/stacks/bns/bns.utils.ts
@@ -1,0 +1,77 @@
+import { BnsNamesOwnByAddressResponse } from '@stacks/stacks-blockchain-api-types';
+import {
+  BufferCV,
+  ClarityType,
+  OptionalCV,
+  TupleCV,
+  cvToHex,
+  deserializeCV,
+  standardPrincipalCV,
+} from '@stacks/transactions';
+
+import { StacksClient } from '@app/query/stacks/stacks-client';
+
+export const BNSX_CONTRACT_CONSTS = {
+  contractAddress: 'SP1JTCR202ECC6333N7ZXD7MK7E3ZTEEE1MJ73C60',
+  contractName: 'bnsx-registry',
+  functionName: 'get-primary-name',
+} as const;
+
+export function bytesToAscii(buffer: Uint8Array) {
+  let ret = '';
+  const end = buffer.length;
+
+  for (let i = 0; i < end; ++i) {
+    ret += String.fromCharCode(buffer[i] & 0x7f);
+  }
+  return ret;
+}
+
+// Fetch an address's "primary name" from the BNSx contract.
+export async function fetchBnsxName(client: StacksClient, address: string): Promise<string | null> {
+  try {
+    const addressCV = standardPrincipalCV(address);
+    const addressHex = cvToHex(addressCV);
+    const res = await client.smartContractsApi.callReadOnlyFunction({
+      ...BNSX_CONTRACT_CONSTS,
+      tip: 'latest',
+      readOnlyFunctionArgs: {
+        sender: address,
+        arguments: [addressHex],
+      },
+    });
+    if (!res.okay || !res.result) return null;
+    const { result } = res;
+    const cv = deserializeCV(result) as OptionalCV<
+      TupleCV<{ name: BufferCV; namespace: BufferCV }>
+    >;
+    if (cv.type === ClarityType.OptionalNone) return null;
+    const { name, namespace } = cv.value.data;
+    const fullName = `${bytesToAscii(name.buffer)}.${bytesToAscii(namespace.buffer)}`;
+    return fullName;
+  } catch (error) {
+    return null;
+  }
+}
+
+// Fetch names owned by an address.
+//
+// If `isTestnet` is `false` (aka mainnet), names are fetched from the
+// BNSx contract directly.
+export async function fetchNamesForAddress(
+  client: StacksClient,
+  address: string,
+  isTestnet: boolean
+): Promise<BnsNamesOwnByAddressResponse> {
+  const fetchFromApi = async () => {
+    return client.namesApi.getNamesOwnedByAddress({ address, blockchain: 'stacks' });
+  };
+  if (isTestnet) {
+    return fetchFromApi();
+  }
+
+  // Return BNSx name if available, otherwise return names from API.
+  const [bnsxName, bnsNames] = await Promise.all([fetchBnsxName(client, address), fetchFromApi()]);
+  if (bnsxName !== null) return { names: [bnsxName] };
+  return bnsNames;
+}

--- a/src/app/query/stacks/bns/bns.utils.ts
+++ b/src/app/query/stacks/bns/bns.utils.ts
@@ -1,12 +1,18 @@
+import { asciiToBytes } from '@stacks/common';
 import { BnsNamesOwnByAddressResponse } from '@stacks/stacks-blockchain-api-types';
 import {
   BufferCV,
   ClarityType,
   OptionalCV,
+  PrincipalCV,
   TupleCV,
+  UIntCV,
+  addressToString,
+  bufferCV,
   cvToHex,
   deserializeCV,
   standardPrincipalCV,
+  tupleCV,
 } from '@stacks/transactions';
 
 import { StacksClient } from '@app/query/stacks/stacks-client';
@@ -14,7 +20,6 @@ import { StacksClient } from '@app/query/stacks/stacks-client';
 export const BNSX_CONTRACT_CONSTS = {
   contractAddress: 'SP1JTCR202ECC6333N7ZXD7MK7E3ZTEEE1MJ73C60',
   contractName: 'bnsx-registry',
-  functionName: 'get-primary-name',
 } as const;
 
 export function bytesToAscii(buffer: Uint8Array) {
@@ -34,6 +39,7 @@ export async function fetchBnsxName(client: StacksClient, address: string): Prom
     const addressHex = cvToHex(addressCV);
     const res = await client.smartContractsApi.callReadOnlyFunction({
       ...BNSX_CONTRACT_CONSTS,
+      functionName: 'get-primary-name',
       tip: 'latest',
       readOnlyFunctionArgs: {
         sender: address,
@@ -52,6 +58,54 @@ export async function fetchBnsxName(client: StacksClient, address: string): Prom
   } catch (error) {
     return null;
   }
+}
+
+// This function is not exported from `@stacks/transactions`
+function principalToString(principal: PrincipalCV): string {
+  if (principal.type === ClarityType.PrincipalStandard) {
+    return addressToString(principal.address);
+  } else if (principal.type === ClarityType.PrincipalContract) {
+    const address = addressToString(principal.address);
+    return `${address}.${principal.contractName.content}`;
+  } else {
+    throw new Error(`Unexpected principal data: ${JSON.stringify(principal)}`);
+  }
+}
+
+// Fetch the owner of a BNSx name
+// If the name is not registered in BNSx, returns null.
+//
+// Subdomains don't exist on-chain, so if the name looks like a subdomain,
+// the function exits early with `null`.
+export async function fetchBnsxOwner(client: StacksClient, fqn: string): Promise<string | null> {
+  const nameParts = fqn.split('.');
+
+  // If the name includes a subdomain, it's not on-chain. Return null
+  if (nameParts.length !== 2) return null;
+
+  const [name, namespace] = nameParts;
+  const nameCV = tupleCV({
+    name: bufferCV(asciiToBytes(name)),
+    namespace: bufferCV(asciiToBytes(namespace)),
+  });
+
+  const res = await client.smartContractsApi.callReadOnlyFunction({
+    ...BNSX_CONTRACT_CONSTS,
+    functionName: 'get-name-properties',
+    tip: 'latest',
+    readOnlyFunctionArgs: {
+      // Sender is irrelevant
+      sender: BNSX_CONTRACT_CONSTS.contractAddress,
+      arguments: [cvToHex(nameCV)],
+    },
+  });
+
+  if (!res.okay || !res.result) return null;
+  const { result } = res;
+  const cv = deserializeCV(result) as OptionalCV<TupleCV<{ owner: PrincipalCV; id: UIntCV }>>;
+  if (cv.type === ClarityType.OptionalNone) return null;
+  const ownerCV = cv.value.data.owner;
+  return principalToString(ownerCV);
 }
 
 // Fetch names owned by an address.
@@ -74,4 +128,22 @@ export async function fetchNamesForAddress(
   const [bnsxName, bnsNames] = await Promise.all([fetchBnsxName(client, address), fetchFromApi()]);
   if (bnsxName !== null) return { names: [bnsxName] };
   return bnsNames;
+}
+
+// Fetch the owner of a name.
+//
+// If on mainnet, this function concurrently fetches a BNSx owner from the contract
+// and a BNS owner from the API.
+export async function fetchNameOwner(client: StacksClient, name: string, isTestnet: boolean) {
+  const fetchFromApi = async () => {
+    const res = await client.namesApi.getNameInfo({ name });
+    if (typeof res.address !== 'string' || res.address.length === 0) return null;
+    return res.address;
+  };
+  if (isTestnet) {
+    return fetchFromApi();
+  }
+
+  const [bnsxOwner, apiOwner] = await Promise.all([fetchBnsxOwner(client, name), fetchFromApi()]);
+  return bnsxOwner ?? apiOwner;
 }

--- a/src/app/store/keys/key.actions.ts
+++ b/src/app/store/keys/key.actions.ts
@@ -8,6 +8,7 @@ import { sendMessage } from '@shared/messages';
 import { recurseAccountsForActivity } from '@app/common/account-restoration/account-restore';
 import { checkForLegacyGaiaConfigWithKnownGeneratedAccountIndex } from '@app/common/account-restoration/legacy-gaia-config-lookup';
 import { BitcoinClient } from '@app/query/bitcoin/bitcoin-client';
+import { fetchNamesForAddress } from '@app/query/stacks/bns/bns.utils';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import { AppThunk } from '@app/store';
 
@@ -40,10 +41,7 @@ function setWalletEncryptionPassword(args: {
     }
 
     async function doesStacksAddressHaveBnsName(address: string) {
-      const resp = await stxClient.namesApi.getNamesOwnedByAddress({
-        address,
-        blockchain: 'stacks',
-      });
+      const resp = await fetchNamesForAddress(stxClient, address, true);
       return resp.names.length > 0;
     }
 


### PR DESCRIPTION
This is a "redo" of #3049. In that PR, I introduced querying BNS state via the BNSx API. This understandably introduced hesitation, especially because it introduced a new third-party API that was outside the team's control.

This PR changes the logic to only pull from on-chain data directly. This way, the user's configured Stacks node is still the only "source of truth" for querying state. Because a Stacks contract's interface can never change, this strategy provides a more stable and reliable data source.

Logic has been updated for both:

- Showing the user's name
- Sending to a name

To test:

- If logged in with a "regular" BNS name, it shows that name
- If the account only has a subdomain, it shows that
- If the account has a BNSx name, show their BNSx primary name
- For the "send" flow, each of the above situations should also work but in "reverse"