### PR TITLE
fix: balances list tr breaking ledger

### DIFF
--- a/src/app/features/balances-list/balances-list.tsx
+++ b/src/app/features/balances-list/balances-list.tsx
@@ -3,17 +3,17 @@ import { HomePageSelectorsLegacy } from '@tests-legacy/page-objects/home.selecto
 
 import { useBtcAssetBalance } from '@app/common/hooks/balance/btc/use-btc-balance';
 import { useStxBalance } from '@app/common/hooks/balance/stx/use-stx-balance';
+import { useWalletType } from '@app/common/use-wallet-type';
 import { CryptoCurrencyAssetItem } from '@app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
 import { BtcIcon } from '@app/components/icons/btc-icon';
 import { LoadingSpinner } from '@app/components/loading-spinner';
-import { useBrc20TokensByAddressQuery } from '@app/query/bitcoin/ordinals/brc20-tokens.query';
+import { Brc20TokensLoader } from '@app/features/balances-list/components/brc-20-tokens-loader';
 import { useConfigBitcoinEnabled } from '@app/query/common/hiro-config/hiro-config.query';
 import {
   useStacksFungibleTokenAssetBalancesAnchoredWithMetadata,
   useStacksUnanchoredCryptoCurrencyAssetBalance,
 } from '@app/query/stacks/balance/stacks-ft-balances.hooks';
-import { useCurrentBtcTaprootAccountAddressIndexZeroPayment } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 
 import { Collectibles } from '../collectibles/collectibles';
 import { BitcoinFungibleTokenAssetList } from './components/bitcoin-fungible-tokens-asset-list';
@@ -28,8 +28,7 @@ export function BalancesList({ address, ...props }: BalancesListProps) {
   const isBitcoinEnabled = useConfigBitcoinEnabled();
   const { stxEffectiveBalance, stxEffectiveUsdBalance } = useStxBalance();
   const { btcAddress, btcAssetBalance, btcUsdBalance } = useBtcAssetBalance();
-  const { address: bitcoinAddressTaproot } = useCurrentBtcTaprootAccountAddressIndexZeroPayment();
-  const { data: brc20Tokens } = useBrc20TokensByAddressQuery(bitcoinAddressTaproot);
+  const { whenWallet } = useWalletType();
 
   // Better handle loading state
   if (!stxUnachoredAssetBalance) return <LoadingSpinner />;
@@ -56,7 +55,15 @@ export function BalancesList({ address, ...props }: BalancesListProps) {
         icon={<StxAvatar {...props} />}
       />
       <StacksFungibleTokenAssetList assetBalances={stacksFtAssetBalances} />
-      <BitcoinFungibleTokenAssetList brc20Tokens={brc20Tokens?.result.list} />
+      {whenWallet({
+        software: (
+          <Brc20TokensLoader>
+            {brc20Tokens => <BitcoinFungibleTokenAssetList brc20Tokens={brc20Tokens} />}
+          </Brc20TokensLoader>
+        ),
+        ledger: null,
+      })}
+
       <Collectibles />
     </Stack>
   );

--- a/src/app/features/balances-list/components/brc-20-tokens-loader.tsx
+++ b/src/app/features/balances-list/components/brc-20-tokens-loader.tsx
@@ -1,0 +1,15 @@
+import {
+  Brc20Token,
+  useBrc20TokensByAddressQuery,
+} from '@app/query/bitcoin/ordinals/brc20-tokens.query';
+import { useCurrentBtcTaprootAccountAddressIndexZeroPayment } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
+
+interface Brc20TokensLoaderProps {
+  children(brc20Tokens: Brc20Token[]): JSX.Element;
+}
+export function Brc20TokensLoader({ children }: Brc20TokensLoaderProps) {
+  const { address: bitcoinAddressTaproot } = useCurrentBtcTaprootAccountAddressIndexZeroPayment();
+  const { data: brc20Tokens } = useBrc20TokensByAddressQuery(bitcoinAddressTaproot);
+  if (!bitcoinAddressTaproot || !brc20Tokens) return null;
+  return children(brc20Tokens.result.list);
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4917503075).<!-- Sticky Header Marker -->

This PR uses a component loader for brc-20 token balances so that using the taproot address doesn't break ledger.