### PR TITLE
Restore form values set on a given tab

### DIFF
--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -304,6 +304,10 @@ export function whenPageMode<T>(pageModeMap: WhenPageModeMap<T>) {
   return pageModeMap[pageMode];
 }
 
+export function isPopupMode() {
+  return pageMode === 'popup';
+}
+
 interface WhenChainIdMap<T> {
   [ChainID.Mainnet]: T;
   [ChainID.Testnet]: T;

--- a/src/app/features/container/container.tsx
+++ b/src/app/features/container/container.tsx
@@ -1,11 +1,31 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 
+import { noop } from '@shared/utils';
+
+import { useOnMount } from '@app/common/hooks/use-on-mount';
+import { whenPageMode } from '@app/common/utils';
 import { useRouteHeaderState } from '@app/store/ui/ui.hooks';
 
 import { ContainerLayout } from './container.layout';
 
 export function Container() {
   const [routeHeader] = useRouteHeaderState();
+  const navigate = useNavigate();
+
+  useOnMount(() =>
+    whenPageMode({
+      full: noop,
+      popup: () => {
+        try {
+          const storageVal = localStorage.getItem('btc-form-state');
+          if (!storageVal) return;
+          const result = JSON.parse(storageVal);
+          navigate('send/btc', { state: result });
+          localStorage.removeItem('btc-form-state');
+        } catch (e) {}
+      },
+    })()
+  );
 
   return (
     <ContainerLayout header={routeHeader}>

--- a/src/app/features/container/container.tsx
+++ b/src/app/features/container/container.tsx
@@ -1,31 +1,14 @@
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
-import { noop } from '@shared/utils';
-
-import { useOnMount } from '@app/common/hooks/use-on-mount';
-import { whenPageMode } from '@app/common/utils';
 import { useRouteHeaderState } from '@app/store/ui/ui.hooks';
 
+import { useRestoreFormState } from '../popup-send-form-restoration/use-restore-form-state';
 import { ContainerLayout } from './container.layout';
 
 export function Container() {
   const [routeHeader] = useRouteHeaderState();
-  const navigate = useNavigate();
 
-  useOnMount(() =>
-    whenPageMode({
-      full: noop,
-      popup: () => {
-        try {
-          const storageVal = localStorage.getItem('btc-form-state');
-          if (!storageVal) return;
-          const result = JSON.parse(storageVal);
-          navigate('send/btc', { state: result });
-          localStorage.removeItem('btc-form-state');
-        } catch (e) {}
-      },
-    })()
-  );
+  useRestoreFormState();
 
   return (
     <ContainerLayout header={routeHeader}>

--- a/src/app/features/popup-send-form-restoration/use-restore-form-state.ts
+++ b/src/app/features/popup-send-form-restoration/use-restore-form-state.ts
@@ -1,0 +1,32 @@
+import { useNavigate } from 'react-router-dom';
+
+import { InternalMethods } from '@shared/message-types';
+import { getActiveTab } from '@shared/utils/get-active-tab';
+
+import { useOnMount } from '@app/common/hooks/use-on-mount';
+import { isPopupMode } from '@app/common/utils';
+
+// Would rather use the `useAsync` hook to call this promise, however this is
+// excuted later in the lifecycle of the app, which causes the homepage to
+// render first.
+let currentTabId = 0;
+async function run() {
+  const tab = await getActiveTab();
+  currentTabId = tab.id ?? 0;
+}
+void run();
+
+export function useRestoreFormState() {
+  const navigate = useNavigate();
+
+  useOnMount(() => {
+    if (!isPopupMode() || !currentTabId) return;
+    chrome.runtime.sendMessage(
+      { method: InternalMethods.GetActiveFormState, payload: { tabId: currentTabId } },
+      persistedState => {
+        if (!persistedState || !persistedState.symbol) return;
+        navigate('send/' + persistedState.symbol, { state: persistedState });
+      }
+    );
+  });
+}

--- a/src/app/features/popup-send-form-restoration/use-update-persisted-send-form-values.ts
+++ b/src/app/features/popup-send-form-restoration/use-update-persisted-send-form-values.ts
@@ -1,0 +1,23 @@
+import { useAsync } from 'react-async-hook';
+
+import { InternalMethods } from '@shared/message-types';
+import { BitcoinSendFormValues } from '@shared/models/form.model';
+import { getActiveTab } from '@shared/utils/get-active-tab';
+
+import { isPopupMode } from '@app/common/utils';
+
+export function useUpdatePersistedSendFormValues() {
+  const activeTab = useAsync(getActiveTab, []).result;
+
+  function onFormStateChange(state: BitcoinSendFormValues) {
+    if (!isPopupMode()) return;
+    if (!activeTab) return;
+
+    chrome.runtime.sendMessage({
+      method: InternalMethods.SetActiveFormState,
+      payload: { tabId: activeTab.id, ...state },
+    });
+  }
+
+  return { onFormStateChange };
+}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
 import { Box } from '@stacks/ui';
@@ -6,13 +5,12 @@ import { Form, Formik } from 'formik';
 
 import { HIGH_FEE_WARNING_LEARN_MORE_URL_BTC } from '@shared/constants';
 import { RouteUrls } from '@shared/route-urls';
-import { noop } from '@shared/utils';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
-import { whenPageMode } from '@app/common/utils';
 import { Header } from '@app/components/header';
 import { BtcIcon } from '@app/components/icons/btc-icon';
 import { HighFeeDrawer } from '@app/features/high-fee-drawer/high-fee-drawer';
+import { useUpdatePersistedSendFormValues } from '@app/features/popup-send-form-restoration/use-update-persisted-send-form-values';
 import { useBitcoinAssetBalance } from '@app/query/bitcoin/address/address.hooks';
 import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
@@ -43,20 +41,10 @@ export function BtcSendForm() {
   const btcBalance = useBitcoinAssetBalance(currentAccountBtcAddress);
 
   const calcMaxSpend = useCalculateMaxBitcoinSpend();
-  const [formState, setFormState] = useState(null);
-
-  useEffect(() => {
-    whenPageMode({
-      full: noop,
-      popup: () => {
-        // eslint-disable-next-line no-console
-        console.log('form values changes', formState);
-        localStorage.setItem('btc-form-state', JSON.stringify(formState));
-      },
-    })();
-  }, [formState]);
 
   const { validationSchema, currentNetwork, formRef, previewTransaction } = useBtcSendForm();
+
+  const { onFormStateChange } = useUpdatePersistedSendFormValues();
 
   return (
     <SendCryptoAssetFormLayout>
@@ -68,7 +56,7 @@ export function BtcSendForm() {
         {...defaultSendFormFormikProps}
       >
         {props => {
-          setFormState(props.values as any);
+          onFormStateChange(props.values);
           return (
             <Form>
               <AmountField

--- a/src/shared/message-types.ts
+++ b/src/shared/message-types.ts
@@ -20,6 +20,8 @@ export enum ExternalMethods {
 
 export enum InternalMethods {
   RequestDerivedStxAccounts = 'RequestDerivedStxAccounts',
+  GetActiveFormState = 'GetActiveFormState',
+  SetActiveFormState = 'SetActiveFormState',
   ShareInMemoryKeyToBackground = 'ShareInMemoryKeyToBackground',
   RequestInMemoryKeys = 'RequestInMemoryKeys',
   RemoveInMemoryKeys = 'RemoveInMemoryKeys',

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -13,6 +13,13 @@ export type RequestDerivedStxAccounts = BackgroundMessage<
   { secretKey: string; highestAccountIndex: number }
 >;
 
+type GetActiveFormState = BackgroundMessage<InternalMethods.GetActiveFormState, { tabId: number }>;
+
+type SetActiveFormState = BackgroundMessage<
+  InternalMethods.SetActiveFormState,
+  { tabId: number; symbol: string; amount?: string; recipient?: string }
+>;
+
 type ShareInMemoryKeyToBackground = BackgroundMessage<
   InternalMethods.ShareInMemoryKeyToBackground,
   { secretKey: string; keyId: string }
@@ -29,6 +36,8 @@ type OriginatingTabClosed = BackgroundMessage<
 
 export type BackgroundMessages =
   | RequestDerivedStxAccounts
+  | GetActiveFormState
+  | SetActiveFormState
   | ShareInMemoryKeyToBackground
   | RequestInMemoryKeys
   | RemoveInMemoryKeys

--- a/src/shared/utils/get-active-tab.ts
+++ b/src/shared/utils/get-active-tab.ts
@@ -1,0 +1,5 @@
+export function getActiveTab(): Promise<chrome.tabs.Tab> {
+  return new Promise(resolve =>
+    chrome.tabs.query({ currentWindow: true, active: true }, tabs => resolve(tabs[0]))
+  );
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4245854678).<!-- Sticky Header Marker -->

The wallet has a bad UX when trying to use pop up mode, as the form resets on close/open. This is especially evident with the below interaction on Gamma.

<details>
<summary>Bad UX demo</summary>

**Bad UX**

https://user-images.githubusercontent.com/1618764/220351168-8d10ab6a-166b-4f01-aade-d92b69444944.mp4


</details>



<details>
<summary>POC</summary>

This PR demos a way we can persist the form state, and route back to it on popup load. It reuses the same route state logic needed to persist form values when returning from the preview screen. The code isn't complete, I wouldn't want to use `localStorage`, and would want a way tidier implementation of this feature, but presenting the work here as a POC.

Ideally we'd use `chrome.storage.session` however this is MV3 only. We'd also want to consider how to: 1) remove the cache, as it should expire, 2) tie to domain origin?

**Good UX**

https://user-images.githubusercontent.com/1618764/220352481-81924904-af81-4409-9e19-68595a1a8466.mp4

</details>

**Proposed behaviour**

Below demos how I propose form restoration works. When a form is edited, we message the background script with the values, and the associated `chrome.tab.Tab` id. We persist these in a `Map`, that exists for the lifecycle of the background script. Keying by tab id ensures values are local to a given page's context. (If I enter values on Gamma, they shouldn't reappear on PlanBetter).

When the popup view is opened, we query the background script to see if there are any form values saved for the given tab id. If there are, we navigate to the send form of the given `symbol`, and set the remaining values as form state. It's then up to the form to handle and set these values. Using route state creates a nice abstraction in that the form remains entirely unaware of this feature.

One complexity of a feature like this is managing how long to persist the form state. By tying the state to a given tab id, we limit this to the life cycle of the tab itself. A background script listener listens for tab closures, and removes any existing state from the `Map`.

Note, these behaviours will change with MV3. Rather than persisting state in the service worker, we'd instead better use `chrome.storage.session` and persisting this with redux persist, as we do other state.

https://user-images.githubusercontent.com/1618764/220702491-feb64b64-c880-4b61-8871-6ea530a57151.mp4
