### PR TITLE
fix: Prevent sign-in while signed in

### DIFF
--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -115,7 +115,14 @@ function AppRoutesAfterUserHasConsented() {
           }
         />
         <Route path={RouteUrls.RequestDiagnostics} element={<AllowDiagnosticsPage />} />
-        <Route path={RouteUrls.SignIn} element={<SignIn />} />
+        <Route
+          path={RouteUrls.SignIn}
+          element={
+            <OnboardingGate>
+              <SignIn />
+            </OnboardingGate>
+          }
+        />
         <Route path={RouteUrls.MagicRecoveryCode} element={<MagicRecoveryCode />} />
         <Route
           path={RouteUrls.AddNetwork}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4296053326).<!-- Sticky Header Marker -->

If a user is already signed in, accessing this route should redirect them to the Home Screen.