### PR TITLE
feat: add taproot keychain

### DIFF
--- a/src/app/common/hooks/use-transferable-asset-balances.hooks.ts
+++ b/src/app/common/hooks/use-transferable-asset-balances.hooks.ts
@@ -7,12 +7,12 @@ import {
   useStacksAnchoredCryptoCurrencyAssetBalance,
   useTransferableStacksFungibleTokenAssetBalances,
 } from '@app/query/stacks/balance/crypto-asset-balances.hooks';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 export function useAllTransferableCryptoAssetBalances(): AllTransferableCryptoAssetBalances[] {
   const account = useCurrentAccount();
-  const currentBtcAddress = useCurrentBtcAccountAddressIndexZero();
+  const currentBtcAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const btcCryptoCurrencyAssetBalance = useBitcoinCryptoCurrencyAssetBalance(currentBtcAddress);
   const { data: stxCryptoCurrencyAssetBalance } = useStacksAnchoredCryptoCurrencyAssetBalance(
     account?.address ?? ''

--- a/src/app/features/activity-list/activity-list.tsx
+++ b/src/app/features/activity-list/activity-list.tsx
@@ -5,7 +5,7 @@ import { useBitcoinPendingTransactions } from '@app/query/bitcoin/address/transa
 import { useGetBitcoinTransactionsByAddressQuery } from '@app/query/bitcoin/address/transactions-by-address.query';
 import { useStacksPendingTransactions } from '@app/query/stacks/mempool/mempool.hooks';
 import { useGetAccountTransactionsWithTransfersQuery } from '@app/query/stacks/transactions/transactions-with-transfers.query';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useBitcoinFeature } from '@app/store/feature-flags/feature-flags.slice';
 import { useSubmittedTransactions } from '@app/store/submitted-transactions/submitted-transactions.selectors';
 
@@ -16,7 +16,7 @@ import { SubmittedTransactionList } from './components/submitted-transaction-lis
 import { TransactionList } from './components/transaction-list/transaction-list';
 
 export function ActivityList() {
-  const bitcoinAddress = useCurrentBtcAccountAddressIndexZero();
+  const bitcoinAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const { isInitialLoading: isInitialLoadingBitcoinTransactions, data: bitcoinTransactions } =
     useGetBitcoinTransactionsByAddressQuery(bitcoinAddress);
   const bitcoinPendingTxs = useBitcoinPendingTransactions();

--- a/src/app/features/activity-list/components/transaction-list/bitcoin-transaction/bitcoin-transaction-item.tsx
+++ b/src/app/features/activity-list/components/transaction-list/bitcoin-transaction/bitcoin-transaction-item.tsx
@@ -8,7 +8,7 @@ import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useExplorerLink } from '@app/common/hooks/use-explorer-link';
 import { BtcIcon } from '@app/components/icons/btc-icon';
 import { TransactionTitle } from '@app/components/transaction/transaction-title';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 import { BitcoinTransactionCaption } from './bitcoin-transaction-caption';
 import { BitcoinTransactionItemLayout } from './bitcoin-transaction-item.layout';
@@ -20,7 +20,7 @@ interface BitcoinTransactionItemProps extends BoxProps {
   transaction?: BitcoinTransaction;
 }
 export function BitcoinTransactionItem({ transaction, ...rest }: BitcoinTransactionItemProps) {
-  const bitcoinAddress = useCurrentBtcAccountAddressIndexZero();
+  const bitcoinAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const { handleOpenTxLink } = useExplorerLink();
   const analytics = useAnalytics();
   const caption = useMemo(() => getBitcoinTxCaption(transaction), [transaction]);

--- a/src/app/features/balances-list/balances-list.tsx
+++ b/src/app/features/balances-list/balances-list.tsx
@@ -17,7 +17,7 @@ import {
   useStacksNonFungibleTokenAssetsUnanchored,
   useStacksUnanchoredCryptoCurrencyAssetBalance,
 } from '@app/query/stacks/balance/crypto-asset-balances.hooks';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useBitcoinFeature } from '@app/store/feature-flags/feature-flags.slice';
 
 import { FundAccount } from './components/fund-account';
@@ -30,7 +30,7 @@ interface BalancesListProps extends StackProps {
 export function BalancesList({ address, ...props }: BalancesListProps) {
   const { data: stxAssetBalance } = useStacksAnchoredCryptoCurrencyAssetBalance(address);
   const { data: stxUnachoredAssetBalance } = useStacksUnanchoredCryptoCurrencyAssetBalance(address);
-  const bitcoinAddress = useCurrentBtcAccountAddressIndexZero();
+  const bitcoinAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const btcAssetBalance = useBitcoinCryptoCurrencyAssetBalance(bitcoinAddress);
   const stacksFtAssetBalances = useStacksFungibleTokenAssetBalancesAnchoredWithMetadata(address);
   const { data: stacksNftAssetBalances = [] } = useStacksNonFungibleTokenAssetsUnanchored();

--- a/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
@@ -6,7 +6,7 @@ import { useLoading } from '@app/common/hooks/use-loading';
 import { AccountBalanceLabel } from '@app/components/account/account-balance-label';
 import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
 import { usePressable } from '@app/components/item-hover';
-import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useBtcNativeSegwitAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.models';
 
 import { AccountAvatarItem } from '../../../components/account/account-avatar';
@@ -23,7 +23,7 @@ export const SwitchAccountListItem = memo(
     const [component, bind] = usePressable(true);
     const name = useAccountDisplayName(account);
 
-    const btcAddress = useBtcAccountIndexAddressIndexZero(account.index);
+    const btcAddress = useBtcNativeSegwitAccountIndexAddressIndexZero(account.index);
 
     const handleClick = async () => {
       setIsLoading();

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -24,7 +24,7 @@ import { Title } from '@app/components/typography';
 import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
 import { useAnchoredStacksAccountBalances } from '@app/query/stacks/balance/balance.hooks';
 import { useHasCreatedAccount } from '@app/store/accounts/account';
-import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useBtcNativeSegwitAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useStacksAccounts } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.models';
 
@@ -69,7 +69,7 @@ const ChooseAccountItem = memo((props: ChooseAccountItemProps) => {
   const { data: balances, isLoading: isBalanceLoading } = useAnchoredStacksAccountBalances(
     account.address
   );
-  const btcAddress = useBtcAccountIndexAddressIndexZero(account.index);
+  const btcAddress = useBtcNativeSegwitAccountIndexAddressIndexZero(account.index);
   const stxMarketData = useCryptoCurrencyMarketData('STX');
 
   const showLoadingProps = !!selectedAddress || !decodedAuthRequest;

--- a/src/app/pages/home/components/account-addresses.tsx
+++ b/src/app/pages/home/components/account-addresses.tsx
@@ -4,7 +4,7 @@ import { Stack, StackProps } from '@stacks/ui';
 
 import { useCurrentAccountNamesQuery } from '@app/query/stacks/bns/bns.hooks';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
-import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useBtcNativeSegwitAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useBitcoinFeature } from '@app/store/feature-flags/feature-flags.slice';
 
@@ -13,7 +13,7 @@ import { AccountAddress } from './account-address';
 export const AccountAddresses = memo((props: StackProps) => {
   const currentAccount = useCurrentAccount();
   const accountIndex = useCurrentAccountIndex();
-  const btcAddress = useBtcAccountIndexAddressIndexZero(accountIndex);
+  const btcAddress = useBtcNativeSegwitAccountIndexAddressIndexZero(accountIndex);
   const currentAccountNamesQuery = useCurrentAccountNamesQuery();
   const isBitcoinEnabled = useBitcoinFeature();
   const bnsName = currentAccountNamesQuery.data?.names[0];

--- a/src/app/pages/receive-tokens/receive-btc.tsx
+++ b/src/app/pages/receive-tokens/receive-btc.tsx
@@ -4,13 +4,13 @@ import { useClipboard } from '@stacks/ui';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
-import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useBtcNativeSegwitAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 import { ReceiveTokensLayout } from './components/receive-tokens.layout';
 
 export function ReceiveBtcModal() {
   const accountIndex = useCurrentAccountIndex();
-  const btcAddress = useBtcAccountIndexAddressIndexZero(accountIndex);
+  const btcAddress = useBtcNativeSegwitAccountIndexAddressIndexZero(accountIndex);
   const analytics = useAnalytics();
   const { onCopy } = useClipboard(btcAddress);
 

--- a/src/app/pages/receive-tokens/receive-modal.tsx
+++ b/src/app/pages/receive-tokens/receive-modal.tsx
@@ -15,13 +15,13 @@ import { BtcIcon } from '@app/components/icons/btc-icon';
 import { Flag } from '@app/components/layout/flag';
 import { QrCodeIcon } from '@app/components/qr-code-icon';
 import { Body, Caption } from '@app/components/typography';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentAccountStxAddressState } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 export function ReceiveModal() {
   const analytics = useAnalytics();
   const navigate = useNavigate();
-  const btcAddress = useCurrentBtcAccountAddressIndexZero();
+  const btcAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const { onCopy: onCopyBitcoin } = useClipboard(btcAddress);
 
   const stxAddress = useCurrentAccountStxAddressState();

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/account-list-item.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/account-list-item.tsx
@@ -10,7 +10,7 @@ import { AccountBalanceLabel } from '@app/components/account/account-balance-lab
 import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
 import { AccountName } from '@app/components/account/account-name';
 import { usePressable } from '@app/components/item-hover';
-import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useBtcNativeSegwitAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.models';
 
 interface AccountListItemProps {
@@ -24,7 +24,7 @@ export const AccountListItem = memo(({ account, onClose }: AccountListItemProps)
   const [component, bind] = usePressable(true);
   const name = useAccountDisplayName(account);
 
-  const btcAddress = useBtcAccountIndexAddressIndexZero(account.index);
+  const btcAddress = useBtcNativeSegwitAccountIndexAddressIndexZero(account.index);
 
   const onSelectAccount = () => {
     const isBitcoin = values.symbol === 'BTC';

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
@@ -8,12 +8,12 @@ import { satToBtc } from '@app/common/money/unit-conversion';
 import { useCurrentBitcoinAddressBalance } from '@app/query/bitcoin/address/address.hooks';
 import { useGetUtxosByAddressQuery } from '@app/query/bitcoin/address/utxos-by-address.query';
 import { useBitcoinFeeRate } from '@app/query/bitcoin/fees/fee-estimates.hooks';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 import { BtcSizeFeeEstimator } from '../fees/tx-size-calculator';
 
 export function useCalculateMaxBitcoinSpend() {
-  const currentAccountBtcAddress = useCurrentBtcAccountAddressIndexZero();
+  const currentAccountBtcAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const balance = useCurrentBitcoinAddressBalance();
   const { data: utxos } = useGetUtxosByAddressQuery(currentAccountBtcAddress);
   const { data: feeRate } = useBitcoinFeeRate();

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -12,7 +12,7 @@ import { Header } from '@app/components/header';
 import { BtcIcon } from '@app/components/icons/btc-icon';
 import { HighFeeDrawer } from '@app/features/high-fee-drawer/high-fee-drawer';
 import { useBitcoinCryptoCurrencyAssetBalance } from '@app/query/bitcoin/address/address.hooks';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 import { AmountField } from '../../components/amount-field';
 import { FormErrors } from '../../components/form-errors';
@@ -33,7 +33,7 @@ export function BtcSendForm() {
   const navigate = useNavigate();
   const routeState = useSendFormRouteState();
 
-  const currentAccountBtcAddress = useCurrentBtcAccountAddressIndexZero();
+  const currentAccountBtcAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const btcCryptoCurrencyAssetBalance =
     useBitcoinCryptoCurrencyAssetBalance(currentAccountBtcAddress);
 

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -15,7 +15,7 @@ import {
 } from '@app/common/validation/forms/address-validators';
 import { btcAmountPrecisionValidator } from '@app/common/validation/forms/currency-validators';
 import { useBitcoinCryptoCurrencyAssetBalance } from '@app/query/bitcoin/address/address.hooks';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
@@ -23,7 +23,7 @@ import { useGenerateSignedBitcoinTx } from './use-generate-bitcoin-raw-tx';
 
 export function useBtcSendForm() {
   const currentNetwork = useCurrentNetwork();
-  const currentAccountBtcAddress = useCurrentBtcAccountAddressIndexZero();
+  const currentAccountBtcAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const btcCryptoCurrencyAssetBalance =
     useBitcoinCryptoCurrencyAssetBalance(currentAccountBtcAddress);
   const { isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation } = useDrawers();

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-generate-bitcoin-raw-tx.ts
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-generate-bitcoin-raw-tx.ts
@@ -10,19 +10,19 @@ import { btcToSat } from '@app/common/money/unit-conversion';
 import { useGetUtxosByAddressQuery } from '@app/query/bitcoin/address/utxos-by-address.query';
 import { useBitcoinFeeRate } from '@app/query/bitcoin/fees/fee-estimates.hooks';
 import {
-  useCurrentBitcoinAddressIndexKeychain,
-  useCurrentBtcAccountAddressIndexZero,
-  useSignBitcoinTx,
-} from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+  useCurrentBitcoinNativeSegwitAddressIndexKeychain,
+  useCurrentBtcNativeSegwitAccountAddressIndexZero,
+  useSignBitcoinNativeSegwitTx,
+} from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { determineUtxosForSpend } from '../../family/bitcoin/coinselect/local-coin-selection';
 
 export function useGenerateSignedBitcoinTx() {
-  const currentAccountBtcAddress = useCurrentBtcAccountAddressIndexZero();
+  const currentAccountBtcAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const { data: utxos } = useGetUtxosByAddressQuery(currentAccountBtcAddress);
-  const currentAddressIndexKeychain = useCurrentBitcoinAddressIndexKeychain();
-  const signTx = useSignBitcoinTx();
+  const currentAddressIndexKeychain = useCurrentBitcoinNativeSegwitAddressIndexKeychain();
+  const signTx = useSignBitcoinNativeSegwitTx();
   const network = useCurrentNetwork();
   const { data: feeRate } = useBitcoinFeeRate();
 

--- a/src/app/query/bitcoin/address/address.hooks.ts
+++ b/src/app/query/bitcoin/address/address.hooks.ts
@@ -5,7 +5,7 @@ import BigNumber from 'bignumber.js';
 import { createMoney } from '@shared/models/money.model';
 
 import { sumNumbers } from '@app/common/utils';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 import { createBitcoinCryptoCurrencyAssetTypeWrapper } from './address.utils';
 import { useGetUtxosByAddressQuery } from './utxos-by-address.query';
@@ -26,11 +26,11 @@ export function useBitcoinCryptoCurrencyAssetBalance(address: string) {
 }
 
 export function useCurrentBitcoinAddress() {
-  const currentAccountBtcAddress = useCurrentBtcAccountAddressIndexZero();
+  const currentAccountBtcAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   return useGetUtxosByAddressQuery(currentAccountBtcAddress);
 }
 
 export function useCurrentBitcoinAddressBalance() {
-  const currentAccountBtcAddress = useCurrentBtcAccountAddressIndexZero();
+  const currentAccountBtcAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   return useBitcoinBalance(currentAccountBtcAddress);
 }

--- a/src/app/query/bitcoin/address/transactions-by-address.hooks.ts
+++ b/src/app/query/bitcoin/address/transactions-by-address.hooks.ts
@@ -3,12 +3,12 @@ import { useMemo } from 'react';
 import { createMoney } from '@shared/models/money.model';
 
 import { sumNumbers } from '@app/common/utils';
-import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 import { useGetBitcoinTransactionsByAddressQuery } from './transactions-by-address.query';
 
 export function useBitcoinPendingTransactions() {
-  const bitcoinAddress = useCurrentBtcAccountAddressIndexZero();
+  const bitcoinAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const { data: bitcoinTransactions } = useGetBitcoinTransactionsByAddressQuery(bitcoinAddress);
   // TODO: use useQuery select method
   return useMemo(
@@ -19,7 +19,7 @@ export function useBitcoinPendingTransactions() {
 
 // ts-unused-exports:disable-next-line
 export function useBitcoinPendingTransactionsBalance() {
-  const bitcoinAddress = useCurrentBtcAccountAddressIndexZero();
+  const bitcoinAddress = useCurrentBtcNativeSegwitAccountAddressIndexZero();
   const pendingTransactions = useBitcoinPendingTransactions();
 
   return useMemo(

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-account.models.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-account.models.ts
@@ -1,11 +1,13 @@
-export interface SoftwareBitcoinAccount {
+import { HDKey } from '@scure/bip32';
+
+interface SoftwareBitcoinAccount {
   type: 'software';
   xpub: string;
   index: number;
 }
 
 // TODO: complete with bitcoin ledger support
-export interface HardwareBitcoinAccount {
+interface HardwareBitcoinAccount {
   type: 'ledger';
   path: string;
   index: number;
@@ -14,3 +16,18 @@ export interface HardwareBitcoinAccount {
 
 // ts-unused-exports:disable-next-line
 export type BitcoinAccount = SoftwareBitcoinAccount | HardwareBitcoinAccount;
+
+export const tempHardwareAccountForTesting: HardwareBitcoinAccount = {
+  type: 'ledger',
+  index: 0,
+  path: '',
+  xpub: '',
+};
+
+export function formatBitcoinAccount(keychain: HDKey) {
+  return (index: number): SoftwareBitcoinAccount => ({
+    type: 'software',
+    index,
+    xpub: keychain.publicExtendedKey,
+  });
+}

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
@@ -1,5 +1,8 @@
 import { createSelector } from '@reduxjs/toolkit';
+import { HDKey } from '@scure/bip32';
 
+import { NetworkModes } from '@shared/constants';
+import { deriveTaprootAccountFromHdKey } from '@shared/crypto/bitcoin/p2tr-address-gen';
 import { deriveNativeSegWitAccountFromHdKey } from '@shared/crypto/bitcoin/p2wpkh-address-gen';
 
 import { mnemonicToRootNode } from '@app/common/keychain/keychain';
@@ -8,16 +11,25 @@ import { selectCurrentKey } from '@app/store/keys/key.selectors';
 import { defaultKeyId } from '@app/store/keys/key.slice';
 import { selectCurrentNetwork } from '@app/store/networks/networks.selectors';
 
-export const selectSoftwareBitcoinNativeSegWitKeychain = createSelector(
-  selectCurrentKey,
-  selectInMemoryKey,
-  selectCurrentNetwork,
-  (currentKey, inMemKey, network) => {
-    if (currentKey?.type !== 'software') return;
-    if (!inMemKey.keys[defaultKeyId]) throw new Error('No in-memory key found');
-    return deriveNativeSegWitAccountFromHdKey(
-      mnemonicToRootNode(inMemKey.keys.default),
-      network.chain.bitcoin.network
-    );
-  }
+function bitcoinKeychainSelectorFactory(
+  keychainFn: (hdkey: HDKey, network: NetworkModes) => (index: number) => HDKey
+) {
+  return createSelector(
+    selectCurrentKey,
+    selectInMemoryKey,
+    selectCurrentNetwork,
+    (currentKey, inMemKey, network) => {
+      if (currentKey?.type !== 'software') return;
+      if (!inMemKey.keys[defaultKeyId]) throw new Error('No in-memory key found');
+      return keychainFn(mnemonicToRootNode(inMemKey.keys.default), network.chain.bitcoin.network);
+    }
+  );
+}
+
+export const selectSoftwareBitcoinNativeSegWitKeychain = bitcoinKeychainSelectorFactory(
+  deriveNativeSegWitAccountFromHdKey
+);
+
+export const selectSoftwareBitcoinTaprootKeychain = bitcoinKeychainSelectorFactory(
+  deriveTaprootAccountFromHdKey
 );

--- a/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { deriveTaprootReceiveAddressIndex } from '@shared/crypto/bitcoin/p2tr-address-gen';
+import { isUndefined } from '@shared/utils';
+
+import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
+
+import { useCurrentAccountIndex } from '../../account';
+import { formatBitcoinAccount, tempHardwareAccountForTesting } from './bitcoin-account.models';
+import { selectSoftwareBitcoinTaprootKeychain } from './bitcoin-keychain';
+
+function useBitcoinTaprootAccount(index: number) {
+  const keychain = useSelector(selectSoftwareBitcoinTaprootKeychain);
+  return useMemo(() => {
+    // TODO: Remove with bitcoin Ledger integration
+    if (isUndefined(keychain)) return tempHardwareAccountForTesting;
+    return formatBitcoinAccount(keychain(index))(index);
+  }, [keychain, index]);
+}
+
+function useCurrentBitcoinTaprootAccount() {
+  const currentAccountIndex = useCurrentAccountIndex();
+  return useBitcoinTaprootAccount(currentAccountIndex);
+}
+
+function useDeriveTaprootAccountIndexAddressIndexZero(xpub: string) {
+  const network = useCurrentNetwork();
+  return useMemo(
+    () =>
+      deriveTaprootReceiveAddressIndex({
+        xpub,
+        index: 0,
+        network: network.chain.bitcoin.network,
+      }),
+    [xpub, network]
+  );
+}
+
+// ts-unused-exports:disable-next-line
+export function useCurrentTaprootAccountAddressIndexZero() {
+  const { xpub } = useCurrentBitcoinTaprootAccount();
+  return useDeriveTaprootAccountIndexAddressIndexZero(xpub)?.address as string;
+}
+// ts-unused-exports:disable-next-line
+export function useTaprootAccountIndexAddressIndexZero(accountIndex: number) {
+  const { xpub } = useBitcoinTaprootAccount(accountIndex);
+  return useDeriveTaprootAccountIndexAddressIndexZero(xpub)?.address as string;
+}

--- a/src/shared/crypto/bitcoin/bitcoin.utils.ts
+++ b/src/shared/crypto/bitcoin/bitcoin.utils.ts
@@ -1,0 +1,10 @@
+import { NetworkModes } from '@shared/constants';
+
+const coinTypeMap: Record<NetworkModes, 0 | 1> = {
+  mainnet: 0,
+  testnet: 1,
+};
+
+export function getBitcoinCoinTypeIndexByNetwork(network: NetworkModes) {
+  return coinTypeMap[network];
+}

--- a/src/shared/crypto/bitcoin/p2tr-address-gen.spec.ts
+++ b/src/shared/crypto/bitcoin/p2tr-address-gen.spec.ts
@@ -1,0 +1,35 @@
+import * as secp from '@noble/secp256k1';
+import { HDKey } from '@scure/bip32';
+import { mnemonicToSeedSync } from '@scure/bip39';
+import { SECRET_KEY } from '@tests-legacy/mocks';
+import * as btc from 'micro-btc-signer';
+
+import { getBtcSignerLibNetworkByMode } from './bitcoin.network';
+
+// Source:
+// generated in Sparrow with same secret key used in tests
+const addresses = [
+  'tb1p05uectcay8ptepqneycknxf0ewvdejcl0zdqex98ux87w7tzqjfsd7yxyl',
+  'tb1papsqvj9s2yn9mavhtuk9jyw4arlwcxey33n49g02rpjcajx88qrszpytxl',
+  'tb1pfnegsp8x0gnjrgzu0p5xrltrms50prpl8c5a3rwfcrp9p9vumnfsv7zn84',
+  'tb1pzqp06cvvcmftc4g69kuqt5z59k3uyuuwzsg796c00scav0vxjevs3gsvpr',
+  'tb1p2acyvr7wzvdr2m9fprg2e48k03rjvvq8au680jtrxqrz5m9m5kdsurrp2z',
+  'tb1p3kautzlyralsnxf2fv7rudlgyhu6u0lcvzdnlhaywl4h8l7yk0ds59lvfg',
+];
+
+describe('taproot address gen', () => {
+  test.each(addresses)('should generate taproot addresses', address => {
+    const keychain = HDKey.fromMasterSeed(mnemonicToSeedSync(SECRET_KEY));
+    const index = addresses.indexOf(address);
+    const accountZero = keychain.derive(`m/86'/1'/0'/0/${index}`);
+
+    if (!accountZero.privateKey) throw new Error('No private key found');
+
+    const addressIndex = btc.p2tr(
+      secp.schnorr.getPublicKey(accountZero.privateKey),
+      undefined,
+      getBtcSignerLibNetworkByMode('testnet')
+    );
+    expect(addressIndex.address).toEqual(address);
+  });
+});

--- a/src/shared/crypto/bitcoin/p2tr-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2tr-address-gen.ts
@@ -1,0 +1,35 @@
+import { HDKey } from '@scure/bip32';
+import * as btc from 'micro-btc-signer';
+
+import { NetworkModes } from '@shared/constants';
+
+import { getBtcSignerLibNetworkByMode } from './bitcoin.network';
+import { getBitcoinCoinTypeIndexByNetwork } from './bitcoin.utils';
+
+function getTaprootAccountDerivationPath(network: NetworkModes, accountIndex: number) {
+  return `m/86'/${getBitcoinCoinTypeIndexByNetwork(network)}'/${accountIndex}'`;
+}
+
+export function deriveTaprootAccountFromHdKey(keychain: HDKey, network: NetworkModes) {
+  return (index: number) => keychain.derive(getTaprootAccountDerivationPath(network, index));
+}
+
+interface DeriveTaprootReceiveAddressIndexArgs {
+  xpub: string;
+  index: number;
+  network: NetworkModes;
+}
+export function deriveTaprootReceiveAddressIndex({
+  xpub,
+  index,
+  network,
+}: DeriveTaprootReceiveAddressIndexArgs) {
+  if (!xpub) return;
+  const keychain = HDKey.fromExtendedKey(xpub);
+  const zeroAddressIndex = keychain?.deriveChild(0).deriveChild(index);
+  return btc.p2tr(
+    undefined,
+    [btc.p2tr_pk(zeroAddressIndex?.publicKey!)],
+    getBtcSignerLibNetworkByMode(network)
+  );
+}

--- a/src/shared/crypto/bitcoin/p2wpkh-address-gen.spec.ts
+++ b/src/shared/crypto/bitcoin/p2wpkh-address-gen.spec.ts
@@ -1,4 +1,4 @@
-import { deriveNativeSegWitReceiveAddressIndexAddress } from './p2wpkh-address-gen';
+import { deriveNativeSegWitReceiveAddressIndex } from './p2wpkh-address-gen';
 
 describe('Bitcoin bech32 (P2WPKH address derivation', () => {
   describe('from extended public key', () => {
@@ -34,12 +34,13 @@ describe('Bitcoin bech32 (P2WPKH address derivation', () => {
     ];
 
     describe.each(accounts)('Account', account => {
-      const address = deriveNativeSegWitReceiveAddressIndexAddress({
+      const keychain = deriveNativeSegWitReceiveAddressIndex({
         xpub: account.extended_public_key,
         index: 0,
         network: 'mainnet',
       });
-      test('bech 32 address', () => expect(address).toEqual(account.zeroIndexChildAddress));
+      test('bech 32 address', () =>
+        expect(keychain?.address).toEqual(account.zeroIndexChildAddress));
     });
   });
 });

--- a/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
@@ -4,15 +4,7 @@ import * as btc from 'micro-btc-signer';
 import { NetworkModes } from '@shared/constants';
 
 import { getBtcSignerLibNetworkByMode } from './bitcoin.network';
-
-const coinTypeMap: Record<NetworkModes, 0 | 1> = {
-  mainnet: 0,
-  testnet: 1,
-};
-
-function getBitcoinCoinTypeIndexByNetwork(network: NetworkModes) {
-  return coinTypeMap[network];
-}
+import { getBitcoinCoinTypeIndexByNetwork } from './bitcoin.utils';
 
 function getNativeSegWitAccountDerivationPath(network: NetworkModes, accountIndex: number) {
   return `m/84'/${getBitcoinCoinTypeIndexByNetwork(network)}'/${accountIndex}'`;
@@ -27,32 +19,18 @@ export function deriveBip32KeychainFromExtendedPublicKey(xpub: string) {
   return HDKey.fromExtendedKey(xpub);
 }
 
-interface DeriveNativeSegWitReceiveAddressIndexKeychainArgs {
+interface DeriveNativeSegWitReceiveAddressIndexArgs {
   xpub: string;
   index: number;
   network: NetworkModes;
 }
-function deriveNativeSegWitReceiveAddressIndexKeychain({
+export function deriveNativeSegWitReceiveAddressIndex({
   xpub,
   index,
   network,
-}: DeriveNativeSegWitReceiveAddressIndexKeychainArgs) {
+}: DeriveNativeSegWitReceiveAddressIndexArgs) {
   if (!xpub) return;
   const keychain = deriveBip32KeychainFromExtendedPublicKey(xpub);
   const zeroAddressIndex = keychain?.deriveChild(0).deriveChild(index);
   return btc.p2wpkh(zeroAddressIndex?.publicKey!, getBtcSignerLibNetworkByMode(network));
-}
-
-interface DeriveNativeSegWitReceiveAddressIndexAddressArgs {
-  xpub: string;
-  index: number;
-  network: NetworkModes;
-}
-export function deriveNativeSegWitReceiveAddressIndexAddress({
-  xpub,
-  index,
-  network,
-}: DeriveNativeSegWitReceiveAddressIndexAddressArgs) {
-  if (!xpub) return;
-  return deriveNativeSegWitReceiveAddressIndexKeychain({ xpub, index, network })?.address;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4206026611).<!-- Sticky Header Marker -->

WIP work to support Ordinals. PR introduces TR address keychain.

@edu-stx the logic to recurse taproot addresses is really similar to looking for account activity and we can easily reuse this.

A user might have 8 inscriptions on a handful of address indexes, perhaps with some gaps. Same with account activity. We want to find all these, but need to set some limits to not infinitely recurse addresses. Many wallets keep looking until they find 20 empty accounts in a row.

See logic here: https://github.com/hirosystems/stacks-wallet-web/blob/924750846fcd94d24374e2a489eaa3bf09628679/src/app/common/account-restoration/account-restore.ts#L33-L76

We could write something like this:

```ts
const highestKnownIndexWithInscription = await recurseAccountsForActivity({
  async doesAddressHaveActivityFn(index) {
    return lookupOfOrdinalsApiToFindInscriptions(index);
  }
});