### PR TITLE
chore: enable allowUnknownOutput flag

### DIFF
--- a/src/shared/crypto/bitcoin/p2tr-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2tr-address-gen.ts
@@ -26,7 +26,8 @@ export function getTaprootPayment(publicKey: Uint8Array, network: NetworkModes) 
   return btc.p2tr(
     ecdsaPublicKeyToSchnorr(publicKey),
     undefined,
-    getBtcSignerLibNetworkByMode(network)
+    getBtcSignerLibNetworkByMode(network),
+    true
   );
 }
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4498980410).<!-- Sticky Header Marker -->

Not to merge.

Test build allow invalid outputs in tr spends per bip322