### PR TITLE
fix: asset page routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "react-icons": "4.7.1",
     "react-lottie": "1.2.3",
     "react-redux": "8.0.5",
-    "react-router-dom": "6.8.0",
+    "react-router-dom": "6.8.1",
     "react-virtuoso": "4.0.8",
     "redux-persist": "6.0.0",
     "rxjs": "7.8.0",

--- a/src/app/common/hooks/use-route-header.ts
+++ b/src/app/common/hooks/use-route-header.ts
@@ -1,11 +1,13 @@
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { useRouteHeaderState } from '@app/store/ui/ui.hooks';
 
-export const useRouteHeader = (header: JSX.Element) => {
+export function useRouteHeader(header: JSX.Element) {
+  const location = useLocation();
   const [_, setRouteHeader] = useRouteHeaderState();
   useEffect(() => {
     setRouteHeader(header);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-};
+  }, [location.pathname]);
+}

--- a/src/app/pages/send/send-container.tsx
+++ b/src/app/pages/send/send-container.tsx
@@ -2,8 +2,6 @@ import { Outlet, useNavigate } from 'react-router-dom';
 
 import { Flex } from '@stacks/ui';
 
-import { RouteUrls } from '@shared/route-urls';
-
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { whenPageMode } from '@app/common/utils';
 import { CENTERED_FULL_PAGE_MAX_WIDTH } from '@app/components/global-styles/full-page-styles';
@@ -11,9 +9,11 @@ import { Header } from '@app/components/header';
 
 export function SendContainer() {
   const navigate = useNavigate();
+
   useRouteHeader(
-    <Header hideActions onClose={() => navigate(RouteUrls.SendCryptoAsset)} title="Send" />
+    <Header hideActions onClose={() => navigate('..', { relative: 'path' })} title="Send" />
   );
+
   return whenPageMode({
     full: (
       <Flex

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,10 +3185,10 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.7"
 
-"@remix-run/router@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.1.tgz#3bb0b6ddc0a276e8dc1138d08f63035e4e23e8bf"
-  integrity sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw==
+"@remix-run/router@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.2.tgz#58cd2bd25df2acc16c628e1b6f6150ea6c7455bc"
+  integrity sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==
 
 "@rjsf/core@^4.2.0":
   version "4.2.3"
@@ -14840,20 +14840,20 @@ react-refresh@0.14.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
-react-router-dom@6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.8.0.tgz#5e5f4c4b15fdec3965d2ad9d7460d0c61971e744"
-  integrity sha512-hQouduSTywGJndE86CXJ2h7YEy4HYC6C/uh19etM+79FfQ6cFFFHnHyDlzO4Pq0eBUI96E4qVE5yUjA00yJZGQ==
+react-router-dom@6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.8.1.tgz#7e136b67d9866f55999e9a8482c7008e3c575ac9"
+  integrity sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==
   dependencies:
-    "@remix-run/router" "1.3.1"
-    react-router "6.8.0"
+    "@remix-run/router" "1.3.2"
+    react-router "6.8.1"
 
-react-router@6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.8.0.tgz#dd61fd1ec44daa2cceaef8e6baa00f99a01a650f"
-  integrity sha512-760bk7y3QwabduExtudhWbd88IBbuD1YfwzpuDUAlJUJ7laIIcqhMvdhSVh1Fur1PE8cGl84L0dxhR3/gvHF7A==
+react-router@6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.8.1.tgz#e362caf93958a747c649be1b47cd505cf28ca63e"
+  integrity sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==
   dependencies:
-    "@remix-run/router" "1.3.1"
+    "@remix-run/router" "1.3.2"
 
 react-select@^5.3.2:
   version "5.7.0"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4254808571).<!-- Sticky Header Marker -->

Issue with the routing was stale closure related, as it only rendered once on the initial mount.

The issue here is with the pattern of using a hook to set the header. The router comes with many tools to set/configure headers. We should use those. 