### PR TITLE
fix: add bitcoin activity to account restore flow

### DIFF
--- a/src/app/common/hooks/use-key-actions.ts
+++ b/src/app/common/hooks/use-key-actions.ts
@@ -10,7 +10,7 @@ import { clearChromeStorage } from '@shared/storage';
 import { partiallyClearLocalStorage } from '@app/common/store-utils';
 import { useAppDispatch } from '@app/store';
 import { createNewAccount, stxChainActions } from '@app/store/chains/stx-chain.actions';
-import { useStacksClientAnchored } from '@app/store/common/api-clients.hooks';
+import { useBitcoinClient, useStacksClientAnchored } from '@app/store/common/api-clients.hooks';
 import { inMemoryKeyActions } from '@app/store/in-memory-key/in-memory-key.actions';
 import { keyActions } from '@app/store/keys/key.actions';
 import { useCurrentKeyDetails } from '@app/store/keys/key.selectors';
@@ -21,12 +21,13 @@ export function useKeyActions() {
   const analytics = useAnalytics();
   const dispatch = useAppDispatch();
   const defaultKeyDetails = useCurrentKeyDetails();
-  const client = useStacksClientAnchored();
+  const stxClient = useStacksClientAnchored();
+  const btcClient = useBitcoinClient();
 
   return useMemo(
     () => ({
       async setPassword(password: string) {
-        return dispatch(keyActions.setWalletEncryptionPassword({ password, client }));
+        return dispatch(keyActions.setWalletEncryptionPassword({ password, stxClient, btcClient }));
       },
 
       generateWalletKey() {
@@ -67,6 +68,6 @@ export function useKeyActions() {
         return dispatch(inMemoryKeyActions.lockWallet());
       },
     }),
-    [analytics, client, defaultKeyDetails, dispatch]
+    [analytics, btcClient, defaultKeyDetails, dispatch, stxClient]
   );
 }

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
@@ -3,7 +3,11 @@ import { HDKey } from '@scure/bip32';
 
 import { NetworkModes } from '@shared/constants';
 import { deriveTaprootAccountFromHdKey } from '@shared/crypto/bitcoin/p2tr-address-gen';
-import { deriveNativeSegWitAccountFromHdKey } from '@shared/crypto/bitcoin/p2wpkh-address-gen';
+import {
+  deriveIndexZeroKeychainFromAccount,
+  deriveNativeSegWitAccountFromHdKey,
+  getNativeSegWitAddressIndexZero,
+} from '@shared/crypto/bitcoin/p2wpkh-address-gen';
 
 import { mnemonicToRootNode } from '@app/common/keychain/keychain';
 import { selectInMemoryKey } from '@app/store/in-memory-key/in-memory-key.selectors';
@@ -24,6 +28,16 @@ function bitcoinKeychainSelectorFactory(
       return keychainFn(mnemonicToRootNode(inMemKey.keys.default), network.chain.bitcoin.network);
     }
   );
+}
+
+export function getNativeSegwitAddressFromMnemonic(secretKey: string) {
+  return (index: number) => {
+    const rootNode = mnemonicToRootNode(secretKey);
+    const account = deriveIndexZeroKeychainFromAccount(
+      deriveNativeSegWitAccountFromHdKey(rootNode, 'mainnet')(index)
+    );
+    return getNativeSegWitAddressIndexZero(account, 'mainnet');
+  };
 }
 
 export const selectSoftwareBitcoinNativeSegWitKeychain = bitcoinKeychainSelectorFactory(

--- a/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -18,8 +18,6 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import { useCurrentAccountIndex } from '../../account';
 import { selectSoftwareBitcoinNativeSegWitKeychain } from './bitcoin-keychain';
 
-const firstAccountIndex = 0;
-
 function useBitcoinNativeSegwitAccount(index: number) {
   const keychain = useSelector(selectSoftwareBitcoinNativeSegWitKeychain);
   return useMemo(() => {
@@ -40,7 +38,6 @@ function useDeriveNativeSegWitAccountIndexAddressIndexZero(xpub: string) {
     () =>
       deriveNativeSegWitReceiveAddressIndex({
         xpub,
-        index: firstAccountIndex,
         network: network.chain.bitcoin.network,
       }),
     [xpub, network]

--- a/src/shared/crypto/bitcoin/p2wpkh-address-gen.spec.ts
+++ b/src/shared/crypto/bitcoin/p2wpkh-address-gen.spec.ts
@@ -36,7 +36,6 @@ describe('Bitcoin bech32 (P2WPKH address derivation', () => {
     describe.each(accounts)('Account', account => {
       const keychain = deriveNativeSegWitReceiveAddressIndex({
         xpub: account.extended_public_key,
-        index: 0,
         network: 'mainnet',
       });
       test('bech 32 address', () =>

--- a/src/shared/crypto/derivation-path.utils.ts
+++ b/src/shared/crypto/derivation-path.utils.ts
@@ -1,0 +1,8 @@
+export enum DerivationPathDepth {
+  Root = 0,
+  Purpose = 1,
+  CoinType = 2,
+  Account = 3,
+  ChangeReceive = 4,
+  AddressIndex = 5,
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4215433980).<!-- Sticky Header Marker -->

This PR adds an additional bitcoin balance check when a user restore an account. 

Now, we check three things to figure out how many accounts to display:
- STX balance
- BNS name
- Native Segwit bitcoin balance

I want to minimise the locations in the code we interact with the keychain directly, and the btc signer library. Right now there's logic spread out between `src/shared/bitcoin` and `src/app/store/accounts`. I hope to soon make a refactor where:
- These libraries are only used in designated places
- Linting prevents their use outside those locations
- It's fully covered with unit tests