### PR TITLE
fix: stable ordinals sorting / migrate to Hiro API

### DIFF
--- a/src/app/features/collectibles/collectibles.tsx
+++ b/src/app/features/collectibles/collectibles.tsx
@@ -9,7 +9,7 @@ import { useConfigNftMetadataEnabled } from '@app/query/common/hiro-config/hiro-
 import { QueryPrefixes } from '@app/query/query-prefixes';
 
 import { AddCollectible } from './components/add-collectible';
-import { Ordinals } from './components/ordinals';
+import { OrdinalInscriptions } from './components/ordinal-inscriptions';
 import { StacksCryptoAssets } from './components/stacks-crypto-assets';
 
 function isSomeQueryFetching(...args: number[]) {
@@ -67,7 +67,7 @@ export function Collectibles() {
           software: (
             <>
               <AddCollectible />
-              <Ordinals />
+              <OrdinalInscriptions />
             </>
           ),
           ledger: null,

--- a/src/app/features/collectibles/components/ordinal-inscriptions.tsx
+++ b/src/app/features/collectibles/components/ordinal-inscriptions.tsx
@@ -79,7 +79,7 @@ function Inscription({ data }: InscriptionProps) {
   }
 }
 
-export function Ordinals() {
+export function OrdinalInscriptions() {
   const { data: utxos = [] } = useTaprootAddressUtxosQuery();
 
   // use each utxo to get inscription details

--- a/src/app/query/bitcoin/ordinals/use-inscription-by-txid.query.ts
+++ b/src/app/query/bitcoin/ordinals/use-inscription-by-txid.query.ts
@@ -1,5 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { QueryPrefixes } from '@app/query/query-prefixes';
 
 import { OrdApiXyzGetTransactionOutput, ordApiXyzGetTransactionOutput } from './utils';
@@ -22,10 +20,14 @@ function makeInscriptionMetadataQueryKey(txid: string) {
   return [QueryPrefixes.InscriptionFromTxid, txid] as const;
 }
 
-export function useInscriptionByTxidQuery(txid: string) {
-  return useQuery({
+export function createQueryOptions(txid: string) {
+  return {
     queryKey: makeInscriptionMetadataQueryKey(txid),
     queryFn: () => getInscriptionByTxid(txid),
     ...queryOptions,
-  });
+  };
 }
+
+// export function useInscriptionByTxidQuery(txid: string) {
+//   return useQuery(createQuery(txid));
+// }

--- a/src/app/query/bitcoin/ordinals/use-inscription.query.ts
+++ b/src/app/query/bitcoin/ordinals/use-inscription.query.ts
@@ -1,5 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { QueryPrefixes } from '@app/query/query-prefixes';
 
 import { ordApiXyzGetInscriptionByInscriptionSchema } from './utils';
@@ -13,10 +11,16 @@ async function getInscriptionMetadata(path: string) {
   return ordApiXyzGetInscriptionByInscriptionSchema.validate(data);
 }
 
-export function useInscriptionQuery(path: string) {
-  return useQuery([QueryPrefixes.InscriptionMetadata, path], () => getInscriptionMetadata(path), {
+export function createQueryOptions(path: string) {
+  return {
+    queryKey: [QueryPrefixes.InscriptionMetadata, path],
+    queryFn: () => getInscriptionMetadata(path),
     enabled: !!path,
     staleTime: Infinity,
     cacheTime: Infinity,
-  });
+  };
 }
+
+// export function useInscriptionQuery(path: string) {
+//   return useQuery(createQuery(path));
+// }

--- a/src/app/query/bitcoin/ordinals/utils.ts
+++ b/src/app/query/bitcoin/ordinals/utils.ts
@@ -22,8 +22,13 @@ export const ordApiXyzGetInscriptionByInscriptionSchema = yup
     content: yup.string().required(),
     preview: yup.string().required(),
     title: yup.string().required(),
+    inscription_number: yup.number().required(),
   })
   .required();
+
+export type OrdApiXyzGetInscriptionByInscriptionSchema = yup.InferType<
+  typeof ordApiXyzGetInscriptionByInscriptionSchema
+>;
 
 /**
  * Schema of data used from the `GET https://ordapi.xyz/output/:tx` endpoint. Additional data


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4366218464).<!-- Sticky Header Marker -->

In order to be able to sort ordinals, it seems that all queries involved must be in the same scope. Therefore, existing work separating queries into individual components has been undone, leading to two unused hooks.

The hooks have been commented out for the time being, as it's possible that they may be used in the near future. If not, can remove them.

I'll happily refactor with a better approach for querying and sorting the inscriptions.