### PR TITLE
fix(analytics): wrong api details, missing token

### DIFF
--- a/src/app/common/hooks/analytics/use-analytics.ts
+++ b/src/app/common/hooks/analytics/use-analytics.ts
@@ -6,6 +6,7 @@ import {
   PageParams,
 } from '@segment/analytics-next/dist/types/core/arguments-resolver';
 
+import { HIRO_API_BASE_URL_MAINNET, HIRO_API_BASE_URL_TESTNET } from '@shared/constants';
 import { IS_TEST_ENV, SEGMENT_WRITE_KEY } from '@shared/environment';
 import { logger } from '@shared/logger';
 import { analytics, initAnalytics } from '@shared/utils/analytics';
@@ -22,7 +23,7 @@ function isIgnoredPath(path: string) {
 }
 
 function isHiroApiUrl(url: string) {
-  return /^https:\/\/.*\.stacks.co/.test(url);
+  return url.includes(HIRO_API_BASE_URL_MAINNET) || url.includes(HIRO_API_BASE_URL_TESTNET);
 }
 
 export function useInitalizeAnalytics() {
@@ -50,9 +51,7 @@ export function useAnalytics() {
       ...(origin && { origin }),
     };
 
-    const defaultOptions = {
-      context: { ip: '0.0.0.0' },
-    };
+    const defaultOptions = { context: { ip: '0.0.0.0' } };
 
     return {
       async identify(properties: object) {

--- a/src/app/common/hooks/use-submit-stx-transaction.ts
+++ b/src/app/common/hooks/use-submit-stx-transaction.ts
@@ -49,7 +49,7 @@ export function useSubmitTransactionCallback({ loadingKey }: UseSubmitTransactio
               txId: safelyFormatHexTxid(response.txid),
             });
             toast.success('Transaction submitted!');
-            void analytics.track('broadcast_transaction', { token: 'stx' });
+            void analytics.track('broadcast_transaction', { symbol: 'stx' });
             onSuccess(safelyFormatHexTxid(response.txid));
             setIsIdle();
             await refreshAccountData(timeForApiToUpdate);

--- a/src/app/common/transactions/stacks/broadcast-transaction.ts
+++ b/src/app/common/transactions/stacks/broadcast-transaction.ts
@@ -17,7 +17,7 @@ interface BroadcastTransactionOptions {
   attachment?: string;
   networkUrl: string;
 }
-export async function broadcastTransaction(options: BroadcastTransactionOptions) {
+export async function broadcastStacksTransaction(options: BroadcastTransactionOptions) {
   const { txRaw, serialized, isSponsored, attachment, networkUrl } = options;
 
   if (isSponsored) {

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-confirmation.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-confirmation.tsx
@@ -88,7 +88,7 @@ export function RpcSendTransferConfirmation() {
       tx,
       async onSuccess(txid) {
         void analytics.track('broadcast_transaction', {
-          token: 'btc',
+          symbol: 'btc',
           amount: transferAmount,
           fee,
           inputs: psbt.inputs.length,

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -72,7 +72,7 @@ export function BtcSendFormConfirmation() {
       tx,
       async onSuccess(txid) {
         void analytics.track('broadcast_transaction', {
-          token: 'btc',
+          symbol: 'btc',
           amount: transferAmount,
           fee,
           inputs: psbt.inputs.length,

--- a/src/app/store/transactions/transaction.hooks.ts
+++ b/src/app/store/transactions/transaction.hooks.ts
@@ -22,7 +22,7 @@ import { isString, isUndefined } from '@shared/utils';
 import { useDefaultRequestParams } from '@app/common/hooks/use-default-request-search-params';
 import { stxToMicroStx } from '@app/common/money/unit-conversion';
 import { validateStacksAddress } from '@app/common/stacks-utils';
-import { broadcastTransaction } from '@app/common/transactions/stacks/broadcast-transaction';
+import { broadcastStacksTransaction } from '@app/common/transactions/stacks/broadcast-transaction';
 import {
   GenerateUnsignedTransactionOptions,
   generateUnsignedTransaction,
@@ -120,7 +120,7 @@ export function useTransactionBroadcast() {
   return async ({ signedTx }: { signedTx: StacksTransaction }) => {
     try {
       const { isSponsored, serialized, txRaw } = prepareTxDetailsForBroadcast(signedTx);
-      const result = await broadcastTransaction({
+      const result = await broadcastStacksTransaction({
         isSponsored,
         serialized,
         txRaw,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5055793560).<!-- Sticky Header Marker -->

Fixes two issues:
1) `isUsingHiroApi` regex was wrong since we updated URLs
2) `token` parameter isn't coming through to Mixpanel, wondering if this is some internal keyword so changing for `symbol`