### PR TITLE
fix: ordinal caching

### DIFF
--- a/src/app/query/bitcoin/ordinals/ordinals.query.ts
+++ b/src/app/query/bitcoin/ordinals/ordinals.query.ts
@@ -172,9 +172,9 @@ export function useGetOrdinalsQuery() {
     },
     {
       enabled: Boolean(keychain),
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
       refetchOnMount: false,
-      staleTime: 5 * 60 * 1000,
+      staleTime: 10 * 1000,
     }
   );
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4227569802).<!-- Sticky Header Marker -->

Changed query options to match bitcoin tx refetching.

*For testing