### PR TITLE
fix: bug with not updating balance list on network change

### DIFF
--- a/src/app/query/stacks/balance/stx-balance.query.ts
+++ b/src/app/query/stacks/balance/stx-balance.query.ts
@@ -9,6 +9,7 @@ import {
   useStacksClientAnchored,
   useStacksClientUnanchored,
 } from '@app/store/common/api-clients.hooks';
+import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 import { RateLimiter, useHiroApiRateLimiter } from '../rate-limiter';
 
@@ -52,10 +53,11 @@ export function useAnchoredStacksAccountBalanceQuery<T extends unknown = FetchAc
 ) {
   const client = useStacksClientAnchored();
   const limiter = useHiroApiRateLimiter();
+  const network = useCurrentNetworkState();
 
   return useQuery({
     enabled: !!address,
-    queryKey: ['get-address-anchored-stx-balance', address],
+    queryKey: ['get-address-anchored-stx-balance', address, network.id],
     queryFn: () => fetchAccountBalance(client, limiter)(address),
     ...balanceQueryOptions,
     ...options,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4479846114).<!-- Sticky Header Marker -->

This pr fixes bug with not updating balance list on network change. it happened only with testnet/custom networks. 


Video: 
https://user-images.githubusercontent.com/46521087/226622711-03da9ffc-1c9e-4dbb-bea8-0169a6dc6bab.mov

