### PR TITLE
fix(ledger): user landing on sign in screen, closes #3632

### DIFF
--- a/src/app/features/ledger/flows/request-keys/ledger-request-keys-container.tsx
+++ b/src/app/features/ledger/flows/request-keys/ledger-request-keys-container.tsx
@@ -87,10 +87,9 @@ export function LedgerRequestKeysContainer() {
       }
       ledgerNavigate.toDeviceBusyStep();
       completeLedgerDeviceOnboarding(resp.publicKeys, latestDeviceResponse?.targetId!);
-      ledgerAnalytics.publicKeysPulledFromLedgerSuccessfully();
-
-      navigate(RouteUrls.Home);
       await stacksApp.transport.close();
+      ledgerAnalytics.publicKeysPulledFromLedgerSuccessfully();
+      navigate(RouteUrls.Home, { replace: true });
     } catch (e) {
       logger.error('Failed to request Ledger keys', e);
       ledgerNavigate.toErrorStep();


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4859928621).<!-- Sticky Header Marker -->

Not sure where this race condition came in, but think that it's trying to navigate before the state's updated, triggering the `OnboardingGate`. This change puts the navigate action a little later, after the USB has disconnected.

cc/ @314159265359879 