### PR TITLE
fix: support form restore for non-btc currencies, clear on exit

### DIFF
--- a/src/app/features/popup-send-form-restoration/use-update-persisted-send-form-values.ts
+++ b/src/app/features/popup-send-form-restoration/use-update-persisted-send-form-values.ts
@@ -1,7 +1,7 @@
+import { useEffect } from 'react';
 import { useAsync } from 'react-async-hook';
 
 import { InternalMethods } from '@shared/message-types';
-import { BitcoinSendFormValues } from '@shared/models/form.model';
 import { getActiveTab } from '@shared/utils/get-active-tab';
 
 import { isPopupMode } from '@app/common/utils';
@@ -9,7 +9,7 @@ import { isPopupMode } from '@app/common/utils';
 export function useUpdatePersistedSendFormValues() {
   const activeTab = useAsync(getActiveTab, []).result;
 
-  function onFormStateChange(state: BitcoinSendFormValues) {
+  function onFormStateChange(state: { recipient: string; amount: string | number }) {
     if (!isPopupMode()) return;
     if (!activeTab) return;
 
@@ -18,6 +18,18 @@ export function useUpdatePersistedSendFormValues() {
       payload: { tabId: activeTab.id, ...state },
     });
   }
+
+  useEffect(
+    () => () => {
+      if (!isPopupMode()) return;
+      if (!activeTab) return;
+      chrome.runtime.sendMessage({
+        method: InternalMethods.SetActiveFormState,
+        payload: { tabId: activeTab.id },
+      });
+    },
+    [activeTab]
+  );
 
   return { onFormStateChange };
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -8,7 +8,6 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { BtcIcon } from '@app/components/icons/btc-icon';
 import { HighFeeDrawer } from '@app/features/high-fee-drawer/high-fee-drawer';
-import { useUpdatePersistedSendFormValues } from '@app/features/popup-send-form-restoration/use-update-persisted-send-form-values';
 import { useBitcoinAssetBalance } from '@app/query/bitcoin/address/address.hooks';
 import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
@@ -36,9 +35,8 @@ export function BtcSendForm() {
 
   const calcMaxSpend = useCalculateMaxBitcoinSpend();
 
-  const { validationSchema, currentNetwork, formRef, previewTransaction } = useBtcSendForm();
-
-  const { onFormStateChange } = useUpdatePersistedSendFormValues();
+  const { validationSchema, currentNetwork, formRef, previewTransaction, onFormStateChange } =
+    useBtcSendForm();
 
   return (
     <SendCryptoAssetFormLayout>

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -20,6 +20,7 @@ import {
   btcMinimumSpendValidator,
 } from '@app/common/validation/forms/amount-validators';
 import { btcAmountPrecisionValidator } from '@app/common/validation/forms/currency-validators';
+import { useUpdatePersistedSendFormValues } from '@app/features/popup-send-form-restoration/use-update-persisted-send-form-values';
 import { useBitcoinAssetBalance } from '@app/query/bitcoin/address/address.hooks';
 import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
@@ -39,9 +40,12 @@ export function useBtcSendForm() {
   const sendFormNavigate = useSendFormNavigate();
   const generateTx = useGenerateSignedBitcoinTx();
   const calcMaxSpend = useCalculateMaxBitcoinSpend();
+  const { onFormStateChange } = useUpdatePersistedSendFormValues();
 
   return {
     formRef,
+
+    onFormStateChange,
 
     currentNetwork,
 

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
@@ -31,6 +31,7 @@ import { FeesRow } from '@app/components/fees-row/fees-row';
 import { NonceSetter } from '@app/components/nonce-setter';
 import { HighFeeDrawer } from '@app/features/high-fee-drawer/high-fee-drawer';
 import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
+import { useUpdatePersistedSendFormValues } from '@app/features/popup-send-form-restoration/use-update-persisted-send-form-values';
 import { useCurrentStacksAccountAnchoredBalances } from '@app/query/stacks/balance/balance.hooks';
 import { useStacksFungibleTokenAssetBalance } from '@app/query/stacks/balance/crypto-asset-balances.hooks';
 import { useCalculateStacksTxFees } from '@app/query/stacks/fees/fees.hooks';
@@ -54,6 +55,7 @@ import { SendCryptoAssetFormLayout } from '../../components/send-crypto-asset-fo
 import { SendMaxButton } from '../../components/send-max-button';
 import { StacksRecipientField } from '../../family/stacks/components/stacks-recipient-field';
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
+import { useSendFormRouteState } from '../../hooks/use-send-form-route-state';
 import { createDefaultInitialFormValues, defaultSendFormFormikProps } from '../../send-form.utils';
 import { useStacksFtRouteState } from './use-stacks-ft-params';
 
@@ -67,6 +69,8 @@ export function StacksSip10FungibleTokenSendForm({}) {
   const { data: ftMetadata } = useGetFungibleTokenMetadataQuery(
     pullContractIdFromIdentity(contractId)
   );
+  const routeState = useSendFormRouteState();
+
   logger.debug('info', ftMetadata);
 
   const assetBalance = useStacksFungibleTokenAssetBalance(contractId);
@@ -80,6 +84,7 @@ export function StacksSip10FungibleTokenSendForm({}) {
   const client = useStacksClientUnanchored();
   const ledgerNavigate = useLedgerNavigate();
   const sendFormNavigate = useSendFormNavigate();
+  const { onFormStateChange } = useUpdatePersistedSendFormValues();
 
   const availableTokenBalance = assetBalance?.balance ?? createMoney(0, 'STX');
   const sendMaxBalance = useMemo(
@@ -95,6 +100,7 @@ export function StacksSip10FungibleTokenSendForm({}) {
     nonce: nextNonce?.nonce,
     recipientAddressOrBnsName: '',
     symbol,
+    ...routeState,
   });
 
   const validationSchema = yup.object({
@@ -146,35 +152,38 @@ export function StacksSip10FungibleTokenSendForm({}) {
         validationSchema={validationSchema}
         {...defaultSendFormFormikProps}
       >
-        {() => (
-          <NonceSetter>
-            <Form style={{ width: '100%' }}>
-              <AmountField
-                balance={availableTokenBalance}
-                bottomInputOverlay={
-                  <SendMaxButton
-                    balance={availableTokenBalance}
-                    sendMaxBalance={sendMaxBalance.toString()}
-                  />
-                }
-              />
-              <FormFieldsLayout>
-                <SelectedAssetField icon={<StxAvatar />} name={symbol} symbol={symbol} />
-                <StacksRecipientField contractId={contractId} />
-                <MemoField />
-              </FormFieldsLayout>
-              <FeesRow fees={stacksFtFees} isSponsored={false} mt="base" />
-              <FormErrors />
-              <PreviewButton />
-              <EditNonceButton
-                onEditNonce={() => navigate(RouteUrls.EditNonce, { state: { contractId } })}
-                my={['loose', 'base']}
-              />
-              <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
-              <Outlet />
-            </Form>
-          </NonceSetter>
-        )}
+        {props => {
+          onFormStateChange(props.values);
+          return (
+            <NonceSetter>
+              <Form style={{ width: '100%' }}>
+                <AmountField
+                  balance={availableTokenBalance}
+                  bottomInputOverlay={
+                    <SendMaxButton
+                      balance={availableTokenBalance}
+                      sendMaxBalance={sendMaxBalance.toString()}
+                    />
+                  }
+                />
+                <FormFieldsLayout>
+                  <SelectedAssetField icon={<StxAvatar />} name={symbol} symbol={symbol} />
+                  <StacksRecipientField contractId={contractId} />
+                  <MemoField />
+                </FormFieldsLayout>
+                <FeesRow fees={stacksFtFees} isSponsored={false} mt="base" />
+                <FormErrors />
+                <PreviewButton />
+                <EditNonceButton
+                  onEditNonce={() => navigate(RouteUrls.EditNonce, { state: { contractId } })}
+                  my={['loose', 'base']}
+                />
+                <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
+                <Outlet />
+              </Form>
+            </NonceSetter>
+          );
+        }}
       </Formik>
     </SendCryptoAssetFormLayout>
   );

--- a/src/app/query/stacks/fungible-tokens/fungible-token-metadata.query.ts
+++ b/src/app/query/stacks/fungible-tokens/fungible-token-metadata.query.ts
@@ -16,6 +16,7 @@ const queryOptions = {
   refetchOnMount: false,
   refetchInterval: false,
   refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
   retry: 0,
 } as const;
 

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -72,6 +72,11 @@ export async function internalBackgroundMessageHandler(
       break;
     }
 
+    case InternalMethods.ClearActiveFormState: {
+      inMemoryFormState.delete(message.payload.tabId);
+      break;
+    }
+
     case InternalMethods.RemoveInMemoryKeys: {
       inMemoryKeys.clear();
       break;

--- a/src/shared/message-types.ts
+++ b/src/shared/message-types.ts
@@ -22,6 +22,7 @@ export enum InternalMethods {
   RequestDerivedStxAccounts = 'RequestDerivedStxAccounts',
   GetActiveFormState = 'GetActiveFormState',
   SetActiveFormState = 'SetActiveFormState',
+  ClearActiveFormState = 'ClearActiveFormState',
   ShareInMemoryKeyToBackground = 'ShareInMemoryKeyToBackground',
   RequestInMemoryKeys = 'RequestInMemoryKeys',
   RemoveInMemoryKeys = 'RemoveInMemoryKeys',

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -20,6 +20,11 @@ type SetActiveFormState = BackgroundMessage<
   { tabId: number; symbol: string; amount?: string; recipient?: string }
 >;
 
+type ClearActiveFormState = BackgroundMessage<
+  InternalMethods.ClearActiveFormState,
+  { tabId: number }
+>;
+
 type ShareInMemoryKeyToBackground = BackgroundMessage<
   InternalMethods.ShareInMemoryKeyToBackground,
   { secretKey: string; keyId: string }
@@ -38,6 +43,7 @@ export type BackgroundMessages =
   | RequestDerivedStxAccounts
   | GetActiveFormState
   | SetActiveFormState
+  | ClearActiveFormState
   | ShareInMemoryKeyToBackground
   | RequestInMemoryKeys
   | RemoveInMemoryKeys


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4252739693).<!-- Sticky Header Marker -->

If a user types something in the form, but then returns to the home screen in the wallet, we shouldn't return directly to form on reinit. I've added a clear method to get rid of the state.

Not a huge fan of all the message passing, should handle this sparingly. We also shouldn't be calling `chrome.runtime.sendMessage` everywhere. Made an issue to refactor this https://github.com/hirosystems/stacks-wallet-web/issues/3266