### PR TITLE
fix: prop error in asset items component

### DIFF
--- a/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
@@ -28,7 +28,6 @@ interface CryptoCurrencyAssetItemLayoutProps extends StackProps {
   address?: string;
   canCopy?: boolean;
   isHovered?: boolean;
-  hasCopied?: boolean;
   currency?: CryptoCurrencies;
 }
 export const CryptoCurrencyAssetItemLayout = forwardRefWithAs(

--- a/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.tsx
+++ b/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.tsx
@@ -71,7 +71,6 @@ export const CryptoCurrencyAssetItem = forwardRefWithAs(
         subBalance={assetSubBalance?.balance}
         title={asset.name}
         isHovered={isHovered}
-        hasCopied={hasCopied}
         address={address}
         usdBalance={usdBalance}
         onClick={onClick}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4870802483).<!-- Sticky Header Marker -->

There is no need in `hasCopied` prop, also it throws an error

![Screenshot 2023-05-03 at 14 17 23](https://user-images.githubusercontent.com/46521087/235890373-43152ba2-56ce-4f8b-b400-0ded5d9f4ded.png)
