### PR TITLE
fix: tx req edit nonce

### DIFF
--- a/src/app/features/errors/requesting-tab-closed-error-msg.tsx
+++ b/src/app/features/errors/requesting-tab-closed-error-msg.tsx
@@ -16,7 +16,7 @@ export function RequestingTabClosedWarningMessage() {
   if (!hasTabClosed) return null;
 
   return (
-    <Box background={color('bg-alt')} py="base" px="base-loose" borderRadius="10px">
+    <Box background={color('bg-alt')} borderRadius="10px" mb="loose" px="base-loose" py="base">
       <Flex>
         <Box mr="base-tight" mt="2px">
           <FiAlertCircle color={color('feedback-alert')} />

--- a/src/app/pages/transaction-request/components/contract-call-details/contract-call-details.tsx
+++ b/src/app/pages/transaction-request/components/contract-call-details/contract-call-details.tsx
@@ -21,12 +21,13 @@ function ContractCallDetailsSuspense() {
 
   return (
     <Stack
-      spacing="loose"
       border="4px solid"
       borderColor={color('border')}
       borderRadius="12px"
-      py="extra-loose"
+      mb="loose"
       px="base-loose"
+      py="extra-loose"
+      spacing="loose"
     >
       <Title as="h2" fontWeight="500">
         Function and arguments

--- a/src/app/pages/transaction-request/components/contract-deploy-details/contract-deploy-details.tsx
+++ b/src/app/pages/transaction-request/components/contract-deploy-details/contract-deploy-details.tsx
@@ -80,7 +80,7 @@ export function ContractDeployDetails(): JSX.Element | null {
   }
 
   return (
-    <Stack spacing="loose">
+    <Stack mb="loose" spacing="loose">
       <Stack spacing="0" isInline>
         <TabButton onClick={() => setTab('details')} isActive={tab === 'details'}>
           Details

--- a/src/app/pages/transaction-request/components/fee-form.tsx
+++ b/src/app/pages/transaction-request/components/fee-form.tsx
@@ -6,7 +6,6 @@ import { StacksTransactionFormValues } from '@shared/models/form.model';
 import { isTxSponsored } from '@app/common/transactions/stacks/transaction.utils';
 import { FeesRow } from '@app/components/fees-row/fees-row';
 import { LoadingRectangle } from '@app/components/loading-rectangle';
-import { MinimalErrorMessage } from '@app/pages/transaction-request/components/minimal-error-message';
 import { useUnsignedPrepareTransactionDetails } from '@app/store/transactions/transaction.hooks';
 
 interface FeeFormProps {
@@ -26,7 +25,6 @@ export function FeeForm({ fees }: FeeFormProps) {
       ) : (
         <LoadingRectangle height="32px" width="100%" />
       )}
-      <MinimalErrorMessage />
     </>
   );
 }

--- a/src/app/pages/transaction-request/components/minimal-error-message.tsx
+++ b/src/app/pages/transaction-request/components/minimal-error-message.tsx
@@ -34,12 +34,13 @@ function MinimalErrorMessageSuspense(props: StackProps) {
 
   return (
     <Stack
-      data-testid={TransactionSigningSelectors.TransactionErrorMessage}
       alignItems="center"
       bg="#FCEEED"
-      p="base"
       borderRadius="12px"
+      data-testid={TransactionSigningSelectors.TransactionErrorMessage}
       isInline
+      p="base"
+      width="100%"
       {...props}
     >
       <Box color={color('feedback-error')} strokeWidth={2} as={FiAlertTriangle} />

--- a/src/app/pages/transaction-request/components/page-top.tsx
+++ b/src/app/pages/transaction-request/components/page-top.tsx
@@ -28,7 +28,7 @@ function PageTopBase() {
   return (
     <Stack
       data-testid={TransactionSigningSelectors.TxSigningPageContainer}
-      pt="extra-loose"
+      mb="loose"
       spacing="base"
     >
       <Title as="h1" fontWeight="bold">

--- a/src/app/pages/transaction-request/components/post-condition-mode-warning.tsx
+++ b/src/app/pages/transaction-request/components/post-condition-mode-warning.tsx
@@ -11,7 +11,7 @@ export function PostConditionModeWarning(): JSX.Element | null {
   if (mode !== PostConditionMode.Allow) return null;
 
   return (
-    <Box background={color('bg-alt')} py="base" px="base-loose" borderRadius="10px">
+    <Box background={color('bg-alt')} borderRadius="10px" mb="loose" px="base-loose" py="base">
       <Flex>
         <Box mr="base-tight" mt="2px">
           <FiAlertCircle color={color('feedback-error')} />

--- a/src/app/pages/transaction-request/components/post-conditions/post-conditions.tsx
+++ b/src/app/pages/transaction-request/components/post-conditions/post-conditions.tsx
@@ -33,8 +33,9 @@ function PostConditionsSuspense(): JSX.Element | null {
       border="4px solid"
       borderColor={color('border')}
       borderRadius="12px"
-      width="100%"
       flexDirection="column"
+      mb="loose"
+      width="100%"
     >
       {hasPostConditions ? (
         <PostConditionsList />

--- a/src/app/pages/transaction-request/components/stx-transfer-details/stx-transfer-details.tsx
+++ b/src/app/pages/transaction-request/components/stx-transfer-details/stx-transfer-details.tsx
@@ -15,12 +15,13 @@ export function StxTransferDetails(): JSX.Element | null {
 
   return (
     <Stack
-      spacing="loose"
       border="4px solid"
       borderColor={color('border')}
       borderRadius="12px"
-      py="extra-loose"
+      mb="loose"
       px="base-loose"
+      py="extra-loose"
+      spacing="loose"
     >
       <Title as="h2" fontWeight="500">
         Transfer details

--- a/src/app/pages/transaction-request/components/submit-action.tsx
+++ b/src/app/pages/transaction-request/components/submit-action.tsx
@@ -14,7 +14,7 @@ import { useTransactionError } from '@app/pages/transaction-request/hooks/use-tr
 
 function BaseConfirmButton(props: ButtonProps): JSX.Element {
   return (
-    <Button borderRadius="10px" py="base" type="submit" width="100%" {...props}>
+    <Button borderRadius="10px" mt="base" py="base" type="submit" width="100%" {...props}>
       Confirm
     </Button>
   );

--- a/src/app/pages/transaction-request/components/transaction-error/error-message.tsx
+++ b/src/app/pages/transaction-request/components/transaction-error/error-message.tsx
@@ -13,13 +13,13 @@ interface ErrorMessageProps extends StackProps {
 export const ErrorMessage = memo(({ title, body, actions, ...rest }: ErrorMessageProps) => {
   return (
     <Stack
-      mt="loose"
-      p="loose"
-      borderRadius="12px"
-      border="4px solid #FCEEED"
-      spacing="extra-loose"
-      color={color('feedback-error')}
       bg={color('bg')}
+      border="4px solid #FCEEED"
+      borderRadius="12px"
+      color={color('feedback-error')}
+      spacing="extra-loose"
+      mb="loose"
+      p="loose"
       {...rest}
     >
       <Stack spacing="base-loose">

--- a/src/app/pages/transaction-request/transaction-request.tsx
+++ b/src/app/pages/transaction-request/transaction-request.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
-import { Flex, Stack } from '@stacks/ui';
+import { Flex } from '@stacks/ui';
 import { Formik } from 'formik';
 import get from 'lodash.get';
 import * as yup from 'yup';
@@ -42,6 +42,7 @@ import {
 } from '@app/store/transactions/transaction.hooks';
 
 import { FeeForm } from './components/fee-form';
+import { MinimalErrorMessage } from './components/minimal-error-message';
 import { SubmitAction } from './components/submit-action';
 
 function TransactionRequestBase() {
@@ -105,37 +106,40 @@ function TransactionRequestBase() {
   };
 
   return (
-    <Flex alignItems="center" flexDirection="column" width="100%">
-      <Stack px="loose" spacing="loose" width="100%">
-        <PageTop />
-        <RequestingTabClosedWarningMessage />
-        <PostConditionModeWarning />
-        <TransactionError />
-        <PostConditions />
-        {transactionRequest.txType === 'contract_call' && <ContractCallDetails />}
-        {transactionRequest.txType === 'token_transfer' && <StxTransferDetails />}
-        {transactionRequest.txType === 'smart_contract' && <ContractDeployDetails />}
-        <Formik
-          initialValues={initialValues}
-          onSubmit={onSubmit}
-          validateOnChange={false}
-          validateOnBlur={false}
-          validateOnMount={false}
-          validationSchema={validationSchema}
-        >
-          {() => (
-            <>
-              <NonceSetter>
-                <FeeForm fees={stxFees} />
-                <SubmitAction />
-                <EditNonceButton onEditNonce={() => navigate(RouteUrls.EditNonce)} />
-                <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
-              </NonceSetter>
-              <Outlet />
-            </>
-          )}
-        </Formik>
-      </Stack>
+    <Flex alignItems="center" flexDirection="column" p="loose" width="100%">
+      <PageTop />
+      <RequestingTabClosedWarningMessage />
+      <PostConditionModeWarning />
+      <TransactionError />
+      <PostConditions />
+      {transactionRequest.txType === 'contract_call' && <ContractCallDetails />}
+      {transactionRequest.txType === 'token_transfer' && <StxTransferDetails />}
+      {transactionRequest.txType === 'smart_contract' && <ContractDeployDetails />}
+      <Formik
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        validateOnChange={false}
+        validateOnBlur={false}
+        validateOnMount={false}
+        validationSchema={validationSchema}
+      >
+        {() => (
+          <>
+            <NonceSetter>
+              <FeeForm fees={stxFees} />
+              <EditNonceButton
+                alignSelf="flex-end"
+                my="base"
+                onEditNonce={() => navigate(RouteUrls.EditNonce)}
+              />
+              <MinimalErrorMessage />
+              <SubmitAction />
+              <HighFeeDrawer learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
+            </NonceSetter>
+            <Outlet />
+          </>
+        )}
+      </Formik>
     </Flex>
   );
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4789394847).<!-- Sticky Header Marker -->

Putting up this PR to fix the bug with the position of the `Edit nonce` button on the tx req popup. I did some minor refactoring here to a `Flex` component so each child is now handling it's own margins rather than using the `Stack` spacing. I'll look at doing further refactoring, but will create another issue for that work.

![Screen Shot 2023-04-24 at 12 37 18 PM](https://user-images.githubusercontent.com/6493321/234074739-59575b71-92f8-40c6-a636-45b68908ff34.png)