### PR TITLE
feat: increase unused taproot address search range

### DIFF
--- a/src/app/query/bitcoin/ordinals/use-taproot-address-utxos.query.ts
+++ b/src/app/query/bitcoin/ordinals/use-taproot-address-utxos.query.ts
@@ -9,7 +9,7 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import { UtxoResponseItem } from '../bitcoin-client';
 import { getTaprootAddress, hasOrdinals } from './utils';
 
-const stopSearchAfterNumberAddressesWithoutOrdinals = 5;
+const stopSearchAfterNumberAddressesWithoutOrdinals = 20;
 
 /**
  * Returns all utxos for the user's current taproot account. The search for


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4313977324).<!-- Sticky Header Marker -->

Closes #3297

Now searches across up to 50 empty addresses.