### PR TITLE
refactor: hiro explorer path

### DIFF
--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -75,7 +75,7 @@ export function makeTxExplorerLink({
     case 'bitcoin':
       return `https://mempool.space/${mode !== 'mainnet' ? mode + '/' : 'mainnet'}tx/${txid}`;
     case 'stacks':
-      return `https://explorer.stacks.co/txid/${txid}?chain=${mode}${suffix}`;
+      return `https://explorer.hiro.so/txid/${txid}?chain=${mode}${suffix}`;
     default:
       return '';
   }

--- a/src/app/pages/transaction-request/components/principal-value.tsx
+++ b/src/app/pages/transaction-request/components/principal-value.tsx
@@ -15,7 +15,7 @@ export function PrincipalValue(props: PrincipalValueProps) {
       fontWeight={500}
       lineHeight="1.6"
       wordBreak="break-all"
-      onClick={() => openInNewTab(`https://explorer.stacks.co/address/${address}?chain=${mode}`)}
+      onClick={() => openInNewTab(`https://explorer.hiro.so/address/${address}?chain=${mode}`)}
       {...rest}
     >
       {address}

--- a/test-app/src/components/explorer-link.tsx
+++ b/test-app/src/components/explorer-link.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Link } from '@components/link';
 import { Box } from '@stacks/ui';
 
@@ -13,7 +14,7 @@ export const ExplorerLink: React.FC<LinkProps> = ({ txId, text }) => {
   if (!id.startsWith('0x') && !id.includes('.')) {
     id = `0x${id}`;
   }
-  const url = `https://explorer.stacks.co/txid/${id}?chain=testnet`;
+  const url = `https://explorer.hiro.so/txid/${id}?chain=testnet`;
   return (
     <Box>
       <Link onClick={() => window.open(url, '_blank')} color="blue" display="inline-block" my={3}>


### PR DESCRIPTION
This PR swaps out the new, correct path for the Hiro explorer links in the wallet.

cc @timstackblock Thanks!