### PR TITLE
chore: error when missing dep

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
     'no-warning-comments': [0],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': [
-      'warn',
+      'error',
       {
         additionalHooks: 'useRecoilCallback',
       },

--- a/src/app/features/activity-list/components/transaction-list/bitcoin-transaction/bitcoin-transaction-item.tsx
+++ b/src/app/features/activity-list/components/transaction-list/bitcoin-transaction/bitcoin-transaction-item.tsx
@@ -24,7 +24,10 @@ export function BitcoinTransactionItem({ transaction, ...rest }: BitcoinTransact
   const { handleOpenTxLink } = useExplorerLink();
   const analytics = useAnalytics();
   const caption = useMemo(() => getBitcoinTxCaption(transaction), [transaction]);
-  const value = useMemo(() => getBitcoinTxValue(bitcoinAddress, transaction), [transaction]);
+  const value = useMemo(
+    () => getBitcoinTxValue(bitcoinAddress, transaction),
+    [bitcoinAddress, transaction]
+  );
 
   if (!transaction) return null;
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4252785181).<!-- Sticky Header Marker -->

Bugs introduced from [stale closures](https://dmitripavlutin.com/react-hooks-stale-closures/) are sometimes hard to identify and often introduced from wrong dep arrays. 

There are exceptional cases where we do need to override the linter here, such as infinite render loops, or wrapper hooks (`useOnMount`). other than these we should always have correct hooks. 