### PR TITLE
fix(activity): fetch on interval

### DIFF
--- a/src/app/query/bitcoin/address/transactions-by-address.query.ts
+++ b/src/app/query/bitcoin/address/transactions-by-address.query.ts
@@ -4,7 +4,7 @@ import { BitcoinTransaction } from '@shared/models/transactions/bitcoin-transact
 
 import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
 
-const staleTime = 10 * 1000;
+const staleTime = 5 * 1000;
 
 export function useGetBitcoinTransactionsByAddressQuery(
   address: string
@@ -15,7 +15,7 @@ export function useGetBitcoinTransactionsByAddressQuery(
     enabled: !!address,
     queryKey: ['btc-txs-by-address', address],
     queryFn: () => client.addressApi.getTransactionsByAddress(address),
+    refetchInterval: staleTime,
     staleTime,
-    refetchOnWindowFocus: true,
   });
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4732339518).<!-- Sticky Header Marker -->

Closes #3409

Adds auto-refresh when hook in use, should decrease time we're on this page and there's no activity. 

Future idea: add route state to activity page with _userHasJustBroadcasted_ information, where we could enable a visual indicator making it clear that we're waiting on new info. A spinner/skeleton tx etc