### PR TITLE
fix: issue with jumbled utxo ordering

### DIFF
--- a/src/app/features/collectibles/components/_collectible-types/collectible-image.tsx
+++ b/src/app/features/collectibles/components/_collectible-types/collectible-image.tsx
@@ -16,6 +16,7 @@ export function CollectibleImage(props: CollectibleImageProps) {
   const { alt, src, ...rest } = props;
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [width, setWidth] = useState(0);
 
   if (isError)
     return (
@@ -30,7 +31,11 @@ export function CollectibleImage(props: CollectibleImageProps) {
       <img
         alt={alt}
         onError={() => setIsError(true)}
-        onLoad={() => setIsLoading(false)}
+        onLoad={event => {
+          const target = event.target as HTMLImageElement;
+          setWidth(target.naturalWidth);
+          setIsLoading(false);
+        }}
         src={src}
         style={{
           width: '100%',
@@ -38,6 +43,7 @@ export function CollectibleImage(props: CollectibleImageProps) {
           aspectRatio: '1 / 1',
           objectFit: 'cover',
           display: isLoading ? 'none' : 'inherit',
+          imageRendering: width <= 40 ? 'pixelated' : 'auto',
         }}
       />
     </CollectibleItemLayout>

--- a/src/app/features/collectibles/components/_collectible-types/collectible-image.tsx
+++ b/src/app/features/collectibles/components/_collectible-types/collectible-image.tsx
@@ -17,7 +17,12 @@ export function CollectibleImage(props: CollectibleImageProps) {
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  if (isError) return <ImageUnavailable />;
+  if (isError)
+    return (
+      <CollectibleItemLayout collectibleTypeIcon={<OrdinalMinimalIcon />} {...rest}>
+        <ImageUnavailable />
+      </CollectibleItemLayout>
+    );
 
   return (
     <CollectibleItemLayout collectibleTypeIcon={<OrdinalMinimalIcon />} {...rest}>

--- a/src/app/features/collectibles/components/bitcoin/ordinals.tsx
+++ b/src/app/features/collectibles/components/bitcoin/ordinals.tsx
@@ -9,7 +9,7 @@ export function Ordinals() {
   return (
     <>
       {utxos.map(utxo => (
-        <InscriptionLoader key={utxo.txid} utxo={utxo}>
+        <InscriptionLoader key={utxo.txid + utxo.vout} utxo={utxo}>
           {path => <Inscription path={path} utxo={utxo} />}
         </InscriptionLoader>
       ))}

--- a/src/app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit.tsx
@@ -69,7 +69,9 @@ export function RetrieveTaprooToNativeSegwit() {
               key={utxo.txid}
               title={`Uninscribed UTXO #${i}`}
               value={
-                <ExternalLink href={`https://ord.ordscan.xyz/output/${utxo.txid}:${utxo.vout}`}>
+                <ExternalLink
+                  href={`https://ordinals-explorer.generative.xyz/output/${utxo.txid}:${utxo.vout}`}
+                >
                   {`${truncateMiddle(utxo.txid, 4)}:${utxo.vout}`} ↗
                 </ExternalLink>
               }

--- a/src/app/pages/psbt-request/components/psbt-decoded-request/psbt-decoded-request-nodes/inputs/psbt-inscription-loader.tsx
+++ b/src/app/pages/psbt-request/components/psbt-decoded-request/psbt-decoded-request-nodes/inputs/psbt-inscription-loader.tsx
@@ -3,13 +3,13 @@ import * as btc from '@scure/btc-signer';
 import { isEmpty } from '@shared/utils';
 
 import {
-  OrdApiXyzGetTransactionOutput,
+  OrdApiInscriptionTxOutput,
   useOrdinalsAwareUtxoQuery,
 } from '@app/query/bitcoin/ordinals/use-ordinals-aware-utxo.query';
 
 interface PsbtInscriptionLoaderProps {
   utxo: btc.TransactionInputRequired;
-  children(txOutput: OrdApiXyzGetTransactionOutput): JSX.Element | null;
+  children(txOutput: OrdApiInscriptionTxOutput): JSX.Element | null;
 }
 export function PsbtInscriptionLoader({ utxo, children }: PsbtInscriptionLoaderProps) {
   const { data: txOutput } = useOrdinalsAwareUtxoQuery(utxo);

--- a/src/app/query/bitcoin/bitcoin-client.ts
+++ b/src/app/query/bitcoin/bitcoin-client.ts
@@ -30,7 +30,10 @@ class AddressApi {
     return fetchData({
       errorMsg: 'No UTXOs fetched',
       url: `${this.configuration.baseUrl}/address/${address}/utxo`,
-    });
+    }).then((utxos: UtxoResponseItem[]) =>
+      // Sort by vout as blockstream API returns them inconsistently
+      utxos.sort((a, b) => a.vout - b.vout)
+    );
   }
 }
 

--- a/src/app/query/bitcoin/ordinals/use-ordinals-aware-utxo.query.ts
+++ b/src/app/query/bitcoin/ordinals/use-ordinals-aware-utxo.query.ts
@@ -25,14 +25,12 @@ const ordApiGetTransactionOutput = yup
   })
   .required();
 
-export type OrdApiXyzGetTransactionOutput = Prettify<
-  yup.InferType<typeof ordApiGetTransactionOutput>
->;
+export type OrdApiInscriptionTxOutput = Prettify<yup.InferType<typeof ordApiGetTransactionOutput>>;
 
 async function getOrdinalsAwareUtxo(
   txid: string,
   index: number
-): Promise<OrdApiXyzGetTransactionOutput> {
+): Promise<OrdApiInscriptionTxOutput> {
   const res = await fetch(`https://ordapi.xyz/output/${txid}:${index}`);
 
   if (!res.ok) throw new Error('Failed to fetch txid metadata');
@@ -51,9 +49,9 @@ const queryOptions = {
   staleTime: 15 * 60 * 1000, // 15 minutes
 } as const;
 
-export function useOrdinalsAwareUtxoQuery<T extends unknown = OrdApiXyzGetTransactionOutput>(
+export function useOrdinalsAwareUtxoQuery<T extends unknown = OrdApiInscriptionTxOutput>(
   utxo: TaprootUtxo | btc.TransactionInputRequired,
-  options?: AppUseQueryConfig<OrdApiXyzGetTransactionOutput, T>
+  options?: AppUseQueryConfig<OrdApiInscriptionTxOutput, T>
 ) {
   const txId = isTypedArray(utxo.txid) ? bytesToHex(utxo.txid) : utxo.txid;
   const txIndex = 'index' in utxo ? utxo.index : utxo.vout;
@@ -71,8 +69,8 @@ export function useOrdinalsAwareUtxoQueries(outputs: TaprootUtxo[]) {
     queries: outputs.map(utxo => ({
       queryKey: makeOrdinalsAwareUtxoQueryKey(utxo.txid, utxo.vout),
       queryFn: () => getOrdinalsAwareUtxo(utxo.txid, utxo.vout),
-      select: (resp: OrdApiXyzGetTransactionOutput) =>
-        ({ ...utxo, ...resp } as TaprootUtxo & OrdApiXyzGetTransactionOutput),
+      select: (resp: OrdApiInscriptionTxOutput) =>
+        ({ ...utxo, ...resp } as TaprootUtxo & OrdApiInscriptionTxOutput),
       ...queryOptions,
     })),
   });

--- a/src/app/query/bitcoin/ordinals/utils.ts
+++ b/src/app/query/bitcoin/ordinals/utils.ts
@@ -37,7 +37,7 @@ export function getTaprootAddress({ index, keychain, network }: GetTaprootAddres
 // Example:
 // https://ordinals.com/output/758bd2703dd9f0a2df31c2898aecf6caba05a906498c9bc076947f9fc4d8f081:0
 async function getOrdinalsComTxOutputHtmlPage(id: string, index: number) {
-  const resp = await fetch(`https://ord.ordscan.xyz/output/${id}:${index}`);
+  const resp = await fetch(`https://ordinals-explorer.generative.xyz/output/${id}:${index}`);
   const html = await resp.text();
   return new DOMParser().parseFromString(html, 'text/html');
 }

--- a/src/shared/utils/type-utils.ts
+++ b/src/shared/utils/type-utils.ts
@@ -3,9 +3,3 @@ export type Prettify<T> = {
 } & {};
 
 export type ValueOf<T> = T[keyof T];
-
-type RequiredProperties<T> = {
-  [P in keyof T]: NonNullable<T[P]>;
-};
-
-export type Ensure<T, K extends keyof T> = T & RequiredProperties<Pick<T, K>>;

--- a/src/shared/utils/type-utils.ts
+++ b/src/shared/utils/type-utils.ts
@@ -3,3 +3,9 @@ export type Prettify<T> = {
 } & {};
 
 export type ValueOf<T> = T[keyof T];
+
+type RequiredProperties<T> = {
+  [P in keyof T]: NonNullable<T[P]>;
+};
+
+export type Ensure<T, K extends keyof T> = T & RequiredProperties<Pick<T, K>>;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4622742224).<!-- Sticky Header Marker -->

Looking into issues with the utxo _is inscribed_ logic, noticed some funky behaviours, esp when there are many inscriptions on a single utxo.

Making a PR of these changes only.

Also inferring pixelated image rendering when <= 40px

<img width="1784" alt="image" src="https://user-images.githubusercontent.com/1618764/230207980-3bab2046-caad-47f4-9a93-339175388974.png">
