### PR TITLE
fix: ft metadata not found

### DIFF
--- a/src/app/common/crypto-assets/stacks-crypto-asset.utils.spec.ts
+++ b/src/app/common/crypto-assets/stacks-crypto-asset.utils.spec.ts
@@ -1,9 +1,24 @@
+import { FungibleTokenMetadata } from '@stacks/stacks-blockchain-api-types';
+
 import { StacksFungibleTokenAsset } from '@shared/models/crypto-asset.model';
 
 import {
   isFtNameLikeStx,
   isTransferableStacksFungibleTokenAsset,
 } from './stacks-crypto-asset.utils';
+
+// Metadata is used here temporarily until we have the new Hiro API types
+const metadata: FungibleTokenMetadata = {
+  name: '',
+  symbol: '',
+  token_uri: '',
+  decimals: 0,
+  description: '',
+  image_uri: '',
+  image_canonical_uri: '',
+  tx_id: '',
+  sender_address: '',
+};
 
 describe(isFtNameLikeStx.name, () => {
   it('detect impersonating token names', () => {
@@ -33,7 +48,7 @@ describe(isTransferableStacksFungibleTokenAsset.name, () => {
       imageCanonicalUri: '',
       symbol: 'CAT',
     };
-    expect(isTransferableStacksFungibleTokenAsset(asset)).toBeTruthy();
+    expect(isTransferableStacksFungibleTokenAsset(asset, metadata)).toBeTruthy();
   });
 
   test('a token with no decimals is transferable', () => {
@@ -49,7 +64,7 @@ describe(isTransferableStacksFungibleTokenAsset.name, () => {
       imageCanonicalUri: '',
       symbol: 'CAT',
     };
-    expect(isTransferableStacksFungibleTokenAsset(asset)).toBeTruthy();
+    expect(isTransferableStacksFungibleTokenAsset(asset, metadata)).toBeTruthy();
   });
 
   test('assets missing either name, symbol or decimals may not be transferred', () => {
@@ -59,11 +74,12 @@ describe(isTransferableStacksFungibleTokenAsset.name, () => {
       decimals: undefined,
       type: 'fungible-token',
     } as unknown as StacksFungibleTokenAsset;
-    expect(isTransferableStacksFungibleTokenAsset(asset)).toBeFalsy();
+    expect(isTransferableStacksFungibleTokenAsset(asset, metadata)).toBeFalsy();
   });
 
   test('NFTs cannot be sent', () => {
     const asset = { type: 'non-fungible-token' } as unknown as StacksFungibleTokenAsset;
-    expect(isTransferableStacksFungibleTokenAsset(asset)).toBeFalsy();
+
+    expect(isTransferableStacksFungibleTokenAsset(asset, metadata)).toBeFalsy();
   });
 });

--- a/src/app/common/crypto-assets/stacks-crypto-asset.utils.ts
+++ b/src/app/common/crypto-assets/stacks-crypto-asset.utils.ts
@@ -1,3 +1,5 @@
+import { FungibleTokenMetadata } from '@stacks/blockchain-api-client';
+
 import { StacksFungibleTokenAsset } from '@shared/models/crypto-asset.model';
 import { isUndefined } from '@shared/utils';
 import { isValidUrl } from '@shared/utils/validate-url';
@@ -31,6 +33,15 @@ export function getImageCanonicalUri(imageCanonicalUri: string, name: string) {
     : '';
 }
 
-export function isTransferableStacksFungibleTokenAsset(asset: StacksFungibleTokenAsset) {
-  return !isUndefined(asset.decimals) && !isUndefined(asset.name) && !isUndefined(asset.symbol);
+// Metadata is used here temporarily until we have the new Hiro API types
+export function isTransferableStacksFungibleTokenAsset(
+  asset: StacksFungibleTokenAsset,
+  metadata: FungibleTokenMetadata
+) {
+  return (
+    !('error' in metadata) &&
+    !isUndefined(asset.decimals) &&
+    !isUndefined(asset.name) &&
+    !isUndefined(asset.symbol)
+  );
 }

--- a/src/app/query/stacks/balance/stacks-ft-balances.utils.ts
+++ b/src/app/query/stacks/balance/stacks-ft-balances.utils.ts
@@ -110,9 +110,9 @@ export function addQueriedMetadataToInitializedStacksFungibleTokenAssetBalance(
     ),
     asset: {
       ...assetBalance.asset,
-      canTransfer: isTransferableStacksFungibleTokenAsset(assetBalance.asset),
+      canTransfer: isTransferableStacksFungibleTokenAsset(assetBalance.asset, metadata),
       decimals: metadata.decimals,
-      hasMemo: isTransferableStacksFungibleTokenAsset(assetBalance.asset),
+      hasMemo: isTransferableStacksFungibleTokenAsset(assetBalance.asset, metadata),
       imageCanonicalUri: metadata.image_canonical_uri,
       name: metadata.name,
       symbol: metadata.symbol,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4438674503).<!-- Sticky Header Marker -->

Error surfaced bc `canTransfer` wasn't successfully filtering out tokens when the new api returned an error string in the data object. I added this temp fix for now until this issue is completed to expose new types for the Hiro api:

https://github.com/hirosystems/token-metadata-api/issues/132