### PR TITLE
refactor: add send container to full page

### DIFF
--- a/src/app/pages/send/choose-crypto-asset/components/choose-crypto-asset.layout.tsx
+++ b/src/app/pages/send/choose-crypto-asset/components/choose-crypto-asset.layout.tsx
@@ -9,14 +9,13 @@ export function ChooseCryptoAssetLayout({ children }: StackProps) {
       alignItems={['left', 'center']}
       flexGrow={1}
       flexDirection="column"
-      minHeight={['70vh', '90vh']}
       justifyContent="start"
-      mb="loose"
     >
       <PageTitle
         fontSize={3}
         maxWidth={['unset', 'unset', CENTERED_FULL_PAGE_MAX_WIDTH]}
         mb={['loose', 'loose', '48px']}
+        mt={['unset', 'loose']}
         px="loose"
         textAlign={['left', 'center']}
       >

--- a/src/app/pages/send/send-container.tsx
+++ b/src/app/pages/send/send-container.tsx
@@ -1,0 +1,29 @@
+import { Outlet } from 'react-router';
+
+import { Flex, color } from '@stacks/ui';
+
+import { whenPageMode } from '@app/common/utils';
+
+export function SendContainer() {
+  return whenPageMode({
+    full: () => (
+      <Flex
+        alignItems="start"
+        borderWidth="1px"
+        borderColor={color('border')}
+        borderRadius="16px"
+        justifyContent="center"
+        maxHeight="90vh"
+        minWidth="480px"
+        pb="loose"
+      >
+        <Outlet />
+      </Flex>
+    ),
+    popup: () => (
+      <>
+        <Outlet />
+      </>
+    ),
+  })();
+}

--- a/src/app/pages/send/send-container.tsx
+++ b/src/app/pages/send/send-container.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router';
+import { Outlet } from 'react-router-dom';
 
 import { Flex, color } from '@stacks/ui';
 
@@ -6,7 +6,7 @@ import { whenPageMode } from '@app/common/utils';
 
 export function SendContainer() {
   return whenPageMode({
-    full: () => (
+    full: (
       <Flex
         alignItems="start"
         borderWidth="1px"
@@ -20,10 +20,6 @@ export function SendContainer() {
         <Outlet />
       </Flex>
     ),
-    popup: () => (
-      <>
-        <Outlet />
-      </>
-    ),
-  })();
+    popup: <Outlet />,
+  });
 }

--- a/src/app/pages/send/send-crypto-asset-form/components/confirmation/components/send-form-confirmation.layout.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/confirmation/components/send-form-confirmation.layout.tsx
@@ -9,10 +9,9 @@ export function SendFormConfirmationLayout({ children }: StackProps) {
       flexGrow={1}
       flexDirection="column"
       justifyContent="start"
-      mb="loose"
-      minHeight={['70vh', '90vh']}
       maxWidth={['unset', 'unset', CENTERED_FULL_PAGE_MAX_WIDTH]}
       mt={['36px', '36px', '48px']}
+      pb="extra-loose"
       px="loose"
     >
       {children}

--- a/src/app/pages/send/send-crypto-asset-form/components/send-crypto-asset-form.layout.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/send-crypto-asset-form.layout.tsx
@@ -16,6 +16,7 @@ export function SendCryptoAssetFormLayout({ children }: SendCryptoAssetFormLayou
       mt={['unset', '48px']}
       maxWidth={['100%', CENTERED_FULL_PAGE_MAX_WIDTH]}
       minWidth={['100%', CENTERED_FULL_PAGE_MAX_WIDTH]}
+      pb="extra-loose"
       px={['loose', 'unset']}
     >
       {children}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-crypto-currency-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-crypto-currency-send-form.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
+import { color } from '@stacks/ui-utils';
 import { Form, Formik, FormikHelpers } from 'formik';
 import * as yup from 'yup';
 
@@ -145,7 +146,11 @@ export function BtcCryptoCurrencySendForm() {
           {/* <FeesRow fees={btcFees} isSponsored={false} allowCustom={false} mt="base" /> */}
           <WarningLabel mt="base-loose" width="100%">
             This is a Bitcoin testnet transaction. Funds have no value.{' '}
-            <ExternalLink href="https://coinfaucet.eu/en/btc-testnet">
+            <ExternalLink
+              href="https://coinfaucet.eu/en/btc-testnet"
+              color={color('text-body')}
+              textDecoration="underline"
+            >
               Get testnet BTC here ↗
             </ExternalLink>
           </WarningLabel>

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -30,6 +30,7 @@ import { ReceiveStxModal } from '@app/pages/receive-tokens/receive-stx';
 import { SelectNetwork } from '@app/pages/select-network/select-network';
 import { SendTokensForm } from '@app/pages/send-tokens/send-tokens';
 import { ChooseCryptoAsset } from '@app/pages/send/choose-crypto-asset/choose-crypto-asset';
+import { SendContainer } from '@app/pages/send/send-container';
 import { sendFormConfirmationRoutes } from '@app/pages/send/send-crypto-asset-form/components/confirmation/send-form-confirmation.routes';
 import { RecipientAccountsDrawer } from '@app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/recipient-accounts-drawer';
 import { SendCryptoAssetForm } from '@app/pages/send/send-crypto-asset-form/send-crypto-asset-form';
@@ -158,24 +159,26 @@ function AppRoutesAfterUserHasConsented() {
           <Route path={RouteUrls.EditNonce} element={<EditNonceDrawer />} />
           <Route path={RouteUrls.TransactionBroadcastError} element={<BroadcastErrorDrawer />} />
         </Route>
-        <Route
-          path={RouteUrls.SendCryptoAsset}
-          element={
-            <AccountGate>
-              <Suspense fallback={<FullPageWithHeaderLoadingSpinner />}>
-                <ChooseCryptoAsset />
-              </Suspense>
-            </AccountGate>
-          }
-        />
-        <Route path={RouteUrls.SendCryptoAssetForm} element={<SendCryptoAssetForm />}>
-          <Route path={RouteUrls.EditNonce} element={<EditNonceDrawer />} />
+        <Route element={<SendContainer />}>
           <Route
-            path={RouteUrls.SendCryptoAssetFormRecipientAccounts}
-            element={<RecipientAccountsDrawer />}
+            path={RouteUrls.SendCryptoAsset}
+            element={
+              <AccountGate>
+                <Suspense fallback={<FullPageWithHeaderLoadingSpinner />}>
+                  <ChooseCryptoAsset />
+                </Suspense>
+              </AccountGate>
+            }
           />
+          <Route path={RouteUrls.SendCryptoAssetForm} element={<SendCryptoAssetForm />}>
+            <Route path={RouteUrls.EditNonce} element={<EditNonceDrawer />} />
+            <Route
+              path={RouteUrls.SendCryptoAssetFormRecipientAccounts}
+              element={<RecipientAccountsDrawer />}
+            />
+          </Route>
+          {sendFormConfirmationRoutes}
         </Route>
-        {sendFormConfirmationRoutes}
         <Route
           path={RouteUrls.TransactionRequest}
           element={


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4191669288).<!-- Sticky Header Marker -->

@kyranjamie I added the `SendContainer` layout route here, but didn't change much else. I know you are going to be working on adding new steps/pages with fees so I didn't want to change too much here. I kept the header in place above the outlined form for navigation, even though the new designs show the arrow inside the outline. Again, didn't want to spend too much time on this before switching over to writing tests. Hope this is helpful.