### PR TITLE
fix: tabIndex error, recreating html behaviour in js

### DIFF
--- a/src/app/features/collectibles/components/base-collectible.tsx
+++ b/src/app/features/collectibles/components/base-collectible.tsx
@@ -21,7 +21,16 @@ export function BaseCollectible({
   children,
 }: BaseCollectibleProps) {
   return (
-    <Box as="button" onClick={onClick}>
+    <Box
+      as="button"
+      onClick={onClick}
+      _focus={{
+        outline: '#CEDAFA solid 4px',
+      }}
+      sx={{
+        borderRadius: '16px',
+      }}
+    >
       <Box pb="base">
         <Box
           sx={{

--- a/src/app/features/collectibles/components/base-collectible.tsx
+++ b/src/app/features/collectibles/components/base-collectible.tsx
@@ -21,14 +21,7 @@ export function BaseCollectible({
   children,
 }: BaseCollectibleProps) {
   return (
-    <Box
-      tabindex="0"
-      onKeyDown={e => {
-        if (['Space', 'Enter'].includes(e.code)) {
-          onClick();
-        }
-      }}
-    >
+    <Box as="button" onClick={onClick}>
       <Box pb="base">
         <Box
           sx={{
@@ -38,7 +31,6 @@ export function BaseCollectible({
           }}
         >
           <Box
-            onClick={onClick}
             borderRadius="16px"
             backgroundColor="black"
             sx={{
@@ -52,7 +44,6 @@ export function BaseCollectible({
               alignItems: 'center',
               justifyContent: 'center',
             }}
-            _hover={{ cursor: 'pointer' }}
             {...backgroundElementProps}
           >
             {children}

--- a/src/app/features/collectibles/components/base-collectible.tsx
+++ b/src/app/features/collectibles/components/base-collectible.tsx
@@ -50,7 +50,7 @@ export function BaseCollectible({
           </Box>
         </Box>
       </Box>
-      <Box pb="base-tight" pl="tight">
+      <Box pb="base-tight" pl="tight" textAlign="initial">
         <Text pb="extra-tight" fontWeight="500" color={color('text-body')}>
           {title}
         </Text>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4232488826).<!-- Sticky Header Marker -->

It's best to avoid using js to replicate native html behaviours.

```ts
      tabindex="0"
      onKeyDown={e => {
        if (['Space', 'Enter'].includes(e.code)) {
          onClick();
        }
      }}
```

is only needed because it's not a button element. A better solution is to make it a button, than replicating the behaviours of a button in js.

https://web.dev/learn/accessibility/javascript/#trigger-events
https://developer.mozilla.org/en-US/docs/Learn/Accessibility/WAI-ARIA_basics
https://medium.com/@matuzo/writing-javascript-with-accessibility-in-mind-a1f6a5f467b9

If this change goes against the design, we should use the `focus-within` css property, which lets us add styles to parents of a button with focus https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within