### PR TITLE
fix: don't subtract balances being returned to sender

### DIFF
--- a/src/app/query/bitcoin/address/transactions-by-address.hooks.ts
+++ b/src/app/query/bitcoin/address/transactions-by-address.hooks.ts
@@ -24,6 +24,7 @@ export function useBitcoinPendingTransactionsBalance(address: string) {
         sumNumbers(
           pendingTransactions
             .flatMap(tx => tx.vout.filter(output => output.scriptpubkey_address === address))
+            .filter(tx => tx.scriptpubkey_address !== address)
             .map(vout => vout.value)
         ),
         'BTC'


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5092202338).<!-- Sticky Header Marker -->

Don't subtract pending balances that are being sent back to sender