### PR TITLE
fix: uninvert imgs, closes #3208

### DIFF
--- a/src/app/components/global-styles/global-styles.tsx
+++ b/src/app/components/global-styles/global-styles.tsx
@@ -19,6 +19,10 @@ export const GlobalStyles = memo(() => {
       transition: filter 0.8s;
     }
 
+    img {
+      ${theme === 'dark' ? 'filter: invert(1) hue-rotate(-180deg)' : ''};
+    }
+
     body {
       &.no-scroll,
       &.no-scroll .main-content {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4221130533).<!-- Sticky Header Marker -->

Uninverts `img`s (not `svg`s, this messes with buttons)