### PR TITLE
feat: create new page header component for send flow

### DIFF
--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from 'react';
-import { FiArrowLeft, FiMoreHorizontal, FiX } from 'react-icons/fi';
+import { FiArrowLeft, FiMoreHorizontal } from 'react-icons/fi';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Box, Flex, FlexProps, IconButton, Stack, Text, color, useMediaQuery } from '@stacks/ui';
@@ -17,13 +17,12 @@ import { Title } from '@app/components/typography';
 
 interface HeaderProps extends FlexProps {
   actionButton?: JSX.Element;
-  closeIcon?: boolean;
   hideActions?: boolean;
   onClose?(): void;
   title?: string;
 }
 export const Header: React.FC<HeaderProps> = memo(props => {
-  const { actionButton, hideActions, onClose, closeIcon, title, ...rest } = props;
+  const { actionButton, hideActions, onClose, title, ...rest } = props;
   const { isShowingSettings, setIsShowingSettings } = useDrawers();
   const { pathname } = useLocation();
   const navigate = useNavigate();
@@ -63,7 +62,7 @@ export const Header: React.FC<HeaderProps> = memo(props => {
     >
       {onClose ? (
         <Box flexBasis="20%" onClick={onClose} as="button">
-          <IconButton alignSelf="center" icon={closeIcon ? FiX : FiArrowLeft} iconSize="16px" />
+          <IconButton alignSelf="center" icon={FiArrowLeft} iconSize="16px" />
         </Box>
       ) : null}
       {!title && (!onClose || desktopViewport) ? (

--- a/src/app/components/modal-header.tsx
+++ b/src/app/components/modal-header.tsx
@@ -1,0 +1,90 @@
+import { FiArrowLeft, FiX } from 'react-icons/fi';
+import { useNavigate } from 'react-router-dom';
+
+import { Box, Flex, FlexProps, IconButton } from '@stacks/ui';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { NetworkModeBadge } from '@app/components/network-mode-badge';
+import { Title } from '@app/components/typography';
+
+interface ModalHeaderProps extends FlexProps {
+  actionButton?: JSX.Element;
+  closeIcon?: boolean;
+  hideActions?: boolean;
+  onClose?(): void;
+  onGoBack?(): void;
+  defaultClose?: boolean;
+  defaultGoBack?: boolean;
+  title: string;
+}
+
+export function ModalHeader({
+  actionButton,
+  hideActions,
+  onClose,
+  onGoBack,
+  closeIcon,
+  title,
+  defaultGoBack,
+  defaultClose,
+  ...rest
+}: ModalHeaderProps) {
+  const navigate = useNavigate();
+
+  function defaultCloseAction() {
+    navigate(RouteUrls.Home);
+  }
+  function defaultGoBackAction() {
+    navigate('..');
+  }
+
+  return (
+    <Flex
+      alignItems={hideActions ? 'center' : 'flex-start'}
+      justifyContent="space-between"
+      p="base"
+      position="relative"
+      {...rest}
+    >
+      {onGoBack || defaultGoBack ? (
+        <Box flexBasis="20%" onClick={onGoBack || defaultGoBackAction} as="button">
+          <IconButton alignSelf="center" icon={FiArrowLeft} iconSize="24px" />
+        </Box>
+      ) : (
+        <Box flexBasis="20%" />
+      )}
+
+      <Flex alignItems="center" flex="60%" justifyContent="center">
+        <Title
+          alignSelf="center"
+          fontSize="16px"
+          fontWeight={500}
+          lineHeight="24px"
+          textAlign="center"
+          {...rest}
+        >
+          {title}
+        </Title>
+      </Flex>
+
+      <Flex
+        alignItems="center"
+        flexBasis="20%"
+        isInline
+        justifyContent="flex-end"
+        position="relative"
+      >
+        <NetworkModeBadge position="absolute" right="35px" />
+        {(onClose || defaultClose) && (
+          <IconButton
+            onClick={onClose || defaultCloseAction}
+            alignSelf="center"
+            icon={FiX}
+            iconSize="24px"
+          />
+        )}
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -13,13 +13,13 @@ import { baseCurrencyAmountInQuote } from '@app/common/money/calculate-money';
 import { formatMoney, i18nFormatCurrency } from '@app/common/money/format-money';
 import { satToBtc } from '@app/common/money/unit-conversion';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
-import { Header } from '@app/components/header';
 import {
   InfoCard,
   InfoCardAssetValue,
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
+import { ModalHeader } from '@app/components/modal-header';
 import { PrimaryButton } from '@app/components/primary-button';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/address.hooks';
 import { useBitcoinFeeRate } from '@app/query/bitcoin/fees/fee-estimates.hooks';
@@ -101,18 +101,7 @@ export function BtcSendFormConfirmation() {
     };
   }
 
-  useRouteHeader(
-    <Header
-      hideActions
-      onClose={() =>
-        nav.backToSendForm({
-          recipient,
-          amount: transferAmount,
-        })
-      }
-      title="Review"
-    />
-  );
+  useRouteHeader(<ModalHeader hideActions defaultClose defaultGoBack title="Review" />);
 
   return (
     <InfoCard pt="extra-loose" pb="extra-loose" px="extra-loose">

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/stx-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/stx-send-form-confirmation.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { Stack } from '@stacks/ui';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
@@ -6,7 +6,6 @@ import get from 'lodash.get';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
-import { Header } from '@app/components/header';
 import {
   InfoCard,
   InfoCardAssetValue,
@@ -14,6 +13,7 @@ import {
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
 import { InfoLabel } from '@app/components/info-label';
+import { ModalHeader } from '@app/components/modal-header';
 import { PrimaryButton } from '@app/components/primary-button';
 
 import { useStacksBroadcastTransaction } from '../../family/stacks/hooks/use-stacks-broadcast-transaction';
@@ -41,11 +41,7 @@ export function StxSendFormConfirmation() {
     symbol,
   } = formReviewTxSummary(stacksDeserializedTransaction);
 
-  const navigate = useNavigate();
-
-  useRouteHeader(
-    <Header hideActions onClose={() => navigate('..', { relative: 'path' })} title="Review" />
-  );
+  useRouteHeader(<ModalHeader hideActions defaultClose defaultGoBack title="Review" />);
 
   return (
     <InfoCard pt="extra-loose" pb="extra-loose" px="extra-loose">

--- a/src/app/pages/send/sent-summary/btc-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/btc-sent-summary.tsx
@@ -1,16 +1,13 @@
 import { toast } from 'react-hot-toast';
 import { FiCheck, FiCopy, FiExternalLink } from 'react-icons/fi';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { Stack, useClipboard } from '@stacks/ui';
-
-import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useExplorerLink } from '@app/common/hooks/use-explorer-link';
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
-import { Header } from '@app/components/header';
 import {
   InfoCard,
   InfoCardAssetValue,
@@ -18,10 +15,10 @@ import {
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
+import { ModalHeader } from '@app/components/modal-header';
 
 export function BtcSentSummary() {
   const { state } = useLocation();
-  const navigate = useNavigate();
 
   const {
     txId,
@@ -49,9 +46,7 @@ export function BtcSentSummary() {
     toast.success('ID copied!');
   };
 
-  useRouteHeader(
-    <Header hideActions onClose={() => navigate(RouteUrls.Home)} title="Sent" closeIcon />
-  );
+  useRouteHeader(<ModalHeader hideActions defaultClose title="Sent" />);
 
   return (
     <InfoCard pt="extra-loose" pb="base-loose" px="extra-loose">

--- a/src/app/pages/send/sent-summary/stx-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/stx-sent-summary.tsx
@@ -1,16 +1,13 @@
 import { toast } from 'react-hot-toast';
 import { FiCheck, FiCopy, FiExternalLink } from 'react-icons/fi';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { Stack, useClipboard } from '@stacks/ui';
-
-import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useExplorerLink } from '@app/common/hooks/use-explorer-link';
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
-import { Header } from '@app/components/header';
 import {
   InfoCard,
   InfoCardAssetValue,
@@ -18,6 +15,7 @@ import {
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
+import { ModalHeader } from '@app/components/modal-header';
 
 export function StxSentSummary() {
   const { state } = useLocation();
@@ -48,16 +46,7 @@ export function StxSentSummary() {
     toast.success('ID copied!');
   };
 
-  const navigate = useNavigate();
-
-  useRouteHeader(
-    <Header
-      hideActions
-      onClose={() => navigate(RouteUrls.Home, { relative: 'path' })}
-      title="Sent"
-      closeIcon
-    />
-  );
+  useRouteHeader(<ModalHeader hideActions defaultClose title="Sent" />);
 
   return (
     <InfoCard pt="extra-loose" pb="extra-loose" px="extra-loose">


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4435706571).<!-- Sticky Header Marker -->

I decided to create to new page header component, as none of current are suitable for send flow pages.


![Screenshot 2023-03-15 at 23 29 27](https://user-images.githubusercontent.com/46521087/225422118-034a5717-5fd2-47fe-9d3a-35772d881de9.png)
![Screenshot 2023-03-15 at 23 29 52](https://user-images.githubusercontent.com/46521087/225422134-2ef8c3ba-9e5c-4897-9f98-8418a9ef0abd.png)
![Screenshot 2023-03-15 at 23 29 33](https://user-images.githubusercontent.com/46521087/225422129-e0c8ffff-0fa0-4393-862f-fe0bb5407688.png)
![Screenshot 2023-03-15 at 23 29 58](https://user-images.githubusercontent.com/46521087/225422142-cd3abae4-54c9-4ddc-ba60-4b54d619838a.png)