### PR TITLE
refactor: send max and add available balance

### DIFF
--- a/src/app/components/edit-nonce-button.tsx
+++ b/src/app/components/edit-nonce-button.tsx
@@ -9,7 +9,6 @@ export function EditNonceButton({ onEditNonce, ...props }: EditNonceButtonProps)
   return (
     <Caption
       _hover={{ cursor: 'pointer', textDecoration: 'underline' }}
-      alignSelf="start"
       as="button"
       color={color('brand')}
       onClick={onEditNonce}

--- a/src/app/pages/send/send-container.tsx
+++ b/src/app/pages/send/send-container.tsx
@@ -15,7 +15,6 @@ export function SendContainer() {
         maxHeight="90vh"
         maxWidth={['100%', CENTERED_FULL_PAGE_MAX_WIDTH]}
         minWidth={['100%', CENTERED_FULL_PAGE_MAX_WIDTH]}
-        pb="loose"
       >
         <Outlet />
       </Flex>

--- a/src/app/pages/send/send-crypto-asset-form/components/available-balance.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/available-balance.tsx
@@ -1,0 +1,14 @@
+import { Money } from '@shared/models/money.model';
+
+import { convertAmountToBaseUnit } from '@app/common/money/calculate-money';
+import { Caption } from '@app/components/typography';
+
+export function AvailableBalance(props: { availableBalance: Money }) {
+  const { availableBalance } = props;
+  return (
+    <Caption>
+      Balance: {convertAmountToBaseUnit(availableBalance).toFormat()}{' '}
+      {availableBalance.symbol.toUpperCase()}
+    </Caption>
+  );
+}

--- a/src/app/pages/send/send-crypto-asset-form/components/preview-button.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/preview-button.tsx
@@ -10,6 +10,7 @@ export function PreviewButton(props: ButtonProps) {
       borderRadius="10px"
       data-testid={SendCryptoAssetSelectors.PreviewSendTxBtn}
       height="48px"
+      mb="base"
       onClick={handleSubmit}
       width="100%"
       {...props}

--- a/src/app/pages/send/send-crypto-asset-form/components/send-crypto-asset-form.layout.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/send-crypto-asset-form.layout.tsx
@@ -7,10 +7,10 @@ interface SendCryptoAssetFormLayoutProps {
 export function SendCryptoAssetFormLayout({ children }: SendCryptoAssetFormLayoutProps) {
   return (
     <Box
-      data-testid={SendCryptoAssetSelectors.SendFormContainer}
+      data-testid={SendCryptoAssetSelectors.SendForm}
       mt={['unset', '48px']}
       width="100%"
-      pb="extra-loose"
+      pb="base"
       px="loose"
     >
       {children}

--- a/src/app/pages/send/send-crypto-asset-form/components/send-max-button.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/send-max-button.tsx
@@ -10,16 +10,16 @@ import { Money } from '@shared/models/money.model';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 
-interface SendAllButtonProps extends ButtonProps {
+interface SendMaxButtonProps extends ButtonProps {
   balance: Money;
-  sendAllBalance: string;
+  sendMaxBalance: string;
 }
-export function SendAllButton({ balance, sendAllBalance, ...props }: SendAllButtonProps) {
+export function SendMaxButton({ balance, sendMaxBalance, ...props }: SendMaxButtonProps) {
   const [, _, amountFieldHelpers] = useField('amount');
 
   const analytics = useAnalytics();
 
-  const onSendAll = useCallback(() => {
+  const onSendMax = useCallback(() => {
     // if (isUndefined(feeField.value)) return toast.error('Loading fee, try again');
     // if (!feeField.value)
     //   return toast.error(
@@ -28,23 +28,23 @@ export function SendAllButton({ balance, sendAllBalance, ...props }: SendAllButt
 
     void analytics.track('select_maximum_amount_for_send');
     if (balance.amount.isLessThanOrEqualTo(0)) return toast.error(`Zero balance`);
-    return amountFieldHelpers.setValue(sendAllBalance);
-  }, [amountFieldHelpers, analytics, balance.amount, sendAllBalance]);
+    return amountFieldHelpers.setValue(sendMaxBalance);
+  }, [amountFieldHelpers, analytics, balance.amount, sendMaxBalance]);
 
   return (
     <Button
-      borderRadius="12px"
-      data-testid={SendCryptoAssetSelectors.SendAllBtn}
+      borderRadius="10px"
+      data-testid={SendCryptoAssetSelectors.SendMaxBtn}
       fontSize={0}
       height="32px"
-      onClick={onSendAll}
+      onClick={onSendMax}
       mode="tertiary"
-      px="tight"
+      px="base-tight"
       type="button"
-      width="70px"
+      width="fit-content"
       {...props}
     >
-      Send all
+      Send max
     </Button>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -1,5 +1,6 @@
 import { Outlet, useNavigate } from 'react-router-dom';
 
+import { Box } from '@stacks/ui';
 import { Form, Formik } from 'formik';
 
 import { HIGH_FEE_WARNING_LEARN_MORE_URL_BTC } from '@shared/constants';
@@ -15,12 +16,13 @@ import { useBitcoinCryptoCurrencyAssetBalance } from '@app/query/bitcoin/address
 import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 import { AmountField } from '../../components/amount-field';
+import { AvailableBalance } from '../../components/available-balance';
 import { FormErrors } from '../../components/form-errors';
 import { FormFieldsLayout } from '../../components/form-fields.layout';
 import { PreviewButton } from '../../components/preview-button';
 import { RecipientField } from '../../components/recipient-field';
 import { SelectedAssetField } from '../../components/selected-asset-field';
-import { SendAllButton } from '../../components/send-all-button';
+import { SendMaxButton } from '../../components/send-max-button';
 import { useCalculateMaxBitcoinSpend } from '../../family/bitcoin/hooks/use-calculate-max-spend';
 import { useSendFormRouteState } from '../../hooks/use-send-form-route-state';
 import { createDefaultInitialFormValues, defaultFormikProps } from '../../send-form.utils';
@@ -62,9 +64,9 @@ export function BtcSendForm() {
           <AmountField
             balance={btcCryptoCurrencyAssetBalance.balance}
             bottomInputOverlay={
-              <SendAllButton
+              <SendMaxButton
                 balance={btcCryptoCurrencyAssetBalance.balance}
-                sendAllBalance={
+                sendMaxBalance={
                   calcMaxSpend(props.values.recipient)?.spendableBitcoin.toString() ?? '0'
                 }
               />
@@ -88,6 +90,9 @@ export function BtcSendForm() {
 
           <FormErrors />
           <PreviewButton />
+          <Box my="base">
+            <AvailableBalance availableBalance={btcCryptoCurrencyAssetBalance.balance} />
+          </Box>
           <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_BTC} />
           <Outlet />
         </Form>

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
@@ -30,6 +30,7 @@ import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-a
 import { EditNonceButton } from '@app/components/edit-nonce-button';
 import { FeesRow } from '@app/components/fees-row/fees-row';
 import { Header } from '@app/components/header';
+import { SpaceBetween } from '@app/components/layout/space-between';
 import { NonceSetter } from '@app/components/nonce-setter';
 import { HighFeeDrawer } from '@app/features/high-fee-drawer/high-fee-drawer';
 import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
@@ -47,12 +48,13 @@ import {
 } from '@app/store/transactions/token-transfer.hooks';
 
 import { AmountField } from '../../components/amount-field';
+import { AvailableBalance } from '../../components/available-balance';
 import { FormErrors } from '../../components/form-errors';
 import { FormFieldsLayout } from '../../components/form-fields.layout';
 import { MemoField } from '../../components/memo-field';
 import { PreviewButton } from '../../components/preview-button';
 import { SelectedAssetField } from '../../components/selected-asset-field';
-import { SendAllButton } from '../../components/send-all-button';
+import { SendMaxButton } from '../../components/send-max-button';
 import { StacksRecipientField } from '../../family/stacks/components/stacks-recipient-field';
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 import { createDefaultInitialFormValues, defaultFormikProps } from '../../send-form.utils';
@@ -88,7 +90,7 @@ export function StacksSip10FungibleTokenSendForm({
   useRouteHeader(<Header hideActions onClose={() => navigate(-1)} title="Send" />);
 
   const availableTokenBalance = assetBalance?.balance ?? createMoney(0, 'STX');
-  const sendAllBalance = useMemo(
+  const sendMaxBalance = useMemo(
     () => convertAmountToBaseUnit(availableTokenBalance),
     [availableTokenBalance]
   );
@@ -154,9 +156,9 @@ export function StacksSip10FungibleTokenSendForm({
             <AmountField
               balance={availableTokenBalance}
               bottomInputOverlay={
-                <SendAllButton
+                <SendMaxButton
                   balance={availableTokenBalance}
-                  sendAllBalance={sendAllBalance.toString()}
+                  sendMaxBalance={sendMaxBalance.toString()}
                 />
               }
             />
@@ -177,10 +179,13 @@ export function StacksSip10FungibleTokenSendForm({
                 )
               }
             />
-            <EditNonceButton
-              onEditNonce={() => navigate(RouteUrls.EditNonce, { state: { contractId } })}
-              my={['loose', 'base']}
-            />
+            <SpaceBetween>
+              <AvailableBalance availableBalance={availableTokenBalance} />
+              <EditNonceButton
+                onEditNonce={() => navigate(RouteUrls.EditNonce, { state: { contractId } })}
+                my={['loose', 'base']}
+              />
+            </SpaceBetween>
             <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
             <Outlet />
           </Form>

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
@@ -10,7 +10,7 @@ import { FeeTypes } from '@shared/models/fees/_fees.model';
 import { StacksSendFormValues } from '@shared/models/form.model';
 import { createMoney } from '@shared/models/money.model';
 import { RouteUrls } from '@shared/route-urls';
-import { isEmpty, isUndefined } from '@shared/utils';
+import { isEmpty } from '@shared/utils';
 
 import { FormErrorMessages } from '@app/common/error-messages';
 import { useDrawers } from '@app/common/hooks/use-drawers';
@@ -150,47 +150,36 @@ export function StacksSip10FungibleTokenSendForm({
       validationSchema={validationSchema}
       {...defaultFormikProps}
     >
-      {props => (
-        <NonceSetter>
-          <Form style={{ width: '100%' }}>
-            <AmountField
-              balance={availableTokenBalance}
-              bottomInputOverlay={
-                <SendMaxButton
-                  balance={availableTokenBalance}
-                  sendMaxBalance={sendMaxBalance.toString()}
-                />
-              }
-            />
-            <FormFieldsLayout>
-              <SelectedAssetField icon={<StxAvatar />} name={symbol} symbol={symbol} />
-              <StacksRecipientField contractId={contractId} />
-              <MemoField />
-            </FormFieldsLayout>
-            <FeesRow fees={stacksFtFees} isSponsored={false} mt="base" />
-            <FormErrors />
-            <PreviewButton
-              isDisabled={
-                !(
-                  props.values.amount &&
-                  props.values.recipient &&
-                  props.values.fee &&
-                  !isUndefined(props.values.nonce)
-                )
-              }
-            />
-            <SpaceBetween>
-              <AvailableBalance availableBalance={availableTokenBalance} />
-              <EditNonceButton
-                onEditNonce={() => navigate(RouteUrls.EditNonce, { state: { contractId } })}
-                my={['loose', 'base']}
+      <NonceSetter>
+        <Form style={{ width: '100%' }}>
+          <AmountField
+            balance={availableTokenBalance}
+            bottomInputOverlay={
+              <SendMaxButton
+                balance={availableTokenBalance}
+                sendMaxBalance={sendMaxBalance.toString()}
               />
-            </SpaceBetween>
-            <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
-            <Outlet />
-          </Form>
-        </NonceSetter>
-      )}
+            }
+          />
+          <FormFieldsLayout>
+            <SelectedAssetField icon={<StxAvatar />} name={symbol} symbol={symbol} />
+            <StacksRecipientField contractId={contractId} />
+            <MemoField />
+          </FormFieldsLayout>
+          <FeesRow fees={stacksFtFees} isSponsored={false} mt="base" />
+          <FormErrors />
+          <PreviewButton />
+          <SpaceBetween>
+            <AvailableBalance availableBalance={availableTokenBalance} />
+            <EditNonceButton
+              onEditNonce={() => navigate(RouteUrls.EditNonce, { state: { contractId } })}
+              my={['loose', 'base']}
+            />
+          </SpaceBetween>
+          <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
+          <Outlet />
+        </Form>
+      </NonceSetter>
     </Formik>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/stx-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/stx-send-form.tsx
@@ -160,7 +160,7 @@ export function StxSendForm() {
             </FormFieldsLayout>
             <FeesRow fees={stxFees} isSponsored={false} mt="base" />
             <FormErrors />
-            <PreviewButton isDisabled={!props.isValid} />
+            <PreviewButton />
             <SpaceBetween>
               <AvailableBalance availableBalance={availableStxBalance} />
               <EditNonceButton

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/stx-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/stx-send-form.tsx
@@ -36,6 +36,7 @@ import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-a
 import { EditNonceButton } from '@app/components/edit-nonce-button';
 import { FeesRow } from '@app/components/fees-row/fees-row';
 import { Header } from '@app/components/header';
+import { SpaceBetween } from '@app/components/layout/space-between';
 import { NonceSetter } from '@app/components/nonce-setter';
 import { HighFeeDrawer } from '@app/features/high-fee-drawer/high-fee-drawer';
 import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
@@ -52,12 +53,13 @@ import {
 } from '@app/store/transactions/token-transfer.hooks';
 
 import { AmountField } from '../../components/amount-field';
+import { AvailableBalance } from '../../components/available-balance';
 import { FormErrors } from '../../components/form-errors';
 import { FormFieldsLayout } from '../../components/form-fields.layout';
 import { MemoField } from '../../components/memo-field';
 import { PreviewButton } from '../../components/preview-button';
 import { SelectedAssetField } from '../../components/selected-asset-field';
-import { SendAllButton } from '../../components/send-all-button';
+import { SendMaxButton } from '../../components/send-max-button';
 import { StacksRecipientField } from '../../family/stacks/components/stacks-recipient-field';
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 import { createDefaultInitialFormValues, defaultFormikProps } from '../../send-form.utils';
@@ -81,7 +83,7 @@ export function StxSendForm() {
   useRouteHeader(<Header hideActions onClose={() => navigate(-1)} title="Send" />);
 
   const availableStxBalance = balances?.stx.availableStx ?? createMoney(0, 'STX');
-  const sendAllBalance = useMemo(
+  const sendMaxBalance = useMemo(
     () =>
       convertAmountToBaseUnit(
         availableStxBalance.amount.minus(pendingTxsBalance.amount),
@@ -145,9 +147,9 @@ export function StxSendForm() {
             <AmountField
               balance={availableStxBalance}
               bottomInputOverlay={
-                <SendAllButton
+                <SendMaxButton
                   balance={availableStxBalance}
-                  sendAllBalance={sendAllBalance.minus(props.values.fee).toString()}
+                  sendMaxBalance={sendMaxBalance.minus(props.values.fee).toString()}
                 />
               }
             />
@@ -159,10 +161,13 @@ export function StxSendForm() {
             <FeesRow fees={stxFees} isSponsored={false} mt="base" />
             <FormErrors />
             <PreviewButton isDisabled={!props.isValid} />
-            <EditNonceButton
-              onEditNonce={() => navigate(RouteUrls.EditNonce)}
-              my={['loose', 'base']}
-            />
+            <SpaceBetween>
+              <AvailableBalance availableBalance={availableStxBalance} />
+              <EditNonceButton
+                onEditNonce={() => navigate(RouteUrls.EditNonce)}
+                my={['loose', 'base']}
+              />
+            </SpaceBetween>
             <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
             <Outlet />
           </Form>

--- a/tests/page-object-models/send.page.ts
+++ b/tests/page-object-models/send.page.ts
@@ -17,7 +17,7 @@ export class SendPage {
       .getByTestId(CryptoAssetSelectors.CryptoAssetListItem.replace('{symbol}', 'btc'))
       .click();
     await this.page.waitForURL('**' + `${RouteUrls.SendCryptoAsset}/btc`);
-    await this.page.getByTestId(SendCryptoAssetSelectors.SendFormContainer).waitFor();
+    await this.page.getByTestId(SendCryptoAssetSelectors.SendForm).waitFor();
   }
 
   async selectStxAndGoToSendForm() {
@@ -26,6 +26,6 @@ export class SendPage {
       .getByTestId(CryptoAssetSelectors.CryptoAssetListItem.replace('{symbol}', 'stx'))
       .click();
     await this.page.waitForURL('**' + `${RouteUrls.SendCryptoAsset}/stx`);
-    await this.page.getByTestId(SendCryptoAssetSelectors.SendFormContainer).waitFor();
+    await this.page.getByTestId(SendCryptoAssetSelectors.SendForm).waitFor();
   }
 }

--- a/tests/selectors/send.selectors.ts
+++ b/tests/selectors/send.selectors.ts
@@ -11,6 +11,6 @@ export enum SendCryptoAssetSelectors {
   ResolvedBnsAddressPreview = 'resolved-bns-address-preview',
   ResolvedBnsAddressHoverInfoIcon = 'resolved-bns-address-hover-info-icon',
   ResolvedBnsAddressCopyToClipboard = 'resolved-bns-address-copy-to-clipboard',
-  SendAllBtn = 'send-all-btn',
-  SendFormContainer = 'send-form-container',
+  SendForm = 'send-form',
+  SendMaxBtn = 'send-max-btn',
 }

--- a/tests/specs/send/send-stx.spec.ts
+++ b/tests/specs/send/send-stx.spec.ts
@@ -29,7 +29,7 @@ test.describe('send stx', () => {
 
   test.describe('send form input fields', () => {
     test('send all button sets available balance minus fee', async ({ page }) => {
-      await page.getByTestId(SendCryptoAssetSelectors.SendAllBtn).click();
+      await page.getByTestId(SendCryptoAssetSelectors.SendMaxBtn).click();
       const inputValue = await page
         .getByTestId(SendCryptoAssetSelectors.AmountFieldInput)
         .inputValue();


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4209030322).<!-- Sticky Header Marker -->

This PR refactors the send all button to now be `Send max`. The available balance is now shown in the lower, left corner. And, if the edit nonce button is present, it is now displayed on the lower right.

![Screen Shot 2023-02-17 at 3 13 56 PM](https://user-images.githubusercontent.com/6493321/219798588-217b4358-b16c-4f81-97e7-ba35097bc963.png)

![Screen Shot 2023-02-17 at 3 15 42 PM](https://user-images.githubusercontent.com/6493321/219798611-5f40d997-614f-4fad-b94f-2ee05e588388.png)
