### PR TITLE
fix: don't hide switch account menu

### DIFF
--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -69,7 +69,7 @@ export function SettingsDropdown() {
             {key && key.type === 'ledger' && (
               <LedgerDeviceItemRow deviceType={extractDeviceNameFromKnownTargetIds(key.targetId)} />
             )}
-            {wallet && wallet?.accounts?.length > 1 && (
+            {wallet && (
               <MenuItem
                 data-testid={SettingsMenuSelectors.SwitchAccountMenuItem}
                 onClick={wrappedCloseCallback(() => setIsShowingSwitchAccountsState(true))}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4438995732).<!-- Sticky Header Marker -->

Remove condition to hide switch account menu when only 1 account

thanks @obycode 