### PR TITLE
fix: sip10 recipient validation

### DIFF
--- a/src/app/store/transactions/token-transfer.hooks.ts
+++ b/src/app/store/transactions/token-transfer.hooks.ts
@@ -125,7 +125,7 @@ export function useGenerateFtTokenTransferUnsignedTx(selectedAssetId: string) {
 
       const recipient =
         values && 'recipient' in values
-          ? createAddress(values.recipient || '')
+          ? createAddress(values.recipient || values.recipientAddressOrBnsName || '')
           : createEmptyAddress();
       const amount = values && 'amount' in values ? values.amount : 0;
       const memo =


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4355257366).<!-- Sticky Header Marker -->

There was one other spot to add this for sip10 tokens.