### PR TITLE
test: send btc tx and UI fixes

### DIFF
--- a/src/app/pages/home/components/account-address.tsx
+++ b/src/app/pages/home/components/account-address.tsx
@@ -1,12 +1,11 @@
 import { FiCopy } from 'react-icons/fi';
 
-import { Box, Stack, useClipboard } from '@stacks/ui';
+import { Box, Stack, Text, useClipboard } from '@stacks/ui';
 import { color, truncateMiddle } from '@stacks/ui-utils';
 import { UserAreaSelectors } from '@tests-legacy/integration/user-area.selectors';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { Tooltip } from '@app/components/tooltip';
-import { Caption } from '@app/components/typography';
 
 interface AccountAddressProps {
   address: string;
@@ -23,7 +22,9 @@ export function AccountAddress({ address, label }: AccountAddressProps) {
 
   return (
     <>
-      <Caption>{truncateMiddle(address, 4)}</Caption>
+      <Text color={color('text-caption')} fontSize={['12px', '14px']}>
+        {truncateMiddle(address, 4)}
+      </Text>
       <Tooltip hideOnClick={false} label={hasCopied ? 'Copied!' : label} placement="right">
         <Stack>
           <Box

--- a/src/app/pages/send/send-container.tsx
+++ b/src/app/pages/send/send-container.tsx
@@ -1,20 +1,20 @@
 import { Outlet } from 'react-router-dom';
 
-import { Flex, color } from '@stacks/ui';
+import { Flex } from '@stacks/ui';
 
 import { whenPageMode } from '@app/common/utils';
+import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
 
 export function SendContainer() {
   return whenPageMode({
     full: (
       <Flex
-        alignItems="start"
-        borderWidth="1px"
-        borderColor={color('border')}
-        borderRadius="16px"
-        justifyContent="center"
+        border={['unset', '1px solid']}
+        borderColor={['unset', '#DCDDE2']}
+        borderRadius={['unset', '16px']}
         maxHeight="90vh"
-        minWidth="480px"
+        maxWidth={['100%', CENTERED_FULL_PAGE_MAX_WIDTH]}
+        minWidth={['100%', CENTERED_FULL_PAGE_MAX_WIDTH]}
         pb="loose"
       >
         <Outlet />

--- a/src/app/pages/send/send-crypto-asset-form/components/confirmation/components/send-form-confirmation.layout.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/confirmation/components/send-form-confirmation.layout.tsx
@@ -1,20 +1,9 @@
-import { Flex, StackProps } from '@stacks/ui';
-
-import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
+import { Box, StackProps } from '@stacks/ui';
 
 export function SendFormConfirmationLayout({ children }: StackProps) {
   return (
-    <Flex
-      alignItems="center"
-      flexGrow={1}
-      flexDirection="column"
-      justifyContent="start"
-      maxWidth={['unset', 'unset', CENTERED_FULL_PAGE_MAX_WIDTH]}
-      mt={['36px', '36px', '48px']}
-      pb="extra-loose"
-      px="loose"
-    >
+    <Box mt={['36px', '36px', '48px']} pb="extra-loose" px="loose" width="100%">
       {children}
-    </Flex>
+    </Box>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/components/confirmation/send-form-confirmation.routes.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/confirmation/send-form-confirmation.routes.tsx
@@ -9,14 +9,8 @@ import { SendFormConfirmationContainer } from './send-form-confirmation-containe
 
 export const sendFormConfirmationRoutes = (
   <Route element={<SendFormConfirmationContainer />}>
-    <Route
-      path={RouteUrls.SendBtcCryptoCurrencyConfirmation}
-      element={<BtcSendFormConfirmation />}
-    />
-    <Route
-      path={RouteUrls.SendStxCryptoCurrencyConfirmation}
-      element={<StxSendFormConfirmation />}
-    />
+    <Route path={RouteUrls.SendBtcConfirmation} element={<BtcSendFormConfirmation />} />
+    <Route path={RouteUrls.SendStxConfirmation} element={<StxSendFormConfirmation />} />
     <Route
       path={RouteUrls.SendStacksSip10Confirmation}
       element={<StacksSip10SendFormConfirmation />}

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-field.tsx
@@ -4,6 +4,7 @@ import { TextInputField } from './text-input-field';
 
 interface RecipientFieldProps {
   labelAction: string;
+  lastChild?: boolean;
   name: string;
   onBlur?(): void;
   onClickLabelAction?(): void;
@@ -11,6 +12,7 @@ interface RecipientFieldProps {
 }
 export function RecipientField({
   labelAction,
+  lastChild,
   name,
   onBlur,
   onClickLabelAction,
@@ -21,6 +23,7 @@ export function RecipientField({
       dataTestId={SendCryptoAssetSelectors.RecipientFieldInput}
       label="To"
       labelAction={labelAction}
+      lastChild={lastChild}
       name={name}
       onBlur={onBlur}
       onClickLabelAction={onClickLabelAction}

--- a/src/app/pages/send/send-crypto-asset-form/components/send-crypto-asset-form.layout.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/send-crypto-asset-form.layout.tsx
@@ -1,25 +1,19 @@
-import { Flex } from '@stacks/ui';
+import { Box } from '@stacks/ui';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
-
-import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
 
 interface SendCryptoAssetFormLayoutProps {
   children: JSX.Element;
 }
 export function SendCryptoAssetFormLayout({ children }: SendCryptoAssetFormLayoutProps) {
   return (
-    <Flex
-      alignItems="center"
+    <Box
       data-testid={SendCryptoAssetSelectors.SendFormContainer}
-      flexDirection="column"
-      justifyContent="center"
       mt={['unset', '48px']}
-      maxWidth={['100%', CENTERED_FULL_PAGE_MAX_WIDTH]}
-      minWidth={['100%', CENTERED_FULL_PAGE_MAX_WIDTH]}
+      width="100%"
       pb="extra-loose"
-      px={['loose', 'unset']}
+      px="loose"
     >
       {children}
-    </Flex>
+    </Box>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation-details.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation-details.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { truncateMiddle } from '@stacks/ui-utils';
 import BigNumber from 'bignumber.js';
 import * as btc from 'micro-btc-signer';
 
@@ -33,7 +34,7 @@ export function BtcSendFormConfirmationDetails(props: BtcSendFormConfirmationDet
   return (
     <ConfirmationDetailsLayout amount={amount}>
       <ConfirmationDetail detail="Token" value="Bitcoin" />
-      <ConfirmationDetail detail="To" value={recipient} />
+      <ConfirmationDetail detail="To" value={truncateMiddle(recipient, 4)} />
       <ConfirmationDetail
         detail="Fee"
         value={<TransactionFee fee={formatMoney(fee)} usdAmount={feeInUsd} />}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -27,7 +27,7 @@ import { createDefaultInitialFormValues, defaultFormikProps } from '../../send-f
 import { TestnetBtcMessage } from './components/testnet-btc-message';
 import { useBtcSendForm } from './use-btc-send-form';
 
-export function BtcCryptoCurrencySendForm() {
+export function BtcSendForm() {
   useRouteHeader(<Header hideActions onClose={() => navigate(-1)} title="Send" />);
 
   const navigate = useNavigate();
@@ -78,6 +78,7 @@ export function BtcCryptoCurrencySendForm() {
             />
             <RecipientField
               labelAction="Choose account"
+              lastChild
               name="recipient"
               onClickLabelAction={() => navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts)}
             />

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/stx-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/stx-send-form.tsx
@@ -62,7 +62,7 @@ import { StacksRecipientField } from '../../family/stacks/components/stacks-reci
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 import { createDefaultInitialFormValues, defaultFormikProps } from '../../send-form.utils';
 
-export function StxCryptoCurrencySendForm() {
+export function StxSendForm() {
   const navigate = useNavigate();
   const { isShowingHighFeeConfirmation, setIsShowingHighFeeConfirmation } = useDrawers();
   const { data: nextNonce } = useNextNonce();
@@ -141,7 +141,7 @@ export function StxCryptoCurrencySendForm() {
     >
       {props => (
         <NonceSetter>
-          <Form style={{ width: '100%' }}>
+          <Form>
             <AmountField
               balance={availableStxBalance}
               bottomInputOverlay={

--- a/src/app/pages/send/send-crypto-asset-form/hooks/use-send-form-navigate.ts
+++ b/src/app/pages/send/send-crypto-asset-form/hooks/use-send-form-navigate.ts
@@ -28,7 +28,7 @@ export function useSendFormNavigate() {
         return navigate('../', { relative: 'path', replace: true, state });
       },
       toConfirmAndSignBtcTransaction(tx: string, recipient: string, fee: number) {
-        return navigate(RouteUrls.SendBtcCryptoCurrencyConfirmation, {
+        return navigate(RouteUrls.SendBtcConfirmation, {
           replace: true,
           state: {
             tx,
@@ -38,7 +38,7 @@ export function useSendFormNavigate() {
         });
       },
       toConfirmAndSignStxTransaction(tx: StacksTransaction) {
-        return navigate(RouteUrls.SendStxCryptoCurrencyConfirmation, {
+        return navigate(RouteUrls.SendStxConfirmation, {
           replace: true,
           state: {
             tx: bytesToHex(tx.serialize()),

--- a/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.tsx
@@ -4,9 +4,9 @@ import { RouteUrls } from '@shared/route-urls';
 import { isString } from '@shared/utils';
 
 import { SendCryptoAssetFormLayout } from './components/send-crypto-asset-form.layout';
-import { BtcCryptoCurrencySendForm } from './form/btc/btc-send-form';
+import { BtcSendForm } from './form/btc/btc-send-form';
 import { StacksSip10FungibleTokenSendForm } from './form/stacks-sip10/stacks-sip10-fungible-token-send-form';
-import { StxCryptoCurrencySendForm } from './form/stx/stx-crypto-currency-send-form';
+import { StxSendForm } from './form/stx/stx-send-form';
 
 export function SendCryptoAssetForm() {
   const { symbol } = useParams();
@@ -18,10 +18,10 @@ export function SendCryptoAssetForm() {
   const content = (() => {
     switch (symbol) {
       case 'btc':
-        return <BtcCryptoCurrencySendForm />;
+        return <BtcSendForm />;
 
       case 'stx':
-        return <StxCryptoCurrencySendForm />;
+        return <StxSendForm />;
 
       // Currently the only other currencies we support are Stacks SIP-10 FTs. This
       // routing logic will need to be updated on addition of new chain tokens

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -55,7 +55,7 @@ export enum RouteUrls {
   SendCryptoAsset = '/send',
   SendCryptoAssetForm = '/send/:symbol',
   SendCryptoAssetFormRecipientAccounts = 'recipient-accounts',
-  SendBtcCryptoCurrencyConfirmation = '/send/btc/confirm',
-  SendStxCryptoCurrencyConfirmation = '/send/stx/confirm',
+  SendBtcConfirmation = '/send/btc/confirm',
+  SendStxConfirmation = '/send/stx/confirm',
   SendStacksSip10Confirmation = '/send/:symbol/confirm',
 }

--- a/tests/mocks/constants.ts
+++ b/tests/mocks/constants.ts
@@ -1,4 +1,5 @@
 export const TEST_ACCOUNT_1_BTC_ADDRESS = 'bc1qhdykvr9eafepm9cf6aryk0stmmwpv4wws9raj5';
+export const TEST_ACCOUNT_2_BTC_ADDRESS = 'bc1qznkpz8fk07nmdhvr2k4nnea5n08tw6tk540snu';
 export const TEST_ACCOUNT_1_STX_ADDRESS = 'SP297VG59W96DPGBT13SGD542QE1XS954X78Z75G0';
 export const TEST_BNS_NAME = 'test-hiro-wallet.btc';
 export const TEST_BNS_RESOLVED_ADDRESS = 'SP12YQ0M2KFT7YMJKVGP71B874YF055F77PFPH9KM';

--- a/tests/page-object-models/send.page.ts
+++ b/tests/page-object-models/send.page.ts
@@ -11,6 +11,15 @@ export class SendPage {
     this.page = page;
   }
 
+  async selectBtcAndGoToSendForm() {
+    await this.page.waitForURL('**' + RouteUrls.SendCryptoAsset);
+    await this.page
+      .getByTestId(CryptoAssetSelectors.CryptoAssetListItem.replace('{symbol}', 'btc'))
+      .click();
+    await this.page.waitForURL('**' + `${RouteUrls.SendCryptoAsset}/btc`);
+    await this.page.getByTestId(SendCryptoAssetSelectors.SendFormContainer).waitFor();
+  }
+
   async selectStxAndGoToSendForm() {
     await this.page.waitForURL('**' + RouteUrls.SendCryptoAsset);
     await this.page

--- a/tests/specs/send/send-btc.spec.ts
+++ b/tests/specs/send/send-btc.spec.ts
@@ -1,0 +1,44 @@
+import { TEST_ACCOUNT_2_BTC_ADDRESS } from '@tests/mocks/constants';
+import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
+
+import { test } from '../../fixtures/fixtures';
+
+test.describe('send btc', () => {
+  // TODO: Remove with legacy send form
+  test.beforeEach(async () => {
+    test.skip();
+  });
+
+  // TODO: Use with mainnet bitcoin
+  // test.beforeEach(async ({ extensionId, globalPage, homePage, onboardingPage, sendPage }) => {
+  //   await globalPage.setupAndUseApiCalls(extensionId);
+  //   await onboardingPage.signInExistingUser();
+
+  //   await homePage.sendButton.click();
+  //   await sendPage.selectBtcAndGoToSendForm();
+  // });
+
+  test.describe('btc send form', () => {
+    test('can preview and send btc', async ({ page }) => {
+      await page.getByTestId(SendCryptoAssetSelectors.AmountFieldInput).fill('0.000001');
+      await page
+        .getByTestId(SendCryptoAssetSelectors.RecipientFieldInput)
+        .fill(TEST_ACCOUNT_2_BTC_ADDRESS);
+      await page.getByTestId(SendCryptoAssetSelectors.PreviewSendTxBtn).click();
+      const details = await page
+        .getByTestId(SendCryptoAssetSelectors.ConfirmationDetails)
+        .allInnerTexts();
+      test.expect(details).toBeTruthy();
+
+      const requestPromise = page.waitForRequest(/tx/);
+      await page.getByTestId(SendCryptoAssetSelectors.ConfirmSendTxBtn).click();
+      const request = await requestPromise;
+      const txData = request.postData();
+      const method = request.method();
+      const postUrl = request.url();
+      test.expect(txData).toBeTruthy();
+      test.expect(method).toEqual('POST');
+      test.expect(postUrl).toEqual('https://blockstream.info/api/tx');
+    });
+  });
+});

--- a/tests/specs/send/send-stx.spec.ts
+++ b/tests/specs/send/send-stx.spec.ts
@@ -7,7 +7,7 @@ import { FormErrorMessages } from '@app/common/error-messages';
 
 import { test } from '../../fixtures/fixtures';
 
-test.describe('send crypto asset', () => {
+test.describe('send stx', () => {
   let testAddress: string;
 
   // TODO: Remove with legacy send form


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4203505073).<!-- Sticky Header Marker -->

This PR adds a test for sending btc. I didn't get far, but we can add more to it quickly once I know what we want to validate, and have the fees and success pages setup.

I also tried to catch/fix minor UI bugs here:
- Fixed send form width 100% not working
- Fixed send form container not being reponsive
- Fixed the btc for recipient field not having `lastChild` to round border corners on error and focus
- Fixed account addresses in header in popup wrapping
- Renamed some forgotten components with the move away from `CryptoCurrency` in names
- Truncated the btc recipient address on the preview (I confirmed CashApp and Coinbase do the same)
