### PR TITLE
fix: insufficient fee validation

### DIFF
--- a/src/app/components/bitcoin-fees-list/bitcoin-fees-list.tsx
+++ b/src/app/components/bitcoin-fees-list/bitcoin-fees-list.tsx
@@ -52,15 +52,20 @@ export function BitcoinFeesList({
       const feeAsMoney = createMoney(feeValue, 'BTC');
 
       if (amount.symbol !== 'BTC') {
-        if (feeAsMoney.amount.isGreaterThan(balance.amount)) setShowInsufficientBalanceError(true);
-        return;
+        if (feeAsMoney.amount.isGreaterThan(balance.amount)) {
+          setShowInsufficientBalanceError(true);
+          return;
+        }
       }
 
-      const totalSpend = sumMoney([amount, feeAsMoney]);
+      // check amount + fee only for BTC
+      if (amount.symbol === 'BTC') {
+        const totalSpend = sumMoney([amount, feeAsMoney]);
 
-      if (totalSpend.amount.isGreaterThan(balance.amount)) {
-        setShowInsufficientBalanceError(true);
-        return;
+        if (totalSpend.amount.isGreaterThan(balance.amount)) {
+          setShowInsufficientBalanceError(true);
+          return;
+        }
       }
 
       await onChooseFee({ feeRate, feeValue, time });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5141661556).<!-- Sticky Header Marker -->

Insufficient fee validation prevented from choosing fee in 2 places. See code logic