### PR TITLE
fix/send-zero-error-msg

### DIFF
--- a/src/app/common/error-formatters.ts
+++ b/src/app/common/error-formatters.ts
@@ -3,14 +3,10 @@ import { isFunction } from '@shared/utils';
 
 import { FormErrorMessages } from '@app/common/error-messages';
 
-export function formatErrorWithSymbol(symbol: string, error: string) {
-  return error.replace('{symbol}', symbol);
-}
-
 export function formatPrecisionError(num?: Money) {
   if (!num) return FormErrorMessages.CannotDeterminePrecision;
   const error = FormErrorMessages.TooMuchPrecision;
-  return formatErrorWithSymbol(num.symbol, error).replace('{decimals}', String(num.decimals));
+  return error.replace('{decimals}', String(num.decimals));
 }
 
 export function formatInsufficientBalanceError(

--- a/src/app/common/error-messages.ts
+++ b/src/app/common/error-messages.ts
@@ -1,7 +1,7 @@
 export enum FormErrorMessages {
   AdjustedFeeExceedsBalance = 'Fee added exceeds current balance',
   AddressRequired = 'Enter an address',
-  AmountRequired = 'Enter an amount of {symbol}',
+  AmountRequired = 'Enter an amount',
   BnsAddressNotFound = 'Address not found',
   CannotDetermineBalance = 'Cannot determine balance',
   CannotDeterminePrecision = 'Cannot determine decimal precision',
@@ -12,9 +12,9 @@ export enum FormErrorMessages {
   InsufficientBalance = 'Insufficient balance. Available:',
   InsufficientFunds = 'Insufficient funds',
   MemoExceedsLimit = 'Memo must be less than 34-bytes',
-  MustBeNumber = 'Amount of {symbol} must be a number',
+  MustBeNumber = 'Amount must be a number',
   MustBePositive = 'Amount must be positive',
   MustSelectAsset = 'Select a valid token to transfer',
   SameAddress = 'Cannot send to yourself',
-  TooMuchPrecision = '{symbol} can only have {decimals} decimals',
+  TooMuchPrecision = 'Token can only have {decimals} decimals',
 }

--- a/src/app/common/error-messages.ts
+++ b/src/app/common/error-messages.ts
@@ -14,7 +14,6 @@ export enum FormErrorMessages {
   MemoExceedsLimit = 'Memo must be less than 34-bytes',
   MustBeNumber = 'Amount of {symbol} must be a number',
   MustBePositive = 'Amount must be positive',
-  MustNotBeZero = 'Must be more than zero',
   MustSelectAsset = 'Select a valid token to transfer',
   SameAddress = 'Cannot send to yourself',
   TooMuchPrecision = '{symbol} can only have {decimals} decimals',

--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -12,20 +12,16 @@ import {
   stxToMicroStx,
 } from '@app/common/money/unit-conversion';
 
-import {
-  formatErrorWithSymbol,
-  formatInsufficientBalanceError,
-  formatPrecisionError,
-} from '../../error-formatters';
+import { formatInsufficientBalanceError, formatPrecisionError } from '../../error-formatters';
 import { FormErrorMessages } from '../../error-messages';
 import { currencyAmountValidator, stxAmountPrecisionValidator } from './currency-validators';
 
 const minSpendAmountInSats = 6000;
 
-function amountValidator(symbol: string) {
+function amountValidator() {
   return yup
     .number()
-    .required(formatErrorWithSymbol(symbol, FormErrorMessages.AmountRequired))
+    .required(FormErrorMessages.AmountRequired)
     .positive(FormErrorMessages.MustBePositive)
     .typeError('Amount must be a number');
 }
@@ -42,7 +38,7 @@ export function btcInsufficientBalanceValidator({
 }: BtcInsufficientBalanceValidatorArgs) {
   return yup
     .number()
-    .typeError(formatErrorWithSymbol('BTC', FormErrorMessages.MustBeNumber))
+    .typeError(FormErrorMessages.MustBeNumber)
     .test({
       message: FormErrorMessages.InsufficientFunds,
       test(value) {
@@ -59,7 +55,7 @@ export function btcInsufficientBalanceValidator({
 export function btcMinimumSpendValidator() {
   return yup
     .number()
-    .typeError(formatErrorWithSymbol('BTC', FormErrorMessages.MustBeNumber))
+    .typeError(FormErrorMessages.MustBeNumber)
     .test({
       message: `Minimum is ${satToBtc(minSpendAmountInSats)}`,
       test(value) {
@@ -74,7 +70,7 @@ export function btcMinimumSpendValidator() {
 export function stxAmountValidator() {
   return yup
     .number()
-    .typeError(formatErrorWithSymbol('STX', FormErrorMessages.MustBeNumber))
+    .typeError(FormErrorMessages.MustBeNumber)
     .concat(currencyAmountValidator())
     .concat(stxAmountPrecisionValidator(formatPrecisionError()));
 }
@@ -82,7 +78,7 @@ export function stxAmountValidator() {
 export function stxAvailableBalanceValidator(availableBalance: Money) {
   return yup
     .number()
-    .typeError(formatErrorWithSymbol('STX', FormErrorMessages.MustBeNumber))
+    .typeError(FormErrorMessages.MustBeNumber)
     .test({
       message: formatInsufficientBalanceError(availableBalance, sum =>
         microStxToStx(sum.amount).toString()
@@ -97,8 +93,8 @@ export function stxAvailableBalanceValidator(availableBalance: Money) {
 }
 
 export function stacksFungibleTokenAmountValidator(balance: Money) {
-  const { amount, decimals, symbol } = balance;
-  return amountValidator(symbol)
+  const { amount, decimals } = balance;
+  return amountValidator()
     .test((value, context) => {
       if (!isNumber(value)) return false;
       if (!decimals && countDecimals(value) > 0)

--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -22,11 +22,11 @@ import { currencyAmountValidator, stxAmountPrecisionValidator } from './currency
 
 const minSpendAmountInSats = 6000;
 
-function amountValidator() {
+function amountValidator(symbol: string) {
   return yup
     .number()
-    .required()
-    .positive(FormErrorMessages.MustNotBeZero)
+    .required(formatErrorWithSymbol(symbol, FormErrorMessages.AmountRequired))
+    .positive(FormErrorMessages.MustBePositive)
     .typeError('Amount must be a number');
 }
 
@@ -97,8 +97,8 @@ export function stxAvailableBalanceValidator(availableBalance: Money) {
 }
 
 export function stacksFungibleTokenAmountValidator(balance: Money) {
-  const { amount, decimals } = balance;
-  return amountValidator()
+  const { amount, decimals, symbol } = balance;
+  return amountValidator(symbol)
     .test((value, context) => {
       if (!isNumber(value)) return false;
       if (!decimals && countDecimals(value) > 0)

--- a/src/app/common/validation/forms/currency-validators.ts
+++ b/src/app/common/validation/forms/currency-validators.ts
@@ -3,7 +3,6 @@ import * as yup from 'yup';
 import { BTC_DECIMALS, STX_DECIMALS } from '@shared/constants';
 import { isNumber } from '@shared/utils';
 
-import { formatErrorWithSymbol } from '@app/common/error-formatters';
 import { FormErrorMessages } from '@app/common/error-messages';
 import { countDecimals } from '@app/common/math/helpers';
 
@@ -14,15 +13,11 @@ export function currencyAmountValidator() {
     .typeError('Currency must be a number');
 }
 
-function currencyPrecisionValidatorFactory(
-  symbol: string,
-  precision: number,
-  errorMessage: string
-) {
+function currencyPrecisionValidatorFactory(precision: number, errorMessage: string) {
   return yup
     .number()
-    .required(formatErrorWithSymbol(symbol, FormErrorMessages.AmountRequired))
-    .typeError(formatErrorWithSymbol(symbol, FormErrorMessages.MustBeNumber))
+    .required(FormErrorMessages.AmountRequired)
+    .typeError(FormErrorMessages.MustBeNumber)
     .test({
       message: errorMessage,
       test(value: unknown) {
@@ -33,9 +28,9 @@ function currencyPrecisionValidatorFactory(
 }
 
 export function btcAmountPrecisionValidator(errorMsg: string) {
-  return currencyPrecisionValidatorFactory('BTC', BTC_DECIMALS, errorMsg);
+  return currencyPrecisionValidatorFactory(BTC_DECIMALS, errorMsg);
 }
 
 export function stxAmountPrecisionValidator(errorMsg: string) {
-  return currencyPrecisionValidatorFactory('STX', STX_DECIMALS, errorMsg);
+  return currencyPrecisionValidatorFactory(STX_DECIMALS, errorMsg);
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -18,7 +18,10 @@ import {
   btcInsufficientBalanceValidator,
   btcMinimumSpendValidator,
 } from '@app/common/validation/forms/amount-validators';
-import { btcAmountPrecisionValidator } from '@app/common/validation/forms/currency-validators';
+import {
+  btcAmountPrecisionValidator,
+  currencyAmountValidator,
+} from '@app/common/validation/forms/currency-validators';
 import { useUpdatePersistedSendFormValues } from '@app/features/popup-send-form-restoration/use-update-persisted-send-form-values';
 import { useNativeSegwitBalance } from '@app/query/bitcoin/balance/bitcoin-balances.query';
 import { useCurrentBtcNativeSegwitAccountAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
@@ -49,6 +52,7 @@ export function useBtcSendForm() {
         .concat(
           btcAmountPrecisionValidator(formatPrecisionError(btcCryptoCurrencyAssetBalance.balance))
         )
+        .concat(currencyAmountValidator())
         .concat(
           btcInsufficientBalanceValidator({
             // TODO: investigate yup features for cross-field validation


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4937633706).<!-- Sticky Header Marker -->

Fixed and coordinated some error msgs in the send forms.

*Do we really think it is nec to show the symbol in an error msg? 🤔 

![Screen Shot 2023-05-09 at 1 10 52 PM](https://github.com/hirosystems/wallet/assets/6493321/cd726394-282d-4adc-b0b6-1d380702b743)

![Screen Shot 2023-05-09 at 1 21 31 PM](https://github.com/hirosystems/wallet/assets/6493321/da93a327-6eff-450a-a591-978fda6b76ef)
