### PR TITLE
fix: recipient field bns address

### DIFF
--- a/src/app/store/transactions/token-transfer.hooks.ts
+++ b/src/app/store/transactions/token-transfer.hooks.ts
@@ -69,7 +69,8 @@ export function useGenerateStxTokenTransferUnsignedTx() {
         txData: {
           txType: TransactionTypes.STXTransfer,
           // Using account address here as a fallback for a fee estimation
-          recipient: values?.recipient || values?.recipientAddressOrBnsName || account.address,
+          recipient:
+            values?.resolvedRecipient || values?.recipientAddressOrBnsName || account.address,
           amount: values?.amount ? stxToMicroStx(values?.amount).toString(10) : '0',
           memo: values?.memo || undefined,
           network: network,
@@ -125,7 +126,7 @@ export function useGenerateFtTokenTransferUnsignedTx(selectedAssetId: string) {
 
       const recipient =
         values && 'recipient' in values
-          ? createAddress(values.recipient || values.recipientAddressOrBnsName || '')
+          ? createAddress(values.resolvedRecipient || values.recipientAddressOrBnsName || '')
           : createEmptyAddress();
       const amount = values && 'amount' in values ? values.amount : 0;
       const memo =


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/4356874555).<!-- Sticky Header Marker -->

Had to replace `recipient` here altogether for bns names. This will fix things until I get the input fields separated.