### PR TITLE
feat: return btc address during auth, closes #2909

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "@stacks/ui-core": "7.3.0",
     "@stacks/ui-theme": "7.5.0",
     "@stacks/ui-utils": "7.5.0",
-    "@stacks/wallet-sdk": "6.1.2-pr.4e0feae.0",
+    "@stacks/wallet-sdk": "6.2.0",
     "@styled-system/theme-get": "5.1.2",
     "@tanstack/query-sync-storage-persister": "4.24.4",
     "@tanstack/react-query": "4.24.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "@stacks/ui-core": "7.3.0",
     "@stacks/ui-theme": "7.5.0",
     "@stacks/ui-utils": "7.5.0",
-    "@stacks/wallet-sdk": "6.1.1",
+    "@stacks/wallet-sdk": "6.1.2-pr.4e0feae.0",
     "@styled-system/theme-get": "5.1.2",
     "@tanstack/query-sync-storage-persister": "4.24.4",
     "@tanstack/react-query": "4.24.4",

--- a/src/app/common/authentication/use-finish-auth-request.ts
+++ b/src/app/common/authentication/use-finish-auth-request.ts
@@ -15,6 +15,7 @@ import { useAuthRequestParams } from '@app/common/hooks/auth/use-auth-request-pa
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 import { useWalletType } from '@app/common/use-wallet-type';
+import { useAllBitcoinNativeSegWitNetworksByAccount } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useStacksAccounts } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useStacksWallet } from '@app/store/accounts/blockchain/stacks/stacks-keychain';
 
@@ -25,6 +26,8 @@ export function useFinishAuthRequest() {
   const { walletType } = useWalletType();
   const accounts = useStacksAccounts();
   const { origin, tabId } = useAuthRequestParams();
+
+  const deriveNativeSegWitAccountAtIndex = useAllBitcoinNativeSegWitNetworksByAccount();
 
   return useCallback(
     async (accountIndex: number) => {
@@ -76,6 +79,11 @@ export function useFinishAuthRequest() {
           transitPublicKey: decodedAuthRequest.public_keys[0],
           scopes: decodedAuthRequest.scopes,
           account: legacyAccount,
+          additionalData: {
+            btcAddress: {
+              p2wpkh: deriveNativeSegWitAccountAtIndex(accountIndex),
+            },
+          },
         });
         keyActions.switchAccount(accountIndex);
         finalizeAuthResponse({
@@ -89,15 +97,16 @@ export function useFinishAuthRequest() {
     },
     [
       accounts,
+      wallet,
+      decodedAuthRequest,
+      authRequest,
+      origin,
+      tabId,
+      walletType,
       appIcon,
       appName,
-      authRequest,
-      decodedAuthRequest,
+      deriveNativeSegWitAccountAtIndex,
       keyActions,
-      origin,
-      wallet,
-      walletType,
-      tabId,
     ]
   );
 }

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -317,6 +317,11 @@ export function whenStxChainId(chainId: ChainID) {
   return <T>(chainIdMap: WhenChainIdMap<T>): T => chainIdMap[chainId];
 }
 
+type NetworkMap<T> = Record<NetworkModes, T>;
+export function whenNetwork(mode: NetworkModes) {
+  return <T>(networkMap: NetworkMap<T>): T => networkMap[mode];
+}
+
 export function sumNumbers(nums: number[]) {
   return nums.reduce((acc, num) => acc.plus(num), new BigNumber(0));
 }

--- a/src/app/pages/send/choose-crypto-asset/choose-crypto-asset.tsx
+++ b/src/app/pages/send/choose-crypto-asset/choose-crypto-asset.tsx
@@ -4,6 +4,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { useAllTransferableCryptoAssetBalances } from '@app/common/hooks/use-transferable-asset-balances.hooks';
+import { useWalletType } from '@app/common/use-wallet-type';
 import { Header } from '@app/components/header';
 
 import { ChooseCryptoAssetLayout } from './components/choose-crypto-asset.layout';
@@ -12,12 +13,20 @@ import { CryptoAssetList } from './components/crypto-asset-list';
 export function ChooseCryptoAsset() {
   const navigate = useNavigate();
   const allTransferableCryptoAssetBalances = useAllTransferableCryptoAssetBalances();
+  const { whenWallet } = useWalletType();
 
   useRouteHeader(<Header hideActions onClose={() => navigate(RouteUrls.Home)} title=" " />);
 
   return (
     <ChooseCryptoAssetLayout>
-      <CryptoAssetList cryptoAssetBalances={allTransferableCryptoAssetBalances} />
+      <CryptoAssetList
+        cryptoAssetBalances={allTransferableCryptoAssetBalances.filter(balance =>
+          whenWallet({
+            ledger: balance.asset.symbol !== 'BTC',
+            software: true,
+          })
+        )}
+      />
     </ChooseCryptoAssetLayout>
   );
 }

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
@@ -2,10 +2,11 @@ import { createSelector } from '@reduxjs/toolkit';
 import { HDKey } from '@scure/bip32';
 
 import { NetworkModes } from '@shared/constants';
+import { deriveAddressIndexZeroFromAccount } from '@shared/crypto/bitcoin/bitcoin.utils';
 import { deriveTaprootAccountFromRootKeychain } from '@shared/crypto/bitcoin/p2tr-address-gen';
 import {
   deriveNativeSegWitAccountKeychain,
-  getNativeSegWitAddressIndex,
+  getNativeSegWitAddressIndexDetails,
 } from '@shared/crypto/bitcoin/p2wpkh-address-gen';
 
 import { mnemonicToRootNode } from '@app/common/keychain/keychain';
@@ -35,7 +36,10 @@ export function getNativeSegwitMainnetAddressFromMnemonic(secretKey: string) {
   return (accountIndex: number) => {
     const rootNode = mnemonicToRootNode(secretKey);
     const account = deriveNativeSegWitAccountKeychain(rootNode, 'mainnet')(accountIndex);
-    return getNativeSegWitAddressIndex(account, 'mainnet');
+    return getNativeSegWitAddressIndexDetails(
+      deriveAddressIndexZeroFromAccount(account),
+      'mainnet'
+    );
   };
 }
 

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
@@ -12,35 +12,49 @@ import { mnemonicToRootNode } from '@app/common/keychain/keychain';
 import { selectInMemoryKey } from '@app/store/in-memory-key/in-memory-key.selectors';
 import { selectCurrentKey } from '@app/store/keys/key.selectors';
 import { defaultKeyId } from '@app/store/keys/key.slice';
-import { selectCurrentNetwork } from '@app/store/networks/networks.selectors';
 
+// This factory selector extends from the wallet root keychain to derive child
+// keychains. It accepts a curried fn that takes a keychain and returns a fn
+// accepting an account index, to further derive a nested layer of derivation.
+// We use this approach to reuse code between both native segwit and taproot
+// keychains.
 function bitcoinKeychainSelectorFactory(
-  keychainFn: (hdkey: HDKey, network: NetworkModes) => (index: number) => HDKey
+  keychainFn: (hdkey: HDKey, network: NetworkModes) => (index: number) => HDKey,
+  network: NetworkModes
 ) {
-  return createSelector(
-    selectCurrentKey,
-    selectInMemoryKey,
-    selectCurrentNetwork,
-    (currentKey, inMemKey, network) => {
-      if (currentKey?.type !== 'software') return;
-      if (!inMemKey.keys[defaultKeyId]) throw new Error('No in-memory key found');
-      return keychainFn(mnemonicToRootNode(inMemKey.keys.default), network.chain.bitcoin.network);
-    }
-  );
+  return createSelector(selectCurrentKey, selectInMemoryKey, (currentKey, inMemKey) => {
+    if (currentKey?.type !== 'software') return;
+
+    if (!inMemKey.keys[defaultKeyId]) throw new Error('No in-memory key found');
+
+    return keychainFn(mnemonicToRootNode(inMemKey.keys.default), network);
+  });
 }
 
-export function getNativeSegwitAddressFromMnemonic(secretKey: string) {
-  return (index: number) => {
+export function getNativeSegwitMainnetAddressFromMnemonic(secretKey: string) {
+  return (accountIndex: number) => {
     const rootNode = mnemonicToRootNode(secretKey);
-    const account = deriveNativeSegWitAccountKeychain(rootNode, 'mainnet')(index);
+    const account = deriveNativeSegWitAccountKeychain(rootNode, 'mainnet')(accountIndex);
     return getNativeSegWitAddressIndex(account, 'mainnet');
   };
 }
 
-export const selectSoftwareBitcoinNativeSegWitKeychain = bitcoinKeychainSelectorFactory(
-  deriveNativeSegWitAccountKeychain
+export const selectMainnetNativeSegWitKeychain = bitcoinKeychainSelectorFactory(
+  deriveNativeSegWitAccountKeychain,
+  'mainnet'
 );
 
-export const selectSoftwareBitcoinTaprootKeychain = bitcoinKeychainSelectorFactory(
-  deriveTaprootAccountFromRootKeychain
+export const selectTestnetNativeSegWitKeychain = bitcoinKeychainSelectorFactory(
+  deriveNativeSegWitAccountKeychain,
+  'testnet'
+);
+
+export const selectMainnetTaprootKeychain = bitcoinKeychainSelectorFactory(
+  deriveTaprootAccountFromRootKeychain,
+  'mainnet'
+);
+
+export const selectTestnetTaprootKeychain = bitcoinKeychainSelectorFactory(
+  deriveTaprootAccountFromRootKeychain,
+  'testnet'
 );

--- a/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
@@ -4,14 +4,25 @@ import { useSelector } from 'react-redux';
 import { deriveTaprootReceiveAddressIndex } from '@shared/crypto/bitcoin/p2tr-address-gen';
 import { isUndefined } from '@shared/utils';
 
+import { whenNetwork } from '@app/common/utils';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useCurrentAccountIndex } from '../../account';
 import { formatBitcoinAccount, tempHardwareAccountForTesting } from './bitcoin-account.models';
-import { selectSoftwareBitcoinTaprootKeychain } from './bitcoin-keychain';
+import { selectMainnetTaprootKeychain, selectTestnetTaprootKeychain } from './bitcoin-keychain';
+
+function useTaprootKeychainByAccount() {
+  const network = useCurrentNetwork();
+  return useSelector(
+    whenNetwork(network.chain.bitcoin.network)({
+      mainnet: selectMainnetTaprootKeychain,
+      testnet: selectTestnetTaprootKeychain,
+    })
+  );
+}
 
 function useBitcoinTaprootAccount(index: number) {
-  const keychain = useSelector(selectSoftwareBitcoinTaprootKeychain);
+  const keychain = useTaprootKeychainByAccount();
   return useMemo(() => {
     // TODO: Remove with bitcoin Ledger integration
     if (isUndefined(keychain)) return tempHardwareAccountForTesting;
@@ -35,10 +46,6 @@ function useDeriveTaprootAccountIndexAddressIndexZero(xpub: string) {
       }),
     [xpub, network]
   );
-}
-
-function useTaprootKeychainByAccount() {
-  return useSelector(selectSoftwareBitcoinTaprootKeychain);
 }
 
 export function useCurrentTaprootAccountKeychain() {

--- a/src/app/store/keys/key.actions.ts
+++ b/src/app/store/keys/key.actions.ts
@@ -11,7 +11,7 @@ import { BitcoinClient } from '@app/query/bitcoin/bitcoin-client';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import { AppThunk } from '@app/store';
 
-import { getNativeSegwitAddressFromMnemonic } from '../accounts/blockchain/bitcoin/bitcoin-keychain';
+import { getNativeSegwitMainnetAddressFromMnemonic } from '../accounts/blockchain/bitcoin/bitcoin-keychain';
 import { getStacksAddressByIndex } from '../accounts/blockchain/stacks/stacks-keychain';
 import { stxChainSlice } from '../chains/stx-chain.slice';
 import { selectDefaultWalletKey } from '../in-memory-key/in-memory-key.selectors';
@@ -67,7 +67,7 @@ function setWalletEncryptionPassword(args: {
         const hasStxBalance = await doesStacksAddressHaveBalance(stxAddress);
         const hasNames = await doesStacksAddressHaveBnsName(stxAddress);
 
-        const btcAddress = getNativeSegwitAddressFromMnemonic(secretKey)(index);
+        const btcAddress = getNativeSegwitMainnetAddressFromMnemonic(secretKey)(index);
         const hasBtcBalance = await doesBitcoinAddressHaveBalance(btcAddress.address!);
         // TODO: add inscription check here also?
         return hasStxBalance || hasNames || hasBtcBalance;

--- a/src/app/store/networks/networks.selectors.ts
+++ b/src/app/store/networks/networks.selectors.ts
@@ -42,7 +42,7 @@ export const selectAppRequestedNetworkId = createSelector(selectNetworks, networ
   return findMatchingNetworkKey({ coreApiUrl, networkChainId, networks });
 });
 
-export const selectCurrentNetwork = createSelector(
+const selectCurrentNetwork = createSelector(
   selectNetworks,
   selectCurrentNetworkId,
   selectAppRequestedNetworkId,

--- a/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
@@ -19,7 +19,7 @@ export function deriveNativeSegWitAccountKeychain(keychain: HDKey, network: Netw
   return (index: number) => keychain.derive(getNativeSegWitAccountDerivationPath(network, index));
 }
 
-export function getNativeSegWitAddressIndex(keychain: HDKey, network: NetworkModes) {
+export function getNativeSegWitAddressIndexDetails(keychain: HDKey, network: NetworkModes) {
   if (keychain.depth !== DerivationPathDepth.AddressIndex)
     throw new Error('Keychain passed is not an address index');
 
@@ -38,5 +38,5 @@ export function deriveNativeSegWitReceiveAddressIndex({
   const keychain = HDKey.fromExtendedKey(xpub);
   if (!keychain) return;
   const zeroAddressIndex = deriveAddressIndexZeroFromAccount(keychain);
-  return getNativeSegWitAddressIndex(zeroAddressIndex, network);
+  return getNativeSegWitAddressIndexDetails(zeroAddressIndex, network);
 }

--- a/test-app/src/common/use-auth.ts
+++ b/test-app/src/common/use-auth.ts
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
+
 import { AppState, defaultState } from '@common/context';
 import { AppConfig, UserSession } from '@stacks/auth';
 import { AuthOptions } from '@stacks/connect';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3468,6 +3468,18 @@
     jsontokens "^4.0.1"
     query-string "^6.13.1"
 
+"@stacks/auth@^6.1.2-pr.4e0feae.0", "@stacks/auth@^6.1.2-pr.f3e03fa.0":
+  version "6.1.2-pr.f3e03fa.0"
+  resolved "https://registry.yarnpkg.com/@stacks/auth/-/auth-6.1.2-pr.f3e03fa.0.tgz#5481e6db6e5c3e26d2f70a3c3b2979fd07608558"
+  integrity sha512-mqeuEPzFNuHYb7kOcRsj03ceLCfMEGhpk6FUoIBsQPmDjPYP8b6bPIP+wU0hMJCQrQBpA3rdZaI22Cuhhkjw4A==
+  dependencies:
+    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/encryption" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/network" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/profile" "^6.1.2-pr.f3e03fa.0"
+    cross-fetch "^3.1.5"
+    jsontokens "^4.0.1"
+
 "@stacks/blockchain-api-client@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@stacks/blockchain-api-client/-/blockchain-api-client-6.3.4.tgz#b9746747ec0563791eb1f3d22dec35cd6a6d6296"
@@ -3497,6 +3509,14 @@
     "@types/bn.js" "^5.1.0"
     "@types/node" "^18.0.4"
     buffer "^6.0.3"
+
+"@stacks/common@^6.1.2-pr.4e0feae.0", "@stacks/common@^6.1.2-pr.f3e03fa.0":
+  version "6.1.2-pr.f3e03fa.0"
+  resolved "https://registry.yarnpkg.com/@stacks/common/-/common-6.1.2-pr.f3e03fa.0.tgz#e70370a2589477c305a1d7b224b7c484db3583bc"
+  integrity sha512-Rq1ToKTamP2O3K3S+BysNmeN9FjvdCREzVeDpK+r5Xzkw7TTfr/bjNXdI30IB5QSxPfjXpqU2rb77WKJH9bUZQ==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    "@types/node" "^18.0.4"
 
 "@stacks/connect-react@21.0.0":
   version "21.0.0"
@@ -3543,6 +3563,21 @@
     ripemd160-min "^0.0.6"
     varuint-bitcoin "^1.1.2"
 
+"@stacks/encryption@^6.1.2-pr.4e0feae.0", "@stacks/encryption@^6.1.2-pr.f3e03fa.0":
+  version "6.1.2-pr.f3e03fa.0"
+  resolved "https://registry.yarnpkg.com/@stacks/encryption/-/encryption-6.1.2-pr.f3e03fa.0.tgz#3fc5e412f8f440aed9f00cd8b91e8a4f513b090e"
+  integrity sha512-avx1phIylxRWxLiRXAL5QavAjMFPLN64VHLw8gh7A96B7hHmoWbo+DzKY2O8fe29H6A5mSEsXylPjMpES25vjg==
+  dependencies:
+    "@noble/hashes" "1.1.5"
+    "@noble/secp256k1" "1.7.1"
+    "@scure/bip39" "1.1.0"
+    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
+    "@types/node" "^18.0.4"
+    base64-js "^1.5.1"
+    bs58 "^5.0.0"
+    ripemd160-min "^0.0.6"
+    varuint-bitcoin "^1.1.2"
+
 "@stacks/eslint-config@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@stacks/eslint-config/-/eslint-config-1.2.0.tgz#40fccf1d96dbe48194f0be4c001cf98b611655ee"
@@ -3573,6 +3608,14 @@
     "@stacks/common" "^4.3.5"
     cross-fetch "^3.1.5"
 
+"@stacks/network@^6.1.2-pr.4e0feae.0", "@stacks/network@^6.1.2-pr.f3e03fa.0":
+  version "6.1.2-pr.f3e03fa.0"
+  resolved "https://registry.yarnpkg.com/@stacks/network/-/network-6.1.2-pr.f3e03fa.0.tgz#614e6adef3613c9a5d035152496a1948859a4071"
+  integrity sha512-FclXUn47tB/edHJoaifcpyA1pNuoNpwJOOUDc477PN8TrBBB85Tc8BE6Ysps5KrJk3xp8o7e5oR/FF5xLzu1fw==
+  dependencies:
+    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
+    cross-fetch "^3.1.5"
+
 "@stacks/prettier-config@0.0.10":
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/@stacks/prettier-config/-/prettier-config-0.0.10.tgz#a63915c1e466a1ca9b34d3947f448ac101764b94"
@@ -3599,6 +3642,18 @@
     schema-inspector "^2.0.2"
     zone-file "^2.0.0-beta.3"
 
+"@stacks/profile@^6.1.2-pr.4e0feae.0", "@stacks/profile@^6.1.2-pr.f3e03fa.0":
+  version "6.1.2-pr.f3e03fa.0"
+  resolved "https://registry.yarnpkg.com/@stacks/profile/-/profile-6.1.2-pr.f3e03fa.0.tgz#3e141433f38a9c4f42a05ef18dc450d068efda7c"
+  integrity sha512-PMX7si/Go3KcwQm0IEk/frtO0cHmnnk42QExFceuwhvSdSU9ZxPyyhLlG+04gNsX0G9cR5ZTPHag9Dq6t0pBXQ==
+  dependencies:
+    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/network" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/transactions" "^6.1.2-pr.f3e03fa.0"
+    jsontokens "^4.0.1"
+    schema-inspector "^2.0.2"
+    zone-file "^2.0.0-beta.3"
+
 "@stacks/rpc-client@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@stacks/rpc-client/-/rpc-client-1.0.3.tgz#2d9b2c9ba60eab276854789df84da8b910446a64"
@@ -3617,7 +3672,7 @@
   resolved "https://registry.yarnpkg.com/@stacks/stacks-blockchain-api-types/-/stacks-blockchain-api-types-6.3.4.tgz#40d672e352310ec5d4dd68dd2d28a9a4b76533a4"
   integrity sha512-zrjKPGJN4p1azzmh8j0Yj+ZjQ0L9F01qJjAxOtBpapmFbGr1NUuPT1GthIg76y+dobdjSDPN39LpoJG/FbWFLw==
 
-"@stacks/storage@6.1.1", "@stacks/storage@^6.1.1":
+"@stacks/storage@6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@stacks/storage/-/storage-6.1.1.tgz#3573fa416c90e341fa2e81f87f5c6d949ef691de"
   integrity sha512-zqbmoJ95L8DTgpQG5k0MvV8cornkrfTNnVEYDp7nefGiVnH3QR6Mx0xnKlOo4bI4ebHDJ0a2gtWo7Ke9HYEoUw==
@@ -3626,6 +3681,18 @@
     "@stacks/common" "^6.0.0"
     "@stacks/encryption" "^6.1.1"
     "@stacks/network" "^6.1.1"
+    base64-js "^1.5.1"
+    jsontokens "^4.0.1"
+
+"@stacks/storage@^6.1.2-pr.4e0feae.0":
+  version "6.1.2-pr.f3e03fa.0"
+  resolved "https://registry.yarnpkg.com/@stacks/storage/-/storage-6.1.2-pr.f3e03fa.0.tgz#2c5ec73c668def97bc7fcced14192cbb56501b88"
+  integrity sha512-6XOhhXxZibk5pfJqw88Ly33hWfSnGvPZHm+2ugM+05wO0GAo9/nkl/GNjONE/QwA5ROAhhOaCOcGNTFTY1oFLw==
+  dependencies:
+    "@stacks/auth" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/encryption" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/network" "^6.1.2-pr.f3e03fa.0"
     base64-js "^1.5.1"
     jsontokens "^4.0.1"
 
@@ -3657,6 +3724,18 @@
     ripemd160-min "^0.0.6"
     sha.js "^2.4.11"
     smart-buffer "^4.1.0"
+
+"@stacks/transactions@^6.1.2-pr.4e0feae.0", "@stacks/transactions@^6.1.2-pr.f3e03fa.0":
+  version "6.1.2-pr.f3e03fa.0"
+  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-6.1.2-pr.f3e03fa.0.tgz#d9675a5373a6d5c14de9d5c5e4c99d4f13d97a67"
+  integrity sha512-54qjEHa3Jk/kkLWxqWD3mXKkJ8MZCmQP+YkZwV6FIrFUsXbMpHx5JP30Y5Rl2A77SFXIsxSVX0max5z/Wh4hig==
+  dependencies:
+    "@noble/hashes" "1.1.5"
+    "@noble/secp256k1" "1.7.1"
+    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/network" "^6.1.2-pr.f3e03fa.0"
+    c32check "^2.0.0"
+    lodash.clonedeep "^4.5.0"
 
 "@stacks/ui-core@7.3.0", "@stacks/ui-core@^7.3.0":
   version "7.3.0"
@@ -3714,20 +3793,20 @@
     use-events "^1.4.1"
     use-onclickoutside "npm:use-onclickoutside-peer-deps@0.3.1"
 
-"@stacks/wallet-sdk@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@stacks/wallet-sdk/-/wallet-sdk-6.1.1.tgz#baf5e320c62d0383f120e34e1f823b319686bd97"
-  integrity sha512-VZ6JGctVY22J0TzX39d5lZ7TEMUxl5TlJF0C6SLcXCn8v80nC9icn/dYb/uq3DShPMavNdbLAe9D4tpE0RM6wg==
+"@stacks/wallet-sdk@6.1.2-pr.4e0feae.0":
+  version "6.1.2-pr.4e0feae.0"
+  resolved "https://registry.yarnpkg.com/@stacks/wallet-sdk/-/wallet-sdk-6.1.2-pr.4e0feae.0.tgz#3187836a28954ca2b5e3d9b51c45788c82e2a5b4"
+  integrity sha512-zmc4jKAVPwfBLca1tuCmsnonbOenAFuT4L0NWX5SJT5S/XAMoFNcYBwIsyJDwRR7FTq3yO94eyR+gls8Y32h+Q==
   dependencies:
     "@scure/bip32" "1.1.3"
     "@scure/bip39" "1.1.0"
-    "@stacks/auth" "^6.1.1"
-    "@stacks/common" "^6.0.0"
-    "@stacks/encryption" "^6.1.1"
-    "@stacks/network" "^6.1.1"
-    "@stacks/profile" "^6.1.1"
-    "@stacks/storage" "^6.1.1"
-    "@stacks/transactions" "^6.1.1"
+    "@stacks/auth" "^6.1.2-pr.4e0feae.0"
+    "@stacks/common" "^6.1.2-pr.4e0feae.0"
+    "@stacks/encryption" "^6.1.2-pr.4e0feae.0"
+    "@stacks/network" "^6.1.2-pr.4e0feae.0"
+    "@stacks/profile" "^6.1.2-pr.4e0feae.0"
+    "@stacks/storage" "^6.1.2-pr.4e0feae.0"
+    "@stacks/transactions" "^6.1.2-pr.4e0feae.0"
     buffer "^6.0.3"
     c32check "^2.0.0"
     jsontokens "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3468,15 +3468,15 @@
     jsontokens "^4.0.1"
     query-string "^6.13.1"
 
-"@stacks/auth@^6.1.2-pr.4e0feae.0", "@stacks/auth@^6.1.2-pr.f3e03fa.0":
-  version "6.1.2-pr.f3e03fa.0"
-  resolved "https://registry.yarnpkg.com/@stacks/auth/-/auth-6.1.2-pr.f3e03fa.0.tgz#5481e6db6e5c3e26d2f70a3c3b2979fd07608558"
-  integrity sha512-mqeuEPzFNuHYb7kOcRsj03ceLCfMEGhpk6FUoIBsQPmDjPYP8b6bPIP+wU0hMJCQrQBpA3rdZaI22Cuhhkjw4A==
+"@stacks/auth@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@stacks/auth/-/auth-6.2.0.tgz#454011a9b2c4700915f1caab60bde8f17d1710bb"
+  integrity sha512-ZE2OKLV9IRKw37SJ2L4Quuf2NlkUONaMNa0+uuJBONTs8MYdyB6T3EjkmD/fvGxiN65dsCdDzDx7BWtWWonBrQ==
   dependencies:
-    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/encryption" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/network" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/profile" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/common" "^6.0.0"
+    "@stacks/encryption" "^6.2.0"
+    "@stacks/network" "^6.1.1"
+    "@stacks/profile" "^6.2.0"
     cross-fetch "^3.1.5"
     jsontokens "^4.0.1"
 
@@ -3509,14 +3509,6 @@
     "@types/bn.js" "^5.1.0"
     "@types/node" "^18.0.4"
     buffer "^6.0.3"
-
-"@stacks/common@^6.1.2-pr.4e0feae.0", "@stacks/common@^6.1.2-pr.f3e03fa.0":
-  version "6.1.2-pr.f3e03fa.0"
-  resolved "https://registry.yarnpkg.com/@stacks/common/-/common-6.1.2-pr.f3e03fa.0.tgz#e70370a2589477c305a1d7b224b7c484db3583bc"
-  integrity sha512-Rq1ToKTamP2O3K3S+BysNmeN9FjvdCREzVeDpK+r5Xzkw7TTfr/bjNXdI30IB5QSxPfjXpqU2rb77WKJH9bUZQ==
-  dependencies:
-    "@types/bn.js" "^5.1.0"
-    "@types/node" "^18.0.4"
 
 "@stacks/connect-react@21.0.0":
   version "21.0.0"
@@ -3563,15 +3555,15 @@
     ripemd160-min "^0.0.6"
     varuint-bitcoin "^1.1.2"
 
-"@stacks/encryption@^6.1.2-pr.4e0feae.0", "@stacks/encryption@^6.1.2-pr.f3e03fa.0":
-  version "6.1.2-pr.f3e03fa.0"
-  resolved "https://registry.yarnpkg.com/@stacks/encryption/-/encryption-6.1.2-pr.f3e03fa.0.tgz#3fc5e412f8f440aed9f00cd8b91e8a4f513b090e"
-  integrity sha512-avx1phIylxRWxLiRXAL5QavAjMFPLN64VHLw8gh7A96B7hHmoWbo+DzKY2O8fe29H6A5mSEsXylPjMpES25vjg==
+"@stacks/encryption@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@stacks/encryption/-/encryption-6.2.0.tgz#86855aacc6e1f023994140cc4d54137f776f2dd6"
+  integrity sha512-l0jeTtnmP2fJJk4rHR8sUjFr67e8Pnz4p7RkiGZm7H+uQ6HKPchgAzySFzgO3EQegRpbUQA6UOPEWJRbdO/kzw==
   dependencies:
     "@noble/hashes" "1.1.5"
     "@noble/secp256k1" "1.7.1"
     "@scure/bip39" "1.1.0"
-    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/common" "^6.0.0"
     "@types/node" "^18.0.4"
     base64-js "^1.5.1"
     bs58 "^5.0.0"
@@ -3608,14 +3600,6 @@
     "@stacks/common" "^4.3.5"
     cross-fetch "^3.1.5"
 
-"@stacks/network@^6.1.2-pr.4e0feae.0", "@stacks/network@^6.1.2-pr.f3e03fa.0":
-  version "6.1.2-pr.f3e03fa.0"
-  resolved "https://registry.yarnpkg.com/@stacks/network/-/network-6.1.2-pr.f3e03fa.0.tgz#614e6adef3613c9a5d035152496a1948859a4071"
-  integrity sha512-FclXUn47tB/edHJoaifcpyA1pNuoNpwJOOUDc477PN8TrBBB85Tc8BE6Ysps5KrJk3xp8o7e5oR/FF5xLzu1fw==
-  dependencies:
-    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
-    cross-fetch "^3.1.5"
-
 "@stacks/prettier-config@0.0.10":
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/@stacks/prettier-config/-/prettier-config-0.0.10.tgz#a63915c1e466a1ca9b34d3947f448ac101764b94"
@@ -3642,14 +3626,14 @@
     schema-inspector "^2.0.2"
     zone-file "^2.0.0-beta.3"
 
-"@stacks/profile@^6.1.2-pr.4e0feae.0", "@stacks/profile@^6.1.2-pr.f3e03fa.0":
-  version "6.1.2-pr.f3e03fa.0"
-  resolved "https://registry.yarnpkg.com/@stacks/profile/-/profile-6.1.2-pr.f3e03fa.0.tgz#3e141433f38a9c4f42a05ef18dc450d068efda7c"
-  integrity sha512-PMX7si/Go3KcwQm0IEk/frtO0cHmnnk42QExFceuwhvSdSU9ZxPyyhLlG+04gNsX0G9cR5ZTPHag9Dq6t0pBXQ==
+"@stacks/profile@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@stacks/profile/-/profile-6.2.0.tgz#70e890a51736af6f7f17b1c4c7c30c270a651117"
+  integrity sha512-3Ib7Y4/gX33S6dywBarLTtCwV0t+1lQGNkpOMhU3tLxA0zgL5NPvfP0x33iZzG9oF0aj13y3z+mT1USVxPEVhQ==
   dependencies:
-    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/network" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/transactions" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/common" "^6.0.0"
+    "@stacks/network" "^6.1.1"
+    "@stacks/transactions" "^6.2.0"
     jsontokens "^4.0.1"
     schema-inspector "^2.0.2"
     zone-file "^2.0.0-beta.3"
@@ -3684,15 +3668,15 @@
     base64-js "^1.5.1"
     jsontokens "^4.0.1"
 
-"@stacks/storage@^6.1.2-pr.4e0feae.0":
-  version "6.1.2-pr.f3e03fa.0"
-  resolved "https://registry.yarnpkg.com/@stacks/storage/-/storage-6.1.2-pr.f3e03fa.0.tgz#2c5ec73c668def97bc7fcced14192cbb56501b88"
-  integrity sha512-6XOhhXxZibk5pfJqw88Ly33hWfSnGvPZHm+2ugM+05wO0GAo9/nkl/GNjONE/QwA5ROAhhOaCOcGNTFTY1oFLw==
+"@stacks/storage@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@stacks/storage/-/storage-6.2.0.tgz#4743c1ca3d283476e13ba860293f4fd282c39479"
+  integrity sha512-RgNy57pCt+KdQzFdG/3BVFrXQewtzFO+HuneSiAbHbUej6CqaiZbY/eTaOldccQDsxCjQsS4I8WS9L8dg3Hbdg==
   dependencies:
-    "@stacks/auth" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/encryption" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/network" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/auth" "^6.2.0"
+    "@stacks/common" "^6.0.0"
+    "@stacks/encryption" "^6.2.0"
+    "@stacks/network" "^6.1.1"
     base64-js "^1.5.1"
     jsontokens "^4.0.1"
 
@@ -3725,15 +3709,15 @@
     sha.js "^2.4.11"
     smart-buffer "^4.1.0"
 
-"@stacks/transactions@^6.1.2-pr.4e0feae.0", "@stacks/transactions@^6.1.2-pr.f3e03fa.0":
-  version "6.1.2-pr.f3e03fa.0"
-  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-6.1.2-pr.f3e03fa.0.tgz#d9675a5373a6d5c14de9d5c5e4c99d4f13d97a67"
-  integrity sha512-54qjEHa3Jk/kkLWxqWD3mXKkJ8MZCmQP+YkZwV6FIrFUsXbMpHx5JP30Y5Rl2A77SFXIsxSVX0max5z/Wh4hig==
+"@stacks/transactions@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-6.2.0.tgz#cd7a68c32d4f361e358bca4fa6f424680fa84caf"
+  integrity sha512-FUqcCNhCC5VlPvfUeeC6TB0gUifFj06E9xlWKbi2jB+oObh6XNBu4fS6I4EKxF1tEtUX9RNXcVbKDgMlX38syw==
   dependencies:
     "@noble/hashes" "1.1.5"
     "@noble/secp256k1" "1.7.1"
-    "@stacks/common" "^6.1.2-pr.f3e03fa.0"
-    "@stacks/network" "^6.1.2-pr.f3e03fa.0"
+    "@stacks/common" "^6.0.0"
+    "@stacks/network" "^6.1.1"
     c32check "^2.0.0"
     lodash.clonedeep "^4.5.0"
 
@@ -3793,20 +3777,20 @@
     use-events "^1.4.1"
     use-onclickoutside "npm:use-onclickoutside-peer-deps@0.3.1"
 
-"@stacks/wallet-sdk@6.1.2-pr.4e0feae.0":
-  version "6.1.2-pr.4e0feae.0"
-  resolved "https://registry.yarnpkg.com/@stacks/wallet-sdk/-/wallet-sdk-6.1.2-pr.4e0feae.0.tgz#3187836a28954ca2b5e3d9b51c45788c82e2a5b4"
-  integrity sha512-zmc4jKAVPwfBLca1tuCmsnonbOenAFuT4L0NWX5SJT5S/XAMoFNcYBwIsyJDwRR7FTq3yO94eyR+gls8Y32h+Q==
+"@stacks/wallet-sdk@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@stacks/wallet-sdk/-/wallet-sdk-6.2.0.tgz#d760b52e39901f6c7053e54fc719365de9fd3753"
+  integrity sha512-5mPn2NOAXLjp/hSD8Ot1wBhDRvcv5LewEAsznN9MG0wK01OxYCMTq0KzlgMZRWcBxUjyIh7XStIdUYGSYVj03Q==
   dependencies:
     "@scure/bip32" "1.1.3"
     "@scure/bip39" "1.1.0"
-    "@stacks/auth" "^6.1.2-pr.4e0feae.0"
-    "@stacks/common" "^6.1.2-pr.4e0feae.0"
-    "@stacks/encryption" "^6.1.2-pr.4e0feae.0"
-    "@stacks/network" "^6.1.2-pr.4e0feae.0"
-    "@stacks/profile" "^6.1.2-pr.4e0feae.0"
-    "@stacks/storage" "^6.1.2-pr.4e0feae.0"
-    "@stacks/transactions" "^6.1.2-pr.4e0feae.0"
+    "@stacks/auth" "^6.2.0"
+    "@stacks/common" "^6.0.0"
+    "@stacks/encryption" "^6.2.0"
+    "@stacks/network" "^6.1.1"
+    "@stacks/profile" "^6.2.0"
+    "@stacks/storage" "^6.2.0"
+    "@stacks/transactions" "^6.2.0"
     buffer "^6.0.3"
     c32check "^2.0.0"
     jsontokens "^4.0.1"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4252690108).<!-- Sticky Header Marker -->

This PR adds returning of btc addresses during auth. 

I had to make [changes to `@stacks/wallet-sdk`](https://github.com/hirosystems/stacks.js/pull/1450) to support this. It follows a similar structure to `stxAddress` but for bitcoin, and nested by payment type.

```js
{
  btcAddress: {
    p2wpkh: {
      mainnet: "bc1qp2tmhmsgr4p9rtw3t2cm4za6xz5zkqukmf6a9c",
      testnet: "tb1qdlr74plsdz0ew5qdfqyr9da2nxqdqtsl4fmq5v"
    }
  }
}
```

I had to do a small refactor of the keychain code to be able to pull both networks, rather than just the current one.

https://user-images.githubusercontent.com/1618764/220606725-9d7935bf-9738-42b2-9ef6-231c42a7674f.mp4

 <br />

(Auth takes ages because of Gaia network requests ✨ )

cc/ @aulneau 