### PR TITLE
feat: add autofocus on custom fees input

### DIFF
--- a/src/app/components/fee-row/components/custom-fee-field.tsx
+++ b/src/app/components/fee-row/components/custom-fee-field.tsx
@@ -64,6 +64,7 @@ export function CustomFeeField(props: CustomFeeFieldProps) {
           textAlign="right"
           type="number"
           value={input.value}
+          autoFocus={true}
         />
       </InputGroup>
     </Stack>


### PR DESCRIPTION
Small ux improvement:
when user selects custom fees we expect him to enter the value in the input field. Now it is necessary to make extra click on input to do it. This pr adds autofocus on custom fees input.

Video:
https://user-images.githubusercontent.com/46521087/219135300-9098c157-b335-45fe-8fc0-540cc5bef553.mov

