### PR TITLE
fix: sip10 token send form bug

### DIFF
--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -13,10 +13,6 @@ import { toUnicode } from 'punycode';
 import { KEBAB_REGEX, NetworkModes } from '@shared/constants';
 import { logger } from '@shared/logger';
 import type { Blockchains } from '@shared/models/blockchain.model';
-import {
-  StacksCryptoCurrencyAssetBalance,
-  StacksFungibleTokenAssetBalance,
-} from '@shared/models/crypto-asset-balance.model';
 
 export function createNullArrayOfLength(length: number) {
   return new Array(length).fill(null);
@@ -273,20 +269,6 @@ export function pullContractIdFromIdentity(identifier: string) {
 
 export function formatContractId(address: string, name: string) {
   return `${address}.${name}`;
-}
-
-/**
- * Refactored with new send form; remove with legacy send form.
- * @deprecated
- */
-export function getFullyQualifiedStacksAssetName(
-  assetBalance: StacksCryptoCurrencyAssetBalance | StacksFungibleTokenAssetBalance
-) {
-  if (assetBalance.type === 'crypto-currency') return '::stacks-token';
-  return `${formatContractId(
-    assetBalance.asset.contractAddress,
-    assetBalance.asset.contractName
-  )}::${assetBalance.asset.contractAssetName}`;
 }
 
 export function doesBrowserSupportWebUsbApi() {

--- a/src/app/pages/send/choose-crypto-asset/components/crypto-asset-list-item.tsx
+++ b/src/app/pages/send/choose-crypto-asset/components/crypto-asset-list-item.tsx
@@ -1,3 +1,4 @@
+import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
 import type {
@@ -25,10 +26,14 @@ export function CryptoAssetListItem(props: CryptoAssetListItemProps) {
     if (blockchain === 'bitcoin' && !isBitcoinSendEnabled) {
       return navigate(RouteUrls.SendBtcDisabled);
     }
-    const symbol = asset.symbol?.toLowerCase();
+    const symbol = asset.symbol.toLowerCase();
 
     if (isFtToken) {
       const asset = (assetBalance as StacksFungibleTokenAssetBalance).asset;
+      if (!asset.contractId) {
+        toast.error('Unable to find contract id');
+        return navigate('..');
+      }
       const contractId = `${asset.contractId.split('::')[0]}`;
       return navigate(`${RouteUrls.SendCryptoAsset}/${symbol}/${contractId}`);
     }

--- a/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-ft-params.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-ft-params.ts
@@ -1,8 +1,0 @@
-import { useLocation } from 'react-router-dom';
-
-import get from 'lodash.get';
-
-export function useStacksFtRouteState() {
-  const location = useLocation();
-  return { contractId: get(location.state, 'contractId') };
-}

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form-container.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form-container.tsx
@@ -1,8 +1,3 @@
-import { Navigate } from 'react-router-dom';
-
-import { RouteUrls } from '@shared/route-urls';
-import { isString } from '@shared/utils';
-
 import { StacksAssetAvatar } from '@app/components/crypto-assets/stacks/components/stacks-asset-avatar';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
 
@@ -12,21 +7,24 @@ import { SendMaxButton } from '../../components/send-max-button';
 import { StacksCommonSendForm } from '../stacks/stacks-common-send-form';
 import { useSip10SendForm } from './use-sip10-send-form';
 
-export function StacksSip10FungibleTokenSendForm() {
+interface Sip10TokenSendFormContainerProps {
+  symbol: string;
+  contractId: string;
+}
+
+export function Sip10TokenSendFormContainer({
+  symbol,
+  contractId,
+}: Sip10TokenSendFormContainerProps) {
   const {
     availableTokenBalance,
     initialValues,
     previewTransaction,
     sendMaxBalance,
     stacksFtFees: fees,
-    symbol,
     validationSchema,
     avatar,
-  } = useSip10SendForm();
-
-  if (!isString(symbol)) {
-    return <Navigate to={RouteUrls.SendCryptoAsset} />;
-  }
+  } = useSip10SendForm({ symbol, contractId });
 
   const amountField = (
     <AmountField
@@ -34,6 +32,7 @@ export function StacksSip10FungibleTokenSendForm() {
       bottomInputOverlay={
         <SendMaxButton balance={availableTokenBalance} sendMaxBalance={sendMaxBalance.toString()} />
       }
+      autoComplete="off"
     />
   );
   const selectedAssetField = (

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form.tsx
@@ -1,0 +1,30 @@
+import { toast } from 'react-hot-toast';
+import { Navigate, useParams } from 'react-router-dom';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { Sip10TokenSendFormContainer } from './sip10-token-send-form-container';
+
+export function Sip10TokenSendForm() {
+  return (
+    <Sip10TokenSendFormLoader>
+      {({ contractId, symbol }) => (
+        <Sip10TokenSendFormContainer symbol={symbol} contractId={contractId} />
+      )}
+    </Sip10TokenSendFormLoader>
+  );
+}
+
+interface Sip10TokenSendFormLoaderProps {
+  children: (data: { symbol: string; contractId: string }) => JSX.Element;
+}
+
+function Sip10TokenSendFormLoader({ children }: Sip10TokenSendFormLoaderProps) {
+  const { symbol, contractId } = useParams();
+  if (!symbol || !contractId) {
+    toast.error('Symbol or contract id not found');
+    return <Navigate to={RouteUrls.SendCryptoAsset} />;
+  }
+
+  return children({ symbol, contractId });
+}

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/use-sip10-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/use-sip10-send-form.tsx
@@ -1,12 +1,10 @@
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 
 import { FormikHelpers } from 'formik';
 import * as yup from 'yup';
 
 import { logger } from '@shared/logger';
 import { StacksSendFormValues } from '@shared/models/form.model';
-import { createMoney } from '@shared/models/money.model';
 
 import { getImageCanonicalUri } from '@app/common/crypto-assets/stacks-crypto-asset.utils';
 import { convertAmountToBaseUnit } from '@app/common/money/calculate-money';
@@ -24,8 +22,12 @@ import {
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 import { useStacksCommonSendForm } from '../stacks/use-stacks-common-send-form';
 
-export function useSip10SendForm() {
-  const { symbol, contractId = '' } = useParams();
+interface UseSip10SendFormArgs {
+  symbol: string;
+  contractId: string;
+}
+
+export function useSip10SendForm({ symbol, contractId }: UseSip10SendFormArgs) {
   const assetBalance = useStacksFungibleTokenAssetBalance(contractId);
   const generateTx = useGenerateFtTokenTransferUnsignedTx(assetBalance);
 
@@ -36,20 +38,19 @@ export function useSip10SendForm() {
   const unsignedTx = useFtTokenTransferUnsignedTx(assetBalance);
   const { data: stacksFtFees } = useCalculateStacksTxFees(unsignedTx);
 
-  const availableTokenBalance = assetBalance?.balance ?? createMoney(0, 'STX');
+  const availableTokenBalance = assetBalance.balance;
   const sendMaxBalance = useMemo(
     () => convertAmountToBaseUnit(availableTokenBalance),
     [availableTokenBalance]
   );
 
   const { initialValues, checkFormValidation, recipient, memo, nonce } = useStacksCommonSendForm({
-    symbol: symbol ?? '',
+    symbol: symbol,
     availableTokenBalance,
   });
 
   function createFtAvatar() {
-    const asset = assetBalance?.asset;
-    if (!asset) return;
+    const asset = assetBalance.asset;
 
     const { contractAddress, contractAssetName, contractName } = asset;
     return {

--- a/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
@@ -62,13 +62,13 @@ export const sendCryptoAssetFormRoutes = (
     </Route>
     <Route path="/send/stx/confirm" element={<StacksSendFormConfirmation />} />
 
-    <Route path={RouteUrls.SendCryptoAssetForm} element={<StacksSip10FungibleTokenSendForm />}>
+    <Route path={RouteUrls.SendSip10Form} element={<StacksSip10FungibleTokenSendForm />}>
       {broadcastErrorDrawerRoute}
       {editNonceDrawerRoute}
       {ledgerTxSigningRoutes}
       {recipientAccountsDrawerRoute}
     </Route>
-    <Route path="/send/:symbol/confirm" element={<StacksSendFormConfirmation />} />
+    <Route path="/send/:symbol/:contractId/confirm" element={<StacksSendFormConfirmation />} />
     <Route path={RouteUrls.SentBtcTxSummary} element={<BtcSentSummary />}></Route>
     <Route path={RouteUrls.SentStxTxSummary} element={<StxSentSummary />}></Route>
   </Route>

--- a/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
@@ -18,7 +18,7 @@ import { StxSentSummary } from '../sent-summary/stx-sent-summary';
 import { RecipientAccountsDrawer } from './components/recipient-accounts-drawer/recipient-accounts-drawer';
 import { BtcSendForm } from './form/btc/btc-send-form';
 import { BtcSendFormConfirmation } from './form/btc/btc-send-form-confirmation';
-import { StacksSip10FungibleTokenSendForm } from './form/stacks-sip10/stacks-sip10-fungible-token-send-form';
+import { Sip10TokenSendForm } from './form/stacks-sip10/sip10-token-send-form';
 import { StacksSendFormConfirmation } from './form/stacks/stacks-send-form-confirmation';
 import { StxSendForm } from './form/stx/stx-send-form';
 
@@ -62,7 +62,7 @@ export const sendCryptoAssetFormRoutes = (
     </Route>
     <Route path="/send/stx/confirm" element={<StacksSendFormConfirmation />} />
 
-    <Route path={RouteUrls.SendSip10Form} element={<StacksSip10FungibleTokenSendForm />}>
+    <Route path={RouteUrls.SendSip10Form} element={<Sip10TokenSendForm />}>
       {broadcastErrorDrawerRoute}
       {editNonceDrawerRoute}
       {ledgerTxSigningRoutes}

--- a/src/app/query/stacks/balance/stacks-ft-balances.hooks.ts
+++ b/src/app/query/stacks/balance/stacks-ft-balances.hooks.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import type { StacksFungibleTokenAssetBalance } from '@shared/models/crypto-asset-balance.model';
 
-import { formatContractId, getFullyQualifiedStacksAssetName } from '@app/common/utils';
+import { formatContractId } from '@app/common/utils';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 import { useGetFungibleTokenMetadataListQuery } from '../tokens/fungible-tokens/fungible-token-metadata.query';
@@ -105,8 +105,8 @@ export function useStacksFungibleTokenAssetBalance(contractId: string) {
     account?.address ?? ''
   );
   return useMemo(() => {
-    if (!assetBalances.length) return;
-    return assetBalances.find(assetBalance => assetBalance.asset.contractId === contractId);
+    if (!assetBalances.length || contractId === '') return;
+    return assetBalances.find(assetBalance => assetBalance.asset.contractId.includes(contractId));
   }, [assetBalances, contractId]);
 }
 
@@ -117,36 +117,6 @@ export function useTransferableStacksFungibleTokenAssetBalances(
   return useMemo(
     () => assetBalances.filter(assetBalance => assetBalance.asset.canTransfer),
     [assetBalances]
-  );
-}
-
-/**
- * Use caution with this hook, is incredibly expensive. To get an asset's
- * balance, we query all balances metadata (possibly hundreds) and then search
- * the results.
- *
- * Remove with legacy send form.
- * @deprecated
- */
-export function useStacksCryptoAssetBalanceByAssetId(selectedAssetId?: string) {
-  const account = useCurrentStacksAccount();
-
-  const { data: stxCryptoCurrencyAssetBalance } = useStacksAnchoredCryptoCurrencyAssetBalance(
-    account?.address ?? ''
-  );
-  const stacksFtCryptoAssetBalances = useStacksFungibleTokenAssetBalancesUnanchoredWithMetadata(
-    account?.address ?? ''
-  );
-
-  return useMemo(
-    () => {
-      if (!stxCryptoCurrencyAssetBalance) return;
-      return [stxCryptoCurrencyAssetBalance, ...stacksFtCryptoAssetBalances].find(
-        assetBalance => getFullyQualifiedStacksAssetName(assetBalance) === selectedAssetId
-      );
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedAssetId]
   );
 }
 

--- a/src/app/query/stacks/balance/stacks-ft-balances.hooks.ts
+++ b/src/app/query/stacks/balance/stacks-ft-balances.hooks.ts
@@ -1,4 +1,6 @@
 import { useMemo } from 'react';
+import { toast } from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
 
 import type { StacksFungibleTokenAssetBalance } from '@shared/models/crypto-asset-balance.model';
 
@@ -101,13 +103,20 @@ function useStacksFungibleTokenAssetBalancesUnanchoredWithMetadata(
 
 export function useStacksFungibleTokenAssetBalance(contractId: string) {
   const account = useCurrentStacksAccount();
+  const navigate = useNavigate();
   const assetBalances = useStacksFungibleTokenAssetBalancesUnanchoredWithMetadata(
     account?.address ?? ''
   );
   return useMemo(() => {
-    if (!assetBalances.length || contractId === '') return;
-    return assetBalances.find(assetBalance => assetBalance.asset.contractId.includes(contractId));
-  }, [assetBalances, contractId]);
+    const balance = assetBalances.find(assetBalance =>
+      assetBalance.asset.contractId.includes(contractId)
+    );
+    if (!balance) {
+      toast.error('Unable to find balance by contract id');
+      navigate('..');
+    }
+    return balance as StacksFungibleTokenAssetBalance;
+  }, [assetBalances, contractId, navigate]);
 }
 
 export function useTransferableStacksFungibleTokenAssetBalances(

--- a/src/app/store/transactions/token-transfer.hooks.ts
+++ b/src/app/store/transactions/token-transfer.hooks.ts
@@ -25,7 +25,6 @@ import {
   GenerateUnsignedTransactionOptions,
   generateUnsignedTransaction,
 } from '@app/common/transactions/stacks/generate-unsigned-txs';
-import { useStacksCryptoAssetBalanceByAssetId } from '@app/query/stacks/balance/stacks-ft-balances.hooks';
 import { getStacksFungibleTokenCurrencyAssetBalance } from '@app/query/stacks/balance/stacks-ft-balances.utils';
 import { useNextNonce } from '@app/query/stacks/nonce/account-nonces.hooks';
 import { useCurrentStacksNetworkState } from '@app/store/networks/networks.hooks';
@@ -100,12 +99,13 @@ export function useStxTokenTransferUnsignedTxState(values?: StacksSendFormValues
   return tx.result;
 }
 
-export function useGenerateFtTokenTransferUnsignedTx(selectedAssetId: string) {
+export function useGenerateFtTokenTransferUnsignedTx(
+  assetBalance?: StacksFungibleTokenAssetBalance
+) {
   const { data: nextNonce } = useNextNonce();
   const account = useCurrentStacksAccount();
-  const selectedAssetBalance = useStacksCryptoAssetBalanceByAssetId(selectedAssetId);
-  const tokenCurrencyAssetBalance =
-    getStacksFungibleTokenCurrencyAssetBalance(selectedAssetBalance);
+
+  const tokenCurrencyAssetBalance = getStacksFungibleTokenCurrencyAssetBalance(assetBalance);
   const assetTransferState = useMakeFungibleTokenTransfer(tokenCurrencyAssetBalance);
 
   return useCallback(
@@ -182,22 +182,10 @@ export function useGenerateFtTokenTransferUnsignedTx(selectedAssetId: string) {
   );
 }
 
-// TODO: Refactor when remove legacy send form?
-export function useFtTokenTransferUnsignedTx(
-  selectedAssetId: string,
-  values?: StacksSendFormValues
-) {
-  const generateTx = useGenerateFtTokenTransferUnsignedTx(selectedAssetId);
+export function useFtTokenTransferUnsignedTx(assetBalance?: StacksFungibleTokenAssetBalance) {
+  const generateTx = useGenerateFtTokenTransferUnsignedTx(assetBalance);
   const account = useCurrentStacksAccount();
-  const selectedAssetBalance = useStacksCryptoAssetBalanceByAssetId(selectedAssetId);
-  const tokenCurrencyAssetBalance =
-    getStacksFungibleTokenCurrencyAssetBalance(selectedAssetBalance);
-  const assetTransferState = useMakeFungibleTokenTransfer(tokenCurrencyAssetBalance);
 
-  const tx = useAsync(
-    async () => generateTx(values ?? undefined),
-    [account, assetTransferState, selectedAssetBalance, values]
-  );
-
+  const tx = useAsync(async () => generateTx(), [account]);
   return tx.result;
 }

--- a/src/app/store/transactions/token-transfer.hooks.ts
+++ b/src/app/store/transactions/token-transfer.hooks.ts
@@ -100,7 +100,7 @@ export function useStxTokenTransferUnsignedTxState(values?: StacksSendFormValues
 }
 
 export function useGenerateFtTokenTransferUnsignedTx(
-  assetBalance?: StacksFungibleTokenAssetBalance
+  assetBalance: StacksFungibleTokenAssetBalance
 ) {
   const { data: nextNonce } = useNextNonce();
   const account = useCurrentStacksAccount();
@@ -182,7 +182,7 @@ export function useGenerateFtTokenTransferUnsignedTx(
   );
 }
 
-export function useFtTokenTransferUnsignedTx(assetBalance?: StacksFungibleTokenAssetBalance) {
+export function useFtTokenTransferUnsignedTx(assetBalance: StacksFungibleTokenAssetBalance) {
   const generateTx = useGenerateFtTokenTransferUnsignedTx(assetBalance);
   const account = useCurrentStacksAccount();
 

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -60,6 +60,7 @@ export enum RouteUrls {
   // Send crypto asset routes
   SendCryptoAsset = '/send',
   SendCryptoAssetForm = '/send/:symbol',
+  SendSip10Form = '/send/:symbol/:contractId',
   SendCryptoAssetFormRecipientAccounts = 'recipient-accounts',
   SendCryptoAssetFormRecipientBns = 'recipient-bns',
   SendBtcConfirmation = '/send/btc/confirm',


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4616524571).<!-- Sticky Header Marker -->

This pr fixes bug with sip10 token send form https://github.com/hirosystems/wallet/pull/3511#issuecomment-1494737691

Problem is that after route change https://github.com/hirosystems/wallet/blob/1395afd26e2e5a7e3966b8ed214cedc9eb48e678/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/use-sip10-send-form.tsx#L31 `routeContractId` becomes undefined and this breaks the code, actually the same problem is currently on production (in order to reproduce, just open sip10 send confirmation page and then go back).

I'm not happy with this implementation, but not sure how to make navigation state work as expected🤔