### PR TITLE
fix: metadata undefined and key error

### DIFF
--- a/src/app/common/crypto-assets/stacks-crypto-asset.utils.ts
+++ b/src/app/common/crypto-assets/stacks-crypto-asset.utils.ts
@@ -36,9 +36,10 @@ export function getImageCanonicalUri(imageCanonicalUri: string, name: string) {
 // Metadata is used here temporarily until we have the new Hiro API types
 export function isTransferableStacksFungibleTokenAsset(
   asset: StacksFungibleTokenAsset,
-  metadata: FungibleTokenMetadata
+  metadata?: FungibleTokenMetadata
 ) {
   return (
+    !isUndefined(metadata) &&
     !('error' in metadata) &&
     !isUndefined(asset.decimals) &&
     !isUndefined(asset.name) &&

--- a/src/app/features/balances-list/components/stacks-fungible-token-asset-list.tsx
+++ b/src/app/features/balances-list/components/stacks-fungible-token-asset-list.tsx
@@ -11,7 +11,10 @@ export function StacksFungibleTokenAssetList({ assetBalances }: StacksFtCryptoAs
   return (
     <Stack spacing="loose">
       {assetBalances.map(assetBalance => (
-        <StacksFungibleTokenAssetItem assetBalance={assetBalance} key={assetBalance.asset.name} />
+        <StacksFungibleTokenAssetItem
+          assetBalance={assetBalance}
+          key={assetBalance.asset.contractId}
+        />
       ))}
     </Stack>
   );


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4440419982).<!-- Sticky Header Marker -->

I briefly saw metadata `undefined` and a white screen (must have been the api bc resolved on own), but probably best to get the new types in asap. It looks like the PR was merged but not released yet.

There was also a React child key error in the console I fixed here.