### PR TITLE
feat: add collectible hover call to action

### DIFF
--- a/src/app/components/icons/arrow-icon.tsx
+++ b/src/app/components/icons/arrow-icon.tsx
@@ -1,0 +1,20 @@
+export function ArrowIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M12.985 3.015 3.5 12.5M6 3h7v7"
+        stroke="#242629"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/app/components/icons/ordinal-minimal-icon.tsx
+++ b/src/app/components/icons/ordinal-minimal-icon.tsx
@@ -1,0 +1,16 @@
+export function OrdinalMinimalIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={30}
+      height={30}
+      viewBox="0 0 30 30"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <circle cx={15} cy={15} r={15} fill="#0C0C0D" />
+      <circle cx={15} cy={15} r={11.25} fill="#fff" />
+      <circle cx={15} cy={15} r={5.625} fill="#0C0C0D" />
+    </svg>
+  );
+}

--- a/src/app/features/collectibles/components/add-collectible.tsx
+++ b/src/app/features/collectibles/components/add-collectible.tsx
@@ -29,7 +29,7 @@ export function AddCollectible() {
   return (
     <CollectibleLayout
       backgroundElementProps={backgroundProps}
-      onSelectCollectible={() => {
+      onClickLayout={() => {
         void analytics.track('select_add_new_collectible');
         navigate(RouteUrls.ReceiveCollectible);
       }}

--- a/src/app/features/collectibles/components/collectible-hover.tsx
+++ b/src/app/features/collectibles/components/collectible-hover.tsx
@@ -1,17 +1,23 @@
-import { Box, Text } from '@stacks/ui';
+import { Box, Flex, color } from '@stacks/ui';
 
-export function CollectibleHover(props: { hoverText?: string }) {
-  const { hoverText } = props;
+import { ArrowIcon } from '@app/components/icons/arrow-icon';
 
+interface CollectibleHoverProps {
+  collectibleTypeIcon?: JSX.Element;
+  isHovered: boolean;
+  onClickCallToAction?(): void;
+}
+export function CollectibleHover({
+  collectibleTypeIcon,
+  isHovered,
+  onClickCallToAction,
+}: CollectibleHoverProps) {
   return (
     <Box
-      _hover={{ opacity: '1' }}
-      alignItems="center"
-      background="linear-gradient(0deg, rgba(0, 0, 0, 0.75) 0%, rgba(12, 12, 13, 0) 100%);"
-      borderRadius="16px"
+      sx={{ opacity: isHovered ? 'inherit' : '0' }}
+      _focusWithin={{ opacity: 'inherit' }}
       display="flex"
       height="100%"
-      justifyContent="center"
       left="0px"
       opacity="0"
       overflow="hidden"
@@ -20,11 +26,30 @@ export function CollectibleHover(props: { hoverText?: string }) {
       width="100%"
       zIndex={999}
     >
-      {hoverText ? (
-        <Text bottom="0px" color="white" left="0px" lineHeight="1.5" p="base" position="absolute">
-          {hoverText}
-        </Text>
-      ) : null}
+      <Box position="absolute" left="12px" bottom="12px">
+        {collectibleTypeIcon}
+      </Box>
+      {onClickCallToAction && (
+        <Flex
+          onClick={e => {
+            e.stopPropagation();
+            onClickCallToAction();
+          }}
+          as="button"
+          position="absolute"
+          right="12px"
+          top="12px"
+          width="30px"
+          height="30px"
+          backgroundColor={color('bg')}
+          borderRadius="50%"
+          justifyContent="center"
+          alignItems="center"
+          _focus={{ outline: '4px solid #CEDAFA' }}
+        >
+          <ArrowIcon />
+        </Flex>
+      )}
     </Box>
   );
 }

--- a/src/app/features/collectibles/components/collectible-image.tsx
+++ b/src/app/features/collectibles/components/collectible-image.tsx
@@ -1,3 +1,5 @@
+import { OrdinalMinimalIcon } from '@app/components/icons/ordinal-minimal-icon';
+
 import { CollectibleImageLayout } from './collectible-image.layout';
 import { CollectibleLayout, CollectibleLayoutProps } from './collectible.layout';
 
@@ -7,7 +9,7 @@ interface ImageCollectibleProps extends Omit<CollectibleLayoutProps, 'children'>
 export function CollectibleImage(props: ImageCollectibleProps) {
   const { src, ...rest } = props;
   return (
-    <CollectibleLayout {...rest}>
+    <CollectibleLayout collectibleTypeIcon={<OrdinalMinimalIcon />} {...rest}>
       <CollectibleImageLayout src={src} />
     </CollectibleLayout>
   );

--- a/src/app/features/collectibles/components/collectible-other.tsx
+++ b/src/app/features/collectibles/components/collectible-other.tsx
@@ -8,7 +8,14 @@ interface OtherCollectibleProps extends Omit<CollectibleLayoutProps, 'children'>
 export function CollectibleOther(props: OtherCollectibleProps) {
   return (
     <CollectibleLayout {...props}>
-      <Box width="90px">
+      <Box
+        backgroundColor="black"
+        height="100%"
+        width="100%"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+      >
         <OrdinalIconFull />
       </Box>
     </CollectibleLayout>

--- a/src/app/features/collectibles/components/collectible-text.layout.tsx
+++ b/src/app/features/collectibles/components/collectible-text.layout.tsx
@@ -18,6 +18,7 @@ export function CollectibleTextLayout(props: CollectibleTextLayoutProps) {
       height="100%"
       width="100%"
       color="white"
+      backgroundColor="black"
       p="20px"
       sx={{
         position: 'relative',

--- a/src/app/features/collectibles/components/collectible-text.tsx
+++ b/src/app/features/collectibles/components/collectible-text.tsx
@@ -1,3 +1,5 @@
+import { OrdinalMinimalIcon } from '@app/components/icons/ordinal-minimal-icon';
+
 import { CollectibleTextLayout } from './collectible-text.layout';
 import { CollectibleLayout, CollectibleLayoutProps } from './collectible.layout';
 
@@ -8,7 +10,7 @@ interface CollectibleTextProps extends Omit<CollectibleLayoutProps, 'children'> 
 export function CollectibleText(props: CollectibleTextProps) {
   const { contentSrc, ...rest } = props;
   return (
-    <CollectibleLayout {...rest}>
+    <CollectibleLayout collectibleTypeIcon={<OrdinalMinimalIcon />} {...rest}>
       <CollectibleTextLayout contentSrc={contentSrc} />
     </CollectibleLayout>
   );

--- a/src/app/features/collectibles/components/collectible.layout.tsx
+++ b/src/app/features/collectibles/components/collectible.layout.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from 'react';
 
-import { Box, Stack, Text } from '@stacks/ui';
+import { Box, Button, Stack, Text } from '@stacks/ui';
 import type { BoxProps } from '@stacks/ui';
 import { color } from '@stacks/ui-utils';
+import { useHover } from 'use-events';
 
 import { CollectibleHover } from './collectible-hover';
 
@@ -10,61 +11,104 @@ export interface CollectibleLayoutProps {
   backgroundElementProps?: BoxProps;
   children: ReactNode;
   hoverText?: string;
-  onSelectCollectible?(): void;
+  onClickCallToAction?(): void;
+  onClickLayout?(): void;
+  onClickSend?(): void;
+  collectibleTypeIcon?: JSX.Element;
   subtitle: string;
   title: string;
 }
 export function CollectibleLayout({
   backgroundElementProps,
   children,
-  hoverText,
-  onSelectCollectible,
+  onClickCallToAction,
+  onClickSend,
+  onClickLayout,
+  collectibleTypeIcon,
   subtitle,
   title,
 }: CollectibleLayoutProps) {
+  const [isHovered, bind] = useHover();
+
   return (
-    <Box
-      _focus={{
-        outline: '4px solid #CEDAFA',
-      }}
-      as={onSelectCollectible ? 'button' : 'div'}
-      borderRadius="16px"
-      onClick={onSelectCollectible}
-    >
-      <Box height="0px" position="relative" pb="100%">
-        <CollectibleHover hoverText={hoverText} />
-        <Box
-          alignItems="center"
-          backgroundColor="black"
-          borderRadius="16px"
-          display="flex"
-          height="100%"
-          justifyContent="center"
-          left="0px"
-          overflow="hidden"
-          position="absolute"
-          top="0px"
-          width="100%"
-          {...backgroundElementProps}
-        >
-          {children}
+    <Box>
+      <Box
+        _focus={{
+          outline: '4px solid #CEDAFA',
+          outlineOffset: '-4px',
+        }}
+        as={onClickLayout ? 'button' : 'div'}
+        borderRadius="20px"
+        onClick={onClickLayout}
+        padding="4px"
+        sx={{
+          // Buttons have had styles applied that center their children text
+          // nodes, which is undesirable in this case. A button is being used more
+          // for its actionability (focus, onclick) & accessibility rather than
+          // for its styles.
+          textAlign: 'inherit',
+          width: '100%',
+        }}
+        {...bind}
+      >
+        <Box height="0px" position="relative" pb="100%">
+          <CollectibleHover
+            onClickCallToAction={onClickCallToAction}
+            collectibleTypeIcon={collectibleTypeIcon}
+            isHovered={isHovered}
+          />
+          <Box
+            alignItems="center"
+            borderRadius="16px"
+            display="flex"
+            height="100%"
+            justifyContent="center"
+            left="0px"
+            overflow="hidden"
+            position="absolute"
+            top="0px"
+            width="100%"
+            {...backgroundElementProps}
+          >
+            {children}
+          </Box>
         </Box>
+        <Stack mt="base" pl="tight" spacing="extra-tight" textAlign="left">
+          <Text
+            color={color('text-body')}
+            fontWeight="500"
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+            width={['150px', '200px']}
+          >
+            {title}
+          </Text>
+          <Text color={color('text-caption')} fontSize={1}>
+            {subtitle}
+          </Text>
+        </Stack>
+
+        {onClickSend && (
+          <Box padding="8px">
+            <Button
+              mode="tertiary"
+              p="6px 12px"
+              sx={{
+                // Used to hide the button visually while keeping it in the accessibility tree.
+                clipPath: isHovered ? 'none' : 'circle(0%)',
+              }}
+              onClick={e => {
+                e.stopPropagation();
+                onClickSend && onClickSend();
+              }}
+              _focus={{ clipPath: 'none', outline: '4px solid #CEDAFA' }}
+            >
+              Send
+            </Button>
+          </Box>
+        )}
       </Box>
-      <Stack mt="base" pl="tight" spacing="extra-tight" textAlign="left">
-        <Text
-          color={color('text-body')}
-          fontWeight="500"
-          overflow="hidden"
-          textOverflow="ellipsis"
-          whiteSpace="nowrap"
-          width={['150px', '200px']}
-        >
-          {title}
-        </Text>
-        <Text color={color('text-caption')} fontSize={1}>
-          {subtitle}
-        </Text>
-      </Stack>
     </Box>
   );
 }

--- a/src/app/features/collectibles/components/ordinals.tsx
+++ b/src/app/features/collectibles/components/ordinals.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { useInscriptionByTxidQuery } from '@app/query/bitcoin/ordinals/use-inscription-by-txid.query';
 import { useInscriptionQuery } from '@app/query/bitcoin/ordinals/use-inscription.query';
 import {
@@ -61,7 +62,8 @@ function Inscription({ path, utxo }: InscriptionProps) {
       return (
         <CollectibleImage
           key={inscriptionMetadata.title}
-          onSelectCollectible={() => openSendInscriptionModal()}
+          onClickCallToAction={() => openInNewTab(inscriptionMetadata.infoUrl)}
+          onClickSend={() => openSendInscriptionModal()}
           src={inscriptionMetadata.src}
           subtitle="Ordinal inscription"
           title={inscriptionMetadata.title}
@@ -72,7 +74,8 @@ function Inscription({ path, utxo }: InscriptionProps) {
       return (
         <CollectibleText
           key={inscriptionMetadata.title}
-          onSelectCollectible={() => openSendInscriptionModal()}
+          onClickCallToAction={() => openInNewTab(inscriptionMetadata.infoUrl)}
+          onClickSend={() => openSendInscriptionModal()}
           contentSrc={inscriptionMetadata.contentSrc}
           subtitle="Ordinal inscription"
           title={inscriptionMetadata.title}
@@ -83,7 +86,8 @@ function Inscription({ path, utxo }: InscriptionProps) {
       return (
         <CollectibleOther
           key={inscriptionMetadata.title}
-          onSelectCollectible={() => openSendInscriptionModal()}
+          onClickCallToAction={() => openInNewTab(inscriptionMetadata.infoUrl)}
+          onClickSend={() => openSendInscriptionModal()}
           subtitle="Ordinal inscription"
           title={inscriptionMetadata.title}
         />


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4354559032).<!-- Sticky Header Marker -->

Adds UI features that allow for two types of actions on collectibles: sending and a "call to action". The call to action on ordinal inscriptions is set to viewing them on ordinals.com.

Styles have also been tweaked as per latest designs, notably, element placement and borders.

[Screencast from 2023-03-06 18-01-43.webm](https://user-images.githubusercontent.com/116000646/223193888-e8cd7cc2-d582-42a5-9093-4bfa54e5222f.webm)
