### PR TITLE
Feat: send BTC to BNS

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "@emotion/css": "11.10.5",
     "@emotion/react": "11.10.5",
     "@emotion/styled": "11.10.5",
+    "@fungible-systems/zone-file": "^2.0.0",
     "@ledgerhq/hw-transport-webusb": "6.27.10",
     "@noble/hashes": "1.2.0",
     "@noble/secp256k1": "1.7.1",

--- a/src/app/common/validation/forms/recipient-validators.ts
+++ b/src/app/common/validation/forms/recipient-validators.ts
@@ -1,3 +1,4 @@
+import { ChainID } from '@stacks/transactions';
 import * as yup from 'yup';
 
 import { NetworkConfiguration } from '@shared/constants';
@@ -5,6 +6,7 @@ import { NetworkConfiguration } from '@shared/constants';
 import { FormErrorMessages } from '@app/common/error-messages';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 
+import { fetchNameOwner } from '../../../query/stacks/bns/bns.utils';
 import {
   notCurrentAddressValidator,
   stxAddressNetworkValidatorFactory,
@@ -41,9 +43,9 @@ export function stxRecipientAddressOrBnsNameValidator({
         return true;
       } catch (e) {}
       try {
-        const res = await client.namesApi.getNameInfo({ name: value ?? '' });
-        if (typeof res.address !== 'string' || res.address.length === 0) return false;
-        return true;
+        const isTestnet = currentNetwork.chain.stacks.chainId === ChainID.Testnet;
+        const owner = await fetchNameOwner(client, value ?? '', isTestnet);
+        return owner !== null;
       } catch (e) {
         return false;
       }

--- a/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-recipient-bns-name.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-recipient-bns-name.tsx
@@ -2,23 +2,28 @@ import { useCallback, useState } from 'react';
 
 import { useField } from 'formik';
 
+import { fetchNameOwner } from '@app/query/stacks/bns/bns.utils';
 import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
+import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 export function useStacksRecipientBnsName() {
   const [, _, recipientFieldHelpers] = useField('recipient');
   const [recipientAddressOrBnsNameField] = useField('recipientAddressOrBnsName');
   const [bnsAddress, setBnsAddress] = useState('');
   const client = useStacksClientUnanchored();
+  const { isTestnet } = useCurrentNetworkState();
 
   const getBnsAddress = useCallback(async () => {
     setBnsAddress('');
     try {
-      const res = await client.namesApi.getNameInfo({
-        name: recipientAddressOrBnsNameField.value ?? '',
-      });
-      if (res.address) {
-        recipientFieldHelpers.setValue(res.address);
-        setBnsAddress(res.address);
+      const owner = await fetchNameOwner(
+        client,
+        recipientAddressOrBnsNameField.value ?? '',
+        isTestnet
+      );
+      if (owner) {
+        recipientFieldHelpers.setValue(owner);
+        setBnsAddress(owner);
       } else {
         recipientFieldHelpers.setValue(recipientAddressOrBnsNameField.value);
       }
@@ -26,7 +31,7 @@ export function useStacksRecipientBnsName() {
     } catch {
       recipientFieldHelpers.setValue(recipientAddressOrBnsNameField.value);
     }
-  }, [client.namesApi, recipientAddressOrBnsNameField.value, recipientFieldHelpers]);
+  }, [recipientAddressOrBnsNameField.value, recipientFieldHelpers, isTestnet, client]);
 
   return { getBnsAddress, bnsAddress };
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -1,10 +1,9 @@
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
 import { Box } from '@stacks/ui';
 import { Form, Formik } from 'formik';
 
 import { HIGH_FEE_WARNING_LEARN_MORE_URL_BTC } from '@shared/constants';
-import { RouteUrls } from '@shared/route-urls';
 
 import { BtcIcon } from '@app/components/icons/btc-icon';
 import { HighFeeDrawer } from '@app/features/high-fee-drawer/high-fee-drawer';
@@ -17,7 +16,6 @@ import { AvailableBalance } from '../../components/available-balance';
 import { FormErrors } from '../../components/form-errors';
 import { FormFieldsLayout } from '../../components/form-fields.layout';
 import { PreviewButton } from '../../components/preview-button';
-import { RecipientField } from '../../components/recipient-field';
 import { SelectedAssetField } from '../../components/selected-asset-field';
 import { SendCryptoAssetFormLayout } from '../../components/send-crypto-asset-form.layout';
 import { SendFiatValue } from '../../components/send-fiat-value';
@@ -25,11 +23,11 @@ import { SendMaxButton } from '../../components/send-max-button';
 import { useCalculateMaxBitcoinSpend } from '../../family/bitcoin/hooks/use-calculate-max-spend';
 import { useSendFormRouteState } from '../../hooks/use-send-form-route-state';
 import { createDefaultInitialFormValues, defaultSendFormFormikProps } from '../../send-form.utils';
+import { BtcRecipientField } from './components/btc-recipient-field';
 import { TestnetBtcMessage } from './components/testnet-btc-message';
 import { useBtcSendForm } from './use-btc-send-form';
 
 export function BtcSendForm() {
-  const navigate = useNavigate();
   const routeState = useSendFormRouteState();
   const btcMarketData = useCryptoCurrencyMarketData('BTC');
 
@@ -44,7 +42,10 @@ export function BtcSendForm() {
   return (
     <SendCryptoAssetFormLayout>
       <Formik
-        initialValues={createDefaultInitialFormValues(routeState)}
+        initialValues={createDefaultInitialFormValues({
+          ...routeState,
+          recipientOrBnsName: '',
+        })}
         onSubmit={previewTransaction}
         validationSchema={validationSchema}
         innerRef={formRef}
@@ -68,15 +69,7 @@ export function BtcSendForm() {
               />
               <FormFieldsLayout>
                 <SelectedAssetField icon={<BtcIcon />} name={btcBalance.asset.name} symbol="BTC" />
-                <RecipientField
-                  labelAction="Choose account"
-                  lastChild
-                  name="recipient"
-                  onClickLabelAction={() =>
-                    navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts)
-                  }
-                  placeholder="Address"
-                />
+                <BtcRecipientField />
               </FormFieldsLayout>
               {currentNetwork.chain.bitcoin.network === 'testnet' && <TestnetBtcMessage />}
               <FormErrors />

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/components/btc-recipient-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/components/btc-recipient-field.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useField } from 'formik';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { fetchBtcNameOwner } from '@app/query/stacks/bns/bns.utils';
+import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
+
+import { RecipientField } from '../../../components/recipient-field';
+import { RecipientFieldBnsAddress } from '../../../family/stacks/components/recipient-field-bns-address';
+
+export function BtcRecipientField() {
+  const client = useStacksClientUnanchored();
+  const [recipientAddressOrBnsField] = useField('recipientOrBnsName');
+  const [, _, recipientFieldHelpers] = useField('recipient');
+  const navigate = useNavigate();
+  const [bnsAddress, setBnsAddress] = useState('');
+  const [lastValidatedInput, setLastValidatedInput] = useState('');
+
+  const getBtcAddressFromBns = useCallback(async () => {
+    // Skip if this input was already handled
+    if (lastValidatedInput === recipientAddressOrBnsField.value) return;
+
+    setBnsAddress('');
+    setLastValidatedInput(recipientAddressOrBnsField.value);
+    try {
+      const btcFromBns = await fetchBtcNameOwner(client, recipientAddressOrBnsField.value);
+      if (btcFromBns) {
+        recipientFieldHelpers.setValue(btcFromBns);
+        setBnsAddress(btcFromBns);
+      } else {
+        recipientFieldHelpers.setValue(recipientAddressOrBnsField.value);
+      }
+    } catch (error) {
+      recipientFieldHelpers.setValue(recipientAddressOrBnsField.value);
+    }
+  }, [
+    client,
+    recipientAddressOrBnsField,
+    recipientFieldHelpers,
+    lastValidatedInput,
+    setLastValidatedInput,
+  ]);
+
+  return (
+    <RecipientField
+      labelAction="Choose account"
+      lastChild
+      name="recipientOrBnsName"
+      onBlur={getBtcAddressFromBns}
+      onClickLabelAction={() => navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts)}
+      placeholder="Address"
+      topInputOverlay={
+        !!bnsAddress ? <RecipientFieldBnsAddress bnsAddress={bnsAddress} /> : undefined
+      }
+    />
+  );
+}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -26,6 +26,8 @@ import { useBitcoinAssetBalance } from '@app/query/bitcoin/address/address.hooks
 import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
+import { btcRecipientOrBnsNameValidator } from '../../../../../common/validation/forms/recipient-validators';
+import { useStacksClientUnanchored } from '../../../../../store/common/api-clients.hooks';
 import { useCalculateMaxBitcoinSpend } from '../../family/bitcoin/hooks/use-calculate-max-spend';
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 import { useGenerateSignedBitcoinTx } from './use-generate-bitcoin-tx';
@@ -42,6 +44,7 @@ export function useBtcSendForm() {
   const generateTx = useGenerateSignedBitcoinTx();
   const calcMaxSpend = useCalculateMaxBitcoinSpend();
   const { onFormStateChange } = useUpdatePersistedSendFormValues();
+  const client = useStacksClientUnanchored();
 
   return {
     formRef,
@@ -65,6 +68,9 @@ export function useBtcSendForm() {
           })
         )
         .concat(btcMinimumSpendValidator()),
+      recipientOrBnsName: btcRecipientOrBnsNameValidator({
+        client,
+      }),
       recipient: yup
         .string()
         .concat(btcAddressValidator())

--- a/src/app/query/stacks/bns/bns.utils.ts
+++ b/src/app/query/stacks/bns/bns.utils.ts
@@ -126,8 +126,11 @@ export async function fetchNamesForAddress(
 
   // Return BNSx name if available, otherwise return names from API.
   const [bnsxName, bnsNames] = await Promise.all([fetchBnsxName(client, address), fetchFromApi()]);
-  if (bnsxName !== null) return { names: [bnsxName] };
-  return bnsNames;
+  const bnsName = 'names' in bnsNames ? bnsNames.names[0] : null;
+  const names: string[] = [];
+  if (bnsName) names.push(bnsName);
+  if (bnsxName) names.push(bnsxName);
+  return { names };
 }
 
 // Fetch the owner of a name.

--- a/src/app/query/stacks/bns/bns.utils.ts
+++ b/src/app/query/stacks/bns/bns.utils.ts
@@ -1,0 +1,77 @@
+import { BnsNamesOwnByAddressResponse } from '@stacks/stacks-blockchain-api-types';
+import {
+  BufferCV,
+  ClarityType,
+  OptionalCV,
+  TupleCV,
+  cvToHex,
+  deserializeCV,
+  standardPrincipalCV,
+} from '@stacks/transactions';
+
+import { StacksClient } from '@app/query/stacks/stacks-client';
+
+export const BNSX_CONTRACT_CONSTS = {
+  contractAddress: 'SP1JTCR202ECC6333N7ZXD7MK7E3ZTEEE1MJ73C60',
+  contractName: 'bnsx-registry',
+  functionName: 'get-primary-name',
+} as const;
+
+export function bytesToAscii(buffer: Uint8Array) {
+  let ret = '';
+  const end = buffer.length;
+
+  for (let i = 0; i < end; ++i) {
+    ret += String.fromCharCode(buffer[i] & 0x7f);
+  }
+  return ret;
+}
+
+// Fetch an address's "primary name" from the BNSx contract.
+export async function fetchBnsxName(client: StacksClient, address: string): Promise<string | null> {
+  try {
+    const addressCV = standardPrincipalCV(address);
+    const addressHex = cvToHex(addressCV);
+    const res = await client.smartContractsApi.callReadOnlyFunction({
+      ...BNSX_CONTRACT_CONSTS,
+      tip: 'latest',
+      readOnlyFunctionArgs: {
+        sender: address,
+        arguments: [addressHex],
+      },
+    });
+    if (!res.okay || !res.result) return null;
+    const { result } = res;
+    const cv = deserializeCV(result) as OptionalCV<
+      TupleCV<{ name: BufferCV; namespace: BufferCV }>
+    >;
+    if (cv.type === ClarityType.OptionalNone) return null;
+    const { name, namespace } = cv.value.data;
+    const fullName = `${bytesToAscii(name.buffer)}.${bytesToAscii(namespace.buffer)}`;
+    return fullName;
+  } catch (error) {
+    return null;
+  }
+}
+
+// Fetch names owned by an address.
+//
+// If `isTestnet` is `false` (aka mainnet), names are fetched from the
+// BNSx contract directly.
+export async function fetchNamesForAddress(
+  client: StacksClient,
+  address: string,
+  isTestnet: boolean
+): Promise<BnsNamesOwnByAddressResponse> {
+  const fetchFromApi = async () => {
+    return client.namesApi.getNamesOwnedByAddress({ address, blockchain: 'stacks' });
+  };
+  if (isTestnet) {
+    return fetchFromApi();
+  }
+
+  // Return BNSx name if available, otherwise return names from API.
+  const [bnsxName, bnsNames] = await Promise.all([fetchBnsxName(client, address), fetchFromApi()]);
+  if (bnsxName !== null) return { names: [bnsxName] };
+  return bnsNames;
+}

--- a/src/app/query/stacks/bns/bns.utils.ts
+++ b/src/app/query/stacks/bns/bns.utils.ts
@@ -1,12 +1,18 @@
+import { asciiToBytes } from '@stacks/common';
 import { BnsNamesOwnByAddressResponse } from '@stacks/stacks-blockchain-api-types';
 import {
   BufferCV,
   ClarityType,
   OptionalCV,
+  PrincipalCV,
   TupleCV,
+  UIntCV,
+  addressToString,
+  bufferCV,
   cvToHex,
   deserializeCV,
   standardPrincipalCV,
+  tupleCV,
 } from '@stacks/transactions';
 
 import { StacksClient } from '@app/query/stacks/stacks-client';
@@ -14,7 +20,6 @@ import { StacksClient } from '@app/query/stacks/stacks-client';
 export const BNSX_CONTRACT_CONSTS = {
   contractAddress: 'SP1JTCR202ECC6333N7ZXD7MK7E3ZTEEE1MJ73C60',
   contractName: 'bnsx-registry',
-  functionName: 'get-primary-name',
 } as const;
 
 export function bytesToAscii(buffer: Uint8Array) {
@@ -34,6 +39,7 @@ export async function fetchBnsxName(client: StacksClient, address: string): Prom
     const addressHex = cvToHex(addressCV);
     const res = await client.smartContractsApi.callReadOnlyFunction({
       ...BNSX_CONTRACT_CONSTS,
+      functionName: 'get-primary-name',
       tip: 'latest',
       readOnlyFunctionArgs: {
         sender: address,
@@ -52,6 +58,54 @@ export async function fetchBnsxName(client: StacksClient, address: string): Prom
   } catch (error) {
     return null;
   }
+}
+
+// This function is not exported from `@stacks/transactions`
+function principalToString(principal: PrincipalCV): string {
+  if (principal.type === ClarityType.PrincipalStandard) {
+    return addressToString(principal.address);
+  } else if (principal.type === ClarityType.PrincipalContract) {
+    const address = addressToString(principal.address);
+    return `${address}.${principal.contractName.content}`;
+  } else {
+    throw new Error(`Unexpected principal data: ${JSON.stringify(principal)}`);
+  }
+}
+
+// Fetch the owner of a BNSx name
+// If the name is not registered in BNSx, returns null.
+//
+// Subdomains don't exist on-chain, so if the name looks like a subdomain,
+// the function exits early with `null`.
+export async function fetchBnsxOwner(client: StacksClient, fqn: string): Promise<string | null> {
+  const nameParts = fqn.split('.');
+
+  // If the name includes a subdomain, it's not on-chain. Return null
+  if (nameParts.length !== 2) return null;
+
+  const [name, namespace] = nameParts;
+  const nameCV = tupleCV({
+    name: bufferCV(asciiToBytes(name)),
+    namespace: bufferCV(asciiToBytes(namespace)),
+  });
+
+  const res = await client.smartContractsApi.callReadOnlyFunction({
+    ...BNSX_CONTRACT_CONSTS,
+    functionName: 'get-name-properties',
+    tip: 'latest',
+    readOnlyFunctionArgs: {
+      // Sender is irrelevant
+      sender: BNSX_CONTRACT_CONSTS.contractAddress,
+      arguments: [cvToHex(nameCV)],
+    },
+  });
+
+  if (!res.okay || !res.result) return null;
+  const { result } = res;
+  const cv = deserializeCV(result) as OptionalCV<TupleCV<{ owner: PrincipalCV; id: UIntCV }>>;
+  if (cv.type === ClarityType.OptionalNone) return null;
+  const ownerCV = cv.value.data.owner;
+  return principalToString(ownerCV);
 }
 
 // Fetch names owned by an address.
@@ -74,4 +128,22 @@ export async function fetchNamesForAddress(
   const [bnsxName, bnsNames] = await Promise.all([fetchBnsxName(client, address), fetchFromApi()]);
   if (bnsxName !== null) return { names: [bnsxName] };
   return bnsNames;
+}
+
+// Fetch the owner of a name.
+//
+// If on mainnet, this function concurrently fetches a BNSx owner from the contract
+// and a BNS owner from the API.
+export async function fetchNameOwner(client: StacksClient, name: string, isTestnet: boolean) {
+  const fetchFromApi = async () => {
+    const res = await client.namesApi.getNameInfo({ name });
+    if (typeof res.address !== 'string' || res.address.length === 0) return null;
+    return res.address;
+  };
+  if (isTestnet) {
+    return fetchFromApi();
+  }
+
+  const [bnsxOwner, apiOwner] = await Promise.all([fetchBnsxOwner(client, name), fetchFromApi()]);
+  return bnsxOwner ?? apiOwner;
 }

--- a/src/app/query/stacks/bns/bns.utils.ts
+++ b/src/app/query/stacks/bns/bns.utils.ts
@@ -1,3 +1,4 @@
+import { parseZoneFile } from '@fungible-systems/zone-file';
 import { asciiToBytes } from '@stacks/common';
 import { BnsNamesOwnByAddressResponse } from '@stacks/stacks-blockchain-api-types';
 import {
@@ -108,10 +109,11 @@ export async function fetchBnsxOwner(client: StacksClient, fqn: string): Promise
   return principalToString(ownerCV);
 }
 
-// Fetch names owned by an address.
-//
-// If `isTestnet` is `false` (aka mainnet), names are fetched from the
-// BNSx contract directly.
+/** Fetch names owned by an address.
+ *
+ * If `isTestnet` is `false` (aka mainnet), names are fetched from the
+ * BNSx contract directly.
+ */
 export async function fetchNamesForAddress(
   client: StacksClient,
   address: string,
@@ -133,10 +135,12 @@ export async function fetchNamesForAddress(
   return { names };
 }
 
-// Fetch the owner of a name.
-//
-// If on mainnet, this function concurrently fetches a BNSx owner from the contract
-// and a BNS owner from the API.
+/**
+ * Fetch the owner of a name.
+ *
+ * If on mainnet, this function concurrently fetches a BNSx owner from the contract
+ * and a BNS owner from the API.
+ */
 export async function fetchNameOwner(client: StacksClient, name: string, isTestnet: boolean) {
   const fetchFromApi = async () => {
     const res = await client.namesApi.getNameInfo({ name });
@@ -149,4 +153,29 @@ export async function fetchNameOwner(client: StacksClient, name: string, isTestn
 
   const [bnsxOwner, apiOwner] = await Promise.all([fetchBnsxOwner(client, name), fetchFromApi()]);
   return bnsxOwner ?? apiOwner;
+}
+
+/**
+ * Fetch the zonefile-based BTC address for a specific name.
+ * The BTC address is found via the `_btc._addr` TXT record,
+ * as specified in https://www.newinternetlabs.com/blog/standardizing-names-for-bitcoin-addresses/
+ *
+ * The value returned from this function is not validated.
+ */
+export async function fetchBtcNameOwner(
+  client: StacksClient,
+  name: string
+): Promise<string | null> {
+  try {
+    const nameResponse = await client.namesApi.getNameInfo({ name });
+    const zonefile = parseZoneFile(nameResponse.zonefile);
+    if (!zonefile.txt) return null;
+    const btcRecord = zonefile.txt.find(record => record.name === '_btc._addr');
+    if (typeof btcRecord === 'undefined') return null;
+    const txtValue = btcRecord.txt;
+    return typeof txtValue === 'string' ? txtValue : txtValue[0] ?? null;
+  } catch (error) {
+    // name not found or invalid zonefile
+    return null;
+  }
 }

--- a/src/app/store/keys/key.actions.ts
+++ b/src/app/store/keys/key.actions.ts
@@ -8,6 +8,7 @@ import { sendMessage } from '@shared/messages';
 import { recurseAccountsForActivity } from '@app/common/account-restoration/account-restore';
 import { checkForLegacyGaiaConfigWithKnownGeneratedAccountIndex } from '@app/common/account-restoration/legacy-gaia-config-lookup';
 import { BitcoinClient } from '@app/query/bitcoin/bitcoin-client';
+import { fetchNamesForAddress } from '@app/query/stacks/bns/bns.utils';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import { AppThunk } from '@app/store';
 
@@ -40,10 +41,7 @@ function setWalletEncryptionPassword(args: {
     }
 
     async function doesStacksAddressHaveBnsName(address: string) {
-      const resp = await stxClient.namesApi.getNamesOwnedByAddress({
-        address,
-        blockchain: 'stacks',
-      });
+      const resp = await fetchNamesForAddress(stxClient, address, true);
       return resp.names.length > 0;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1183,6 +1183,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@fungible-systems/zone-file@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@fungible-systems/zone-file/-/zone-file-2.0.0.tgz#ab19e9d9efba573680e8e9b536b3b7b399ef35f5"
+  integrity sha512-l7IqAjJSvvwKuShfVsQ70nhNfoTtqoow5vxblLaJJyl4XeIVdD28+clwTkJkag8oEPHPobJXfqLBDHHdF+E0hA==
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
This PR adds "send BTC to a BNS name" functionality, similar to how it works with STX asset transfers.

This is built on top of #3147, and only the latest commit includes this functionality. I've built it on top of that PR to re-use some of the organizational structure of BNS-related queries.

Preview:

https://user-images.githubusercontent.com/1109058/222636762-38c54628-19a1-487f-a339-45c01d7d3ec6.mp4

In the video you'll notice some janky validation behavior. I'm not exactly sure what's causing this, though I'm sure it has to do with async validation. I copied the structure from the send STX page, and I sometimes saw similar behavior on that page, but I'm not sure if they're related. I'm certain this code could use some improvement, especially due to my lack of familiarity with a lot of the codebase.

The way this works is that it fetches the name's zonefile, parses it, and looks for the `_btc._addr` TXT record, as specified in https://newinternetlabs.com.

At the moment the only way I know of to add this record to your name is via https://btc.us/manage, but we're aiming to add this functionality to https://dots.so soon.