### PR TITLE
refactor: use observable events in background script

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,20 +1,19 @@
-import * as Sentry from '@sentry/react';
-
 import { logger } from '@shared/logger';
-import { CONTENT_SCRIPT_PORT, LegacyMessageFromContentScript } from '@shared/message-types';
 import { RouteUrls } from '@shared/route-urls';
-import { WalletRequests } from '@shared/rpc/rpc-methods';
 import { initSentry } from '@shared/utils/analytics';
 import { warnUsersAboutDevToolsDangers } from '@shared/utils/dev-tools-warning-log';
 
 import { backupOldWalletSalt } from './backup-old-wallet-salt';
 import { initContextMenuActions } from './init-context-menus';
+import { isLegacyMessage } from './messaging/legacy-external-message-handler';
 import {
-  handleLegacyExternalMethodFormat,
-  isLegacyMessage,
-} from './messaging/legacy-external-message-handler';
+  contentScriptMessage$,
+  install$,
+  legacyMessage$,
+  message$,
+  rpcMessages$,
+} from './messaging/message-events';
 import { internalBackgroundMessageHandler } from './messaging/message-handler';
-import { rpcMessageHandler } from './messaging/rpc-message-handler';
 
 initSentry();
 initContextMenuActions();
@@ -23,54 +22,33 @@ warnUsersAboutDevToolsDangers();
 
 const IS_TEST_ENV = process.env.TEST_ENV === 'true';
 
-chrome.runtime.onInstalled.addListener(details => {
-  Sentry.wrap(async () => {
-    if (details.reason === 'install' && !IS_TEST_ENV) {
-      await chrome.tabs.create({
-        url: chrome.runtime.getURL(`index.html#${RouteUrls.Onboarding}`),
-      });
-    }
-  });
-});
-
-//
-// Listen for connection to the content-script - port for two-way communication
-chrome.runtime.onConnect.addListener(port =>
-  Sentry.wrap(() => {
-    if (port.name !== CONTENT_SCRIPT_PORT) return;
-
-    port.onMessage.addListener((message: LegacyMessageFromContentScript | WalletRequests, port) => {
-      if (!port.sender?.tab?.id)
-        return logger.error('Message reached background script without a corresponding tab');
-
-      // Chromium/Firefox discrepancy
-      const originUrl = port.sender?.origin ?? port.sender?.url;
-
-      if (!originUrl)
-        return logger.error('Message reached background script without a corresponding origin');
-
-      // Legacy JWT format messages
-      if (isLegacyMessage(message)) {
-        void handleLegacyExternalMethodFormat(message, port);
-        return;
-      }
-
-      // TODO:
-      // Here we'll handle all messages using the rpc style comm method
-      // For now all messages are handled as legacy format
-      void rpcMessageHandler(message, port);
-    });
-  })
+install$.subscribe(
+  () =>
+    void chrome.tabs.create({
+      url: chrome.runtime.getURL(`index.html#${RouteUrls.Onboarding}`),
+    })
 );
 
-//
-// Events from the extension frames script
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>
-  Sentry.wrap(() => {
-    void internalBackgroundMessageHandler(message, sender, sendResponse);
-    // Listener fn must return `true` to indicate the response will be async
-    return true;
-  })
+contentScriptMessage$.subscribe(({ message, port }) => {
+  if (!port.sender?.tab?.id)
+    return logger.error('Message reached background script without a corresponding tab');
+
+  // Chromium/Firefox discrepancy
+  const originUrl = port.sender.origin ?? port.sender.url;
+
+  if (!originUrl)
+    return logger.error('Message reached background script without a corresponding origin');
+
+  if (isLegacyMessage(message)) {
+    legacyMessage$.next({ message, port });
+    return;
+  }
+
+  rpcMessages$.next({ message, port });
+});
+
+message$.subscribe(({ message, sender, sendResponse }) =>
+  internalBackgroundMessageHandler(message, sender, sendResponse)
 );
 
 if (IS_TEST_ENV) {

--- a/src/background/messaging/legacy-external-message-handler.ts
+++ b/src/background/messaging/legacy-external-message-handler.ts
@@ -14,6 +14,8 @@ import {
   triggerRequestWindowOpen,
 } from '@background/messaging/messaging-utils';
 
+import { legacyMessage$ } from './message-events';
+
 export function isLegacyMessage(message: any): message is LegacyMessageFromContentScript {
   // Now that we use a RPC communication style, we can infer
   // legacy message types by presence of an id
@@ -31,7 +33,7 @@ function getNetworkParamsFromPayload(payload: string): [string, string][] {
   ];
 }
 
-export async function handleLegacyExternalMethodFormat(
+async function handleLegacyExternalMethodFormat(
   message: LegacyMessageFromContentScript,
   port: chrome.runtime.Port
 ) {
@@ -134,3 +136,5 @@ export async function handleLegacyExternalMethodFormat(
     }
   }
 }
+
+legacyMessage$.subscribe(({ message, port }) => handleLegacyExternalMethodFormat(message, port));

--- a/src/background/messaging/message-events.ts
+++ b/src/background/messaging/message-events.ts
@@ -1,0 +1,56 @@
+import * as Sentry from '@sentry/react';
+import { Subject, fromEventPattern } from 'rxjs';
+import { filter, switchMap } from 'rxjs/operators';
+
+import { CONTENT_SCRIPT_PORT, LegacyMessageFromContentScript } from '@shared/message-types';
+import { WalletRequests } from '@shared/rpc/rpc-methods';
+
+const IS_TEST_ENV = process.env.TEST_ENV === 'true';
+
+export const install$ = fromEventPattern<chrome.runtime.InstalledDetails>(handler =>
+  chrome.runtime.onInstalled.addListener(handler)
+).pipe(filter(detail => detail.reason === 'install' && !IS_TEST_ENV));
+
+export const message$ = fromEventPattern(
+  handler =>
+    chrome.runtime.onMessage.addListener((...args) =>
+      Sentry.wrap(() => {
+        handler(...args);
+        return true;
+      })
+    ),
+  handler => chrome.runtime.onMessage.removeListener(handler),
+  (message, sender: chrome.runtime.MessageSender, sendResponse: () => void) => ({
+    message,
+    sender,
+    sendResponse,
+  })
+);
+
+const connect$ = fromEventPattern<chrome.runtime.Port>(
+  handler => chrome.runtime.onConnect.addListener(handler),
+  handler => chrome.runtime.onConnect.removeListener(handler)
+);
+
+//
+// Listen for connection to the content-script - port for two-way communication
+export const contentScriptMessage$ = connect$.pipe(
+  filter(port => port.name === CONTENT_SCRIPT_PORT),
+  switchMap(port =>
+    fromEventPattern(
+      handler => port.onMessage.addListener(handler),
+      handler => port.onMessage.removeListener(handler),
+      (message: LegacyMessageFromContentScript | WalletRequests, port: chrome.runtime.Port) => ({
+        message,
+        port,
+      })
+    )
+  )
+);
+
+export const rpcMessages$ = new Subject<{ message: WalletRequests; port: chrome.runtime.Port }>();
+
+export const legacyMessage$ = new Subject<{
+  message: LegacyMessageFromContentScript;
+  port: chrome.runtime.Port;
+}>();

--- a/src/background/messaging/rpc-message-handler.ts
+++ b/src/background/messaging/rpc-message-handler.ts
@@ -3,6 +3,7 @@ import { RpcErrorCode } from '@btckit/types';
 import { RouteUrls } from '@shared/route-urls';
 import { WalletRequests, makeRpcErrorResponse } from '@shared/rpc/rpc-methods';
 
+import { rpcMessages$ } from './message-events';
 import {
   getTabIdFromPort,
   listenForPopupClose,
@@ -10,7 +11,7 @@ import {
   triggerRequestWindowOpen,
 } from './messaging-utils';
 
-export async function rpcMessageHandler(message: WalletRequests, port: chrome.runtime.Port) {
+async function rpcMessageHandler(message: WalletRequests, port: chrome.runtime.Port) {
   switch (message.method) {
     case 'getAddresses': {
       const { urlParams, tabId } = makeSearchParamsWithDefaults(port, [['requestId', message.id]]);
@@ -54,3 +55,13 @@ export async function rpcMessageHandler(message: WalletRequests, port: chrome.ru
     }
   }
 }
+
+rpcMessages$.subscribe({
+  complete() {
+    // eslint-disable-next-line no-console
+    console.log('rpcMessages$ completed');
+  },
+  next: ({ message, port }) => rpcMessageHandler(message, port),
+  // eslint-disable-next-line no-console
+  error: console.error,
+});


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4806045118).<!-- Sticky Header Marker -->

**🚧 Experimental 🚧**

Making this PR as an experiment to see how we might better use the [`Observable`](https://github.com/tc39/proposal-observable) pattern to handle the background event streams (and see if tests pass). One package already exists for this, [`@extend-chrome/events-rxjs`](https://github.com/extend-chrome/events-rxjs/tree/master), though I'm recreating the Observables manually rn.

Motivation to look into this came from the need for us to add some kind of middleware to the event flow. Consider the use case on permissions we discussed yesterday. Depending on certain state, we might want to interrupt certain actions, such as to ask for user consent, before returning to the original action. This seems to me like an event-heavy flow that observables may make easier.

Would like feedback from @alter-eggo and @fbwoolf on this approach