### PR TITLE
refactor: use zero index for taproot receive address

### DIFF
--- a/src/app/components/receive/receive-collectible.tsx
+++ b/src/app/components/receive/receive-collectible.tsx
@@ -13,16 +13,18 @@ import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-a
 import { OrdinalIcon } from '@app/components/icons/ordinal-icon';
 import { Flag } from '@app/components/layout/flag';
 import { Caption } from '@app/components/typography';
-import { useNextFreshTaprootAddressQuery } from '@app/query/bitcoin/ordinals/use-next-fresh-taproot-address.query';
+import { useZeroIndexTaprootAddress } from '@app/query/bitcoin/ordinals/use-zero-index-taproot-address';
 import { useCurrentAccountStxAddressState } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 export function ReceiveCollectible() {
   const analytics = useAnalytics();
-  const navigate = useNavigate();
   const location = useLocation();
+  const navigate = useNavigate();
   const accountIndex = get(location.state, 'accountIndex', undefined);
+  const btcAddress = useZeroIndexTaprootAddress(accountIndex);
 
-  const { isLoading, isError, data: btcAddress } = useNextFreshTaprootAddressQuery(accountIndex);
+  // TODO: Reuse later for privacy mode
+  // const { isLoading, isError, data: btcAddress } = useNextFreshTaprootAddressQuery(accountIndex);
 
   const stxAddress = useCurrentAccountStxAddressState();
   const { onCopy: onCopyStacks } = useClipboard(stxAddress);
@@ -33,22 +35,19 @@ export function ReceiveCollectible() {
     copyHandler();
   }
 
+  if (!btcAddress) return null;
+
   return (
     <Stack spacing="loose" mt="base" mb="extra-loose">
       <Flag img={<OrdinalIcon />} spacing="base">
         <Flex justifyContent="space-between">
           <Box>
             Ordinal inscription
-            {isLoading ? (
-              <Caption mt="2px">Loading…</Caption>
-            ) : (
-              !isError && <Caption mt="2px">{truncateMiddle(btcAddress, 6)}</Caption>
-            )}
+            <Caption mt="2px">{truncateMiddle(btcAddress, 6)}</Caption>
           </Box>
           <Stack>
             <Box>
               <Button
-                isDisabled={isLoading || isError}
                 borderRadius="10px"
                 mode="tertiary"
                 onClick={() => {

--- a/src/app/query/bitcoin/ordinals/use-next-fresh-taproot-address.query.ts
+++ b/src/app/query/bitcoin/ordinals/use-next-fresh-taproot-address.query.ts
@@ -11,6 +11,7 @@ import { useTaprootAccountKeychain } from '@app/store/accounts/blockchain/bitcoi
 import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
+// ts-unused-exports:disable-next-line
 export function useNextFreshTaprootAddressQuery(accIndex?: number) {
   const network = useCurrentNetwork();
   const currentAccountIndex = useCurrentAccountIndex();

--- a/src/app/query/bitcoin/ordinals/use-zero-index-taproot-address.ts
+++ b/src/app/query/bitcoin/ordinals/use-zero-index-taproot-address.ts
@@ -1,0 +1,21 @@
+import { getTaprootAddress } from '@app/query/bitcoin/ordinals/utils';
+import { useCurrentAccountIndex } from '@app/store/accounts/account';
+import { useTaprootAccountKeychain } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
+import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
+
+// Temporary - remove with privacy mode
+export function useZeroIndexTaprootAddress(accIndex?: number) {
+  const network = useCurrentNetwork();
+  const currentAccountIndex = useCurrentAccountIndex();
+  const keychain = useTaprootAccountKeychain(accIndex ?? currentAccountIndex);
+
+  if (!keychain) throw new Error('Expected keychain to be provided');
+
+  const address = getTaprootAddress({
+    index: 0,
+    keychain,
+    network: network.chain.bitcoin.network,
+  });
+
+  return address;
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4461667979).<!-- Sticky Header Marker -->

This PR changes our current behavior for requesting a receive address for ordinals. With this change, we only provide the user with the zero index address rather than a new, fresh address each time.