### PR TITLE
feat: add regtest support to BTC address config files

### DIFF
--- a/src/app/common/transactions/stacks/transaction.utils.spec.ts
+++ b/src/app/common/transactions/stacks/transaction.utils.spec.ts
@@ -1,12 +1,12 @@
 import { ChainID } from '@stacks/transactions';
 
-import { whenStxChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 
-describe(whenStxChainId.name, () => {
+describe(whenStacksChainId.name, () => {
   const expectedResult = 'should be this value';
   test('that it returns testnet when given a testnet chain id', () => {
     expect(
-      whenStxChainId(ChainID.Testnet)({
+      whenStacksChainId(ChainID.Testnet)({
         [ChainID.Testnet]: expectedResult,
         [ChainID.Mainnet]: 'One plus one equals two.',
       })
@@ -15,7 +15,7 @@ describe(whenStxChainId.name, () => {
   test('that it returns mainnet when given a mainnet chain id', () => {
     const expectedResult = 'should be this value';
     expect(
-      whenStxChainId(ChainID.Mainnet)({
+      whenStacksChainId(ChainID.Mainnet)({
         [ChainID.Testnet]: 'The capital city of Mongolia is Ulaanbaatar.',
         [ChainID.Mainnet]: expectedResult,
       })

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -10,7 +10,7 @@ import {
 import BigNumber from 'bignumber.js';
 import { toUnicode } from 'punycode';
 
-import { KEBAB_REGEX, NetworkModes } from '@shared/constants';
+import { BitcoinNetworkModes, KEBAB_REGEX, NetworkModes } from '@shared/constants';
 import { logger } from '@shared/logger';
 import type { Blockchains } from '@shared/models/blockchain.model';
 
@@ -61,7 +61,7 @@ export function validateAndCleanRecoveryInput(value: string) {
 
 interface MakeTxExplorerLinkArgs {
   blockchain: Blockchains;
-  mode: NetworkModes;
+  mode: BitcoinNetworkModes;
   suffix?: string;
   txid: string;
 }
@@ -73,7 +73,7 @@ export function makeTxExplorerLink({
 }: MakeTxExplorerLinkArgs) {
   switch (blockchain) {
     case 'bitcoin':
-      return `https://mempool.space/${mode === 'testnet' ? 'testnet/' : ''}tx/${txid}`;
+      return `https://mempool.space/${mode !== 'mainnet' ? mode + '/' : 'mainnet'}tx/${txid}`;
     case 'stacks':
       return `https://explorer.stacks.co/txid/${txid}?chain=${mode}${suffix}`;
     default:
@@ -291,17 +291,27 @@ export function isPopupMode() {
   return pageMode === 'popup';
 }
 
-interface WhenChainIdMap<T> {
+interface WhenStacksChainIdMap<T> {
   [ChainID.Mainnet]: T;
   [ChainID.Testnet]: T;
 }
-export function whenStxChainId(chainId: ChainID) {
-  return <T>(chainIdMap: WhenChainIdMap<T>): T => chainIdMap[chainId];
+export function whenStacksChainId(chainId: ChainID) {
+  return <T>(chainIdMap: WhenStacksChainIdMap<T>): T => chainIdMap[chainId];
 }
 
 type NetworkMap<T> = Record<NetworkModes, T>;
 export function whenNetwork(mode: NetworkModes) {
   return <T>(networkMap: NetworkMap<T>): T => networkMap[mode];
+}
+
+const bitcoinNetworkToCoreNetworkMap: Record<BitcoinNetworkModes, NetworkModes> = {
+  mainnet: 'mainnet',
+  testnet: 'testnet',
+  regtest: 'testnet',
+  signet: 'testnet',
+};
+export function bitcoinNetworkModeToCoreNetworkMode(mode: BitcoinNetworkModes) {
+  return bitcoinNetworkToCoreNetworkMap[mode];
 }
 
 export function sumNumbers(nums: number[]) {

--- a/src/app/common/validation/forms/address-validators.ts
+++ b/src/app/common/validation/forms/address-validators.ts
@@ -1,7 +1,7 @@
 import { AddressType, Network, getAddressInfo, validate } from 'bitcoin-address-validation';
 import * as yup from 'yup';
 
-import { NetworkConfiguration, NetworkModes } from '@shared/constants';
+import { BitcoinNetworkModes, NetworkConfiguration } from '@shared/constants';
 import { isString } from '@shared/utils';
 
 import { FormErrorMessages } from '@app/common/error-messages';
@@ -43,14 +43,14 @@ export function btcTaprootAddressValidator() {
   });
 }
 
-function btcAddressNetworkValidatorFactory(network: NetworkModes) {
+function btcAddressNetworkValidatorFactory(network: BitcoinNetworkModes) {
   return (value?: string) => {
     if (!isString(value)) return false;
     return validate(value, network as Network);
   };
 }
 
-export function btcAddressNetworkValidator(network: NetworkModes) {
+export function btcAddressNetworkValidator(network: BitcoinNetworkModes) {
   return yup.string().test({
     test: btcAddressNetworkValidatorFactory(network),
     message: FormErrorMessages.IncorrectNetworkAddress,

--- a/src/app/components/network-row.tsx
+++ b/src/app/components/network-row.tsx
@@ -1,7 +1,7 @@
 import { ChainID } from '@stacks/transactions';
 import { Box } from '@stacks/ui';
 
-import { whenStxChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 import { SpaceBetween } from '@app/components/layout/space-between';
 import { Caption } from '@app/components/typography';
 
@@ -17,7 +17,7 @@ export function NetworkRow({ chainId }: NetworkRowProps) {
         </Box>
         <Caption>
           <span>
-            {whenStxChainId(chainId)({
+            {whenStacksChainId(chainId)({
               [ChainID.Testnet]: 'Testnet',
               [ChainID.Mainnet]: 'Mainnet',
             })}

--- a/src/app/features/ledger/flows/message-signing/message-signing.utils.ts
+++ b/src/app/features/ledger/flows/message-signing/message-signing.utils.ts
@@ -10,7 +10,7 @@ import {
 
 import { SignedMessageStructured } from '@shared/signature/signature-types';
 
-import { whenStxChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 
 export function cvToDisplay(cv: ClarityValue): string {
   return cvToString(cv).replaceAll('"', '');
@@ -22,7 +22,7 @@ export function chainIdToDisplay(chainIdCv: ClarityValue): string {
   const chainId = parseInt(chainIdString.replace('u', ''));
   if (!Object.values(ChainID).includes(chainId)) return '';
 
-  return whenStxChainId(chainId as ChainID)({
+  return whenStacksChainId(chainId as ChainID)({
     [ChainID.Testnet]: 'Testnet',
     [ChainID.Mainnet]: 'Mainnet',
   });

--- a/src/app/query/bitcoin/ordinals/utils.ts
+++ b/src/app/query/bitcoin/ordinals/utils.ts
@@ -1,6 +1,6 @@
 import { HDKey } from '@scure/bip32';
 
-import { NetworkModes } from '@shared/constants';
+import { BitcoinNetworkModes } from '@shared/constants';
 import { deriveAddressIndexKeychainFromAccount } from '@shared/crypto/bitcoin/bitcoin.utils';
 import { getTaprootPayment } from '@shared/crypto/bitcoin/p2tr-address-gen';
 import { DerivationPathDepth } from '@shared/crypto/derivation-path.utils';
@@ -12,7 +12,7 @@ export function hasInscriptions(data: unknown[]) {
 interface GetTaprootAddressArgs {
   index: number;
   keychain?: HDKey;
-  network: NetworkModes;
+  network: BitcoinNetworkModes;
 }
 export function getTaprootAddress({ index, keychain, network }: GetTaprootAddressArgs) {
   if (!keychain) throw new Error('Expected keychain to be provided');

--- a/src/app/query/stacks/rate-limiter.ts
+++ b/src/app/query/stacks/rate-limiter.ts
@@ -1,7 +1,7 @@
 import { ChainID } from '@stacks/transactions';
 import { RateLimiter } from 'limiter';
 
-import { whenStxChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 
 const hiroStacksMainnetApiLimiter = new RateLimiter({
@@ -17,7 +17,7 @@ const hiroStacksTestnetApiLimiter = new RateLimiter({
 export function useHiroApiRateLimiter() {
   const network = useCurrentNetworkState();
 
-  return whenStxChainId(network.chain.stacks.chainId)({
+  return whenStacksChainId(network.chain.stacks.chainId)({
     [ChainID.Mainnet]: hiroStacksMainnetApiLimiter,
     [ChainID.Testnet]: hiroStacksTestnetApiLimiter,
   });

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin-keychain.ts
@@ -2,7 +2,7 @@ import { createSelector } from '@reduxjs/toolkit';
 import { HDKey } from '@scure/bip32';
 
 import { NetworkModes } from '@shared/constants';
-import { getBtcSignerLibNetworkByMode } from '@shared/crypto/bitcoin/bitcoin.network';
+import { getBtcSignerLibNetworkConfigByMode } from '@shared/crypto/bitcoin/bitcoin.network';
 import { deriveAddressIndexZeroFromAccount } from '@shared/crypto/bitcoin/bitcoin.utils';
 import { deriveTaprootAccountFromRootKeychain } from '@shared/crypto/bitcoin/p2tr-address-gen';
 import {
@@ -67,5 +67,5 @@ export const selectTestnetTaprootKeychain = bitcoinKeychainSelectorFactory(
 
 export function useBitcoinLibNetworkConfig() {
   const network = useCurrentNetwork();
-  return getBtcSignerLibNetworkByMode(network.chain.bitcoin.network);
+  return getBtcSignerLibNetworkConfigByMode(network.chain.bitcoin.network);
 }

--- a/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -8,7 +8,7 @@ import { deriveAddressIndexZeroFromAccount } from '@shared/crypto/bitcoin/bitcoi
 import { deriveNativeSegWitReceiveAddressIndex } from '@shared/crypto/bitcoin/p2wpkh-address-gen';
 import { isUndefined } from '@shared/utils';
 
-import { whenNetwork } from '@app/common/utils';
+import { bitcoinNetworkModeToCoreNetworkMode, whenNetwork } from '@app/common/utils';
 import {
   formatBitcoinAccount,
   tempHardwareAccountForTesting,
@@ -24,7 +24,7 @@ import {
 function useNativeSegWitCurrentNetworkAccountKeychain() {
   const network = useCurrentNetwork();
   return useSelector(
-    whenNetwork(network.chain.bitcoin.network)({
+    whenNetwork(bitcoinNetworkModeToCoreNetworkMode(network.chain.bitcoin.network))({
       mainnet: selectMainnetNativeSegWitKeychain,
       testnet: selectTestnetNativeSegWitKeychain,
     })
@@ -63,6 +63,10 @@ export function useAllBitcoinNativeSegWitNetworksByAccount() {
         testnet: deriveNativeSegWitReceiveAddressIndex({
           xpub: testnetKeychainAtAccount(accountIndex).publicExtendedKey,
           network: 'testnet',
+        })?.address,
+        regtest: deriveNativeSegWitReceiveAddressIndex({
+          xpub: testnetKeychainAtAccount(accountIndex).publicExtendedKey,
+          network: 'regtest',
         })?.address,
       };
     },

--- a/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
@@ -13,7 +13,7 @@ import {
 } from '@shared/crypto/bitcoin/p2tr-address-gen';
 import { isUndefined } from '@shared/utils';
 
-import { whenNetwork } from '@app/common/utils';
+import { bitcoinNetworkModeToCoreNetworkMode, whenNetwork } from '@app/common/utils';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useCurrentAccountIndex } from '../../account';
@@ -23,7 +23,7 @@ import { selectMainnetTaprootKeychain, selectTestnetTaprootKeychain } from './bi
 function useTaprootCurrentNetworkAccountPrivateKeychain() {
   const network = useCurrentNetwork();
   return useSelector(
-    whenNetwork(network.chain.bitcoin.network)({
+    whenNetwork(bitcoinNetworkModeToCoreNetworkMode(network.chain.bitcoin.network))({
       mainnet: selectMainnetTaprootKeychain,
       testnet: selectTestnetTaprootKeychain,
     })

--- a/src/app/store/common/api-clients.hooks.ts
+++ b/src/app/store/common/api-clients.hooks.ts
@@ -9,7 +9,7 @@ import {
   HIRO_API_BASE_URL_TESTNET,
 } from '@shared/constants';
 
-import { whenStxChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 import { BitcoinClient } from '@app/query/bitcoin/bitcoin-client';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import { TokenMetadataClient } from '@app/query/stacks/token-metadata-client';
@@ -24,7 +24,7 @@ import { useCurrentNetworkState } from '../networks/networks.hooks';
 export function useBitcoinClient() {
   const network = useCurrentNetworkState();
 
-  const baseUrl = whenStxChainId(network.chain.stacks.chainId)({
+  const baseUrl = whenStacksChainId(network.chain.stacks.chainId)({
     [ChainID.Mainnet]: BITCOIN_API_BASE_URL_MAINNET,
     [ChainID.Testnet]: BITCOIN_API_BASE_URL_TESTNET,
   });
@@ -55,7 +55,7 @@ export function useStacksClientAnchored() {
 export function useTokenMetadataClient() {
   const network = useCurrentNetworkState();
 
-  const basePath = whenStxChainId(network.chain.stacks.chainId)({
+  const basePath = whenStacksChainId(network.chain.stacks.chainId)({
     [ChainID.Mainnet]: HIRO_API_BASE_URL_MAINNET,
     [ChainID.Testnet]: HIRO_API_BASE_URL_TESTNET,
   });

--- a/src/app/store/networks/networks.hooks.ts
+++ b/src/app/store/networks/networks.hooks.ts
@@ -4,9 +4,9 @@ import { useSelector } from 'react-redux';
 import { StacksMainnet, StacksNetwork, StacksTestnet } from '@stacks/network';
 import { ChainID } from '@stacks/transactions';
 
-import { DefaultNetworkModes } from '@shared/constants';
+import { NetworkModes } from '@shared/constants';
 
-import { whenStxChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 import { useAppDispatch } from '@app/store';
 
 import { networksActions } from './networks.actions';
@@ -18,7 +18,7 @@ export function useCurrentNetworkState() {
 
   return useMemo(() => {
     const isTestnet = currentNetwork.chain.stacks.chainId === ChainID.Testnet;
-    const mode = isTestnet ? DefaultNetworkModes.testnet : DefaultNetworkModes.mainnet;
+    const mode = (isTestnet ? 'testnet' : 'mainnet') as NetworkModes;
     return { ...currentNetwork, isTestnet, mode };
   }, [currentNetwork]);
 }
@@ -29,7 +29,7 @@ export function useCurrentStacksNetworkState(): StacksNetwork {
   return useMemo(() => {
     if (!currentNetwork) throw new Error('No current network');
 
-    const stacksNetwork = whenStxChainId(currentNetwork.chain.stacks.chainId || 1)({
+    const stacksNetwork = whenStacksChainId(currentNetwork.chain.stacks.chainId)({
       [ChainID.Mainnet]: new StacksMainnet({ url: currentNetwork.chain.stacks.url }),
       [ChainID.Testnet]: new StacksTestnet({ url: currentNetwork.chain.stacks.url }),
     });

--- a/src/app/store/networks/networks.slice.ts
+++ b/src/app/store/networks/networks.slice.ts
@@ -1,8 +1,8 @@
 import { EntityId, PayloadAction, createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 
-import { DefaultNetworkConfigurationIds, NetworkConfiguration } from '@shared/constants';
+import { NetworkConfiguration, WalletDefaultNetworkConfigurationIds } from '@shared/constants';
 
-const defaultCurrentNetworkId = DefaultNetworkConfigurationIds.mainnet as EntityId;
+const defaultCurrentNetworkId = WalletDefaultNetworkConfigurationIds.mainnet as EntityId;
 
 // Creates type that replicates network store before addition of Bitcoin.
 // Current implementation uses a static btc config, based on stx config, so

--- a/src/app/store/networks/networks.utils.ts
+++ b/src/app/store/networks/networks.utils.ts
@@ -7,7 +7,7 @@ import {
   NetworkConfiguration,
 } from '@shared/constants';
 
-import { whenStxChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 
 import { PersistedNetworkConfiguration } from './networks.slice';
 
@@ -65,7 +65,7 @@ export function transformNetworkStateToMultichainStucture(
               bitcoin: {
                 blockchain: 'bitcoin',
                 network: ChainID[chainId].toLowerCase(),
-                url: whenStxChainId(chainId)({
+                url: whenStacksChainId(chainId)({
                   [ChainID.Mainnet]: BITCOIN_API_BASE_URL_MAINNET,
                   [ChainID.Testnet]: BITCOIN_API_BASE_URL_TESTNET,
                 }),

--- a/src/app/store/transactions/transaction.ts
+++ b/src/app/store/transactions/transaction.ts
@@ -8,7 +8,7 @@ import {
 import { atom } from 'jotai';
 
 import { stacksTransactionToHex } from '@app/common/transactions/stacks/transaction.utils';
-import { whenStxChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 import { currentNetworkAtom } from '@app/store/networks/networks';
 
 export function prepareTxDetailsForBroadcast(tx: StacksTransaction) {
@@ -28,7 +28,7 @@ export const transactionNetworkVersionState = atom(get => {
   const defaultChainId = TransactionVersion.Testnet;
   if (!chainId) return defaultChainId;
 
-  return whenStxChainId(chainId)({
+  return whenStacksChainId(chainId)({
     [ChainID.Mainnet]: TransactionVersion.Mainnet,
     [ChainID.Testnet]: TransactionVersion.Testnet,
   });
@@ -36,7 +36,7 @@ export const transactionNetworkVersionState = atom(get => {
 
 export const addressNetworkVersionState = atom(get => {
   const chainId = get(currentNetworkAtom)?.chain.stacks.chainId;
-  return whenStxChainId(chainId)({
+  return whenStacksChainId(chainId)({
     [ChainID.Mainnet]: AddressVersion.MainnetSingleSig,
     [ChainID.Testnet]: AddressVersion.TestnetSingleSig,
   });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -27,13 +27,19 @@ export const MICROBLOCKS_ENABLED = !IS_TEST_ENV && true;
 export const GITHUB_ORG = 'hirosystems';
 export const GITHUB_REPO = 'wallet';
 
-export enum DefaultNetworkConfigurationIds {
+export enum WalletDefaultNetworkConfigurationIds {
   mainnet = 'mainnet',
   testnet = 'testnet',
   devnet = 'devnet',
 }
 
-export type DefaultNetworkConfigurations = keyof typeof DefaultNetworkConfigurationIds;
+export type DefaultNetworkConfigurations = keyof typeof WalletDefaultNetworkConfigurationIds;
+
+export type NetworkModes = 'mainnet' | 'testnet';
+
+type BitcoinTestnetModes = 'testnet' | 'regtest' | 'signet';
+
+export type BitcoinNetworkModes = NetworkModes | BitcoinTestnetModes;
 
 interface BaseChainConfig {
   blockchain: Blockchains;
@@ -42,7 +48,7 @@ interface BaseChainConfig {
 interface BitcoinChainConfig extends BaseChainConfig {
   blockchain: 'bitcoin';
   url: string;
-  network: NetworkModes;
+  network: BitcoinNetworkModes;
 }
 
 interface StacksChainConfig extends BaseChainConfig {
@@ -60,13 +66,6 @@ export interface NetworkConfiguration {
   };
 }
 
-export enum DefaultNetworkModes {
-  mainnet = 'mainnet',
-  testnet = 'testnet',
-}
-
-export type NetworkModes = keyof typeof DefaultNetworkModes;
-
 const DEFAULT_SERVER_MAINNET = 'https://stacks-node-api.stacks.co';
 export const DEFAULT_SERVER_TESTNET = 'https://stacks-node-api.testnet.stacks.co';
 
@@ -77,7 +76,7 @@ export const BITCOIN_API_BASE_URL_MAINNET = 'https://blockstream.info/api';
 export const BITCOIN_API_BASE_URL_TESTNET = 'https://blockstream.info/testnet/api';
 
 const networkMainnet: NetworkConfiguration = {
-  id: DefaultNetworkConfigurationIds.mainnet,
+  id: WalletDefaultNetworkConfigurationIds.mainnet,
   name: 'Mainnet',
   chain: {
     stacks: {
@@ -94,7 +93,7 @@ const networkMainnet: NetworkConfiguration = {
 };
 
 const networkTestnet: NetworkConfiguration = {
-  id: DefaultNetworkConfigurationIds.testnet,
+  id: WalletDefaultNetworkConfigurationIds.testnet,
   name: 'Testnet',
   chain: {
     stacks: {
@@ -111,7 +110,7 @@ const networkTestnet: NetworkConfiguration = {
 };
 
 const networkDevnet: NetworkConfiguration = {
-  id: DefaultNetworkConfigurationIds.devnet,
+  id: WalletDefaultNetworkConfigurationIds.devnet,
   name: 'Devnet',
   chain: {
     stacks: {
@@ -121,8 +120,8 @@ const networkDevnet: NetworkConfiguration = {
     },
     bitcoin: {
       blockchain: 'bitcoin',
-      network: 'testnet',
-      url: BITCOIN_API_BASE_URL_TESTNET,
+      network: 'regtest',
+      url: 'http://localhost:18443',
     },
   },
 };
@@ -130,12 +129,12 @@ const networkDevnet: NetworkConfiguration = {
 export const defaultCurrentNetwork: NetworkConfiguration = networkMainnet;
 
 export const defaultNetworksKeyedById: Record<
-  DefaultNetworkConfigurationIds,
+  WalletDefaultNetworkConfigurationIds,
   NetworkConfiguration
 > = {
-  [DefaultNetworkConfigurationIds.mainnet]: networkMainnet,
-  [DefaultNetworkConfigurationIds.testnet]: networkTestnet,
-  [DefaultNetworkConfigurationIds.devnet]: networkDevnet,
+  [WalletDefaultNetworkConfigurationIds.mainnet]: networkMainnet,
+  [WalletDefaultNetworkConfigurationIds.testnet]: networkTestnet,
+  [WalletDefaultNetworkConfigurationIds.devnet]: networkDevnet,
 };
 
 export const DEFAULT_LIST_LIMIT = 50;

--- a/src/shared/crypto/bitcoin/bitcoin.network.ts
+++ b/src/shared/crypto/bitcoin/bitcoin.network.ts
@@ -1,4 +1,4 @@
-import { NetworkModes } from '@shared/constants';
+import { BitcoinNetworkModes } from '@shared/constants';
 
 // See this PR https://github.com/paulmillr/@scure/btc-signer/pull/15
 // Atttempting to add these directly to the library
@@ -23,11 +23,27 @@ const bitcoinTestnet: BitcoinNetwork = {
   wif: 0xef,
 };
 
-const bitcoinNetworks: Record<NetworkModes, BitcoinNetwork> = {
-  mainnet: bitcoinMainnet,
-  testnet: bitcoinTestnet,
+const bitcoinRegtest: BitcoinNetwork = {
+  bech32: 'bcrt',
+  pubKeyHash: 0x6f,
+  scriptHash: 0xc4,
+  wif: 0xef,
 };
 
-export function getBtcSignerLibNetworkByMode(network: NetworkModes) {
+const bitcoinSignet: BitcoinNetwork = {
+  bech32: 'sb',
+  pubKeyHash: 0x3f,
+  scriptHash: 0x7f,
+  wif: 0x80,
+};
+
+const bitcoinNetworks: Record<BitcoinNetworkModes, BitcoinNetwork> = {
+  mainnet: bitcoinMainnet,
+  testnet: bitcoinTestnet,
+  regtest: bitcoinRegtest,
+  signet: bitcoinSignet,
+};
+
+export function getBtcSignerLibNetworkConfigByMode(network: BitcoinNetworkModes) {
   return bitcoinNetworks[network];
 }

--- a/src/shared/crypto/bitcoin/p2tr-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2tr-address-gen.ts
@@ -1,10 +1,10 @@
 import { HDKey } from '@scure/bip32';
 import * as btc from '@scure/btc-signer';
 
-import { NetworkModes } from '@shared/constants';
+import { BitcoinNetworkModes, NetworkModes } from '@shared/constants';
 
 import { DerivationPathDepth } from '../derivation-path.utils';
-import { getBtcSignerLibNetworkByMode } from './bitcoin.network';
+import { getBtcSignerLibNetworkConfigByMode } from './bitcoin.network';
 import {
   deriveAddressIndexKeychainFromAccount,
   ecdsaPublicKeyToSchnorr,
@@ -22,15 +22,15 @@ export function deriveTaprootAccountFromRootKeychain(keychain: HDKey, network: N
   return (index: number) => keychain.derive(getTaprootAccountDerivationPath(network, index));
 }
 
-export function getTaprootPayment(publicKey: Uint8Array, network: NetworkModes) {
+export function getTaprootPayment(publicKey: Uint8Array, network: BitcoinNetworkModes) {
   return btc.p2tr(
     ecdsaPublicKeyToSchnorr(publicKey),
     undefined,
-    getBtcSignerLibNetworkByMode(network)
+    getBtcSignerLibNetworkConfigByMode(network)
   );
 }
 
-export function getTaprootPaymentFromAddressIndex(keychain: HDKey, network: NetworkModes) {
+export function getTaprootPaymentFromAddressIndex(keychain: HDKey, network: BitcoinNetworkModes) {
   if (keychain.depth !== DerivationPathDepth.AddressIndex)
     throw new Error('Keychain passed is not an address index');
 
@@ -42,7 +42,7 @@ export function getTaprootPaymentFromAddressIndex(keychain: HDKey, network: Netw
 interface DeriveTaprootReceiveAddressIndexArgs {
   xpub: string;
   index: number;
-  network: NetworkModes;
+  network: BitcoinNetworkModes;
 }
 export function deriveTaprootReceiveAddressIndex({
   xpub,

--- a/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
@@ -1,10 +1,10 @@
 import { HDKey } from '@scure/bip32';
 import * as btc from '@scure/btc-signer';
 
-import { NetworkModes } from '@shared/constants';
+import { BitcoinNetworkModes, NetworkModes } from '@shared/constants';
 
 import { DerivationPathDepth } from '../derivation-path.utils';
-import { getBtcSignerLibNetworkByMode } from './bitcoin.network';
+import { getBtcSignerLibNetworkConfigByMode } from './bitcoin.network';
 import {
   deriveAddressIndexZeroFromAccount,
   getBitcoinCoinTypeIndexByNetwork,
@@ -19,16 +19,19 @@ export function deriveNativeSegWitAccountKeychain(keychain: HDKey, network: Netw
   return (index: number) => keychain.derive(getNativeSegWitAccountDerivationPath(network, index));
 }
 
-export function getNativeSegWitAddressIndexFromKeychain(keychain: HDKey, network: NetworkModes) {
+export function getNativeSegWitAddressIndexFromKeychain(
+  keychain: HDKey,
+  network: BitcoinNetworkModes
+) {
   if (keychain.depth !== DerivationPathDepth.AddressIndex)
     throw new Error('Keychain passed is not an address index');
 
-  return btc.p2wpkh(keychain.publicKey!, getBtcSignerLibNetworkByMode(network));
+  return btc.p2wpkh(keychain.publicKey!, getBtcSignerLibNetworkConfigByMode(network));
 }
 
 interface DeriveNativeSegWitReceiveAddressIndexArgs {
   xpub: string;
-  network: NetworkModes;
+  network: BitcoinNetworkModes;
 }
 export function deriveNativeSegWitReceiveAddressIndex({
   xpub,

--- a/tests/page-object-models/home.page.ts
+++ b/tests/page-object-models/home.page.ts
@@ -5,14 +5,16 @@ import { SettingsMenuSelectors } from '@tests/selectors/settings.selectors';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { createTestSelector } from '@tests/utils';
 
-import { DefaultNetworkConfigurationIds } from '@shared/constants';
+import { WalletDefaultNetworkConfigurationIds } from '@shared/constants';
 
 export class HomePage {
   readonly page: Page;
   readonly drawerActionButton: Locator;
   readonly receiveButton: Locator;
   readonly sendButton: Locator;
-  readonly testNetworkSelector: string = createTestSelector(DefaultNetworkConfigurationIds.testnet);
+  readonly testNetworkSelector: string = createTestSelector(
+    WalletDefaultNetworkConfigurationIds.testnet
+  );
 
   constructor(page: Page) {
     this.page = page;
@@ -54,6 +56,6 @@ export class HomePage {
     await (
       await this.page.waitForSelector(this.testNetworkSelector, { timeout: 30000 })
     ).isEnabled();
-    await this.page.getByTestId(DefaultNetworkConfigurationIds.testnet).click();
+    await this.page.getByTestId(WalletDefaultNetworkConfigurationIds.testnet).click();
   }
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4622539791).<!-- Sticky Header Marker -->

Clone of @kenrogers' PR https://github.com/hirosystems/wallet/pull/3513

Some changes made here:
- Removed use of `2` for regtest coin type in derivation path. Afaict, _all_ testnets use `1`
- Removed regtest keychain. Because of above, we can reuse testnet keychain
- Created new, more specific bitcoin mode containing regtest/signet
- Removed chain id changes, this is a stacks-only concept which has no regtest