### PR TITLE
fix: collectibles on ledger

### DIFF
--- a/src/app/features/balances-list/balances-list.tsx
+++ b/src/app/features/balances-list/balances-list.tsx
@@ -1,7 +1,6 @@
 import { Box, Stack, StackProps } from '@stacks/ui';
 import { HomePageSelectorsLegacy } from '@tests-legacy/page-objects/home.selectors';
 
-import { useWalletType } from '@app/common/use-wallet-type';
 import { CryptoCurrencyAssetItem } from '@app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
 import { BtcIcon } from '@app/components/icons/btc-icon';
@@ -28,7 +27,6 @@ export function BalancesList({ address, ...props }: BalancesListProps) {
   const btcAssetBalance = useBitcoinAssetBalance(bitcoinAddress);
   const stacksFtAssetBalances = useStacksFungibleTokenAssetBalancesAnchoredWithMetadata(address);
   const isBitcoinEnabled = useConfigBitcoinEnabled();
-  const { whenWallet } = useWalletType();
 
   // Better handle loading state
   if (!stxAssetBalance || !stxUnachoredAssetBalance) return <LoadingSpinner />;
@@ -51,7 +49,7 @@ export function BalancesList({ address, ...props }: BalancesListProps) {
       />
 
       <StacksFungibleTokenAssetList assetBalances={stacksFtAssetBalances} />
-      {whenWallet({ software: <Collectibles />, ledger: null })}
+      <Collectibles />
     </Stack>
   );
 }

--- a/src/app/features/collectibles/collectibles.tsx
+++ b/src/app/features/collectibles/collectibles.tsx
@@ -1,5 +1,6 @@
 import { Grid } from '@stacks/ui';
 
+import { useWalletType } from '@app/common/use-wallet-type';
 import { Caption } from '@app/components/typography';
 import { useConfigNftMetadataEnabled } from '@app/query/common/hiro-config/hiro-config.query';
 
@@ -8,6 +9,7 @@ import { Ordinals } from './components/ordinals';
 import { StacksCryptoAssets } from './components/stacks-crypto-assets';
 
 export function Collectibles() {
+  const { whenWallet } = useWalletType();
   const isNftMetadataEnabled = useConfigNftMetadataEnabled();
 
   return (
@@ -21,8 +23,15 @@ export function Collectibles() {
           'repeat(auto-fill, minmax(184px, 1fr))',
         ]}
       >
-        <AddCollectible />
-        <Ordinals />
+        {whenWallet({
+          software: (
+            <>
+              <AddCollectible />
+              <Ordinals />
+            </>
+          ),
+          ledger: null,
+        })}
         {isNftMetadataEnabled ? <StacksCryptoAssets /> : null}
       </Grid>
     </>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4257320886).<!-- Sticky Header Marker -->

This PR fixes where the check happens to show/hide collectibles on Ledger. Now, it checks just to show/hide ordinals but will show Stacks nfts...

![Screen Shot 2023-02-23 at 2 40 34 PM](https://user-images.githubusercontent.com/6493321/221025567-9cd5c977-7e65-46bf-b5a4-2c08f0b4e883.png)
