### PR TITLE
fix: stamps query key

### DIFF
--- a/src/app/query/bitcoin/stamps/stamps-by-address.query.ts
+++ b/src/app/query/bitcoin/stamps/stamps-by-address.query.ts
@@ -28,7 +28,7 @@ export function useStampsByAddressQuery<T extends unknown = FetchStampsByAddress
   options?: AppUseQueryConfig<FetchStampsByAddressResp, T>
 ) {
   return useQuery({
-    queryKey: [QueryPrefixes.StampsByAddress],
+    queryKey: [QueryPrefixes.StampsByAddress, address],
     queryFn: () => fetchStampsByAddress(address),
     ...options,
   });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5071298645).<!-- Sticky Header Marker -->

Fixes users seeing Stamps in wrong accounts. Reported in Discord.