### PR TITLE
test: restore wallet addresses

### DIFF
--- a/src/app/pages/home/components/account-address.tsx
+++ b/src/app/pages/home/components/account-address.tsx
@@ -1,10 +1,11 @@
 import { FiCopy } from 'react-icons/fi';
 
-import { Box, Stack, Tooltip, useClipboard } from '@stacks/ui';
+import { Box, Stack, useClipboard } from '@stacks/ui';
 import { color, truncateMiddle } from '@stacks/ui-utils';
 import { UserAreaSelectors } from '@tests-legacy/integration/user-area.selectors';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { Tooltip } from '@app/components/tooltip';
 import { Caption } from '@app/components/typography';
 
 interface AccountAddressProps {

--- a/src/app/pages/receive-tokens/components/receive-tokens.layout.tsx
+++ b/src/app/pages/receive-tokens/components/receive-tokens.layout.tsx
@@ -12,15 +12,16 @@ import { QrCode } from './address-qr-code';
 
 interface ReceiveTokensLayoutProps {
   address: string;
-  accountName: string;
+  accountName?: string;
   onCopyAddressToClipboard(address: string): void;
+  title: string;
 }
 export function ReceiveTokensLayout(props: ReceiveTokensLayoutProps) {
-  const { address, accountName, onCopyAddressToClipboard } = props;
+  const { address, accountName, onCopyAddressToClipboard, title } = props;
   const navigate = useNavigate();
 
   return (
-    <BaseDrawer title="Receive" isShowing onClose={() => navigate(-1)}>
+    <BaseDrawer title={title} isShowing onClose={() => navigate(-1)}>
       <Flex alignItems="center" flexDirection="column" pb={['loose', '48px']} px="loose">
         <Text color={color('text-caption')} mb="tight" textAlign="left">
           Share your account's unique address to receive tokens or collectibles. Including a memo is

--- a/src/app/pages/receive-tokens/receive-btc.tsx
+++ b/src/app/pages/receive-tokens/receive-btc.tsx
@@ -1,0 +1,30 @@
+import toast from 'react-hot-toast';
+
+import { useClipboard } from '@stacks/ui';
+
+import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useCurrentAccountIndex } from '@app/store/accounts/account';
+import { useBtcAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
+
+import { ReceiveTokensLayout } from './components/receive-tokens.layout';
+
+export function ReceiveBtcModal() {
+  const accountIndex = useCurrentAccountIndex();
+  const btcAddress = useBtcAccountIndexAddressIndexZero(accountIndex);
+  const analytics = useAnalytics();
+  const { onCopy } = useClipboard(btcAddress);
+
+  function copyToClipboard() {
+    void analytics.track('copy_btc_address_to_clipboard');
+    toast.success('Copied to clipboard!');
+    onCopy();
+  }
+
+  return (
+    <ReceiveTokensLayout
+      address={btcAddress}
+      onCopyAddressToClipboard={copyToClipboard}
+      title="Bitcoin address"
+    />
+  );
+}

--- a/src/app/pages/receive-tokens/receive-modal.tsx
+++ b/src/app/pages/receive-tokens/receive-modal.tsx
@@ -3,13 +3,17 @@ import { FiCopy } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
 import { Box, Button, Flex, Stack, useClipboard } from '@stacks/ui';
-import { truncateMiddle } from '@stacks/ui-utils';
+import { color, truncateMiddle } from '@stacks/ui-utils';
+import { HomePageSelectors } from '@tests/selectors/home.selectors';
+
+import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { BtcIcon } from '@app/components/icons/btc-icon';
 import { Flag } from '@app/components/layout/flag';
+import { QrCodeIcon } from '@app/components/qr-code-icon';
 import { Body, Caption } from '@app/components/typography';
 import { useCurrentBtcAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/bitcoin-account.hooks';
 import { useCurrentAccountStxAddressState } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
@@ -29,7 +33,7 @@ export function ReceiveModal() {
     copyHandler();
   }
   return (
-    <BaseDrawer title="Select asset to receive" isShowing onClose={() => navigate('../')} px="base">
+    <BaseDrawer title="Select asset to receive" isShowing onClose={() => navigate('../')}>
       <Box mx="extra-loose">
         <Body>Share your account's unique address to receive any token or collectible</Body>
         <Stack spacing="loose" mt="loose" mb="extra-loose">
@@ -39,14 +43,28 @@ export function ReceiveModal() {
                 Bitcoin
                 <Caption mt="2px">{truncateMiddle(btcAddress, 6)}</Caption>
               </Box>
-              <Box>
-                <Button mode="tertiary" onClick={() => copyToClipboard(onCopyBitcoin)}>
-                  <FiCopy />
-                </Button>
-                {/* <Button mode="tertiary" onClick={() => {}}>
-                  <QrCodeIcon />
-                </Button> */}
-              </Box>
+              <Stack>
+                <Box>
+                  <Button
+                    borderRadius="10px"
+                    mode="tertiary"
+                    mr="tight"
+                    onClick={() => copyToClipboard(onCopyBitcoin)}
+                  >
+                    <FiCopy />
+                  </Button>
+                  <Button
+                    borderRadius="10px"
+                    data-testId={HomePageSelectors.ReceiveBtcQrCodeBtn}
+                    mode="tertiary"
+                    onClick={() => navigate(RouteUrls.ReceiveBtc)}
+                  >
+                    <Box color={color('text-caption')} size="14px">
+                      <QrCodeIcon />
+                    </Box>
+                  </Button>
+                </Box>
+              </Stack>
             </Flex>
           </Flag>
           <Flag img={<StxAvatar />} spacing="base">
@@ -55,14 +73,28 @@ export function ReceiveModal() {
                 Stacks
                 <Caption mt="2px">{truncateMiddle(stxAddress, 6)}</Caption>
               </Box>
-              <Box>
-                <Button mode="tertiary" onClick={() => copyToClipboard(onCopyStacks)}>
-                  <FiCopy />
-                </Button>
-                {/* <Button mode="tertiary" onClick={() => {}}>
-                  <QrCodeIcon />
-                </Button> */}
-              </Box>
+              <Stack>
+                <Box>
+                  <Button
+                    borderRadius="10px"
+                    mode="tertiary"
+                    mr="tight"
+                    onClick={() => copyToClipboard(onCopyStacks)}
+                  >
+                    <FiCopy />
+                  </Button>
+                  <Button
+                    borderRadius="10px"
+                    data-testId={HomePageSelectors.ReceiveStxQrCodeBtn}
+                    mode="tertiary"
+                    onClick={() => navigate(RouteUrls.ReceiveStx)}
+                  >
+                    <Box color={color('text-caption')} size="14px">
+                      <QrCodeIcon />
+                    </Box>
+                  </Button>
+                </Box>
+              </Stack>
             </Flex>
           </Flag>
         </Stack>

--- a/src/app/pages/receive-tokens/receive-stx.tsx
+++ b/src/app/pages/receive-tokens/receive-stx.tsx
@@ -15,7 +15,7 @@ export function ReceiveStxModal() {
   const accountName = useCurrentAccountDisplayName();
 
   function copyToClipboard() {
-    void analytics.track('copy_address_to_clipboard');
+    void analytics.track('copy_stx_address_to_clipboard');
     toast.success('Copied to clipboard!');
     onCopy();
   }
@@ -27,6 +27,7 @@ export function ReceiveStxModal() {
       address={currentAccount.address}
       accountName={accountName}
       onCopyAddressToClipboard={copyToClipboard}
+      title="Stacks address"
     />
   );
 }

--- a/src/app/pages/receive-tokens/receive-tokens.tsx
+++ b/src/app/pages/receive-tokens/receive-tokens.tsx
@@ -28,6 +28,7 @@ export function ReceiveTokens() {
       accountName={accountName}
       address={currentAccount.address}
       onCopyAddressToClipboard={copyToClipboard}
+      title="Receive"
     />
   );
 }

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -25,6 +25,7 @@ import { MagicRecoveryCode } from '@app/pages/onboarding/magic-recovery-code/mag
 import { SetPasswordPage } from '@app/pages/onboarding/set-password/set-password';
 import { SignIn } from '@app/pages/onboarding/sign-in/sign-in';
 import { WelcomePage } from '@app/pages/onboarding/welcome/welcome';
+import { ReceiveBtcModal } from '@app/pages/receive-tokens/receive-btc';
 import { ReceiveModal } from '@app/pages/receive-tokens/receive-modal';
 import { ReceiveStxModal } from '@app/pages/receive-tokens/receive-stx';
 import { SelectNetwork } from '@app/pages/select-network/select-network';
@@ -81,7 +82,7 @@ function AppRoutesAfterUserHasConsented() {
           </Route>
           <Route path={RouteUrls.Receive} element={<ReceiveModal />} />
           <Route path={RouteUrls.ReceiveStx} element={<ReceiveStxModal />} />
-          <Route path={RouteUrls.ReceiveBtc} element={<ReceiveModal />} />
+          <Route path={RouteUrls.ReceiveBtc} element={<ReceiveBtcModal />} />
           {settingsModalRoutes}
           {ledgerTxSigningRoutes}
         </Route>
@@ -144,7 +145,7 @@ function AppRoutesAfterUserHasConsented() {
         >
           <Route path={RouteUrls.FundReceive} element={<ReceiveModal />} />
           <Route path={RouteUrls.FundReceiveStx} element={<ReceiveStxModal />} />
-          <Route path={RouteUrls.FundReceiveBtc} element={<ReceiveModal />} />
+          <Route path={RouteUrls.FundReceiveBtc} element={<ReceiveBtcModal />} />
           {settingsModalRoutes}
         </Route>
         <Route

--- a/tests/mocks/constants.ts
+++ b/tests/mocks/constants.ts
@@ -1,3 +1,5 @@
+export const TEST_ACCOUNT_1_BTC_ADDRESS = 'bc1qhdykvr9eafepm9cf6aryk0stmmwpv4wws9raj5';
+export const TEST_ACCOUNT_1_STX_ADDRESS = 'SP297VG59W96DPGBT13SGD542QE1XS954X78Z75G0';
 export const TEST_BNS_NAME = 'test-hiro-wallet.btc';
 export const TEST_BNS_RESOLVED_ADDRESS = 'SP12YQ0M2KFT7YMJKVGP71B874YF055F77PFPH9KM';
 export const TEST_PASSWORD = 'my_s3cret_p@ssw0r4';

--- a/tests/page-object-models/home.page.ts
+++ b/tests/page-object-models/home.page.ts
@@ -14,13 +14,27 @@ export class HomePage {
     this.sendButton = page.getByTestId(HomePageSelectors.SendCryptoAssetBtn);
   }
 
-  async getAddress() {
-    // Open issue with Playwright's ability to copyToClipboard from legacy tests:
-    // https://github.com/microsoft/playwright/issues/8114#issuecomment-1103317576
-    // Also, an open issue to consistently determine `isMac` in the workaround:
-    // https://github.com/microsoft/playwright/issues/12168
-    // Using the `Receive` route to get the account address for now.
+  async goToReceiveModal() {
     await this.page.getByTestId(HomePageSelectors.ReceiveCryptoAssetBtn).click();
+  }
+
+  // Open issue with Playwright's ability to copyToClipboard from legacy tests:
+  // https://github.com/microsoft/playwright/issues/8114#issuecomment-1103317576
+  // Also, an open issue to consistently determine `isMac` in the workaround:
+  // https://github.com/microsoft/playwright/issues/12168
+  // Using the `Receive` route to get the account address for now.
+  async getReceiveBtcAddress() {
+    await this.goToReceiveModal();
+    await this.page.getByTestId(HomePageSelectors.ReceiveBtcQrCodeBtn).click();
+    const displayerAddress = await this.page
+      .getByTestId(HomePageSelectors.AddressDisplayer)
+      .innerText();
+    return displayerAddress.replaceAll('\n', '');
+  }
+
+  async getReceiveStxAddress() {
+    await this.goToReceiveModal();
+    await this.page.getByTestId(HomePageSelectors.ReceiveStxQrCodeBtn).click();
     const displayerAddress = await this.page
       .getByTestId(HomePageSelectors.AddressDisplayer)
       .innerText();

--- a/tests/selectors/home.selectors.ts
+++ b/tests/selectors/home.selectors.ts
@@ -3,5 +3,7 @@ export enum HomePageSelectors {
   DrawerHeaderActionBtn = 'drawer-header-action-btn',
   HomePageContainer = 'home-page-container',
   ReceiveCryptoAssetBtn = 'receive-crypto-asset-btn',
+  ReceiveBtcQrCodeBtn = 'receive-btc-qr-code-btn',
+  ReceiveStxQrCodeBtn = 'receive-stx-qr-code-btn',
   SendCryptoAssetBtn = 'send-crypto-asset-btn',
 }

--- a/tests/specs/onboarding/onboarding.spec.ts
+++ b/tests/specs/onboarding/onboarding.spec.ts
@@ -1,0 +1,26 @@
+import { TEST_ACCOUNT_1_BTC_ADDRESS, TEST_ACCOUNT_1_STX_ADDRESS } from '@tests/mocks/constants';
+
+import { test } from '../../fixtures/fixtures';
+
+test.describe('onboarding existing user', () => {
+  // TODO: Remove with mainnet bitcoin
+  test.beforeEach(async () => {
+    test.skip();
+  });
+
+  // TODO: Use with mainnet bitcoin
+  // test.beforeEach(async ({ extensionId, globalPage, onboardingPage }) => {
+  //   await globalPage.setupAndUseApiCalls(extensionId);
+  //   await onboardingPage.signInExistingUser();
+  // });
+
+  test('restoring a wallet generates the correct bitcoin segwit address', async ({ homePage }) => {
+    const testAddress = await homePage.getReceiveBtcAddress();
+    test.expect(testAddress).toEqual(TEST_ACCOUNT_1_BTC_ADDRESS);
+  });
+
+  test('restoring a wallet generates the correct stacks address', async ({ homePage }) => {
+    const testAddress = await homePage.getReceiveStxAddress();
+    test.expect(testAddress).toEqual(TEST_ACCOUNT_1_STX_ADDRESS);
+  });
+});

--- a/tests/specs/send/send-crypto-asset.spec.ts
+++ b/tests/specs/send/send-crypto-asset.spec.ts
@@ -20,7 +20,7 @@ test.describe('send crypto asset', () => {
   //   await globalPage.setupAndUseApiCalls(extensionId);
   //   await onboardingPage.signInExistingUser();
 
-  //   testAddress = await homePage.getAddress();
+  //   testAddress = await homePage.getReceiveStxAddress();
   //   await homePage.drawerActionButton.click();
 
   //   await homePage.sendButton.click();


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4196841715).<!-- Sticky Header Marker -->

This PR adds tests to restore a wallet from seed and check the addresses generated are correct. To accomplish this, I added the QR code to the receive modal and routes to the modals to view/copy the btc and stx addresses.

![Screen Shot 2023-02-16 at 11 50 55 AM](https://user-images.githubusercontent.com/6493321/219447463-8eaf6795-746d-469f-bfd6-780c38adc443.png)

![Screen Shot 2023-02-16 at 11 12 18 AM](https://user-images.githubusercontent.com/6493321/219447560-41dafc56-ca47-4261-9fd2-4f3b152add9a.png)
