### PR TITLE
fix: ensure users don't accidentally send stamped utxos

### DIFF
--- a/src/app/query/bitcoin/ordinals/use-taproot-address-utxos.query.ts
+++ b/src/app/query/bitcoin/ordinals/use-taproot-address-utxos.query.ts
@@ -7,6 +7,7 @@ import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { UtxoResponseItem } from '../bitcoin-client';
+import { useIsStampedTx } from '../stamps/use-is-stamped-tx';
 import { getTaprootAddress, hasInscriptions } from './utils';
 
 const stopSearchAfterNumberAddressesWithoutOrdinals = 20;
@@ -23,6 +24,7 @@ export interface TaprootUtxo extends UtxoResponseItem {
 export function useTaprootAccountUtxosQuery() {
   const network = useCurrentNetwork();
   const keychain = useCurrentTaprootAccountKeychain();
+  const isStamped = useIsStampedTx();
   const client = useBitcoinClient();
 
   const currentAccountIndex = useCurrentAccountIndex();
@@ -60,6 +62,6 @@ export function useTaprootAccountUtxosQuery() {
       currentNumberOfAddressesWithoutOrdinals = 0;
       addressIndexCounter.increment();
     }
-    return foundUnspentTransactions;
+    return foundUnspentTransactions.filter(tx => !isStamped(tx.txid));
   });
 }

--- a/src/app/query/bitcoin/stamps/stamp-collection.query.ts
+++ b/src/app/query/bitcoin/stamps/stamp-collection.query.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { AppUseQueryConfig } from '@app/query/query-config';
+import { QueryPrefixes } from '@app/query/query-prefixes';
+
+interface Stamp {
+  message_index: number;
+  block_index: number;
+  timestamp: number;
+  tx_hash: string;
+  asset: string;
+  tx_index: number;
+  stamp_mimetype: string;
+  stamp_url: string;
+  stamp: number;
+}
+
+async function fetchStampCollection() {
+  return (
+    fetch('https://stampchain.io/stamp.json')
+      .then(res => res.json())
+      // Currently we only filter UTXOs for stamps. As we collect, and cache,
+      // all stamps, we cache only the ID to lower the amount of storage used
+      .then((allStamps: Stamp[]) => allStamps.map(s => ({ tx_hash: s.tx_hash })))
+  );
+}
+
+type FetchStampCollectionResp = Awaited<ReturnType<typeof fetchStampCollection>>;
+
+export function useStampCollectionQuery<T extends unknown = FetchStampCollectionResp>(
+  options?: AppUseQueryConfig<FetchStampCollectionResp, T>
+) {
+  return useQuery({
+    queryKey: [QueryPrefixes.StampCollection],
+    queryFn: () => fetchStampCollection(),
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: 1000 * 60 * 60 * 5,
+    ...options,
+  });
+}

--- a/src/app/query/bitcoin/stamps/use-is-stamped-tx.ts
+++ b/src/app/query/bitcoin/stamps/use-is-stamped-tx.ts
@@ -1,0 +1,12 @@
+import { useCallback } from 'react';
+
+import { useStampCollectionQuery } from './stamp-collection.query';
+
+export function useIsStampedTx() {
+  const { data: stampCollection = [] } = useStampCollectionQuery();
+
+  return useCallback(
+    (txid: string) => stampCollection.some(stamp => stamp.tx_hash === txid),
+    [stampCollection]
+  );
+}

--- a/src/app/query/query-prefixes.ts
+++ b/src/app/query/query-prefixes.ts
@@ -10,4 +10,6 @@ export enum QueryPrefixes {
   InscriptionMetadata = 'inscription-metadata',
   InscriptionFromTxid = 'inscription-from-txid',
   GetNftMetadata = 'get-nft-metadata',
+
+  StampCollection = 'stamp-collection',
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4798888301).<!-- Sticky Header Marker -->

WIP. Had a quick look at how stamps work. 

There's a single API with a 6MB response, and not sure if that's a bit too heavy/big to cache. Either way, wanted to look at how we might filter out stamped utxos from our coin selection, as a preventative measure ahead of any feature support.