### PR TITLE
fix: live reload losing in memory key

### DIFF
--- a/webpack/dev-server.js
+++ b/webpack/dev-server.js
@@ -17,7 +17,7 @@ const excludeEntriesFromHotModuleReload = ['content-script', 'inpage'];
 Object.keys(config.entry).forEach(entryName => {
   if (!excludeEntriesFromHotModuleReload.includes(entryName) && config.entry) {
     config.entry[entryName] = [
-      `webpack-dev-server/client?hot=true&live-reload=true&hostname=${HOST}&port=${PORT}`,
+      `webpack-dev-server/client?hot=true&live-reload=true&logging=none&hostname=${HOST}&port=${PORT}`,
       'webpack/hot/dev-server',
     ].concat(config.entry[entryName]);
   }
@@ -37,10 +37,7 @@ const server = new WebpackDevServer(
     // Disabled as web configure manually above
     hot: false,
     // We disable client bc we do a manual setup for specific entries
-    client: {
-      overlay: false,
-      logging: 'none',
-    },
+    client: false,
     port: process.env.PORT,
     static: {
       directory: path.join(__dirname, '../build'),


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5067794529).<!-- Sticky Header Marker -->

I'd changed the `client` dev server options to try disabling all the dev server console logging. This caused the bg script to be reloaded rather than HMR'd.

Here, I turn off the client entirely, as before, and disable logging via the URL params.