### PR TITLE
fix: btc recipient form validation

### DIFF
--- a/src/app/common/validation/forms/address-validators.ts
+++ b/src/app/common/validation/forms/address-validators.ts
@@ -4,7 +4,19 @@ import * as yup from 'yup';
 import { NetworkConfiguration, NetworkModes } from '@shared/constants';
 import { isString } from '@shared/utils';
 
+import { FormErrorMessages } from '@app/common/error-messages';
 import { validateAddressChain, validateStacksAddress } from '@app/common/stacks-utils';
+
+function notCurrentAddressValidatorFactory(currentAddress: string) {
+  return (value: unknown) => value !== currentAddress;
+}
+
+export function notCurrentAddressValidator(currentAddress: string) {
+  return yup.string().test({
+    test: notCurrentAddressValidatorFactory(currentAddress),
+    message: FormErrorMessages.SameAddress,
+  });
+}
 
 export function btcAddressValidator() {
   return yup
@@ -39,10 +51,6 @@ export function stxAddressNetworkValidatorFactory(currentNetwork: NetworkConfigu
     if (!isString(value)) return false;
     return validateAddressChain(value, currentNetwork);
   };
-}
-
-export function stxNotCurrentAddressValidatorFactory(currentAddress: string) {
-  return (value: unknown) => value !== currentAddress;
 }
 
 export function stxAddressValidator(errorMsg: string) {

--- a/src/app/common/validation/forms/recipient-validators.ts
+++ b/src/app/common/validation/forms/recipient-validators.ts
@@ -6,9 +6,9 @@ import { FormErrorMessages } from '@app/common/error-messages';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 
 import {
+  notCurrentAddressValidator,
   stxAddressNetworkValidatorFactory,
   stxAddressValidator,
-  stxNotCurrentAddressValidatorFactory,
 } from './address-validators';
 
 export function stxRecipientValidator(
@@ -20,10 +20,7 @@ export function stxRecipientValidator(
       message: FormErrorMessages.IncorrectNetworkAddress,
       test: stxAddressNetworkValidatorFactory(currentNetwork),
     })
-    .test({
-      message: FormErrorMessages.SameAddress,
-      test: stxNotCurrentAddressValidatorFactory(currentAddress || ''),
-    });
+    .concat(notCurrentAddressValidator(currentAddress));
 }
 
 interface StxRecipientAddressOrBnsNameValidatorArgs {

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/recipient-accounts-drawer.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/recipient-accounts-drawer.tsx
@@ -26,7 +26,7 @@ export const RecipientAccountsDrawer = memo(() => {
 
   return accounts ? (
     <BaseDrawer title="My accounts" isShowing onClose={onGoBack}>
-      <Box mx={['base-loose', 'extra-loose']}>
+      <Box mb="loose" mx={['base-loose', 'extra-loose']}>
         {accounts.length <= smallNumberOfAccountsToRenderWholeList ? (
           <Box marginBottom={8} mb={whenWallet({ ledger: 'base', software: '' })}>
             {accounts.map(item => (

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -66,6 +66,7 @@ export function BtcSendForm() {
                 <SelectedAssetField icon={<BtcIcon />} name={btcBalance.asset.name} symbol="BTC" />
                 <RecipientField
                   labelAction="Choose account"
+                  lastChild
                   name="recipient"
                   onClickLabelAction={() =>
                     navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts)

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -14,6 +14,7 @@ import { useWalletType } from '@app/common/use-wallet-type';
 import {
   btcAddressNetworkValidator,
   btcAddressValidator,
+  notCurrentAddressValidator,
 } from '@app/common/validation/forms/address-validators';
 import {
   btcInsufficientBalanceValidator,
@@ -67,7 +68,8 @@ export function useBtcSendForm() {
       recipient: yup
         .string()
         .concat(btcAddressValidator())
-        .concat(btcAddressNetworkValidator(currentNetwork.chain.bitcoin.network)),
+        .concat(btcAddressNetworkValidator(currentNetwork.chain.bitcoin.network))
+        .concat(notCurrentAddressValidator(currentAccountBtcAddress)),
     }),
 
     async previewTransaction(

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/stacks-sip10-fungible-token-send-form.tsx
@@ -169,7 +169,7 @@ export function StacksSip10FungibleTokenSendForm({}) {
                 <FormFieldsLayout>
                   <SelectedAssetField icon={<StxAvatar />} name={symbol} symbol={symbol} />
                   <StacksRecipientField contractId={contractId} />
-                  <MemoField />
+                  <MemoField lastChild />
                 </FormFieldsLayout>
                 <FeesRow fees={stacksFtFees} isSponsored={false} mt="base" />
                 <FormErrors />

--- a/src/app/query/stacks/balance/crypto-asset-balances.hooks.ts
+++ b/src/app/query/stacks/balance/crypto-asset-balances.hooks.ts
@@ -81,6 +81,7 @@ function useStacksFungibleTokenAssetBalancesUnanchoredWithMetadata(
       formatContractId(assetBalance.asset.contractAddress, assetBalance.asset.contractName)
     )
   );
+
   return useMemo(
     () =>
       initializedAssetBalances.map((assetBalance, i) => {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4256341213).<!-- Sticky Header Marker -->

This PR fixes a user from being able to send btc to themselves. The form was missing this validation check on the recipient field.

Thx @timstackblock for reporting!

![Screen Shot 2023-02-23 at 12 02 28 PM](https://user-images.githubusercontent.com/6493321/221015299-0f7330a2-f4c7-4be9-be5b-57d968953cd2.png)


