### PR TITLE
fix(ordinals): improved check, all_inscrptions first

### DIFF
--- a/.github/workflows/ordinals-checker.yml
+++ b/.github/workflows/ordinals-checker.yml
@@ -1,0 +1,49 @@
+name: Playwright Tests
+
+on:
+  pull_request:
+  schedule:
+    # https://crontab.guru
+    - cron: '0 * * * *'
+env:
+  CI: true
+
+jobs:
+  test-ordinals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: Install Playwright deps
+        run: yarn playwright install chrome
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - name: Run Playwright tests
+        run: yarn playwright test tests/specs/ordinals/ordinals.spec.ts
+
+      - name: Discord notification
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ALERT_CHANNEL }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: "Something funky's up with the OrdAPI.xyz. Wallet team engineer to investigate. See `ordinals-checker.yml Github Action."

--- a/src/app/query/bitcoin/ordinals/ordinals-aware-utxo.query.ts
+++ b/src/app/query/bitcoin/ordinals/ordinals-aware-utxo.query.ts
@@ -30,8 +30,9 @@ export type OrdApiInscriptionTxOutput = Prettify<yup.InferType<typeof ordApiGetT
 
 export async function getNumberOfInscriptionOnUtxo(id: string, index: number) {
   const resp = await fetchOrdinalsAwareUtxo(id, index);
+  if (resp.all_inscriptions) return resp.all_inscriptions.length;
   if (resp.inscriptions) return 1;
-  return resp.all_inscriptions?.length ?? 0;
+  return 0;
 }
 
 async function fetchOrdinalsAwareUtxo(

--- a/tests/specs/ordinals/ordinals.spec.ts
+++ b/tests/specs/ordinals/ordinals.spec.ts
@@ -1,0 +1,21 @@
+import { test } from '@playwright/test';
+
+import { getNumberOfInscriptionOnUtxo } from '@app/query/bitcoin/ordinals/ordinals-aware-utxo.query';
+
+test.describe(getNumberOfInscriptionOnUtxo.name, () => {
+  test('should return 3 in case of 3 inscriptions', async () => {
+    const resp = await getNumberOfInscriptionOnUtxo(
+      'aa24aecb0e60afa43b646c5a61fee76aebdbbf85b8f85a4aa429f9d0c52c9623',
+      0
+    );
+    test.expect(resp).toBe(3);
+  });
+
+  test('should return 0 in case of this random address', async () => {
+    const resp = await getNumberOfInscriptionOnUtxo(
+      '75d11f43163ca0c3a1656e124a63bc08da267c0f8454aa5244ef7346839dc5d5',
+      0
+    );
+    test.expect(resp).toBe(0);
+  });
+});


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4851550292).<!-- Sticky Header Marker -->

In light of @markmhx's observation, we need to check `all_inscriptions` first, as `inscription` is defined even when there are many.