### PR TITLE
fix: google docs breaking, closes #3502

### DIFF
--- a/src/inpage/inpage.ts
+++ b/src/inpage/inpage.ts
@@ -20,7 +20,7 @@ import {
   SignatureResponseMessage,
   TransactionResponseMessage,
 } from '@shared/message-types';
-import { WalletMethodMap, WalletMethodNames, WalletResponses } from '@shared/rpc/rpc-methods';
+import type { WalletMethodMap, WalletMethodNames, WalletResponses } from '@shared/rpc/rpc-methods';
 
 type CallableMethods = keyof typeof ExternalMethods;
 
@@ -252,15 +252,17 @@ window.StacksProvider = provider;
 
 (window as any).HiroWalletProvider = provider;
 
-(window as any).btc = {
-  request: getStacksProvider()?.request,
-  listen(event: 'accountChange', callback: (arg: any) => void) {
-    function handler(e: MessageEvent) {
-      if (!e.data) return;
-      if ((e as any).event !== event) return;
-      callback((e as any).event);
-    }
-    window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
-  },
-};
+if (typeof window.btc === 'undefined') {
+  (window as any).btc = {
+    request: getStacksProvider()?.request,
+    listen(event: 'accountChange', callback: (arg: any) => void) {
+      function handler(e: MessageEvent) {
+        if (!e.data) return;
+        if ((e as any).event !== event) return;
+        callback((e as any).event);
+      }
+      window.addEventListener('message', handler);
+      return () => window.removeEventListener('message', handler);
+    },
+  };
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4665031246).<!-- Sticky Header Marker -->

Turns out Google docs uses a `btc` global