### PR TITLE
fix(analytics): exploring use of traits

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@scure/bip32": "1.3.0",
     "@scure/bip39": "1.2.0",
     "@scure/btc-signer": "0.5.1",
-    "@segment/analytics-next": "1.49.2",
+    "@segment/analytics-next": "1.51.5",
     "@sentry/react": "7.35.0",
     "@sentry/tracing": "7.35.0",
     "@stacks/auth": "6.1.1",

--- a/src/app/features/collectibles/components/bitcoin/ordinals.tsx
+++ b/src/app/features/collectibles/components/bitcoin/ordinals.tsx
@@ -15,6 +15,7 @@ export function Ordinals() {
       void analytics.track('view_collectibles', {
         ordinals_count: utxos.length,
       });
+      void analytics.identify({ ordinals_count: utxos.length });
     }
   }, [utxos.length, analytics]);
 

--- a/src/app/features/collectibles/components/stacks/stacks-crypto-assets.tsx
+++ b/src/app/features/collectibles/components/stacks/stacks-crypto-assets.tsx
@@ -18,6 +18,7 @@ export function StacksCryptoAssets() {
       void analytics.track('view_collectibles', {
         stacks_nfts_count: stacksNftsMetadataResp.length,
       });
+      void analytics.identify({ stacks_nfts_count: stacksNftsMetadataResp.length });
     }
   }, [stacksNftsMetadataResp.length, analytics]);
 

--- a/src/app/features/container/container.tsx
+++ b/src/app/features/container/container.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
+import { useInitalizeAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useRouteHeaderState } from '@app/store/ui/ui.hooks';
 
 import { useRestoreFormState } from '../popup-send-form-restoration/use-restore-form-state';
@@ -9,6 +10,8 @@ export function Container() {
   const [routeHeader] = useRouteHeaderState();
 
   useRestoreFormState();
+
+  useInitalizeAnalytics();
 
   return (
     <ContainerLayout header={routeHeader}>

--- a/src/shared/utils/analytics.ts
+++ b/src/shared/utils/analytics.ts
@@ -13,10 +13,10 @@ import { persistConfig } from '@shared/storage';
 
 import type { RootState } from '@app/store';
 
-function initAnalytics() {
-  if (IS_TEST_ENV || !SEGMENT_WRITE_KEY) return null;
+export const analytics = new AnalyticsBrowser();
 
-  return AnalyticsBrowser.load(
+export function initAnalytics() {
+  return analytics.load(
     { writeKey: SEGMENT_WRITE_KEY },
     {
       integrations: {
@@ -33,7 +33,6 @@ function initAnalytics() {
     }
   );
 }
-export const analytics: null | AnalyticsBrowser = initAnalytics();
 
 export function initSentry() {
   if (IS_TEST_ENV || !SENTRY_DSN) return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,22 +3299,22 @@
     "@scure/base" "~1.1.0"
     micro-packed "~0.3.2"
 
-"@segment/analytics-core@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@segment/analytics-core/-/analytics-core-1.2.1.tgz#6f551b74a6af2331cb86c7e29428487f3d135266"
-  integrity sha512-FaKE7uIBXsclO4GcA7cEgb4iyQ23aFHRcxqLpxaCGeB5nqIdVQHigmGgL3hAjCZeBqtojLEV6as27ozXHQXCkg==
+"@segment/analytics-core@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-core/-/analytics-core-1.2.4.tgz#a01f0c87246292e0b9790e12c73d2f7e5fceb168"
+  integrity sha512-M16osD6+z/bQPSVCZdlU+BAhCk968ppi+SGxU2gVa4B196Qr8SEkBPr3NxUCGTSoULo4/T+k8Ea5cF+pXlgf6Q==
   dependencies:
     "@lukeed/uuid" "^2.0.0"
     dset "^3.1.2"
     tslib "^2.4.1"
 
-"@segment/analytics-next@1.49.2":
-  version "1.49.2"
-  resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.49.2.tgz#7499f0adbdf8ad5eca840e4e31f3858bd716792a"
-  integrity sha512-i1Z5OfapDQQkielF9Cz9q8PeLvRTgBMPxHn5SoIx3SZJEzWTzFkvrmg/v98P8TcyjzbSa6hsVySm4E0tVdj8mA==
+"@segment/analytics-next@1.51.5":
+  version "1.51.5"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.51.5.tgz#2f4558a13cb2ccc0be394f4ad9de253f659a3bba"
+  integrity sha512-al/8j/GKuTLV7vK4qKrsb2uTfh07Q8ETChPnklIgKfgUMsMZJHJWj/TAjuIgVt7SPmoiqH+ESOrH4yzKT1Wvag==
   dependencies:
     "@lukeed/uuid" "^2.0.0"
-    "@segment/analytics-core" "1.2.1"
+    "@segment/analytics-core" "1.2.4"
     "@segment/analytics.js-video-plugins" "^0.2.1"
     "@segment/facade" "^3.4.9"
     "@segment/tsub" "1.0.1"


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4742809599).<!-- Sticky Header Marker -->

Two changes here: 

1) Initialising analytics as per segment library documentation. Behaviour is the same, but by loading the analytics key later (only if user has consented), we avoid the case of analytics sometimes being `undefined`.

2) Trials use of [Segment/Mixpanel traits](https://segment.com/docs/connections/spec/identify/), used to store account-level details that don't correspond to a given event