### PR TITLE
fix: btc/stx sent tx summary

### DIFF
--- a/src/app/components/info-card/info-card.tsx
+++ b/src/app/components/info-card/info-card.tsx
@@ -1,10 +1,8 @@
 import { Box, Button, Flex, FlexProps, Stack, Text } from '@stacks/ui';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 
-import { Money } from '@shared/models/money.model';
 import { isString } from '@shared/utils';
 
-import { i18nFormatCurrency } from '@app/common/money/format-money';
 import { figmaTheme } from '@app/common/utils/figma-theme';
 
 import { SpaceBetween } from '../layout/space-between';
@@ -58,12 +56,19 @@ export function InfoCardSeparator() {
 // InfoCardAssetValue
 interface InfoCardAssetValueProps {
   value: number;
-  fiatValue?: Money;
+  fiatValue?: string;
+  fiatSymbol?: string;
   symbol: string;
   icon?: React.FC;
 }
 
-export function InfoCardAssetValue({ value, fiatValue, symbol, icon }: InfoCardAssetValueProps) {
+export function InfoCardAssetValue({
+  value,
+  fiatValue,
+  fiatSymbol,
+  symbol,
+  icon,
+}: InfoCardAssetValueProps) {
   return (
     <Stack
       mb="44px"
@@ -87,7 +92,7 @@ export function InfoCardAssetValue({ value, fiatValue, symbol, icon }: InfoCardA
         </Text>
         {fiatValue && (
           <Text fontSize="12px" mt="4px">
-            ~ {i18nFormatCurrency(fiatValue)} {fiatValue.symbol}
+            ~ {fiatValue} {fiatSymbol}
           </Text>
         )}
       </Flex>

--- a/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-transaction-summary.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-transaction-summary.ts
@@ -13,7 +13,7 @@ import { CryptoCurrencies } from '@shared/models/currencies.model';
 import { createMoney } from '@shared/models/money.model';
 
 import { baseCurrencyAmountInQuote } from '@app/common/money/calculate-money';
-import { formatMoney } from '@app/common/money/format-money';
+import { formatMoney, i18nFormatCurrency } from '@app/common/money/format-money';
 import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
 import { useStacksBlockTime } from '@app/query/stacks/info/info.hooks';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
@@ -58,10 +58,10 @@ export function useStacksTransactionSummary(token: CryptoCurrencies) {
       symbol: 'STX',
       txValue: microStxToStx(Number(txValue)),
       sendingValue: formatMoney(convertToMoneyTypeWithDefaultOfZero('STX', Number(txValue))),
-      txFiatValue: baseCurrencyAmountInQuote(
-        createMoney(Number(payload.amount), 'STX'),
-        tokenMarketData
+      txFiatValue: i18nFormatCurrency(
+        baseCurrencyAmountInQuote(createMoney(Number(payload.amount), 'STX'), tokenMarketData)
       ),
+      txFiatValueSymbol: tokenMarketData.price.symbol,
       nonce: String(tx.auth.spendingCondition.nonce),
       memoDisplayText,
     };
@@ -85,7 +85,9 @@ export function useStacksTransactionSummary(token: CryptoCurrencies) {
       tokenMarketData
     );
 
-    const txFiatValue = currencyTxAmount.amount.toNumber() ? currencyTxAmount : undefined;
+    const txFiatValue = currencyTxAmount.amount.toNumber()
+      ? i18nFormatCurrency(currencyTxAmount)
+      : undefined;
 
     return {
       recipient: cvToString(payload.functionArgs[2]),
@@ -96,6 +98,7 @@ export function useStacksTransactionSummary(token: CryptoCurrencies) {
       totalSpend,
       sendingValue,
       txFiatValue,
+      txFiatValueSymbol: tokenMarketData.price.symbol,
       memoDisplayText,
       symbol,
     };

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -11,7 +11,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { baseCurrencyAmountInQuote } from '@app/common/money/calculate-money';
-import { formatMoney } from '@app/common/money/format-money';
+import { formatMoney, i18nFormatCurrency } from '@app/common/money/format-money';
 import { satToBtc } from '@app/common/money/unit-conversion';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
 import {
@@ -48,11 +48,10 @@ export function BtcSendFormConfirmation() {
   const nav = useSendFormNavigate();
 
   const transferAmount = satToBtc(psbt.outputs[0].amount.toString()).toString();
-  const txFiatValue = baseCurrencyAmountInQuote(
-    createMoneyFromDecimal(Number(transferAmount), symbol),
-    btcMarketData
+  const txFiatValue = i18nFormatCurrency(
+    baseCurrencyAmountInQuote(createMoneyFromDecimal(Number(transferAmount), symbol), btcMarketData)
   );
-
+  const txFiatValueSymbol = btcMarketData.price.symbol;
   const { data: feeRate } = useBitcoinFeeRate();
   const arrivesIn = feeRate ? `~${feeRate.fastestFee} min` : '~10 – 20 min';
 
@@ -101,6 +100,7 @@ export function BtcSendFormConfirmation() {
       symbol,
       sendingValue,
       txFiatValue,
+      txFiatValueSymbol,
     };
   }
 
@@ -111,6 +111,7 @@ export function BtcSendFormConfirmation() {
       <InfoCardAssetValue
         value={Number(transferAmount)}
         fiatValue={txFiatValue}
+        fiatSymbol={txFiatValueSymbol}
         symbol={symbol}
         data-testid={SendCryptoAssetSelectors.ConfirmationDetailsAssetValue}
       />

--- a/src/app/pages/send/send-crypto-asset-form/form/send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/send-form-confirmation.tsx
@@ -1,8 +1,6 @@
 import { Stack } from '@stacks/ui';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 
-import { Money } from '@shared/models/money.model';
-
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
 import {
   InfoCard,
@@ -21,7 +19,8 @@ interface SendFormConfirmationProps {
   symbol: string;
   txValue: string | number;
   sendingValue: string;
-  txFiatValue?: Money;
+  txFiatValue?: string;
+  txFiatValueSymbol?: string;
   nonce: string;
   memoDisplayText: string;
   isLoading: boolean;
@@ -31,6 +30,7 @@ interface SendFormConfirmationProps {
 export function SendFormConfirmation({
   txValue,
   txFiatValue,
+  txFiatValueSymbol,
   recipient,
   fee,
   totalSpend,
@@ -47,6 +47,7 @@ export function SendFormConfirmation({
       <InfoCardAssetValue
         value={Number(txValue)}
         fiatValue={txFiatValue}
+        fiatSymbol={txFiatValueSymbol}
         symbol={symbol}
         data-testid={SendCryptoAssetSelectors.ConfirmationDetailsAssetValue}
       />

--- a/src/app/pages/send/sent-summary/btc-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/btc-sent-summary.tsx
@@ -24,6 +24,7 @@ export function BtcSentSummary() {
     txId,
     txValue,
     txFiatValue,
+    txFiatValueSymbol,
     symbol,
     txLink,
     arrivesIn,
@@ -50,7 +51,13 @@ export function BtcSentSummary() {
 
   return (
     <InfoCard pt="extra-loose" pb="base-loose" px="extra-loose">
-      <InfoCardAssetValue value={txValue} fiatValue={txFiatValue} symbol={symbol} icon={FiCheck} />
+      <InfoCardAssetValue
+        value={txValue}
+        fiatValue={txFiatValue}
+        fiatSymbol={txFiatValueSymbol}
+        symbol={symbol}
+        icon={FiCheck}
+      />
 
       <Stack width="100%" mb="44px">
         <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />

--- a/src/app/pages/send/sent-summary/stx-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/stx-sent-summary.tsx
@@ -23,6 +23,7 @@ export function StxSentSummary() {
   const {
     txValue,
     txFiatValue,
+    txFiatValueSymbol,
     symbol,
     txLink,
     arrivesIn,
@@ -53,6 +54,7 @@ export function StxSentSummary() {
       <InfoCardAssetValue
         value={txValue}
         fiatValue={txFiatValue}
+        fiatSymbol={txFiatValueSymbol}
         symbol={symbol}
         icon={FiCheck}
       ></InfoCardAssetValue>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4554736547).<!-- Sticky Header Marker -->

Currently in dev branch btc/stx sent summary screen is broken, because `txFiatValue` is passed in navigate state and amount in it loses its BigNumber prototype