### PR TITLE
fix(brc-20): caching without query key

### DIFF
--- a/src/app/query/bitcoin/ordinals/brc20-tokens.query.ts
+++ b/src/app/query/bitcoin/ordinals/brc20-tokens.query.ts
@@ -42,7 +42,7 @@ export function useBrc20TokensByAddressQuery<T extends unknown = FetchBrc20Token
   options?: AppUseQueryConfig<FetchBrc20TokensByAddressResp, T>
 ) {
   return useQuery({
-    queryKey: [QueryPrefixes.Brc20TokenBalance],
+    queryKey: [QueryPrefixes.Brc20TokenBalance, address],
     queryFn: () => fetchBrc20TokensByAddress(address),
     ...options,
   });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5089204514).<!-- Sticky Header Marker -->

Missing query key results in wrong balances for different accounts