### PR TITLE
feat: minimum spend amount

### DIFF
--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -4,15 +4,57 @@ import * as yup from 'yup';
 import { Money } from '@shared/models/money.model';
 import { isNumber } from '@shared/utils';
 
-import { microStxToStx, stxToMicroStx } from '@app/common/money/unit-conversion';
+import {
+  btcToSat,
+  microStxToStx,
+  satToBtc,
+  stxToMicroStx,
+} from '@app/common/money/unit-conversion';
 
 import { formatInsufficientBalanceError, formatPrecisionError } from '../../error-formatters';
 import { FormErrorMessages } from '../../error-messages';
 import { countDecimals } from '../../utils';
 import { currencyAmountValidator, stxAmountPrecisionValidator } from './currency-validators';
 
+const minSpendAmountInSats = 6000;
+
 function amountValidator() {
   return yup.number().required().positive(FormErrorMessages.MustNotBeZero);
+}
+
+interface BtcInsufficientBalanceValidatorArgs {
+  recipient: string;
+  calcMaxSpend(recipient: string): {
+    spendableBitcoin: BigNumber;
+  };
+}
+export function btcInsufficientBalanceValidator({
+  recipient,
+  calcMaxSpend,
+}: BtcInsufficientBalanceValidatorArgs) {
+  return yup.number().test({
+    message: 'Insufficient funds',
+    test(value) {
+      if (!value) return false;
+      const maxSpend = calcMaxSpend(recipient);
+      if (!maxSpend) return false;
+      const desiredSpend = new BigNumber(value);
+      if (desiredSpend.isGreaterThan(maxSpend.spendableBitcoin)) return false;
+      return true;
+    },
+  });
+}
+
+export function btcMinimumSpendValidator() {
+  return yup.number().test({
+    message: `Minimum is ${satToBtc(minSpendAmountInSats)}`,
+    test(value) {
+      if (!value) return false;
+      const desiredSpend = btcToSat(value);
+      if (desiredSpend.isLessThan(minSpendAmountInSats)) return false;
+      return true;
+    },
+  });
 }
 
 export function stxAmountValidator() {

--- a/src/app/common/validation/forms/currency-validators.ts
+++ b/src/app/common/validation/forms/currency-validators.ts
@@ -1,4 +1,3 @@
-import BigNumber from 'bignumber.js';
 import * as yup from 'yup';
 
 import { BTC_DECIMALS, STX_DECIMALS } from '@shared/constants';
@@ -36,29 +35,6 @@ function currencyPrecisionValidatorFactory(
 
 export function btcAmountPrecisionValidator(errorMsg: string) {
   return currencyPrecisionValidatorFactory('BTC', BTC_DECIMALS, errorMsg);
-}
-
-interface BtcInsufficientBalanceValidatorArgs {
-  recipient: string;
-  calcMaxSpend(recipient: string): {
-    spendableBitcoin: BigNumber;
-  };
-}
-export function btcInsufficientBalanceValidator({
-  recipient,
-  calcMaxSpend,
-}: BtcInsufficientBalanceValidatorArgs) {
-  return yup.number().test({
-    message: 'Insufficient funds',
-    test(value) {
-      if (!value) return false;
-      const maxSpend = calcMaxSpend(recipient);
-      if (!maxSpend) return false;
-      const desiredSpend = new BigNumber(value);
-      if (desiredSpend.isGreaterThan(maxSpend.spendableBitcoin)) return false;
-      return true;
-    },
-  });
 }
 
 export function stxAmountPrecisionValidator(errorMsg: string) {

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -15,8 +15,11 @@ import {
   btcAddressNetworkValidator,
   btcAddressValidator,
 } from '@app/common/validation/forms/address-validators';
+import {
+  btcInsufficientBalanceValidator,
+  btcMinimumSpendValidator,
+} from '@app/common/validation/forms/amount-validators';
 import { btcAmountPrecisionValidator } from '@app/common/validation/forms/currency-validators';
-import { btcInsufficientBalanceValidator } from '@app/common/validation/forms/currency-validators';
 import { useBitcoinAssetBalance } from '@app/query/bitcoin/address/address.hooks';
 import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
@@ -53,7 +56,8 @@ export function useBtcSendForm() {
             recipient: formRef.current?.values.recipient ?? '',
             calcMaxSpend,
           })
-        ),
+        )
+        .concat(btcMinimumSpendValidator()),
       recipient: yup
         .string()
         .concat(btcAddressValidator())


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4210453285).<!-- Sticky Header Marker -->

This PR adds the minimum spend amount validator to the btc form (set at 6000 sats). This is branched off the insufficient balance validator branch. Proposing here to move that in with other amount field validators ...or maybe those two files should be merged in some way?


![Screen Shot 2023-02-17 at 12 49 50 PM](https://user-images.githubusercontent.com/6493321/219758773-4eceee55-d72e-4b60-8aa4-ee9714e00a1a.png)