### PR TITLE
fix: ft metadata

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     '@typescript-eslint/ban-types': [0],
     '@typescript-eslint/restrict-template-expressions': [0],
     '@typescript-eslint/explicit-module-boundary-types': [0],
+    '@typescript-eslint/no-unnecessary-condition': 'warn',
     'no-warning-comments': [0],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': [

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: kyranjamie/pull-request-fixed-header@v1.0.1
         with:
-          header: '> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/stacks-wallet-web/actions/runs/${{ github.run_id }}).'
+          header: '> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_chrome_extension:

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/stars/ldinpeekobnhjjdofggfgjlcehhmanlj?label=Chrome%20Web%20Store)](https://chrome.google.com/webstore/detail/stacks-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj)
 [![Mozilla Add-on](https://img.shields.io/amo/stars/hiro-wallet?label=Firefox%20Add-on)](https://addons.mozilla.org/en-US/firefox/addon/hiro-wallet/)
-[![coverage](https://raw.githubusercontent.com/hirosystems/stacks-wallet-web/gh-pages/badge.svg)](https://hirosystems.github.io/stacks-wallet-web/)
+[![coverage](https://raw.githubusercontent.com/hirosystems/wallet/gh-pages/badge.svg)](https://hirosystems.github.io/wallet/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 Hiro Wallet is the most popular and trusted wallet for apps built on Bitcoin. Connect to apps and manage assets secured by Bitcoin and Bitcoin L2s with battle-tested wallet for the Stacks blockchain.
 
 To integrate this wallet into your app, we recommend [@stacks/connect](https://github.com/hirosystems/connect).
 
-[📚 See Hiro Wallet API Reference →](https://github.com/hirosystems/stacks-wallet-web/wiki)
+[📚 See Hiro Wallet API Reference →](https://github.com/hirosystems/wallet/wiki)
 
 [📩 Join the mailing list for updates →](https://forms.gle/sdZPu2jbX1AeQ8Fi9)
 
@@ -97,4 +97,4 @@ Please note this email is strictly for reporting security vulnerabilities. For s
 
 In Q1 2021, Hiro partnered with [Least Authority](https://leastauthority.com/), a leading security consultancy with experience in the crypto space, to audit Hiro Wallet for Web. On April 29th 2021, after addressing the major concerns described in the initial findings, as well as a concluding sign off from the Least Authority team, a final report was delivered.
 
-[Download and read the full report here](https://github.com/hirosystems/stacks-wallet-web/blob/main/public/docs/least-authority-security-audit-report.pdf)
+[Download and read the full report here](https://github.com/hirosystems/wallet/blob/main/public/docs/least-authority-security-audit-report.pdf)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:hirosystems/stacks-wallet-web.git"
+    "url": "git@github.com:hirosystems/wallet.git"
   },
   "webExt": {
     "sourceDir": "dist/"

--- a/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.tsx
+++ b/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.tsx
@@ -25,7 +25,7 @@ export const StacksFungibleTokenAssetItem = forwardRefWithAs(
     const avatar = `${formatContractId(contractAddress, contractName)}::${contractAssetName}`;
     const dataTestId = CryptoAssetSelectors.CryptoAssetListItem.replace(
       '{symbol}',
-      symbol.toLowerCase()
+      symbol?.toLowerCase()
     );
     const friendlyName =
       name ||

--- a/src/app/features/ledger/ledger-utils.ts
+++ b/src/app/features/ledger/ledger-utils.ts
@@ -149,7 +149,7 @@ export function doesLedgerStacksAppVersionSupportJwtAuth(versionInfo: SemVerObje
 }
 
 // https://github.com/Zondax/ledger-stacks/issues/119
-// https://github.com/hirosystems/stacks-wallet-web/issues/2567
+// https://github.com/hirosystems/wallet/issues/2567
 const versionFromWhichContractPrincipalBugIsFixed = '0.23.3';
 
 export function isVersionOfLedgerStacksAppWithContractPrincipalBug(

--- a/src/app/pages/update-profile-request/components/page-top.tsx
+++ b/src/app/pages/update-profile-request/components/page-top.tsx
@@ -14,7 +14,6 @@ function PageTopBase() {
   if (!requestToken) return null;
   const profileUpdaterPayload = getProfileDataContentFromToken(requestToken);
   if (!profileUpdaterPayload) return null;
-
   const appName = profileUpdaterPayload?.appDetails?.name;
   const originAddition = origin ? ` (${getUrlHostname(origin)})` : '';
   const testnetAddition = isTestnet

--- a/src/app/query/stacks/balance/stacks-ft-balances.hooks.ts
+++ b/src/app/query/stacks/balance/stacks-ft-balances.hooks.ts
@@ -56,6 +56,7 @@ export function useStacksFungibleTokenAssetBalancesAnchoredWithMetadata(address:
       formatContractId(assetBalance.asset.contractAddress, assetBalance.asset.contractName)
     )
   );
+
   return useMemo(
     () =>
       initializedAssetBalances.map((assetBalance, i) => {

--- a/src/app/query/stacks/fungible-tokens/fungible-token-metadata.query.ts
+++ b/src/app/query/stacks/fungible-tokens/fungible-token-metadata.query.ts
@@ -1,8 +1,9 @@
 import { FungibleTokenMetadata } from '@stacks/stacks-blockchain-api-types';
 import { UseQueryResult, useQueries, useQuery } from '@tanstack/react-query';
 
-import { StacksClient } from '@app/query/stacks/stacks-client';
-import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
+import { NetworkModes, chainIdToNetworkModeMap } from '@shared/constants';
+
+import { fetcher } from '@app/common/api/wrapped-fetch';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 import { RateLimiter, useHiroApiRateLimiter } from '../rate-limiter';
@@ -20,22 +21,31 @@ const queryOptions = {
   retry: 0,
 } as const;
 
-function fetchUnanchoredAccountInfo(client: StacksClient, limiter: RateLimiter) {
+const hiroApiUrlMap: Record<NetworkModes, string> = {
+  mainnet: 'https://api.hiro.so',
+  testnet: 'https://api.testnet.hiro.so',
+};
+
+function fetchUnanchoredAccountInfo(network: NetworkModes, limiter: RateLimiter) {
   return (contractId: string) => async () => {
     await limiter.removeTokens(1);
-    return client.fungibleTokensApi.getContractFtMetadata({ contractId });
+    const resp = await fetcher(hiroApiUrlMap[network] + `/metadata/v1/ft/${contractId}`);
+    const data = await resp.json();
+    return data;
   };
 }
 
 export function useGetFungibleTokenMetadataQuery(
   contractId: string
 ): UseQueryResult<FungibleTokenMetadata> {
-  const client = useStacksClientUnanchored();
-  const network = useCurrentNetworkState();
+  const { chain } = useCurrentNetworkState();
   const limiter = useHiroApiRateLimiter();
   return useQuery({
-    queryKey: ['get-ft-metadata', contractId, network.chain.stacks.url],
-    queryFn: fetchUnanchoredAccountInfo(client, limiter)(contractId),
+    queryKey: ['get-ft-metadata', contractId, chain.stacks.url],
+    queryFn: fetchUnanchoredAccountInfo(
+      chainIdToNetworkModeMap[chain.stacks.chainId],
+      limiter
+    )(contractId),
     ...queryOptions,
   });
 }
@@ -43,13 +53,15 @@ export function useGetFungibleTokenMetadataQuery(
 export function useGetFungibleTokenMetadataListQuery(
   contractIds: string[]
 ): UseQueryResult<FungibleTokenMetadata>[] {
-  const client = useStacksClientUnanchored();
-  const network = useCurrentNetworkState();
+  const { chain } = useCurrentNetworkState();
   const limiter = useHiroApiRateLimiter();
   return useQueries({
     queries: contractIds.map(contractId => ({
-      queryKey: ['get-ft-metadata', contractId, network.chain.stacks.url],
-      queryFn: fetchUnanchoredAccountInfo(client, limiter)(contractId),
+      queryKey: ['get-ft-metadata', contractId, chain.stacks.url],
+      queryFn: fetchUnanchoredAccountInfo(
+        chainIdToNetworkModeMap[chain.stacks.chainId],
+        limiter
+      )(contractId),
       ...queryOptions,
     })),
   });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -25,7 +25,7 @@ export const KEBAB_REGEX = /[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g;
 export const MICROBLOCKS_ENABLED = !IS_TEST_ENV && true;
 
 export const GITHUB_ORG = 'hirosystems';
-export const GITHUB_REPO = 'stacks-wallet-web';
+export const GITHUB_REPO = 'wallet';
 
 export enum DefaultNetworkConfigurationIds {
   mainnet = 'mainnet',
@@ -34,6 +34,11 @@ export enum DefaultNetworkConfigurationIds {
 }
 
 export type DefaultNetworkConfigurations = keyof typeof DefaultNetworkConfigurationIds;
+
+export const chainIdToNetworkModeMap: Record<ChainID, NetworkModes> = {
+  [ChainID.Mainnet]: 'mainnet',
+  [ChainID.Testnet]: 'testnet',
+};
 
 interface BaseChainConfig {
   blockchain: Blockchains;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4424382969).<!-- Sticky Header Marker -->

Did quick so might be a better solution for using the hiro api path long term. Putting this up as a fix for reports of ft decimals be broken and seeing myself on mainnet now.

https://stacks-node-api.stacks.co/extended/v1/tokens/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-token/ft/metadata?unanchored=true

https://api.hiro.so/metadata/v1/ft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.age000-governance-token

Broken:
<img width="904" alt="Screen Shot 2023-03-14 at 7 38 05 PM" src="https://user-images.githubusercontent.com/6493321/225179714-b2aaeaef-56a0-4929-a509-2662b0c81c9f.png">

Fixed:
<img width="900" alt="Screen Shot 2023-03-14 at 8 04 52 PM" src="https://user-images.githubusercontent.com/6493321/225179756-c12021cc-1e27-497a-8d1c-bc902b13b0a8.png">
