### PR TITLE
fix: fee tests

### DIFF
--- a/tests/specs/send/send-stx.spec.ts
+++ b/tests/specs/send/send-stx.spec.ts
@@ -44,7 +44,10 @@ test.describe('send stx', () => {
       const feeToBePaid = await page
         .getByTestId(SharedComponentsSelectors.FeeToBePaidLabel)
         .innerText();
-      test.expect(feeToBePaid).toEqual('0.003 STX');
+      const fee = Number(feeToBePaid.split(' ')[0]);
+      // Using min/max fee caps
+      const isMiddleFee = fee >= 0.003 && fee < 0.75;
+      test.expect(isMiddleFee).toBeTruthy();
     });
 
     test('that low fee estimate can be selected', async ({ page }) => {
@@ -53,7 +56,10 @@ test.describe('send stx', () => {
       const feeToBePaid = await page
         .getByTestId(SharedComponentsSelectors.FeeToBePaidLabel)
         .innerText();
-      test.expect(feeToBePaid).toEqual('0.0025 STX');
+      const fee = Number(feeToBePaid.split(' ')[0]);
+      // Using min/max fee caps
+      const isLowFee = fee >= 0.0025 && fee < 0.5;
+      test.expect(isLowFee).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4503991689).<!-- Sticky Header Marker -->

Fee estimates seem to have changed with the upgrade ...changing tests here to test for a range b/w caps instead of our hardcoded cap values.