### PR TITLE
fix: retrieve bitcoin from tr addresses

### DIFF
--- a/src/app/query/bitcoin/ordinals/ordinals-aware-utxo.query.ts
+++ b/src/app/query/bitcoin/ordinals/ordinals-aware-utxo.query.ts
@@ -30,7 +30,7 @@ export type OrdApiInscriptionTxOutput = Prettify<yup.InferType<typeof ordApiGetT
 
 export async function getNumberOfInscriptionOnUtxo(id: string, index: number) {
   const resp = await fetchOrdinalsAwareUtxo(id, index);
-  return resp.all_inscriptions?.length ?? 1;
+  return resp.all_inscriptions?.length ?? 0;
 }
 
 async function fetchOrdinalsAwareUtxo(


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4807281644).<!-- Sticky Header Marker -->

Closes #3575

Looks like this has been broken for a while. Previously, to double check whether or not a UTXO contained an inscription, we'd parse the DOM from the Ordinals explorer. If this request would fail, to be safe, we'd assume it contains an inscription, and return `1`.

The more recent implementation checks the OrdAPI for the `all_inscriptions` property (missing if there are 0), and uses the nullish coalescing operator to default to `1` (a detail from the previous implementation).

This results in the expression `undefined ?? 1`, which equals `1`. As this is used in `useGenerateRetrieveTaprootFundsTx` to ensure the user isn't spending inscriptions, it fails with a false positive. 

https://github.com/hirosystems/wallet/blob/1c6c57bae0191ce842bb0137387d7e7433fbfb60/src/app/features/retrieve-taproot-to-native-segwit/use-generate-retrieve-taproot-funds-tx.tsx#L51-L53

Now that the approach is different, I believe we can default to 0.

cc/ @314159265359879 