### PR TITLE
fix: account addresses

### DIFF
--- a/src/app/pages/home/components/account-address.tsx
+++ b/src/app/pages/home/components/account-address.tsx
@@ -1,7 +1,7 @@
 import { FiCopy } from 'react-icons/fi';
 
 import { Box, Flex, Text, useClipboard } from '@stacks/ui';
-import { color, truncateMiddle } from '@stacks/ui-utils';
+import { color } from '@stacks/ui-utils';
 import { UserAreaSelectors } from '@tests-legacy/integration/user-area.selectors';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
@@ -9,9 +9,10 @@ import { Tooltip } from '@app/components/tooltip';
 
 interface AccountAddressProps {
   address: string;
+  addressLabel: string;
   label: string;
 }
-export function AccountAddress({ address, label }: AccountAddressProps) {
+export function AccountAddress({ address, addressLabel, label }: AccountAddressProps) {
   const { onCopy, hasCopied } = useClipboard(address);
   const analytics = useAnalytics();
 
@@ -25,14 +26,14 @@ export function AccountAddress({ address, label }: AccountAddressProps) {
       <Tooltip hideOnClick={false} label={hasCopied ? 'Copied!' : label} placement="right">
         <Flex onClick={copyToClipboard} as="button">
           <Text color={color('text-caption')} fontSize={['12px', '14px']} mr="4px">
-            {truncateMiddle(address, 4)}
+            {addressLabel}
           </Text>
           <Box
             size="12px"
             color={color('text-caption')}
             data-testid={UserAreaSelectors.AccountCopyAddress}
             as={FiCopy}
-            mt="1px"
+            mt="2px"
           />
         </Flex>
       </Tooltip>

--- a/src/app/pages/home/components/account-address.tsx
+++ b/src/app/pages/home/components/account-address.tsx
@@ -1,6 +1,6 @@
 import { FiCopy } from 'react-icons/fi';
 
-import { Box, Button, Text, useClipboard } from '@stacks/ui';
+import { Box, Flex, Text, useClipboard } from '@stacks/ui';
 import { color, truncateMiddle } from '@stacks/ui-utils';
 import { UserAreaSelectors } from '@tests-legacy/integration/user-area.selectors';
 
@@ -23,18 +23,18 @@ export function AccountAddress({ address, label }: AccountAddressProps) {
   return (
     <>
       <Tooltip hideOnClick={false} label={hasCopied ? 'Copied!' : label} placement="right">
-        <Button onClick={copyToClipboard}>
-          <Text color={color('text-caption')} fontSize={['12px', '14px']}>
+        <Flex onClick={copyToClipboard} as="button">
+          <Text color={color('text-caption')} fontSize={['12px', '14px']} mr="4px">
             {truncateMiddle(address, 4)}
           </Text>
           <Box
-            _hover={{ cursor: 'pointer' }}
             size="12px"
             color={color('text-caption')}
             data-testid={UserAreaSelectors.AccountCopyAddress}
             as={FiCopy}
+            mt="1px"
           />
-        </Button>
+        </Flex>
       </Tooltip>
     </>
   );

--- a/src/app/pages/home/components/account-address.tsx
+++ b/src/app/pages/home/components/account-address.tsx
@@ -1,6 +1,6 @@
 import { FiCopy } from 'react-icons/fi';
 
-import { Box, Stack, Text, useClipboard } from '@stacks/ui';
+import { Box, Button, Text, useClipboard } from '@stacks/ui';
 import { color, truncateMiddle } from '@stacks/ui-utils';
 import { UserAreaSelectors } from '@tests-legacy/integration/user-area.selectors';
 
@@ -22,20 +22,19 @@ export function AccountAddress({ address, label }: AccountAddressProps) {
 
   return (
     <>
-      <Text color={color('text-caption')} fontSize={['12px', '14px']}>
-        {truncateMiddle(address, 4)}
-      </Text>
       <Tooltip hideOnClick={false} label={hasCopied ? 'Copied!' : label} placement="right">
-        <Stack>
+        <Button onClick={copyToClipboard}>
+          <Text color={color('text-caption')} fontSize={['12px', '14px']}>
+            {truncateMiddle(address, 4)}
+          </Text>
           <Box
             _hover={{ cursor: 'pointer' }}
-            onClick={copyToClipboard}
             size="12px"
             color={color('text-caption')}
             data-testid={UserAreaSelectors.AccountCopyAddress}
             as={FiCopy}
           />
-        </Stack>
+        </Button>
       </Tooltip>
     </>
   );

--- a/src/app/pages/home/components/account-addresses.tsx
+++ b/src/app/pages/home/components/account-addresses.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 
 import { Stack, StackProps } from '@stacks/ui';
+import { truncateMiddle } from '@stacks/ui-utils';
 
 import { useCurrentAccountNamesQuery } from '@app/query/stacks/bns/bns.hooks';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
@@ -20,11 +21,21 @@ export const AccountAddresses = memo((props: StackProps) => {
 
   return currentAccount ? (
     <Stack isInline {...props}>
-      <AccountAddress address={currentAccount.address} label="Copy Stacks address" />
+      <AccountAddress
+        address={currentAccount.address}
+        addressLabel={truncateMiddle(currentAccount.address, 4)}
+        label="Copy Stacks address"
+      />
       {isBitcoinEnabled ? (
-        <AccountAddress address={btcAddress} label="Copy Bitcoin address" />
+        <AccountAddress
+          address={btcAddress}
+          addressLabel={truncateMiddle(btcAddress, 4)}
+          label="Copy Bitcoin address"
+        />
       ) : null}
-      {bnsName ? <AccountAddress address={bnsName} label="Copy BNS address" /> : null}
+      {bnsName ? (
+        <AccountAddress address={bnsName} addressLabel={bnsName} label="Copy BNS address" />
+      ) : null}
     </Stack>
   ) : null;
 });

--- a/src/app/pages/home/components/account-addresses.tsx
+++ b/src/app/pages/home/components/account-addresses.tsx
@@ -20,11 +20,11 @@ export const AccountAddresses = memo((props: StackProps) => {
 
   return currentAccount ? (
     <Stack isInline {...props}>
-      <AccountAddress address={currentAccount.address} label="Copy Stacks addres" />
+      <AccountAddress address={currentAccount.address} label="Copy Stacks address" />
       {isBitcoinEnabled ? (
         <AccountAddress address={btcAddress} label="Copy Bitcoin address" />
       ) : null}
-      {bnsName ? <AccountAddress address={bnsName} label="Copy BNS addres" /> : null}
+      {bnsName ? <AccountAddress address={bnsName} label="Copy BNS address" /> : null}
     </Stack>
   ) : null;
 });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4217487181).<!-- Sticky Header Marker -->

This PR cherry-picks commits from: https://github.com/hirosystems/stacks-wallet-web/pull/3168, thanks again @alter-eggo! And, it fixes the copy address being broken for bns names 