### PR TITLE
fix: gamma route and add analytics

### DIFF
--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -103,7 +103,7 @@ export function SettingsDropdown() {
             <MenuItem
               data-testid={SettingsSelectors.ToggleTheme}
               onClick={wrappedCloseCallback(() => {
-                void analytics.track('change_theme_menu_item');
+                void analytics.track('click_change_theme_menu_item');
                 navigate(RouteUrls.ChangeTheme, { relative: 'path' });
               })}
             >
@@ -114,7 +114,10 @@ export function SettingsDropdown() {
               popup: (
                 <MenuItem
                   data-testid={SettingsMenuSelectors.OpenWalletInNewTab}
-                  onClick={() => openIndexPageInNewTab(location.pathname)}
+                  onClick={() => {
+                    void analytics.track('click_open_in_new_tab_menu_item');
+                    openIndexPageInNewTab(location.pathname);
+                  }}
                 >
                   <Stack isInline>
                     <Box>Open in new tab</Box>
@@ -152,7 +155,7 @@ export function SettingsDropdown() {
             <MenuItem
               data-testid={SettingsSelectors.ChangeNetworkAction}
               onClick={wrappedCloseCallback(() => {
-                void analytics.track('choose_to_change_network');
+                void analytics.track('click_change_network_menu_item');
                 navigate(RouteUrls.SelectNetwork, { relative: 'path' });
               })}
             >

--- a/src/app/pages/receive/receive-collectible/receive-collectible-oridinal.tsx
+++ b/src/app/pages/receive/receive-collectible/receive-collectible-oridinal.tsx
@@ -44,7 +44,10 @@ export function ReceiveCollectibleOrdinal() {
               color={color('accent')}
               fontSize={1}
               isInline
-              onClick={() => openInNewTab('https://gamma.io/')}
+              onClick={() => {
+                void analytics.track('go_to_create_ordinal_on_gamma');
+                openInNewTab('https://gamma.io/ordinals');
+              }}
               spacing="extra-tight"
               textDecoration="underline"
               type="button"
@@ -59,7 +62,10 @@ export function ReceiveCollectibleOrdinal() {
               color={color('accent')}
               fontSize={1}
               isInline
-              onClick={() => openInNewTab('https://ordinalsbot.com/')}
+              onClick={() => {
+                void analytics.track('go_to_create_ordinal_on_ordinalsbot');
+                openInNewTab('https://ordinalsbot.com/');
+              }}
               spacing="extra-tight"
               textDecoration="underline"
               type="button"

--- a/src/app/pages/receive/receive-collectible/receive-collectible.tsx
+++ b/src/app/pages/receive/receive-collectible/receive-collectible.tsx
@@ -51,7 +51,7 @@ export function ReceiveCollectible() {
                     borderRadius="10px"
                     mode="tertiary"
                     onClick={() => {
-                      analytics.track('select_inscription_to_add_new_collectible');
+                      void analytics.track('select_inscription_to_add_new_collectible');
                       navigate(RouteUrls.ReceiveCollectibleOrdinal, { state: { btcAddress } });
                     }}
                   >


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4247281327).<!-- Sticky Header Marker -->

This PR fixes our route to Gamma so it goes straight to their ordinals page to create a new ordinal.