### PR TITLE
fix: filter unconfirmed utxos

### DIFF
--- a/src/app/query/bitcoin/balance/bitcoin-balances.query.ts
+++ b/src/app/query/bitcoin/balance/bitcoin-balances.query.ts
@@ -35,13 +35,16 @@ export function useCurrentNativeSegwitAddressBalance() {
 
 export function useCurrentTaprootAccountUninscribedUtxos() {
   const { data: utxos = [] } = useTaprootAccountUtxosQuery();
-  const utxoQueries = useOrdinalsAwareUtxoQueries(utxos ?? []);
+  const utxoQueries = useOrdinalsAwareUtxoQueries(utxos);
 
   return useMemo(
     () =>
       utxoQueries
         .map(query => query.data)
         .filter(isDefined)
+        // If tx isn't confirmed, we can't tell yet whether or not it has
+        // inscriptions
+        .filter(utxo => utxo.status.confirmed)
         .filter(utxo => !utxo.inscriptions),
     [utxoQueries]
   );


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4477562041).<!-- Sticky Header Marker -->

Closes #3468

This PR introduces a filter to the utxo array excluding those not confirmed. 

@314159265359879 do you think it's necessary to filter a # of blocks until which we consider it confirmed? This uses the API confirmed value.