### PR TITLE
Add regtest support to BTC address config files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,13 +10,22 @@
       "request": "launch",
       "reAttach": false,
       "addonPath": "${workspaceFolder}/dist",
-      "skipFiles": ["${workspaceRoot}/node_modules/**", "stacks/wallet-web/node_modules/**"],
+      "skipFiles": [
+        "${workspaceRoot}/node_modules/**",
+        "stacks/wallet-web/node_modules/**"
+      ],
       "pathMappings": [
         {
           "url": "webpack://stacks/wallet-web/src",
           "path": "${workspaceFolder}/src"
         }
       ]
+    },
+    {
+      "type": "chrome",
+      "name": "chrome-extension://heblfebjiladnnikadeekgoadgaedkdg/index.html#/",
+      "request": "launch",
+      "url": "chrome-extension://heblfebjiladnnikadeekgoadgaedkdg/index.html#/"
     }
   ]
 }

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -312,6 +312,7 @@ export function isPopupMode() {
 interface WhenChainIdMap<T> {
   [ChainID.Mainnet]: T;
   [ChainID.Testnet]: T;
+  [ChainID.Regtest]: T;
 }
 export function whenStxChainId(chainId: ChainID) {
   return <T>(chainIdMap: WhenChainIdMap<T>): T => chainIdMap[chainId];

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
@@ -50,6 +50,11 @@ export const selectMainnetNativeSegWitKeychain = bitcoinKeychainSelectorFactory(
   'mainnet'
 );
 
+export const selectRegtestNativeSegWitKeychain = bitcoinKeychainSelectorFactory(
+  deriveNativeSegWitAccountKeychain,
+  'regtest'
+);
+
 export const selectTestnetNativeSegWitKeychain = bitcoinKeychainSelectorFactory(
   deriveNativeSegWitAccountKeychain,
   'testnet'
@@ -63,6 +68,11 @@ export const selectMainnetTaprootKeychain = bitcoinKeychainSelectorFactory(
 export const selectTestnetTaprootKeychain = bitcoinKeychainSelectorFactory(
   deriveTaprootAccountFromRootKeychain,
   'testnet'
+);
+
+export const selectRegtestTaprootKeychain = bitcoinKeychainSelectorFactory(
+  deriveTaprootAccountFromRootKeychain,
+  'regtest'
 );
 
 export function useBitcoinLibNetworkConfig() {

--- a/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -19,6 +19,7 @@ import { useCurrentAccountIndex } from '../../account';
 import {
   selectMainnetNativeSegWitKeychain,
   selectTestnetNativeSegWitKeychain,
+  selectRegtestNativeSegWitKeychain
 } from './bitcoin-keychain';
 
 function useNativeSegWitCurrentNetworkAccountKeychain() {
@@ -27,6 +28,7 @@ function useNativeSegWitCurrentNetworkAccountKeychain() {
     whenNetwork(network.chain.bitcoin.network)({
       mainnet: selectMainnetNativeSegWitKeychain,
       testnet: selectTestnetNativeSegWitKeychain,
+      regtest: selectRegtestNativeSegWitKeychain,
     })
   );
 }
@@ -63,6 +65,10 @@ export function useAllBitcoinNativeSegWitNetworksByAccount() {
         testnet: deriveNativeSegWitReceiveAddressIndex({
           xpub: testnetKeychainAtAccount(accountIndex).publicExtendedKey,
           network: 'testnet',
+        })?.address,
+        regtest: deriveNativeSegWitReceiveAddressIndex({
+          xpub: testnetKeychainAtAccount(accountIndex).publicExtendedKey,
+          network: 'regtest',
         })?.address,
       };
     },

--- a/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
@@ -18,7 +18,7 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useCurrentAccountIndex } from '../../account';
 import { formatBitcoinAccount, tempHardwareAccountForTesting } from './bitcoin-account.models';
-import { selectMainnetTaprootKeychain, selectTestnetTaprootKeychain } from './bitcoin-keychain';
+import { selectMainnetTaprootKeychain, selectTestnetTaprootKeychain, selectRegtestTaprootKeychain } from './bitcoin-keychain';
 
 function useTaprootCurrentNetworkAccountPrivateKeychain() {
   const network = useCurrentNetwork();
@@ -26,6 +26,7 @@ function useTaprootCurrentNetworkAccountPrivateKeychain() {
     whenNetwork(network.chain.bitcoin.network)({
       mainnet: selectMainnetTaprootKeychain,
       testnet: selectTestnetTaprootKeychain,
+      regtest: selectRegtestTaprootKeychain,
     })
   );
 }

--- a/src/app/store/networks/networks.utils.ts
+++ b/src/app/store/networks/networks.utils.ts
@@ -55,7 +55,7 @@ export function transformNetworkStateToMultichainStucture(
           key,
           {
             id,
-            name,
+          name,
             chain: {
               stacks: {
                 blockchain: 'stacks',
@@ -68,6 +68,7 @@ export function transformNetworkStateToMultichainStucture(
                 url: whenStxChainId(chainId)({
                   [ChainID.Mainnet]: BITCOIN_API_BASE_URL_MAINNET,
                   [ChainID.Testnet]: BITCOIN_API_BASE_URL_TESTNET,
+                  [ChainID.Regtest]: 'http://localhost:18443',
                 }),
               },
             },

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -63,9 +63,17 @@ export interface NetworkConfiguration {
 export enum DefaultNetworkModes {
   mainnet = 'mainnet',
   testnet = 'testnet',
+  regtest = 'regtest'
+}
+
+export enum DefaultTestnetModes {
+  testnet = 'testnet',
+  signet = 'signet'
 }
 
 export type NetworkModes = keyof typeof DefaultNetworkModes;
+
+export type TestnetModes = keyof typeof DefaultTestnetModes;
 
 const DEFAULT_SERVER_MAINNET = 'https://stacks-node-api.stacks.co';
 export const DEFAULT_SERVER_TESTNET = 'https://stacks-node-api.testnet.stacks.co';
@@ -121,8 +129,8 @@ const networkDevnet: NetworkConfiguration = {
     },
     bitcoin: {
       blockchain: 'bitcoin',
-      network: 'testnet',
-      url: BITCOIN_API_BASE_URL_TESTNET,
+      network: 'regtest',
+      url: 'http://localhost:18443',
     },
   },
 };

--- a/src/shared/crypto/bitcoin/bitcoin.network.ts
+++ b/src/shared/crypto/bitcoin/bitcoin.network.ts
@@ -23,9 +23,24 @@ const bitcoinTestnet: BitcoinNetwork = {
   wif: 0xef,
 };
 
+const bitcoinRegtest: BitcoinNetwork = {
+  bech32: 'bcrt',
+  pubKeyHash: 0x6f,
+  scriptHash: 0xc4,
+  wif: 0xef,
+};
+
+const bitcoinSignet: BitcoinNetwork = {
+  bech32: 'sb',
+  pubKeyHash: 0x3f,
+  scriptHash: 0x7f,
+  wif: 0x80,
+};
+
 const bitcoinNetworks: Record<NetworkModes, BitcoinNetwork> = {
   mainnet: bitcoinMainnet,
   testnet: bitcoinTestnet,
+  regtest: bitcoinRegtest,
 };
 
 export function getBtcSignerLibNetworkByMode(network: NetworkModes) {

--- a/src/shared/crypto/bitcoin/bitcoin.utils.ts
+++ b/src/shared/crypto/bitcoin/bitcoin.utils.ts
@@ -6,9 +6,10 @@ import { NetworkModes } from '@shared/constants';
 
 import { DerivationPathDepth } from '../derivation-path.utils';
 
-const coinTypeMap: Record<NetworkModes, 0 | 1> = {
+const coinTypeMap: Record<NetworkModes, 0 | 1 | 2> = {
   mainnet: 0,
   testnet: 1,
+  regtest: 2
 };
 
 export function getBitcoinCoinTypeIndexByNetwork(network: NetworkModes) {

--- a/src/shared/crypto/bitcoin/bitcoin.utils.ts
+++ b/src/shared/crypto/bitcoin/bitcoin.utils.ts
@@ -6,10 +6,10 @@ import { NetworkModes } from '@shared/constants';
 
 import { DerivationPathDepth } from '../derivation-path.utils';
 
-const coinTypeMap: Record<NetworkModes, 0 | 1 | 2> = {
+const coinTypeMap: Record<NetworkModes, 0 | 1> = {
   mainnet: 0,
   testnet: 1,
-  regtest: 2
+  regtest: 1
 };
 
 export function getBitcoinCoinTypeIndexByNetwork(network: NetworkModes) {

--- a/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
@@ -16,6 +16,7 @@ function getNativeSegWitAccountDerivationPath(network: NetworkModes, accountInde
 
 export function deriveNativeSegWitAccountKeychain(keychain: HDKey, network: NetworkModes) {
   if (keychain.depth !== DerivationPathDepth.Root) throw new Error('Keychain passed is not a root');
+  console.log(network)
   return (index: number) => keychain.derive(getNativeSegWitAccountDerivationPath(network, index));
 }
 


### PR DESCRIPTION
Resolves #3492

This PR adds regtest support to Devnet in the wallet. This is a V1 of the full solution.

This version automatically sets the Bitcoin network to regtest when Devnet mode is chosen in the wallet UI.

However, I am not sure this PR completely resolves the issue, as I believe an additional change needs to be made to the @stacks/transactions repo to update the ChainID type that the wallet uses.