### PR TITLE
fix: bitcoin bugs on testnet

### DIFF
--- a/src/app/pages/fund/components/fiat-providers-list.tsx
+++ b/src/app/pages/fund/components/fiat-providers-list.tsx
@@ -43,7 +43,7 @@ export const FiatProvidersList = (props: FiatProvidersProps) => {
       templateColumns="repeat(auto-fill, minmax(270px, 1fr))"
       width="100%"
     >
-      <ReceiveStxItem onReceiveStx={() => navigate(RouteUrls.FundReceive)} />
+      <ReceiveStxItem onReceiveStx={() => navigate(RouteUrls.FundReceiveStx)} />
       {Object.entries(activeProviders).map(([providerKey, providerValue]) => {
         const providerUrl = getProviderUrl({
           address,

--- a/src/app/pages/home/components/account-address.tsx
+++ b/src/app/pages/home/components/account-address.tsx
@@ -1,0 +1,40 @@
+import { FiCopy } from 'react-icons/fi';
+
+import { Box, Stack, Tooltip, useClipboard } from '@stacks/ui';
+import { color, truncateMiddle } from '@stacks/ui-utils';
+import { UserAreaSelectors } from '@tests-legacy/integration/user-area.selectors';
+
+import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { Caption } from '@app/components/typography';
+
+interface AccountAddressProps {
+  address: string;
+  label: string;
+}
+export function AccountAddress({ address, label }: AccountAddressProps) {
+  const { onCopy, hasCopied } = useClipboard(address);
+  const analytics = useAnalytics();
+
+  const copyToClipboard = () => {
+    void analytics.track('copy_address_to_clipboard');
+    onCopy();
+  };
+
+  return (
+    <>
+      <Caption>{truncateMiddle(address, 4)}</Caption>
+      <Tooltip hideOnClick={false} label={hasCopied ? 'Copied!' : label} placement="right">
+        <Stack>
+          <Box
+            _hover={{ cursor: 'pointer' }}
+            onClick={copyToClipboard}
+            size="12px"
+            color={color('text-caption')}
+            data-testid={UserAreaSelectors.AccountCopyAddress}
+            as={FiCopy}
+          />
+        </Stack>
+      </Tooltip>
+    </>
+  );
+}

--- a/src/app/pages/home/components/account-addresses.tsx
+++ b/src/app/pages/home/components/account-addresses.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+
+import { Stack, StackProps } from '@stacks/ui';
+
+import { useCurrentAccountNamesQuery } from '@app/query/stacks/bns/bns.hooks';
+import { useCurrentAccountIndex } from '@app/store/accounts/account';
+import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+import { useBitcoinFeature } from '@app/store/feature-flags/feature-flags.slice';
+
+import { AccountAddress } from './account-address';
+
+export const AccountAddresses = memo((props: StackProps) => {
+  const currentAccount = useCurrentAccount();
+  const accountIndex = useCurrentAccountIndex();
+  const btcAddress = useBtcAccountIndexAddressIndexZero(accountIndex);
+  const currentAccountNamesQuery = useCurrentAccountNamesQuery();
+  const isBitcoinEnabled = useBitcoinFeature();
+  const bnsName = currentAccountNamesQuery.data?.names[0];
+
+  return currentAccount ? (
+    <Stack isInline {...props}>
+      <AccountAddress address={currentAccount.address} label="Copy Stacks addres" />
+      {isBitcoinEnabled ? (
+        <AccountAddress address={btcAddress} label="Copy Bitcoin address" />
+      ) : null}
+      {bnsName ? <AccountAddress address={bnsName} label="Copy BNS addres" /> : null}
+    </Stack>
+  ) : null;
+});

--- a/src/app/pages/home/components/account-area.tsx
+++ b/src/app/pages/home/components/account-area.tsx
@@ -1,113 +1,12 @@
 import { memo } from 'react';
-import { FiCopy } from 'react-icons/fi';
 
-import { Box, Stack, StackProps, color, useClipboard } from '@stacks/ui';
-import { truncateMiddle } from '@stacks/ui-utils';
-import { UserAreaSelectors } from '@tests-legacy/integration/user-area.selectors';
+import { Stack, StackProps } from '@stacks/ui';
 
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
-import { Tooltip } from '@app/components/tooltip';
-import { Caption } from '@app/components/typography';
 import { CurrentAccountAvatar } from '@app/features/current-account/current-account-avatar';
 import { CurrentAccountName } from '@app/features/current-account/current-account-name';
-import { useCurrentAccountNamesQuery } from '@app/query/stacks/bns/bns.hooks';
-import { useCurrentAccountIndex } from '@app/store/accounts/account';
-import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
 import { useCurrentAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
-import { useBitcoinFeature } from '@app/store/feature-flags/feature-flags.slice';
 
-const AccountBnsAddress = memo(() => {
-  const currentAccountNamesQuery = useCurrentAccountNamesQuery();
-
-  const bnsName = currentAccountNamesQuery.data?.names[0];
-  const { onCopy, hasCopied } = useClipboard(bnsName || '');
-  const analytics = useAnalytics();
-  const copyToClipboard = () => {
-    void analytics.track('copy_address_to_clipboard');
-    onCopy();
-  };
-
-  if (!bnsName) return null;
-
-  return (
-    <>
-      <Caption>{bnsName}</Caption>
-      <Tooltip
-        hideOnClick={false}
-        label={hasCopied ? 'Copied!' : 'Copy BNS name'}
-        placement="right"
-      >
-        <Stack>
-          <Box
-            _hover={{ cursor: 'pointer' }}
-            onClick={copyToClipboard}
-            size="12px"
-            color={color('text-caption')}
-            data-testid={UserAreaSelectors.AccountCopyBnsAddress}
-            as={FiCopy}
-          />
-        </Stack>
-      </Tooltip>
-    </>
-  );
-});
-
-const AccountAddress = memo((props: StackProps) => {
-  const currentAccount = useCurrentAccount();
-  const accountIndex = useCurrentAccountIndex();
-  const btcAddress = useBtcAccountIndexAddressIndexZero(accountIndex);
-  const { onCopy, hasCopied } = useClipboard(currentAccount?.address || '');
-  const analytics = useAnalytics();
-  const isBitcoinEnabled = useBitcoinFeature();
-
-  const copyToClipboard = () => {
-    void analytics.track('copy_address_to_clipboard');
-    onCopy();
-  };
-
-  return currentAccount ? (
-    <Stack isInline {...props}>
-      <Caption>{truncateMiddle(currentAccount.address, 4)}</Caption>
-      <Tooltip
-        hideOnClick={false}
-        label={hasCopied ? 'Copied!' : 'Copy Stacks address'}
-        placement="right"
-      >
-        <Stack>
-          <Box
-            _hover={{ cursor: 'pointer' }}
-            onClick={copyToClipboard}
-            size="12px"
-            color={color('text-caption')}
-            data-testid={UserAreaSelectors.AccountCopyAddress}
-            as={FiCopy}
-          />
-        </Stack>
-      </Tooltip>
-      {isBitcoinEnabled ? (
-        <>
-          <Caption>{truncateMiddle(btcAddress, 4)}</Caption>
-          <Tooltip
-            hideOnClick={false}
-            label={hasCopied ? 'Copied!' : 'Copy Bitcoin address'}
-            placement="right"
-          >
-            <Stack>
-              <Box
-                _hover={{ cursor: 'pointer' }}
-                onClick={copyToClipboard}
-                size="12px"
-                color={color('text-caption')}
-                data-testid={UserAreaSelectors.AccountCopyAddress}
-                as={FiCopy}
-              />
-            </Stack>
-          </Tooltip>
-        </>
-      ) : null}
-    </Stack>
-  ) : null;
-});
+import { AccountAddresses } from './account-addresses';
 
 export const CurrentAccount = memo((props: StackProps) => {
   const currentAccount = useCurrentAccount();
@@ -118,8 +17,7 @@ export const CurrentAccount = memo((props: StackProps) => {
       <Stack overflow="hidden" display="block" alignItems="flex-start" spacing="base-tight">
         <CurrentAccountName />
         <Stack isInline>
-          <AccountAddress />
-          <AccountBnsAddress />
+          <AccountAddresses />
         </Stack>
       </Stack>
     </Stack>

--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { Flex, Input, Stack, Text, color } from '@stacks/ui';
+import { Box, Flex, Input, Stack, Text, color } from '@stacks/ui';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { useField } from 'formik';
 
@@ -31,7 +31,7 @@ function getAmountModifiedFontSize(props: GetAmountModifiedFontSize) {
 
 interface AmountFieldProps {
   balance: Money;
-  bottomInputOverlay: JSX.Element;
+  bottomInputOverlay?: JSX.Element;
 }
 export function AmountField({ balance, bottomInputOverlay }: AmountFieldProps) {
   const [field, meta] = useField('amount');
@@ -102,7 +102,7 @@ export function AmountField({ balance, bottomInputOverlay }: AmountFieldProps) {
           {meta.error}
         </ErrorLabel>
       )}
-      {bottomInputOverlay}
+      {bottomInputOverlay ?? <Box size="36px" />}
     </Stack>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-crypto-currency-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-crypto-currency-send-form.tsx
@@ -36,7 +36,7 @@ import { FormFieldsLayout } from '../../components/form-fields.layout';
 import { PreviewButton } from '../../components/preview-button';
 import { RecipientField } from '../../components/recipient-field';
 import { SelectedAssetField } from '../../components/selected-asset-field';
-import { SendAllButton } from '../../components/send-all-button';
+// import { SendAllButton } from '../../components/send-all-button';
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 import { createDefaultInitialFormValues } from '../../send-form.utils';
 import { useGenerateBitcoinRawTx } from './use-generate-bitcoin-raw-tx';
@@ -67,6 +67,7 @@ export function BtcCryptoCurrencySendForm() {
       ),
     [availableBtcBalance, pendingTxsBalance]
   );
+  logger.debug('send all', sendAllBalance);
 
   const initialValues: BitcoinSendFormValues = createDefaultInitialFormValues({
     amount: '',
@@ -119,16 +120,16 @@ export function BtcCryptoCurrencySendForm() {
         <Form style={{ width: '100%' }}>
           <AmountField
             balance={availableBtcBalance}
-            bottomInputOverlay={
-              <SendAllButton
-                balance={availableBtcBalance}
-                // sendAllBalance={sendAllBalance.minus(props.values.fee).toString()}
-                sendAllBalance={sendAllBalance
-                  .multipliedBy(0.99)
-                  .decimalPlaces(BTC_DECIMALS)
-                  .toString()}
-              />
-            }
+            // bottomInputOverlay={
+            //   <SendAllButton
+            //     balance={availableBtcBalance}
+            //     // sendAllBalance={sendAllBalance.minus(props.values.fee).toString()}
+            //     sendAllBalance={sendAllBalance
+            //       .multipliedBy(0.99)
+            //       .decimalPlaces(BTC_DECIMALS)
+            //       .toString()}
+            //   />
+            // }
           />
           <FormFieldsLayout>
             <SelectedAssetField

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-generate-bitcoin-raw-tx.ts
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-generate-bitcoin-raw-tx.ts
@@ -26,8 +26,7 @@ export function useGenerateBitcoinRawTx() {
   const signTx = useSignBitcoinTx();
   const network = useCurrentNetwork();
   const { data: feeRate } = useBitcoinFeeRatesInVbytes();
-  console.log('here', currentAddressIndexKeychain);
-  console.log('address', currentAccountBtcAddress);
+
   return useCallback(
     (values: BitcoinSendFormValues) => {
       if (!utxos) return;
@@ -35,7 +34,7 @@ export function useGenerateBitcoinRawTx() {
 
       // console.log(utxos);
       const networkMode = getBtcSignerLibNetworkByMode(network.chain.bitcoin.network);
-      console.log('amount', values.amount);
+
       try {
         const tx = new btc.Transaction();
 
@@ -76,7 +75,6 @@ export function useGenerateBitcoinRawTx() {
         tx.finalize();
         return { hex: tx.hex, fee };
       } catch (e) {
-        console.log('error', e);
         logger.error('Error signing bitcoin transaction', e);
         return null;
       }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-generate-bitcoin-raw-tx.ts
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-generate-bitcoin-raw-tx.ts
@@ -26,7 +26,8 @@ export function useGenerateBitcoinRawTx() {
   const signTx = useSignBitcoinTx();
   const network = useCurrentNetwork();
   const { data: feeRate } = useBitcoinFeeRatesInVbytes();
-
+  console.log('here', currentAddressIndexKeychain);
+  console.log('address', currentAccountBtcAddress);
   return useCallback(
     (values: BitcoinSendFormValues) => {
       if (!utxos) return;
@@ -34,7 +35,7 @@ export function useGenerateBitcoinRawTx() {
 
       // console.log(utxos);
       const networkMode = getBtcSignerLibNetworkByMode(network.chain.bitcoin.network);
-
+      console.log('amount', values.amount);
       try {
         const tx = new btc.Transaction();
 
@@ -75,6 +76,7 @@ export function useGenerateBitcoinRawTx() {
         tx.finalize();
         return { hex: tx.hex, fee };
       } catch (e) {
+        console.log('error', e);
         logger.error('Error signing bitcoin transaction', e);
         return null;
       }

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -142,6 +142,8 @@ function AppRoutesAfterUserHasConsented() {
           }
         >
           <Route path={RouteUrls.FundReceive} element={<ReceiveModal />} />
+          <Route path={RouteUrls.FundReceiveStx} element={<ReceiveStxModal />} />
+          <Route path={RouteUrls.FundReceiveBtc} element={<ReceiveModal />} />
           {settingsModalRoutes}
         </Route>
         <Route

--- a/src/shared/environment.ts
+++ b/src/shared/environment.ts
@@ -1,6 +1,6 @@
 export const BITCOIN_ENABLED = process.env.BITCOIN_ENABLED;
 export const BRANCH = process.env.GITHUB_REF;
-export const BRANCH_NAME = process.env.BRANCH_NAME;
+export const BRANCH_NAME = process.env.GITHUB_HEAD_REF;
 export const COINBASE_APP_ID = process.env.COINBASE_APP_ID ?? '';
 export const COMMIT_SHA = process.env.GITHUB_SHA;
 export const IS_DEV_ENV = process.env.WALLET_ENVIRONMENT === 'development';

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -28,6 +28,8 @@ export enum RouteUrls {
   ChooseAccount = '/choose-account',
   Fund = '/fund',
   FundReceive = '/fund/receive',
+  FundReceiveStx = '/fund/receive/stx',
+  FundReceiveBtc = '/fund/receive/btc',
   IncreaseFee = '/increase-fee',
   Receive = '/receive',
   ReceiveStx = '/receive/stx',

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -4,7 +4,6 @@ const webpack = require('webpack');
 const { version: _version } = require('../package.json');
 const generateManifest = require('../scripts/generate-manifest');
 
-const { execSync } = require('child_process');
 const Dotenv = require('dotenv-webpack');
 const GenerateJsonPlugin = require('generate-json-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -26,16 +25,6 @@ const BRANCH = process.env.GITHUB_REF;
 const IS_DEV = NODE_ENV === 'development';
 const IS_PROD = !IS_DEV;
 const MAIN_BRANCH = 'refs/heads/main';
-
-// https://stackoverflow.com/a/69167552
-function executeGitCommand(command) {
-  return execSync(command)
-    .toString('utf8')
-    .replace(/[\n\r\s]+$/, '');
-}
-
-const BRANCH_NAME = executeGitCommand('git rev-parse --abbrev-ref HEAD');
-process.env.BRANCH_NAME = BRANCH_NAME;
 
 // For non main branch builds, add a random number
 const getVersionWithRandomSuffix = ref => {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4189918875).<!-- Sticky Header Marker -->

This PR fixes a couple of bugs found while testing btc on testnet. I removed the send all button for now bc we aren't properly calculating it, and we aren't showing an insufficient balance warning. That appears to be the error I was running into as well. I believe @kyranjamie added the insufficient balance warning to bitcoin? If not, we need to make an issue for it.

Bitcoin mainnet address was shown from the Fund page when clicking on receive tile, so I routed that properly to the stx only modal for now.

I am also reverting a small change I made here to our env variable `BRANCH_NAME`. I want to fix it for dev builds properly and needs more testing.