### PR TITLE
chore: test infinite query

### DIFF
--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -12,6 +12,7 @@ import { BalancesList } from '@app/features/balances-list/balances-list';
 import { InAppMessages } from '@app/features/hiro-messages/in-app-messages';
 import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggested-first-steps';
 import { HomeActions } from '@app/pages/home/components/home-actions';
+import { useTaprootUtxoInfiniteQuery } from '@app/query/bitcoin/ordinals/use-taproot-address-utxos.query';
 import { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.models';
 
 import { CurrentAccount } from './components/account-area';
@@ -31,6 +32,12 @@ function HomeContainer({ account }: HomeContainerProps) {
   const navigate = useNavigate();
   useTrackFirstDeposit();
 
+  const { data: result } = useTaprootUtxoInfiniteQuery();
+  // Below line causes infinite render loop, not sure why
+  // const { data: result, ...rest } = useTaprootUtxoInfiniteQuery();
+
+  console.log('result', result);
+
   useRouteHeader(
     <>
       <InAppMessages />
@@ -46,7 +53,13 @@ function HomeContainer({ account }: HomeContainerProps) {
     <HomeLayout
       suggestedFirstSteps={<SuggestedFirstSteps />}
       currentAccount={<CurrentAccount />}
-      actions={<HomeActions />}
+      actions={
+        <>
+          {/* <button onClick={() => rest.refetch()}>refetch</button>
+          <button onClick={() => rest.fetchNextPage()}>next page</button> */}
+          <HomeActions />
+        </>
+      }
     >
       <HomeTabs balances={<BalancesList address={account.address} />} activity={<ActivityList />} />
       <Outlet />

--- a/src/app/query/bitcoin/ordinals/use-taproot-address-utxos.query.ts
+++ b/src/app/query/bitcoin/ordinals/use-taproot-address-utxos.query.ts
@@ -1,4 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { createCounter } from '@app/common/utils/counter';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
@@ -27,39 +29,103 @@ export function useTaprootAccountUtxosQuery() {
 
   const currentAccountIndex = useCurrentAccountIndex();
 
-  return useQuery(['taproot-address-utxos-metadata', currentAccountIndex, network.id], async () => {
-    let currentNumberOfAddressesWithoutOrdinals = 0;
-    const addressIndexCounter = createCounter(0);
-    let foundUnspentTransactions: TaprootUtxo[] = [];
-    while (
-      currentNumberOfAddressesWithoutOrdinals < stopSearchAfterNumberAddressesWithoutOrdinals
-    ) {
+  return useQuery(
+    ['taproot-address-utxos-metadata', currentAccountIndex, network.id],
+    async () => {
+      let currentNumberOfAddressesWithoutOrdinals = 0;
+      const addressIndexCounter = createCounter(0);
+      let foundUnspentTransactions: TaprootUtxo[] = [];
+      while (
+        currentNumberOfAddressesWithoutOrdinals < stopSearchAfterNumberAddressesWithoutOrdinals
+      ) {
+        const address = getTaprootAddress({
+          index: addressIndexCounter.getValue(),
+          keychain,
+          network: network.chain.bitcoin.network,
+        });
+
+        const unspentTransactions = await client.addressApi.getUtxosByAddress(address);
+
+        if (!hasInscriptions(unspentTransactions)) {
+          currentNumberOfAddressesWithoutOrdinals += 1;
+          addressIndexCounter.increment();
+          continue;
+        }
+
+        foundUnspentTransactions = [
+          ...unspentTransactions.map(utxo => ({
+            // adds addresss index of which utxo belongs
+            ...utxo,
+            addressIndex: addressIndexCounter.getValue(),
+          })),
+          ...foundUnspentTransactions,
+        ];
+
+        currentNumberOfAddressesWithoutOrdinals = 0;
+        addressIndexCounter.increment();
+      }
+      // return f/oundUnspentTransactions;
+
+      return [];
+    },
+    {
+      staleTime: Infinity,
+      cacheTime: 0,
+    }
+  );
+}
+
+export function useTaprootUtxoInfiniteQuery() {
+  const network = useCurrentNetwork();
+  const keychain = useCurrentTaprootAccountKeychain();
+  const client = useBitcoinClient();
+
+  const currentAccountIndex = useCurrentAccountIndex();
+
+  const query = useInfiniteQuery({
+    queryKey: ['taproot-utxo-query', currentAccountIndex, network.id],
+    async queryFn({ pageParam = 0 }) {
       const address = getTaprootAddress({
-        index: addressIndexCounter.getValue(),
+        index: pageParam,
         keychain,
         network: network.chain.bitcoin.network,
       });
 
+      // eslint-disable-next-line no-console
+      console.log('address', address);
+
       const unspentTransactions = await client.addressApi.getUtxosByAddress(address);
 
-      if (!hasInscriptions(unspentTransactions)) {
-        currentNumberOfAddressesWithoutOrdinals += 1;
-        addressIndexCounter.increment();
-        continue;
+      return {
+        index: pageParam,
+        utxos: unspentTransactions.map(utxo => ({ ...utxo, addressIndex: pageParam })),
+      };
+    },
+    getNextPageParam(prevUtxoQuery, utxoQueries) {
+      const lastUtxos = [...utxoQueries].slice(-20);
+
+      const hasCheckedMinAmount =
+        lastUtxos.length === stopSearchAfterNumberAddressesWithoutOrdinals;
+
+      const hasFoundRecentUtxoActivity = lastUtxos.some(page => page.utxos.length);
+
+      if (hasCheckedMinAmount && !hasFoundRecentUtxoActivity) {
+        // Prevents the query from fetching more pages
+        return undefined;
       }
-
-      foundUnspentTransactions = [
-        ...unspentTransactions.map(utxo => ({
-          // adds addresss index of which utxo belongs
-          ...utxo,
-          addressIndex: addressIndexCounter.getValue(),
-        })),
-        ...foundUnspentTransactions,
-      ];
-
-      currentNumberOfAddressesWithoutOrdinals = 0;
-      addressIndexCounter.increment();
-    }
-    return foundUnspentTransactions;
+      return (prevUtxoQuery.index ?? 0) + 1;
+    },
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    staleTime: 0,
+    cacheTime: 0,
   });
+
+  // This is to auto trigger new changes. Not 100% sure this is the best way
+  useEffect(() => {
+    void query.fetchNextPage();
+  }, [query, query.data]);
+
+  return query;
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4945938543).<!-- Sticky Header Marker -->

@alter-eggo @fbwoolf tried out using infinite query to do the recursion, rather than looping within the body itself. See `useTaprootUtxoInfiniteQuery`

Not 100% convinced on this approach myself, but follows the conventions of ReactQuery so is more idiomatic in that sense. Not a fan of the logic to refetch, so open to other ideas to more reliably do this.