### PR TITLE
fix: send transfer success response

### DIFF
--- a/src/app/pages/rpc-send-transfer/use-rpc-send-transfer.ts
+++ b/src/app/pages/rpc-send-transfer/use-rpc-send-transfer.ts
@@ -8,7 +8,7 @@ import { useDefaultRequestParams } from '@app/common/hooks/use-default-request-s
 import { initialSearchParams } from '@app/common/initial-search-params';
 import { useWalletType } from '@app/common/use-wallet-type';
 
-function useRpcSendTransferRequestParams() {
+export function useRpcSendTransferRequestParams() {
   const defaultParams = useDefaultRequestParams();
   return useMemo(
     () => ({


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4801584379).<!-- Sticky Header Marker -->

This PR fixes my oversight of not delivering the txid back to the app in the success response.

*This should be merged and included in the current release PR.

<img width="1098" alt="Screen Shot 2023-04-25 at 2 44 52 PM" src="https://user-images.githubusercontent.com/6493321/234387166-d08be526-d508-4e4b-8e90-494d166fe03a.png">