### PR TITLE
refactor: send max, closes #3136, closes #3576

### DIFF
--- a/src/app/components/bitcoin-fees-list/components/fees-list-error.tsx
+++ b/src/app/components/bitcoin-fees-list/components/fees-list-error.tsx
@@ -1,0 +1,30 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Box, Text } from '@stacks/ui';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { GenericError } from '@app/components/generic-error/generic-error';
+
+const body = 'Check balance and try again';
+const helpTextList = [
+  <Box as="li" mt="base" key={1}>
+    <Text>Possibly caused by api issues</Text>
+  </Box>,
+];
+const title = 'Unable to calculate fees';
+
+export function FeesListError() {
+  const navigate = useNavigate();
+
+  return (
+    <Box textAlign="center" px={['unset', 'loose']} py="base" width="100%">
+      <GenericError
+        body={body}
+        helpTextList={helpTextList}
+        onClose={() => navigate(RouteUrls.SendCryptoAsset)}
+        title={title}
+      />
+    </Box>
+  );
+}

--- a/src/app/components/bitcoin-fees-list/components/fees-list-item.tsx
+++ b/src/app/components/bitcoin-fees-list/components/fees-list-item.tsx
@@ -3,22 +3,24 @@ import { SharedComponentsSelectors } from '@tests/selectors/shared-component.sel
 
 import { figmaTheme } from '@app/common/utils/figma-theme';
 
-interface FeesCardProps {
+interface FeesListItemProps {
   arrivesIn: string;
   feeAmount: string;
   feeFiatValue: string;
+  feeRate: number;
   feeType: string;
   isSelected?: boolean;
   onClick: () => void;
 }
-export function FeesCard({
+export function FeesListItem({
   arrivesIn,
   feeAmount,
   feeFiatValue,
+  feeRate,
   feeType,
   isSelected,
   ...props
-}: FeesCardProps) {
+}: FeesListItemProps) {
   return (
     <Box
       _hover={{ background: '#F9F9FA' }}
@@ -27,19 +29,21 @@ export function FeesCard({
       borderColor={isSelected ? figmaTheme.borderFocused : color('border')}
       borderRadius="16px"
       boxShadow="0px 1px 2px rgba(0, 0, 0, 0.04)"
-      data-testid={SharedComponentsSelectors.FeeCard}
-      padding="extra-loose"
+      data-testid={SharedComponentsSelectors.FeesListItem}
+      px="base"
+      py="extra-loose"
       transition={transition}
       width="100%"
       {...props}
     >
-      <Flex justifyContent="space-between" mb="tight" fontWeight={500}>
-        <Text>{feeType}</Text>
-        <Text data-testid={SharedComponentsSelectors.FeeCardFeeValue}>{feeAmount}</Text>
-      </Flex>
-      <Flex justifyContent="space-between" color="#74777D">
+      <Flex justifyContent="center" mb="base-tight" fontWeight={500}>
+        <Text mr="tight">{feeType}</Text>
         <Text>{arrivesIn}</Text>
-        <Text>{feeFiatValue}</Text>
+      </Flex>
+      <Flex justifyContent="center" color={color('text-caption')}>
+        <Text
+          data-testid={SharedComponentsSelectors.FeesListItemFeeValue}
+        >{`${feeFiatValue} | ${feeRate} sats/vB | ${feeAmount}`}</Text>
       </Flex>
     </Box>
   );

--- a/src/app/components/bitcoin-fees-list/components/fees-list-subtitle.tsx
+++ b/src/app/components/bitcoin-fees-list/components/fees-list-subtitle.tsx
@@ -1,0 +1,21 @@
+import { Text, color } from '@stacks/ui';
+
+export function FeesListSubtitle(props: { isSendingMax: boolean }) {
+  const { isSendingMax } = props;
+
+  const subtitle = isSendingMax ? (
+    'Chosen fee will affect your sending amount'
+  ) : (
+    <>
+      Fees are deducted from your balance,
+      <br />
+      it won't affect your sending amount.
+    </>
+  );
+
+  return (
+    <Text color={color('text-caption')} fontSize={1} lineHeight="20px" textAlign="center">
+      {subtitle}
+    </Text>
+  );
+}

--- a/src/app/components/bitcoin-fees-list/components/insufficient-balance-error.tsx
+++ b/src/app/components/bitcoin-fees-list/components/insufficient-balance-error.tsx
@@ -1,0 +1,11 @@
+import { Box, Text, color } from '@stacks/ui';
+
+export function InsufficientBalanceError() {
+  return (
+    <Box display="flex" alignItems="center" minHeight="40px">
+      <Text color={color('feedback-error')} fontSize={1} textAlign="center">
+        Fee is too expensive for available balance
+      </Text>
+    </Box>
+  );
+}

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
@@ -66,6 +66,7 @@ export function RpcSendTransferChooseFee() {
       amount={amountAsMoney}
       feesList={feesList}
       isLoading={isLoading}
+      isSendingMax={false}
       onChooseFee={previewTransfer}
       onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
       selectedFeeType={selectedFeeType}

--- a/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
@@ -41,6 +41,7 @@ export function SendInscriptionChooseFee() {
           amount={createMoney(0, 'BTC')}
           feesList={feesList}
           isLoading={isLoading}
+          isSendingMax={false}
           onChooseFee={previewTransaction}
           onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
           selectedFeeType={selectedFeeType}

--- a/src/app/pages/send/send-crypto-asset-form/components/send-max-button.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/send-max-button.tsx
@@ -25,8 +25,8 @@ export function SendMaxButton({ balance, sendMaxBalance, ...props }: SendMaxButt
     return amountFieldHelpers.setValue(sendMaxBalance);
   }, [amountFieldHelpers, analytics, balance.amount, sendMaxBalance]);
 
-  // Hide send max button if using lowest fee to perform the calc
-  // is greater than available balance and will show zero
+  // Hide send max button if lowest fee calc is greater
+  // than available balance which will default to zero
   if (sendMaxBalance === '0') return <Box height="32px" />;
 
   return (

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-send-max-button.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-send-max-button.tsx
@@ -1,0 +1,65 @@
+import { Box, Button, color } from '@stacks/ui';
+import { ButtonProps } from '@stacks/ui';
+import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
+
+import { Money } from '@shared/models/money.model';
+
+import { Tooltip } from '@app/components/tooltip';
+
+import { useSendMax } from '../hooks/use-send-max';
+
+const sendMaxTooltipLabel = 'This amount is affected by the fee you choose';
+
+interface BitcoinSendMaxButtonProps extends ButtonProps {
+  balance: Money;
+  isSendingMax?: boolean;
+  onSetIsSendingMax(value: boolean): void;
+  sendMaxBalance: string;
+  sendMaxFee: string;
+}
+export function BitcoinSendMaxButton({
+  balance,
+  isSendingMax,
+  onSetIsSendingMax,
+  sendMaxBalance,
+  sendMaxFee,
+  ...props
+}: BitcoinSendMaxButtonProps) {
+  const onSendMax = useSendMax({
+    balance,
+    isSendingMax,
+    onSetIsSendingMax,
+    sendMaxBalance,
+    sendMaxFee,
+  });
+
+  // Hide send max button if lowest fee calc is greater
+  // than available balance which will default to zero
+  if (sendMaxBalance === '0') return <Box height="32px" />;
+
+  return (
+    <Tooltip
+      label={sendMaxTooltipLabel}
+      labelProps={{ padding: 'tight', textAlign: 'center' }}
+      maxWidth="220px"
+      placement="bottom"
+    >
+      <Button
+        _hover={{ bg: isSendingMax ? color('border') : color('bg') }}
+        bg={isSendingMax ? color('border') : color('bg')}
+        borderRadius="10px"
+        data-testid={SendCryptoAssetSelectors.SendMaxBtn}
+        fontSize={0}
+        height="32px"
+        onClick={onSendMax}
+        mode="tertiary"
+        px="base-tight"
+        type="button"
+        width="fit-content"
+        {...props}
+      >
+        Sending max
+      </Button>
+    </Tooltip>
+  );
+}

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
@@ -19,7 +19,7 @@ export function useCalculateMaxBitcoinSpend() {
   const { avgApiFeeRates: feeRates } = useAverageBitcoinFeeRates();
 
   return useCallback(
-    (address = '') => {
+    (address = '', feeRate?: number) => {
       if (!utxos || !feeRates)
         return {
           spendAllFee: 0,
@@ -35,7 +35,7 @@ export function useCalculateMaxBitcoinSpend() {
         input_count: utxos.length,
         [`${addressTypeWithFallback}_output_count`]: 2,
       });
-      const fee = Math.ceil(size.txVBytes * feeRates.hourFee.toNumber());
+      const fee = Math.ceil(size.txVBytes * (feeRate ?? feeRates.hourFee.toNumber()));
 
       const spendableAmount = BigNumber.max(0, balance.amount.minus(fee));
 

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-send-max.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-send-max.tsx
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+
+import { useField } from 'formik';
+
+import { Money } from '@shared/models/money.model';
+
+import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+
+interface UseSendMaxArgs {
+  balance: Money;
+  isSendingMax?: boolean;
+  onSetIsSendingMax(value: boolean): void;
+  sendMaxBalance: string;
+  sendMaxFee: string;
+}
+export function useSendMax({
+  balance,
+  isSendingMax,
+  onSetIsSendingMax,
+  sendMaxBalance,
+  sendMaxFee,
+}: UseSendMaxArgs) {
+  const [, _, amountFieldHelpers] = useField('amount');
+  const [, __, feeFieldHelpers] = useField('fee');
+
+  const analytics = useAnalytics();
+
+  return useCallback(() => {
+    void analytics.track('select_maximum_amount_for_send');
+    if (balance.amount.isLessThanOrEqualTo(0)) return toast.error(`Zero balance`);
+    onSetIsSendingMax(!isSendingMax);
+    amountFieldHelpers.setError('');
+    feeFieldHelpers.setValue(sendMaxFee);
+    return amountFieldHelpers.setValue(sendMaxBalance);
+  }, [
+    amountFieldHelpers,
+    analytics,
+    balance.amount,
+    feeFieldHelpers,
+    isSendingMax,
+    onSetIsSendingMax,
+    sendMaxBalance,
+    sendMaxFee,
+  ]);
+}

--- a/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
@@ -106,6 +106,7 @@ export function BrcChooseFee() {
         amount={amountAsMoney}
         feesList={feesList}
         isLoading={isLoading}
+        isSendingMax={false}
         onChooseFee={previewTransaction}
         onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
         selectedFeeType={selectedFeeType}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -17,8 +17,8 @@ import { FormFooter } from '../../components/form-footer';
 import { SelectedAssetField } from '../../components/selected-asset-field';
 import { SendCryptoAssetFormLayout } from '../../components/send-crypto-asset-form.layout';
 import { SendFiatValue } from '../../components/send-fiat-value';
-import { SendMaxButton } from '../../components/send-max-button';
 import { BitcoinRecipientField } from '../../family/bitcoin/components/bitcoin-recipient-field';
+import { BitcoinSendMaxButton } from '../../family/bitcoin/components/bitcoin-send-max-button';
 import { TestnetBtcMessage } from '../../family/bitcoin/components/testnet-btc-message';
 import { useSendFormRouteState } from '../../hooks/use-send-form-route-state';
 import { createDefaultInitialFormValues, defaultSendFormFormikProps } from '../../send-form.utils';
@@ -36,7 +36,9 @@ export function BtcSendForm() {
     chooseTransactionFee,
     currentNetwork,
     formRef,
+    isSendingMax,
     onFormStateChange,
+    onSetIsSendingMax,
     validationSchema,
   } = useBtcSendForm();
 
@@ -54,23 +56,27 @@ export function BtcSendForm() {
       >
         {props => {
           onFormStateChange(props.values);
+          const sendMaxCalculation = calcMaxSpend(props.values.recipient);
+
           return (
             <Form>
               <SendCryptoAssetFormLayout>
                 <AmountField
+                  autoComplete="off"
                   balance={btcBalance.balance}
+                  bottomInputOverlay={
+                    <BitcoinSendMaxButton
+                      balance={btcBalance.balance}
+                      isSendingMax={isSendingMax}
+                      onSetIsSendingMax={onSetIsSendingMax}
+                      sendMaxBalance={sendMaxCalculation.spendableBitcoin.toString()}
+                      sendMaxFee={sendMaxCalculation.spendAllFee.toString()}
+                    />
+                  }
+                  isSendingMax={isSendingMax}
                   switchableAmount={
                     <SendFiatValue marketData={btcMarketData} assetSymbol={'BTC'} />
                   }
-                  bottomInputOverlay={
-                    <SendMaxButton
-                      balance={btcBalance.balance}
-                      sendMaxBalance={calcMaxSpend(
-                        props.values.recipient
-                      ).spendableBitcoin.toString()}
-                    />
-                  }
-                  autoComplete="off"
                 />
                 <SelectedAssetField icon={<BtcIcon />} name={btcBalance.asset.name} symbol="BTC" />
                 <BitcoinRecipientField />

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import { FormikHelpers, FormikProps } from 'formik';
 import * as yup from 'yup';
@@ -31,6 +31,7 @@ import { useCalculateMaxBitcoinSpend } from '../../family/bitcoin/hooks/use-calc
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 
 export function useBtcSendForm() {
+  const [isSendingMax, setIsSendingMax] = useState(false);
   const formRef = useRef<FormikProps<BitcoinSendFormValues>>(null);
   const currentNetwork = useCurrentNetwork();
   const currentAccountBtcAddress = useCurrentAccountNativeSegwitAddressIndexZero();
@@ -44,7 +45,9 @@ export function useBtcSendForm() {
     calcMaxSpend,
     currentNetwork,
     formRef,
+    isSendingMax,
     onFormStateChange,
+    onSetIsSendingMax: (value: boolean) => setIsSendingMax(value),
 
     validationSchema: yup.object({
       amount: yup
@@ -78,7 +81,7 @@ export function useBtcSendForm() {
       await formikHelpers.validateForm();
 
       whenWallet({
-        software: () => sendFormNavigate.toChooseTransactionFee(values),
+        software: () => sendFormNavigate.toChooseTransactionFee(isSendingMax, values),
         ledger: noop,
       })();
     },

--- a/src/app/pages/send/send-crypto-asset-form/hooks/use-send-form-navigate.ts
+++ b/src/app/pages/send/send-crypto-asset-form/hooks/use-send-form-navigate.ts
@@ -35,9 +35,10 @@ export function useSendFormNavigate() {
       backToSendForm(state: any) {
         return navigate('../', { relative: 'path', replace: true, state });
       },
-      toChooseTransactionFee(values: BitcoinSendFormValues) {
+      toChooseTransactionFee(isSendingMax: boolean, values: BitcoinSendFormValues) {
         return navigate('choose-fee', {
           state: {
+            isSendingMax,
             values,
             hasHeaderTitle: true,
           },

--- a/tests/page-object-models/send.page.ts
+++ b/tests/page-object-models/send.page.ts
@@ -23,7 +23,7 @@ export class SendPage {
   readonly sendMaxButton: Locator;
   readonly feesRow: Locator;
   readonly memoRow: Locator;
-  readonly feesCard: Locator;
+  readonly feesListItem: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -55,7 +55,7 @@ export class SendPage {
     this.memoRow = page.getByTestId(SendCryptoAssetSelectors.ConfirmationDetailsMemo);
 
     this.sendMaxButton = page.getByTestId(SendCryptoAssetSelectors.SendMaxBtn);
-    this.feesCard = page.getByTestId(SharedComponentsSelectors.FeeCard);
+    this.feesListItem = page.getByTestId(SharedComponentsSelectors.FeesListItem);
   }
 
   async selectBtcAndGoToSendForm() {

--- a/tests/selectors/shared-component.selectors.ts
+++ b/tests/selectors/shared-component.selectors.ts
@@ -15,6 +15,6 @@ export enum SharedComponentsSelectors {
   FeeToBePaidLabel = 'fee-to-be-paid-label',
   LowFeeEstimateItem = 'low-fee',
   MiddleFeeEstimateItem = 'standard-fee',
-  FeeCard = 'fee-card',
-  FeeCardFeeValue = 'fee-card-fee-value',
+  FeesListItem = 'fee-list-item',
+  FeesListItemFeeValue = 'fee-list-item-fee-value',
 }

--- a/tests/specs/send/send-btc.spec.ts
+++ b/tests/specs/send/send-btc.spec.ts
@@ -23,7 +23,7 @@ test.describe('send btc', () => {
       await sendPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS);
 
       await sendPage.previewSendTxButton.click();
-      await sendPage.feesCard.filter({ hasText: BtcFeeType.High }).click();
+      await sendPage.feesListItem.filter({ hasText: BtcFeeType.High }).click();
 
       const details = await sendPage.confirmationDetails.allInnerTexts();
       test.expect(details).toBeTruthy();
@@ -39,7 +39,7 @@ test.describe('send btc', () => {
       await sendPage.page.waitForTimeout(1000);
 
       await sendPage.previewSendTxButton.click();
-      await sendPage.feesCard.filter({ hasText: BtcFeeType.High }).click();
+      await sendPage.feesListItem.filter({ hasText: BtcFeeType.High }).click();
 
       const displayerAddress = await getDisplayerAddress(sendPage.confirmationDetailsRecipient);
       test.expect(displayerAddress).toEqual(TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS);
@@ -57,19 +57,19 @@ test.describe('send btc', () => {
       await sendPage.previewSendTxButton.click();
 
       const feeType = BtcFeeType.Standard;
-      const fee = await sendPage.feesCard
+      const fee = await sendPage.feesListItem
         .filter({ hasText: feeType })
-        .getByTestId(SharedComponentsSelectors.FeeCardFeeValue)
+        .getByTestId(SharedComponentsSelectors.FeesListItemFeeValue)
         .innerText();
 
-      await sendPage.feesCard.filter({ hasText: feeType }).click();
+      await sendPage.feesListItem.filter({ hasText: feeType }).click();
 
       const confirmationFee = await sendPage.confirmationDetails
         .getByTestId(SendCryptoAssetSelectors.ConfirmationDetailsFee)
         .getByTestId(SharedComponentsSelectors.InfoCardRowValue)
         .innerText();
 
-      test.expect(confirmationFee).toEqual(fee);
+      test.expect(fee).toContain(confirmationFee);
     });
   });
 });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5145236614).<!-- Sticky Header Marker -->

This PR refactors how we handle sending all utxos when a user clicks on the `Send max` button. Currently, not all utxos are sent with dust amounts left. Here, the code has been refactored so the SendMaxButton behaves as a toggle to switch on/off `isSendingMax`. When a user now clicks on `Send max` all utxos are used and the amount field becomes disabled until the user clicks on the button again to reenable it. Moving fwd in the flow, if a user isSendingMax, the fee is subtracted from the available total to send, whereas when a user manually enters an amount the fee will be added onto that send amount. A tooltip has also been added to aid the user with more info regarding this calculation process.

@kyranjamie can you test this build to make sure I have the flow correct?

![Screen Shot 2023-05-30 at 4 18 10 PM](https://github.com/hirosystems/wallet/assets/6493321/070137e7-f546-48c8-8b89-1861d7b2e014)

![Screen Shot 2023-05-30 at 12 26 55 PM](https://github.com/hirosystems/wallet/assets/6493321/8b2403a1-bdf9-4df1-9618-4bd8f01709f3)

In addition,, the fees list item has been refactored here to include `sats/Vb`...

![Screen Shot 2023-05-30 at 12 48 22 PM](https://github.com/hirosystems/wallet/assets/6493321/2ab172dc-3ea6-40f4-bc2f-7c6d6854f4e1)

Also, added this change temporarily but will be further resolved in new work to add custom fees: https://github.com/hirosystems/wallet/issues/3760

![Screen Shot 2023-05-30 at 3 28 54 PM](https://github.com/hirosystems/wallet/assets/6493321/a80be361-12ca-451a-a140-1c1b54f89e4d)
