### PR TITLE
feat: support for text inscriptions

### DIFF
--- a/src/app/features/collectibles/components/collectible-text.tsx
+++ b/src/app/features/collectibles/components/collectible-text.tsx
@@ -1,0 +1,42 @@
+import { Box, Text } from '@stacks/ui';
+
+import { useTextInscriptionContentQuery } from '@app/query/bitcoin/ordinals/use-text-ordinal-content.query';
+
+import { CollectibleLayout, CollectibleLayoutProps } from './collectible.layout';
+
+interface CollectibleTextProps extends Omit<CollectibleLayoutProps, 'children'> {
+  contentSrc: string;
+}
+
+export function CollectibleText(props: CollectibleTextProps) {
+  const query = useTextInscriptionContentQuery(props.contentSrc);
+
+  if (query.isLoading) return null; // TODO
+
+  if (query.isError) return null; // TODO
+
+  const { contentSrc, ...rest } = props;
+  return (
+    <CollectibleLayout {...rest}>
+      <Box
+        height="100%"
+        color="white"
+        p="20px"
+        sx={{
+          overflow: 'hidden',
+        }}
+        _after={{
+          content: '""',
+          position: 'absolute',
+          bottom: '0',
+          left: '0',
+          height: '30px',
+          width: '100%',
+          backgroundImage: 'linear-gradient(rgba(0,0,0,0), rgba(0,0,0,1))',
+        }}
+      >
+        <Text>{query.data}</Text>
+      </Box>
+    </CollectibleLayout>
+  );
+}

--- a/src/app/features/collectibles/components/ordinals.tsx
+++ b/src/app/features/collectibles/components/ordinals.tsx
@@ -12,6 +12,7 @@ import {
 
 import { CollectibleImage } from './collectible-image';
 import { CollectibleOther } from './collectible-other';
+import { CollectibleText } from './collectible-text';
 
 interface InscriptionProps {
   path: string;
@@ -26,15 +27,21 @@ function Inscription({ path }: InscriptionProps) {
 
   const inscription = whenOrdinalType(data['content type'], {
     image: () => ({
-      type: 'image',
-      title: data.title,
       infoUrl: createInfoUrl(data.content),
       src: `https://ordinals.com${data.content}`,
+      title: data.title,
+      type: 'image',
+    }),
+    text: () => ({
+      contentSrc: `https://ordinals.com${data.content}`,
+      infoUrl: createInfoUrl(data.content),
+      title: data.title,
+      type: 'text',
     }),
     other: () => ({
-      type: 'other',
+      infoUrl: createInfoUrl(data.content),
       title: data.title,
-      infoUrl: `https://ordinals.com${data.content}`.replace('content', 'inscription'),
+      type: 'other',
     }),
   });
 
@@ -45,6 +52,17 @@ function Inscription({ path }: InscriptionProps) {
           key={inscription.title}
           onSelectCollectible={() => openInNewTab(inscription.infoUrl)}
           src={inscription.src}
+          subtitle="Ordinal inscription"
+          title={inscription.title}
+        />
+      );
+    }
+    case 'text': {
+      return (
+        <CollectibleText
+          key={inscription.title}
+          onSelectCollectible={() => openInNewTab(inscription.infoUrl)}
+          contentSrc={inscription.contentSrc}
           subtitle="Ordinal inscription"
           title={inscription.title}
         />

--- a/src/app/query/bitcoin/ordinals/use-text-ordinal-content.query.ts
+++ b/src/app/query/bitcoin/ordinals/use-text-ordinal-content.query.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function useTextInscriptionContentQuery(contentSrc: string) {
+  return useQuery(
+    ['ordinal-text-content', contentSrc] as const,
+    async ({ queryKey }) => {
+      const [_, contentSrc] = queryKey;
+      const res = await fetch(contentSrc);
+      if (!res.ok) throw new Error('Failed to fetch ordinal text content.');
+
+      return res.text();
+    },
+    {
+      cacheTime: Infinity,
+      staleTime: Infinity,
+    }
+  );
+}

--- a/src/app/query/bitcoin/ordinals/utils.ts
+++ b/src/app/query/bitcoin/ordinals/utils.ts
@@ -70,7 +70,7 @@ export function getTaprootAddress(index: number, keychain: HDKey, network: Netwo
  * appropriately and securely. Ordinals of types not ready to be handled by the
  * app should be classified as "other".
  */
-const supportedOrdinalTypes = ['image', 'other'] as const;
+const supportedOrdinalTypes = ['image', 'text', 'other'] as const;
 
 type SupportedOrdinalType = (typeof supportedOrdinalTypes)[number];
 
@@ -101,11 +101,20 @@ interface ImageOrdinalInfo extends BaseOrdinalInfo {
   src: string;
 }
 
+interface TextOrdinalInfo extends BaseOrdinalInfo {
+  type: 'text';
+
+  /**
+   * URL where the text content can be found.
+   */
+  contentSrc: string;
+}
+
 interface OtherOrdinalInfo extends BaseOrdinalInfo {
   type: 'other';
 }
 
-type OrdinalInfo = ImageOrdinalInfo | OtherOrdinalInfo;
+type OrdinalInfo = ImageOrdinalInfo | TextOrdinalInfo | OtherOrdinalInfo;
 
 export function createInfoUrl(contentPath: string) {
   return `https://ordinals.com${contentPath}`.replace('content', 'inscription');
@@ -117,6 +126,10 @@ export function whenOrdinalType(
 ) {
   if (mimeType.startsWith('image/') && branches.image) {
     return branches.image();
+  }
+
+  if (mimeType.startsWith('text') && branches.text) {
+    return branches.text();
   }
 
   if (branches.other) return branches.other();


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4284558792).<!-- Sticky Header Marker -->

Closes #3245

Support for text inscriptions. Includes a fade-out gradient for when inscriptions are too long.

![image](https://user-images.githubusercontent.com/116000646/221622381-be80556e-3001-4fb0-921b-2ec60b644105.png)


![image](https://user-images.githubusercontent.com/116000646/221547147-68e584db-69eb-4dbb-ae71-5bf5736fe5b8.png)
