### PR TITLE
fix: copy taproot address

### DIFF
--- a/src/app/pages/receive/receive-collectible/receive-collectible-oridinal.tsx
+++ b/src/app/pages/receive/receive-collectible/receive-collectible-oridinal.tsx
@@ -18,7 +18,7 @@ export function ReceiveCollectibleOrdinal() {
   const navigate = useNavigate();
   const analytics = useAnalytics();
   const { state } = useLocation();
-  const { onCopy } = useClipboard(state.btcAddress);
+  const { onCopy } = useClipboard(state.btcAddressTaproot);
 
   function copyToClipboard() {
     void analytics.track('copy_address_to_add_new_inscription');
@@ -82,7 +82,7 @@ export function ReceiveCollectibleOrdinal() {
             difficulty retrieving it
           </Text>
           <Flex sx={{ maxWidth: '100%', flexWrap: 'wrap', justifyContent: 'center' }}>
-            <Caption mt="2px">{truncateMiddle(state.btcAddress, 6)}</Caption>
+            <Caption mt="2px">{truncateMiddle(state.btcAddressTaproot, 6)}</Caption>
           </Flex>
         </Stack>
         <PrimaryButton flexGrow={1} my="extra-loose" onClick={copyToClipboard} width="100%">


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4917534060).<!-- Sticky Header Marker -->

I had to rename state in the receive modal to include both address types for Stamps. I missed it was used in this component.