### PR TITLE
fix: insufficient funds error, closes #3661, closes #3651

### DIFF
--- a/src/app/components/bitcoin-fees-list/bitcoin-fees-list.tsx
+++ b/src/app/components/bitcoin-fees-list/bitcoin-fees-list.tsx
@@ -1,6 +1,13 @@
-import { Stack, Text } from '@stacks/ui';
+import { useCallback, useState } from 'react';
+
+import { Box, Stack, Text, color } from '@stacks/ui';
 
 import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
+import { Money, createMoney } from '@shared/models/money.model';
+
+import { sumMoney } from '@app/common/money/calculate-money';
+import { formatMoney } from '@app/common/money/format-money';
+import { useCurrentNativeSegwitAddressBalance } from '@app/query/bitcoin/balance/bitcoin-balances.query';
 
 import { LoadingSpinner } from '../loading-spinner';
 import { FeesCard } from './components/fees-card';
@@ -14,26 +21,88 @@ export interface FeesListItem {
   feeRate: number;
 }
 
+export interface OnChooseFeeArgs {
+  feeRate: number;
+  feeValue: number;
+  time: string;
+}
+
 interface BitcoinFeesListProps {
+  amount: Money;
   feesList: FeesListItem[];
   isLoading: boolean;
-  onChooseFee(feeRate: number, feeValue: number, time: string): Promise<void> | void;
+  onChooseFee({ feeRate, feeValue, time }: OnChooseFeeArgs): Promise<void>;
+  onSetSelectedFeeType(value: BtcFeeType): void;
+  selectedFeeType: BtcFeeType;
 }
-export function BitcoinFeesList({ feesList, isLoading, onChooseFee }: BitcoinFeesListProps) {
+export function BitcoinFeesList({
+  amount,
+  feesList,
+  isLoading,
+  onChooseFee,
+  onSetSelectedFeeType,
+  selectedFeeType,
+}: BitcoinFeesListProps) {
+  const [showInsufficientBalanceError, setShowInsufficientBalanceError] = useState(false);
+  const balance = useCurrentNativeSegwitAddressBalance();
+
+  const validateTotalSpend = useCallback(
+    (feeValue: number) => {
+      const feeAsMoney = createMoney(feeValue, 'BTC');
+      const totalSpend = sumMoney([amount, feeAsMoney]);
+      if (totalSpend.amount.isGreaterThan(balance.amount)) {
+        setShowInsufficientBalanceError(true);
+        return;
+      }
+    },
+    [amount, balance.amount]
+  );
+
+  const onSelectBtcFeeType = useCallback(
+    async ({ feeRate, feeValue, time }: OnChooseFeeArgs, label: BtcFeeType) => {
+      onSetSelectedFeeType(label);
+      validateTotalSpend(feeValue);
+      await onChooseFee({ feeRate, feeValue, time });
+    },
+    [onChooseFee, onSetSelectedFeeType, validateTotalSpend]
+  );
+
   if (isLoading) return <LoadingSpinner />;
 
   if (!feesList.length) {
     return (
-      <Stack alignItems="center" spacing="extra-loose" width="100%">
-        <Text color="#74777D" fontSize="14px" textAlign="center">
-          Unable to fetch fees. Please try again later.
-        </Text>
-      </Stack>
+      <Text color={color('text-caption')} fontSize={1} lineHeight="20px" textAlign="center">
+        Unable to calculate fees.
+        <br />
+        Check balance and try again.
+      </Text>
     );
   }
+
   return (
-    <Stack alignItems="center" spacing="extra-loose" width="100%">
-      <Stack spacing="base" width="100%">
+    <Stack alignItems="center" spacing="base" width="100%">
+      {amount.amount.isGreaterThan(0) ? (
+        <Text
+          color={showInsufficientBalanceError ? color('feedback-error') : 'unset'}
+          fontSize={6}
+          fontWeight={500}
+        >
+          {formatMoney(amount)}
+        </Text>
+      ) : null}
+      {showInsufficientBalanceError ? (
+        <Box display="flex" alignItems="center" minHeight="40px">
+          <Text color={color('feedback-error')} fontSize={1} textAlign="center">
+            Fee is too expensive for available balance
+          </Text>
+        </Box>
+      ) : (
+        <Text color={color('text-caption')} fontSize={1} lineHeight="20px" textAlign="center">
+          Fees are deducted from your balance,
+          <br /> it won't affect your sending amount.
+        </Text>
+      )}
+      <Stack mt="tight" spacing="base" width="100%">
         {feesList.map(({ label, value, btcValue, fiatValue, time, feeRate }) => (
           <FeesCard
             arrivesIn={time}
@@ -41,14 +110,11 @@ export function BitcoinFeesList({ feesList, isLoading, onChooseFee }: BitcoinFee
             feeFiatValue={fiatValue}
             feeType={label}
             key={label}
-            onClick={() => onChooseFee(feeRate, value, time)}
+            isSelected={label === selectedFeeType}
+            onClick={() => onSelectBtcFeeType({ feeRate, feeValue: value, time }, label)}
           />
         ))}
       </Stack>
-      <Text color="#74777D" fontSize="14px" textAlign="center">
-        Fees are deducted from your balance,
-        <br /> it won't affect your sending amount.
-      </Text>
     </Stack>
   );
 }

--- a/src/app/components/bitcoin-fees-list/components/bitcoin-fees-list.layout.tsx
+++ b/src/app/components/bitcoin-fees-list/components/bitcoin-fees-list.layout.tsx
@@ -4,7 +4,7 @@ import { HasChildren } from '@app/common/has-children';
 
 export function BitcoinFeesListLayout({ children }: HasChildren) {
   return (
-    <Stack alignItems="center" p="extra-loose" spacing="extra-loose" width="100%">
+    <Stack alignItems="center" p="extra-loose" spacing="base" width="100%">
       {children}
     </Stack>
   );

--- a/src/app/components/bitcoin-fees-list/components/fees-card.tsx
+++ b/src/app/components/bitcoin-fees-list/components/fees-card.tsx
@@ -1,26 +1,36 @@
 import { Box, Flex, Text, color, transition } from '@stacks/ui';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 
+import { figmaTheme } from '@app/common/utils/figma-theme';
+
 interface FeesCardProps {
-  feeType: string;
+  arrivesIn: string;
   feeAmount: string;
   feeFiatValue: string;
-  arrivesIn: string;
+  feeType: string;
+  isSelected?: boolean;
   onClick: () => void;
 }
-export function FeesCard({ feeType, feeAmount, feeFiatValue, arrivesIn, ...props }: FeesCardProps) {
+export function FeesCard({
+  arrivesIn,
+  feeAmount,
+  feeFiatValue,
+  feeType,
+  isSelected,
+  ...props
+}: FeesCardProps) {
   return (
     <Box
+      _hover={{ background: '#F9F9FA' }}
       as="button"
-      border="1px solid"
-      borderColor={color('border')}
+      border={isSelected ? '4px solid' : '1px solid'}
+      borderColor={isSelected ? figmaTheme.borderFocused : color('border')}
       borderRadius="16px"
       boxShadow="0px 1px 2px rgba(0, 0, 0, 0.04)"
-      transition={transition}
-      padding="extra-loose"
-      width="100%"
-      _hover={{ background: '#F9F9FA' }}
       data-testid={SharedComponentsSelectors.FeeCard}
+      padding="extra-loose"
+      transition={transition}
+      width="100%"
       {...props}
     >
       <Flex justifyContent="space-between" mb="tight" fontWeight={500}>

--- a/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list.ts
+++ b/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list.ts
@@ -32,7 +32,7 @@ export function useBitcoinFeesList({ amount, recipient }: UseBitcoinFeesListArgs
       )}`;
     }
 
-    if (!feeRate || !utxos) return [];
+    if (!feeRate || !utxos || !utxos.length) return [];
 
     const satAmount = btcToSat(amount).toNumber();
     const { fee: highFeeValue } = determineUtxosForSpend({

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
@@ -3,38 +3,45 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import get from 'lodash.get';
 
 import { logger } from '@shared/logger';
+import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
 import { createMoney } from '@shared/models/money.model';
 import { RouteUrls } from '@shared/route-urls';
 import { noop } from '@shared/utils';
 
 import { useGenerateSignedBitcoinTx } from '@app/common/transactions/bitcoin/use-generate-bitcoin-tx';
 import { useWalletType } from '@app/common/use-wallet-type';
-import { BitcoinFeesList } from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
+import {
+  BitcoinFeesList,
+  OnChooseFeeArgs,
+} from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
 import { useBitcoinFeesList } from '@app/components/bitcoin-fees-list/use-bitcoin-fees-list';
+
+import { useRpcSendTransferState } from './rpc-send-transfer-container';
 
 function useRpcSendTransferFeeState() {
   const location = useLocation();
+  const amount = get(location.state, 'amount');
+  const amountAsMoney = createMoney(Number(amount), 'BTC');
+
   return {
     address: get(location.state, 'address') as string,
-    amount: get(location.state, 'amount') as string,
+    amountAsMoney,
   };
 }
 
 export function RpcSendTransferChooseFee() {
-  const { address, amount } = useRpcSendTransferFeeState();
+  const { selectedFeeType, setSelectedFeeType } = useRpcSendTransferState();
+  const { address, amountAsMoney } = useRpcSendTransferFeeState();
   const navigate = useNavigate();
   const { whenWallet } = useWalletType();
   const generateTx = useGenerateSignedBitcoinTx();
   const { feesList, isLoading } = useBitcoinFeesList({
-    amount: Number(amount),
+    amount: Number(amountAsMoney.amount),
     recipient: address,
   });
 
-  async function previewTransfer(feeRate: number, feeValue: number, time: string) {
-    const resp = generateTx(
-      { amount: createMoney(Number(amount), 'BTC'), recipient: address },
-      feeRate
-    );
+  async function previewTransfer({ feeRate, feeValue, time }: OnChooseFeeArgs) {
+    const resp = generateTx({ amount: amountAsMoney, recipient: address }, feeRate);
 
     if (!resp) return logger.error('Attempted to generate raw tx, but no tx exists');
 
@@ -55,6 +62,13 @@ export function RpcSendTransferChooseFee() {
   }
 
   return (
-    <BitcoinFeesList feesList={feesList} isLoading={isLoading} onChooseFee={previewTransfer} />
+    <BitcoinFeesList
+      amount={amountAsMoney}
+      feesList={feesList}
+      isLoading={isLoading}
+      onChooseFee={previewTransfer}
+      onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
+      selectedFeeType={selectedFeeType}
+    />
   );
 }

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-container.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-container.tsx
@@ -1,4 +1,7 @@
-import { Outlet } from 'react-router-dom';
+import { useState } from 'react';
+import { Outlet, useOutletContext } from 'react-router-dom';
+
+import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { PopupHeader } from '@app/features/current-account/popup-header';
@@ -6,7 +9,17 @@ import { PopupHeader } from '@app/features/current-account/popup-header';
 import { RpcSendTransferContainerLayout } from './components/rpc-send-transfer-container.layout';
 import { useRpcSendTransfer } from './use-rpc-send-transfer';
 
+interface RpcSendTransferContextState {
+  selectedFeeType: BtcFeeType;
+  setSelectedFeeType(value: BtcFeeType): void;
+}
+export function useRpcSendTransferState() {
+  const context = useOutletContext<RpcSendTransferContextState>();
+  return { ...context };
+}
+
 export function RpcSendTransferContainer() {
+  const [selectedFeeType, setSelectedFeeType] = useState(BtcFeeType.Low);
   const { origin } = useRpcSendTransfer();
 
   useRouteHeader(<PopupHeader displayAddresssBalanceOf="all" />);
@@ -18,7 +31,7 @@ export function RpcSendTransferContainer() {
 
   return (
     <RpcSendTransferContainerLayout>
-      <Outlet />
+      <Outlet context={{ selectedFeeType, setSelectedFeeType }} />
     </RpcSendTransferContainerLayout>
   );
 }

--- a/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.spec.ts
+++ b/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.spec.ts
@@ -37,7 +37,7 @@ describe(selectInscriptionTransferCoins.name, () => {
         Number(inscriptionInputAmount)
     );
 
-    expect(result.txFee).toEqual(8483);
+    expect(result.txFee).toEqual(6765);
   });
 
   test('when there are not enough utxo to cover fee', () => {

--- a/src/app/pages/send/ordinal-inscription/components/send-inscription-container.tsx
+++ b/src/app/pages/send/ordinal-inscription/components/send-inscription-container.tsx
@@ -1,11 +1,36 @@
-import { Outlet } from 'react-router-dom';
+import { useState } from 'react';
+import { Outlet, useLocation, useOutletContext } from 'react-router-dom';
+
+import get from 'lodash.get';
+
+import { AverageBitcoinFeeRates, BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
+import { SupportedInscription } from '@shared/models/inscription.model';
+
+import { TaprootUtxo } from '@app/query/bitcoin/ordinals/use-taproot-address-utxos.query';
 
 import { SendInscriptionLoader } from './send-inscription-loader';
 
+export interface SendInscriptionContextState {
+  feeRates: AverageBitcoinFeeRates;
+  inscription: SupportedInscription;
+  selectedFeeType: BtcFeeType;
+  setSelectedFeeType(value: BtcFeeType): void;
+  utxo: TaprootUtxo;
+}
+export function useSendInscriptionState() {
+  const location = useLocation();
+  const context = useOutletContext<SendInscriptionContextState>();
+  return { ...context, recipient: get(location.state, 'recipient', '') as string };
+}
+
 export function SendInscriptionContainer() {
+  const [selectedFeeType, setSelectedFeeType] = useState(BtcFeeType.Low);
+
   return (
     <SendInscriptionLoader>
-      {({ feeRates, inscription, utxo }) => <Outlet context={{ feeRates, inscription, utxo }} />}
+      {({ feeRates, inscription, utxo }) => (
+        <Outlet context={{ feeRates, inscription, selectedFeeType, setSelectedFeeType, utxo }} />
+      )}
     </SendInscriptionLoader>
   );
 }

--- a/src/app/pages/send/ordinal-inscription/components/send-inscription-loader.tsx
+++ b/src/app/pages/send/ordinal-inscription/components/send-inscription-loader.tsx
@@ -1,30 +1,15 @@
-import { Navigate, useLocation, useOutletContext } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 
-import get from 'lodash.get';
-
-import { AverageBitcoinFeeRates } from '@shared/models/fees/bitcoin-fees.model';
-import { SupportedInscription } from '@shared/models/inscription.model';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useAverageBitcoinFeeRates } from '@app/query/bitcoin/fees/fee-estimates.hooks';
-import { TaprootUtxo } from '@app/query/bitcoin/ordinals/use-taproot-address-utxos.query';
 
 import { useSendInscriptionRouteState } from '../hooks/use-send-inscription-route-state';
 import { createUtxoFromInscription } from './create-utxo-from-inscription';
-
-interface InscriptionSendState {
-  feeRates: AverageBitcoinFeeRates;
-  inscription: SupportedInscription;
-  utxo: TaprootUtxo;
-}
-export function useInscriptionSendState() {
-  const location = useLocation();
-  const context = useOutletContext<InscriptionSendState>();
-  return { ...context, recipient: get(location.state, 'recipient', '') as string };
-}
+import { SendInscriptionContextState } from './send-inscription-container';
 
 interface SendInscriptionLoaderProps {
-  children(data: InscriptionSendState): JSX.Element;
+  children(data: Partial<SendInscriptionContextState>): JSX.Element;
 }
 export function SendInscriptionLoader({ children }: SendInscriptionLoaderProps) {
   const { inscription } = useSendInscriptionRouteState();

--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
@@ -19,7 +19,7 @@ import {
 import { getNumberOfInscriptionOnUtxo } from '@app/query/bitcoin/ordinals/ordinals-aware-utxo.query';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
-import { useInscriptionSendState } from '../components/send-inscription-loader';
+import { useSendInscriptionState } from '../components/send-inscription-container';
 import { recipeintFieldName } from '../send-inscription-form';
 import { useGenerateSignedOrdinalTx } from './use-generate-ordinal-tx';
 
@@ -28,7 +28,7 @@ export function useSendInscriptionForm() {
   const analytics = useAnalytics();
   const navigate = useNavigate();
   const { whenWallet } = useWalletType();
-  const { inscription, utxo } = useInscriptionSendState();
+  const { inscription, utxo } = useSendInscriptionState();
   const currentNetwork = useCurrentNetwork();
 
   const { coverFeeFromAdditionalUtxos } = useGenerateSignedOrdinalTx(utxo);
@@ -37,7 +37,7 @@ export function useSendInscriptionForm() {
     currentError,
 
     async chooseTransactionFee(values: OrdinalSendFormValues) {
-      // Check tx with fastest fee for errors before routing and
+      // Check tx with lowest fee for errors before routing and
       // generating the final transaction with the chosen fee to send
       const resp = coverFeeFromAdditionalUtxos(values);
 

--- a/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
@@ -1,23 +1,29 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { BitcoinFeesList } from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
+import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
+import { createMoney } from '@shared/models/money.model';
+
+import {
+  BitcoinFeesList,
+  OnChooseFeeArgs,
+} from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
 import { BitcoinFeesListLayout } from '@app/components/bitcoin-fees-list/components/bitcoin-fees-list.layout';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { LoadingSpinner } from '@app/components/loading-spinner';
 
-import { useInscriptionSendState } from './components/send-inscription-loader';
+import { useSendInscriptionState } from './components/send-inscription-container';
 import { useSendInscriptionFeesList } from './hooks/use-send-inscription-fees-list';
 import { useSendInscriptionForm } from './hooks/use-send-inscription-form';
 
 export function SendInscriptionChooseFee() {
   const [isLoadingReview, setIsLoadingReview] = useState(false);
   const navigate = useNavigate();
-  const { recipient, utxo } = useInscriptionSendState();
+  const { recipient, selectedFeeType, setSelectedFeeType, utxo } = useSendInscriptionState();
   const { feesList, isLoading } = useSendInscriptionFeesList({ recipient, utxo });
   const { reviewTransaction } = useSendInscriptionForm();
 
-  async function previewTransaction(feeRate: number, feeValue: number, time: string) {
+  async function previewTransaction({ feeRate, feeValue, time }: OnChooseFeeArgs) {
     try {
       setIsLoadingReview(true);
       await reviewTransaction(feeValue, time, { feeRate, recipient });
@@ -32,9 +38,12 @@ export function SendInscriptionChooseFee() {
     <BaseDrawer title="Choose fee" isShowing enableGoBack onClose={() => navigate(-1)}>
       <BitcoinFeesListLayout>
         <BitcoinFeesList
+          amount={createMoney(0, 'BTC')}
           feesList={feesList}
           isLoading={isLoading}
           onChooseFee={previewTransaction}
+          onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
+          selectedFeeType={selectedFeeType}
         />
       </BitcoinFeesListLayout>
     </BaseDrawer>

--- a/src/app/pages/send/ordinal-inscription/send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-form.tsx
@@ -13,14 +13,14 @@ import { InscriptionPreviewCard } from '@app/components/inscription-preview-card
 
 import { RecipientField } from '../send-crypto-asset-form/components/recipient-field';
 import { CollectibleAsset } from './components/collectible-asset';
-import { useInscriptionSendState } from './components/send-inscription-loader';
+import { useSendInscriptionState } from './components/send-inscription-container';
 import { useSendInscriptionForm } from './hooks/use-send-inscription-form';
 
 export const recipeintFieldName = 'recipient';
 
 export function SendInscriptionForm() {
   const navigate = useNavigate();
-  const { feeRates, inscription, recipient } = useInscriptionSendState();
+  const { feeRates, inscription, recipient } = useSendInscriptionState();
   const { chooseTransactionFee, currentError, validationSchema } = useSendInscriptionForm();
 
   return (
@@ -29,7 +29,7 @@ export function SendInscriptionForm() {
       initialValues={{
         [recipeintFieldName]: recipient,
         inscription,
-        feeRate: feeRates.fastestFee.toNumber(),
+        feeRate: feeRates.hourFee.toNumber(),
       }}
       onSubmit={chooseTransactionFee}
     >

--- a/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
@@ -17,7 +17,7 @@ import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/address.
 
 import { InscriptionPreviewCard } from '../../../components/inscription-preview-card/inscription-preview-card';
 import { useBitcoinBroadcastTransaction } from '../../../query/bitcoin/transaction/use-bitcoin-broadcast-transaction';
-import { useInscriptionSendState } from './components/send-inscription-loader';
+import { useSendInscriptionState } from './components/send-inscription-container';
 
 function useSendInscriptionReviewState() {
   const location = useLocation();
@@ -35,7 +35,7 @@ export function SendInscriptionReview() {
 
   const { arrivesIn, signedTx, recipient, fee } = useSendInscriptionReviewState();
 
-  const { inscription } = useInscriptionSendState();
+  const { inscription } = useSendInscriptionState();
   const { refetch } = useCurrentNativeSegwitUtxos();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
 

--- a/src/app/pages/send/send-crypto-asset-form/components/send-max-button.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/send-max-button.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import toast from 'react-hot-toast';
 
-import { Button } from '@stacks/ui';
+import { Box, Button } from '@stacks/ui';
 import { ButtonProps } from '@stacks/ui';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { useField } from 'formik';
@@ -20,16 +20,14 @@ export function SendMaxButton({ balance, sendMaxBalance, ...props }: SendMaxButt
   const analytics = useAnalytics();
 
   const onSendMax = useCallback(() => {
-    // if (isUndefined(feeField.value)) return toast.error('Loading fee, try again');
-    // if (!feeField.value)
-    //   return toast.error(
-    //     `A fee must be set to calculate max ${balance.symbol.toUpperCase()} transfer amount`
-    //   );
-
     void analytics.track('select_maximum_amount_for_send');
     if (balance.amount.isLessThanOrEqualTo(0)) return toast.error(`Zero balance`);
     return amountFieldHelpers.setValue(sendMaxBalance);
   }, [amountFieldHelpers, analytics, balance.amount, sendMaxBalance]);
+
+  // Hide send max button if using lowest fee to perform the calc
+  // is greater than available balance and will show zero
+  if (sendMaxBalance === '0') return <Box height="32px" />;
 
   return (
     <Button

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/send-btc-container.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/send-btc-container.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { Outlet, useOutletContext } from 'react-router-dom';
+
+import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
+
+interface SendBtcContextState {
+  selectedFeeType: BtcFeeType;
+  setSelectedFeeType(value: BtcFeeType): void;
+}
+export function useSendBtcState() {
+  const context = useOutletContext<SendBtcContextState>();
+  return { ...context };
+}
+
+export function SendBtcContainer() {
+  const [selectedFeeType, setSelectedFeeType] = useState(BtcFeeType.Low);
+  return <Outlet context={{ selectedFeeType, setSelectedFeeType }} />;
+}

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
@@ -35,7 +35,7 @@ export function useCalculateMaxBitcoinSpend() {
         input_count: utxos.length,
         [`${addressTypeWithFallback}_output_count`]: 2,
       });
-      const fee = Math.ceil(size.txVBytes * feeRates.fastestFee.toNumber());
+      const fee = Math.ceil(size.txVBytes * feeRates.hourFee.toNumber());
 
       const spendableAmount = BigNumber.max(0, balance.amount.minus(fee));
 

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import get from 'lodash.get';
 
 import { logger } from '@shared/logger';
+import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
 import { BitcoinSendFormValues } from '@shared/models/form.model';
 import { createMoney } from '@shared/models/money.model';
 import { noop } from '@shared/utils';
@@ -11,11 +12,15 @@ import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { btcToSat } from '@app/common/money/unit-conversion';
 import { useGenerateSignedBitcoinTx } from '@app/common/transactions/bitcoin/use-generate-bitcoin-tx';
 import { useWalletType } from '@app/common/use-wallet-type';
-import { BitcoinFeesList } from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
+import {
+  BitcoinFeesList,
+  OnChooseFeeArgs,
+} from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
 import { BitcoinFeesListLayout } from '@app/components/bitcoin-fees-list/components/bitcoin-fees-list.layout';
 import { useBitcoinFeesList } from '@app/components/bitcoin-fees-list/use-bitcoin-fees-list';
 import { ModalHeader } from '@app/components/modal-header';
 
+import { useSendBtcState } from '../../family/bitcoin/components/send-btc-container';
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 
 function useBtcChooseFeeState() {
@@ -30,15 +35,18 @@ export function BtcChooseFee() {
   const { whenWallet } = useWalletType();
   const sendFormNavigate = useSendFormNavigate();
   const generateTx = useGenerateSignedBitcoinTx();
+  const { selectedFeeType, setSelectedFeeType } = useSendBtcState();
   const { feesList, isLoading } = useBitcoinFeesList({
     amount: Number(txValues.amount),
     recipient: txValues.recipient,
   });
 
-  async function previewTransaction(feeRate: number, feeValue: number, time: string) {
+  const amountAsMoney = createMoney(btcToSat(txValues.amount).toNumber(), 'BTC');
+
+  async function previewTransaction({ feeRate, feeValue, time }: OnChooseFeeArgs) {
     const resp = generateTx(
       {
-        amount: createMoney(btcToSat(txValues.amount).toNumber(), 'BTC'),
+        amount: amountAsMoney,
         recipient: txValues.recipient,
       },
       feeRate
@@ -60,11 +68,18 @@ export function BtcChooseFee() {
     })();
   }
 
-  useRouteHeader(<ModalHeader hideActions defaultGoBack title="Choose fee" />);
+  useRouteHeader(<ModalHeader defaultGoBack hideActions title="Choose fee" />);
 
   return (
     <BitcoinFeesListLayout>
-      <BitcoinFeesList feesList={feesList} isLoading={isLoading} onChooseFee={previewTransaction} />
+      <BitcoinFeesList
+        amount={amountAsMoney}
+        feesList={feesList}
+        isLoading={isLoading}
+        onChooseFee={previewTransaction}
+        onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
+        selectedFeeType={selectedFeeType}
+      />
     </BitcoinFeesListLayout>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -33,10 +33,10 @@ export function BtcSendForm() {
 
   const {
     calcMaxSpend,
+    chooseTransactionFee,
     currentNetwork,
     formRef,
     onFormStateChange,
-    chooseTransactionFee,
     validationSchema,
   } = useBtcSendForm();
 
@@ -65,9 +65,9 @@ export function BtcSendForm() {
                   bottomInputOverlay={
                     <SendMaxButton
                       balance={btcBalance.balance}
-                      sendMaxBalance={
-                        calcMaxSpend(props.values.recipient)?.spendableBitcoin.toString() ?? '0'
-                      }
+                      sendMaxBalance={calcMaxSpend(
+                        props.values.recipient
+                      ).spendableBitcoin.toString()}
                     />
                   }
                   autoComplete="off"

--- a/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
@@ -16,6 +16,7 @@ import { SendContainer } from '../send-container';
 import { BtcSentSummary } from '../sent-summary/btc-sent-summary';
 import { StxSentSummary } from '../sent-summary/stx-sent-summary';
 import { RecipientAccountsDrawer } from './components/recipient-accounts-drawer/recipient-accounts-drawer';
+import { SendBtcContainer } from './family/bitcoin/components/send-btc-container';
 import { BtcChooseFee } from './form/btc/btc-choose-fee';
 import { BtcSendForm } from './form/btc/btc-send-form';
 import { BtcSendFormConfirmation } from './form/btc/btc-send-form-confirmation';
@@ -48,13 +49,20 @@ export const sendCryptoAssetFormRoutes = (
       }
     />
 
-    <Route path={RouteUrls.SendCryptoAssetForm.replace(':symbol', 'btc')} element={<BtcSendForm />}>
-      {recipientAccountsDrawerRoute}
+    <Route element={<SendBtcContainer />}>
+      <Route
+        path={RouteUrls.SendCryptoAssetForm.replace(':symbol', 'btc')}
+        element={<BtcSendForm />}
+      >
+        {recipientAccountsDrawerRoute}
+      </Route>
+      <Route path="/send/btc/disabled" element={<SendBtcDisabled />} />
+      <Route path="/send/btc/error" element={<BroadcastError />} />
+      <Route path="/send/btc/confirm" element={<BtcSendFormConfirmation />} />
+      <Route path={RouteUrls.SendBtcChooseFee} element={<BtcChooseFee />}></Route>
+      <Route path={RouteUrls.SentBtcTxSummary} element={<BtcSentSummary />}></Route>
     </Route>
-    <Route path="/send/btc/confirm" element={<BtcSendFormConfirmation />} />
-    <Route path="/send/btc/disabled" element={<SendBtcDisabled />} />
-    <Route path="/send/btc/error" element={<BroadcastError />} />
-    <Route path={RouteUrls.SendBtcChooseFee} element={<BtcChooseFee />}></Route>
+
     <Route path={RouteUrls.SendCryptoAssetForm.replace(':symbol', 'stx')} element={<StxSendForm />}>
       {broadcastErrorDrawerRoute}
       {editNonceDrawerRoute}
@@ -70,7 +78,7 @@ export const sendCryptoAssetFormRoutes = (
       {recipientAccountsDrawerRoute}
     </Route>
     <Route path="/send/:symbol/:contractId/confirm" element={<StacksSendFormConfirmation />} />
-    <Route path={RouteUrls.SentBtcTxSummary} element={<BtcSentSummary />}></Route>
+
     <Route path={RouteUrls.SentStxTxSummary} element={<StxSentSummary />}></Route>
   </Route>
 );


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/4980318506).<!-- Sticky Header Marker -->

This PR addresses several issues coming up with our insufficient funds error while sending both BTC and inscriptions (and rpc send transfers). Here, we have changed to use the lowest fee to calc the send max which triggers the insufficient funds error, letting the user move to the screen to select a fee where we then show an error if they decide to select a higher fee that exceeds their balance.

There will be a second part to this work which will refactor the send max button into a toggle: https://github.com/hirosystems/wallet/issues/3136

![choose-fee](https://github.com/hirosystems/wallet/assets/6493321/0691bb72-25ba-4d1e-830d-7bac625fb9a4)
