### PR TITLE
feat: remove btc copy icon from acc switch modal

### DIFF
--- a/src/app/components/account/account-list-item-layout.tsx
+++ b/src/app/components/account/account-list-item-layout.tsx
@@ -22,9 +22,8 @@ interface AccountListItemLayoutProps extends StackProps {
   avatar: React.ReactNode;
   balanceLabel: React.ReactNode;
   hasCopied?: boolean;
-  hasCopiedBtc?: boolean;
   onCopyToClipboard?(e: React.MouseEvent): void;
-  onCopyBtcToClipboard?(e: React.MouseEvent): void;
+  onClickBtcCopyIcon?(e: React.MouseEvent): void;
   onSelectAccount(): void;
 }
 export function AccountListItemLayout(props: AccountListItemLayoutProps) {
@@ -40,8 +39,7 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
     onSelectAccount,
     hasCopied,
     onCopyToClipboard,
-    hasCopiedBtc,
-    onCopyBtcToClipboard,
+    onClickBtcCopyIcon,
     children = null,
     ...rest
   } = props;
@@ -76,43 +74,33 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
                     label={hasCopied ? 'Copied!' : 'Copy Stacks address'}
                     hideOnClick={false}
                   >
-                    <Stack>
-                      <Box
-                        _hover={{ cursor: 'pointer' }}
-                        onClick={e => onCopyToClipboard?.(e)}
-                        size="12px"
-                        color={color('text-caption')}
-                        data-testid={UserAreaSelectors.AccountCopyAddress}
-                        as={FiCopy}
-                        mt="2px"
-                        ml="4px"
-                      />
-                    </Stack>
+                    <Box
+                      as="button"
+                      onClick={e => onCopyToClipboard?.(e)}
+                      color={color('text-caption')}
+                      data-testid={UserAreaSelectors.AccountCopyAddress}
+                      mt="2px"
+                      ml="4px"
+                    >
+                      <FiCopy size="12px" />
+                    </Box>
                   </Tooltip>
                 )}
               </Flex>
               {isBitcoinEnabled && (
                 <Flex>
                   <Caption>{truncateMiddle(btcAddress, 5)}</Caption>
-                  {onCopyBtcToClipboard && (
-                    <Tooltip
-                      placement="right"
-                      label={hasCopiedBtc ? 'Copied!' : 'Copy Bitcoin address'}
-                      hideOnClick={false}
+                  {onClickBtcCopyIcon && (
+                    <Box
+                      as="button"
+                      onClick={e => onClickBtcCopyIcon?.(e)}
+                      color={color('text-caption')}
+                      data-testid={UserAreaSelectors.AccountCopyAddress}
+                      mt="2px"
+                      ml="4px"
                     >
-                      <Stack>
-                        <Box
-                          _hover={{ cursor: 'pointer' }}
-                          onClick={e => onCopyBtcToClipboard?.(e)}
-                          size="12px"
-                          color={color('text-caption')}
-                          data-testid={UserAreaSelectors.AccountCopyAddress}
-                          as={FiCopy}
-                          mt="2px"
-                          ml="4px"
-                        />
-                      </Stack>
-                    </Tooltip>
+                      <FiCopy size="12px" />
+                    </Box>
                   )}
                 </Flex>
               )}

--- a/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list-item.tsx
@@ -1,10 +1,14 @@
 import { memo } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useClipboard } from '@stacks/ui';
+
+import { RouteUrls } from '@shared/route-urls';
 
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { useSwitchAccount } from '@app/common/hooks/account/use-switch-account';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useDrawers } from '@app/common/hooks/use-drawers';
 import { useLoading } from '@app/common/hooks/use-loading';
 import { AccountBalanceLabel } from '@app/components/account/account-balance-label';
 import { AccountListItemLayout } from '@app/components/account/account-list-item-layout';
@@ -25,6 +29,7 @@ export const SwitchAccountListItem = memo(
     const { handleSwitchAccount, getIsActive } = useSwitchAccount(handleClose);
     const [component, bind] = usePressable(true);
     const name = useAccountDisplayName(account);
+    const navigate = useNavigate();
 
     const btcAddress = useBtcNativeSegwitAccountIndexAddressIndexZero(account.index);
 
@@ -38,7 +43,7 @@ export const SwitchAccountListItem = memo(
 
     const analytics = useAnalytics();
     const { onCopy, hasCopied } = useClipboard(account.address || '');
-    const { onCopy: onCopyBtc, hasCopied: hasCopiedBtc } = useClipboard(btcAddress || '');
+    const { setIsShowingSwitchAccountsState } = useDrawers();
 
     const onCopyToClipboard = (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -46,10 +51,10 @@ export const SwitchAccountListItem = memo(
       onCopy();
     };
 
-    const onCopyBtcToClipboard = (e: React.MouseEvent) => {
+    const onClickBtcCopyIcon = (e: React.MouseEvent) => {
       e.stopPropagation();
-      void analytics.track('copy_btc_address_to_clipboard');
-      onCopyBtc();
+      setIsShowingSwitchAccountsState(false);
+      navigate(RouteUrls.ReceiveBtc, { state: { btcAddress } });
     };
 
     return (
@@ -66,9 +71,8 @@ export const SwitchAccountListItem = memo(
         accountName={<AccountName account={account} />}
         balanceLabel={<AccountBalanceLabel address={account.address} />}
         hasCopied={hasCopied}
-        hasCopiedBtc={hasCopiedBtc}
         onCopyToClipboard={onCopyToClipboard}
-        onCopyBtcToClipboard={onCopyBtcToClipboard}
+        onClickBtcCopyIcon={onClickBtcCopyIcon}
         mt="loose"
         {...bind}
       >

--- a/src/app/pages/receive-tokens/receive-btc.tsx
+++ b/src/app/pages/receive-tokens/receive-btc.tsx
@@ -1,6 +1,8 @@
 import toast from 'react-hot-toast';
+import { useLocation } from 'react-router-dom';
 
 import { useClipboard } from '@stacks/ui';
+import get from 'lodash.get';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
@@ -11,8 +13,11 @@ import { ReceiveTokensLayout } from './components/receive-tokens.layout';
 
 export function ReceiveBtcModal() {
   const accountIndex = useCurrentAccountIndex();
-  const btcAddress = useBtcNativeSegwitAccountIndexAddressIndexZero(accountIndex);
+  const activeAccountBtcAddress = useBtcNativeSegwitAccountIndexAddressIndexZero(accountIndex);
   const analytics = useAnalytics();
+  const { state } = useLocation();
+  const btcAddress = get(state, 'btcAddress', activeAccountBtcAddress);
+
   const { onCopy } = useClipboard(btcAddress);
 
   function copyToClipboard() {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4374890495).<!-- Sticky Header Marker -->

Closes https://github.com/hirosystems/stacks-wallet-web/issues/3327

It seems users may feel a little bit confused why it is possible to copy stacks address, and btc not 🤔 
may be we should provide some tooltip explaining it? 