### PR TITLE
fix: error thrown during account restore, wrong depth

### DIFF
--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
@@ -33,10 +33,10 @@ function bitcoinKeychainSelectorFactory(
 export function getNativeSegwitAddressFromMnemonic(secretKey: string) {
   return (index: number) => {
     const rootNode = mnemonicToRootNode(secretKey);
-    const account = deriveIndexZeroKeychainFromAccount(
+    const addressIndexKeychain = deriveIndexZeroKeychainFromAccount(
       deriveNativeSegWitAccountFromHdKey(rootNode, 'mainnet')(index)
     );
-    return getNativeSegWitAddressIndexZero(account, 'mainnet');
+    return getNativeSegWitAddressIndexZero(addressIndexKeychain, 'mainnet');
   };
 }
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4223088088).<!-- Sticky Header Marker -->

**wip**
Glad I added the depth checks because I was checking wrong addresses during account restore. Though can't replicate the error thrown 🤔 