### PR TITLE
fix: left align text inscription text

### DIFF
--- a/src/app/features/collectibles/components/collectible-text.layout.tsx
+++ b/src/app/features/collectibles/components/collectible-text.layout.tsx
@@ -16,6 +16,7 @@ export function CollectibleTextLayout(props: CollectibleTextLayoutProps) {
   return (
     <Box
       height="100%"
+      width="100%"
       color="white"
       p="20px"
       sx={{


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4316679386).<!-- Sticky Header Marker -->

Ensures text is left-aligned,

![image](https://user-images.githubusercontent.com/116000646/222507151-7cc6c5c6-9e5c-46b1-9d6c-d087f5d94857.png)
