### PR TITLE
fix: request signatures should work with unsecured tokens

### DIFF
--- a/src/app/common/signature/requests.ts
+++ b/src/app/common/signature/requests.ts
@@ -72,6 +72,10 @@ export async function verifySignatureRequest({
   const token = decodeToken(requestToken);
   const signature = token.payload as unknown as CommonSignaturePayload;
   const { publicKey, stxAddress } = signature;
+  if (!publicKey) {
+    return signature;
+  }
+
   const verifier = new TokenVerifier('ES256k', publicKey);
   const isSigned = await verifier.verifyAsync(requestToken);
   if (!isSigned) {

--- a/src/app/common/signature/requests.ts
+++ b/src/app/common/signature/requests.ts
@@ -72,10 +72,6 @@ export async function verifySignatureRequest({
   const token = decodeToken(requestToken);
   const signature = token.payload as unknown as CommonSignaturePayload;
   const { publicKey, stxAddress } = signature;
-  if (!publicKey) {
-    return signature;
-  }
-
   const verifier = new TokenVerifier('ES256k', publicKey);
   const isSigned = await verifier.verifyAsync(requestToken);
   if (!isSigned) {

--- a/src/app/common/signature/requests.ts
+++ b/src/app/common/signature/requests.ts
@@ -1,13 +1,9 @@
 import { CommonSignaturePayload, SignaturePayload } from '@stacks/connect';
-import { getPublicKeyFromPrivate } from '@stacks/encryption';
 import { deserializeCV } from '@stacks/transactions';
-import { getAppPrivateKey } from '@stacks/wallet-sdk';
-import { TokenInterface, TokenVerifier, decodeToken } from 'jsontokens';
+import { TokenInterface, decodeToken } from 'jsontokens';
 
 import { StructuredMessageDataDomain } from '@shared/signature/signature-types';
 import { isString } from '@shared/utils';
-
-import { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.models';
 
 export function getGenericSignaturePayloadFromToken(requestToken: string): CommonSignaturePayload {
   const token = decodeToken(requestToken);
@@ -33,68 +29,4 @@ export function getStructuredDataPayloadFromToken(requestToken: string) {
     message: deserializeCV(Buffer.from(result.message, 'hex')),
     domain: deserializeCV(Buffer.from(result.domain, 'hex')) as StructuredMessageDataDomain,
   };
-}
-
-const UNAUTHORIZED_SIGNATURE_REQUEST =
-  'The signature request provided is not signed by this wallet.';
-
-/**
- * Verify a signature request.
- * A transaction request is a signed JWT that is created on an app,
- * via `@stacks/connect`. The private key used to sign this JWT is an
- * `appPrivateKey`, which an app can get from authentication.
- *
- * The payload in this JWT can include an `stxAddress`. This indicates the
- * 'default' STX address that should be used to sign this transaction. This allows
- * the wallet to use the same account to sign a transaction as it used to sign
- * in to the app.
- *
- * This JWT is invalidated if:
- * - The JWT is not signed properly
- * - The public key used to sign this tx request does not match an `appPrivateKey`
- * for any of the accounts in this wallet.
- * - The `stxAddress` provided in the payload does not match an STX address
- * for any of the accounts in this wallet.
- *
- * @returns The decoded and validated `SignaturePayload`
- * @throws if the transaction request is invalid
- */
-interface VerifySignatureRequestArgs {
-  requestToken: string;
-  accounts: StacksAccount[];
-  appDomain: string;
-}
-export async function verifySignatureRequest({
-  requestToken,
-  accounts,
-  appDomain,
-}: VerifySignatureRequestArgs): Promise<CommonSignaturePayload> {
-  const token = decodeToken(requestToken);
-  const signature = token.payload as unknown as CommonSignaturePayload;
-  const { publicKey, stxAddress } = signature;
-  const verifier = new TokenVerifier('ES256k', publicKey);
-  const isSigned = await verifier.verifyAsync(requestToken);
-  if (!isSigned) {
-    throw new Error('Signature request is not signed');
-  }
-  const foundAccount = accounts.find(account => {
-    if (account.type === 'ledger') {
-      throw new Error('Invalid account type');
-    }
-    const appPrivateKey = getAppPrivateKey({
-      account,
-      appDomain,
-    });
-    const appPublicKey = getPublicKeyFromPrivate(appPrivateKey);
-    if (appPublicKey !== publicKey) return false;
-    if (!stxAddress) return true;
-
-    if (stxAddress !== account.address) return false;
-    return true;
-  });
-
-  if (!foundAccount) {
-    throw new Error(UNAUTHORIZED_SIGNATURE_REQUEST);
-  }
-  return signature;
 }

--- a/src/app/pages/stacks-message-signing-request/stacks-message-signing-request.tsx
+++ b/src/app/pages/stacks-message-signing-request/stacks-message-signing-request.tsx
@@ -7,14 +7,10 @@ import {
 } from '@shared/signature/signature-types';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
-import { WarningLabel } from '@app/components/warning-label';
 import { PopupHeader } from '@app/features/current-account/popup-header';
 import { MessageSigningHeader } from '@app/features/message-signer/message-signing-header';
 import { useOnOriginTabClose } from '@app/routes/hooks/use-on-tab-closed';
-import {
-  useIsSignatureRequestValid,
-  useSignatureRequestSearchParams,
-} from '@app/store/signatures/requests.hooks';
+import { useSignatureRequestSearchParams } from '@app/store/signatures/requests.hooks';
 
 import { MessageSigningRequestLayout } from '../../features/message-signer/message-signing-request.layout';
 import { StacksSignatureRequestMessageContent } from './components/stacks-signature-message-content';
@@ -24,7 +20,6 @@ export function StacksMessageSigningRequest() {
   useRouteHeader(<PopupHeader />);
   useOnOriginTabClose(() => window.close());
 
-  const validSignatureRequest = useIsSignatureRequestValid();
   const { requestToken, messageType, tabId, origin } = useSignatureRequestSearchParams();
 
   if (!requestToken || !tabId) return null;
@@ -35,12 +30,6 @@ export function StacksMessageSigningRequest() {
     <MessageSigningRequestLayout>
       <MessageSigningHeader name={origin} origin={origin} />
 
-      {!validSignatureRequest && (
-        <WarningLabel>
-          Signing messages can have unintended consequences. Only sign messages from trusted
-          sources.
-        </WarningLabel>
-      )}
       {isUtf8MessageType(messageType) && (
         <StacksSignatureRequestMessageContent requestToken={requestToken} />
       )}

--- a/src/app/pages/stacks-message-signing-request/stacks-message-signing.utils.ts
+++ b/src/app/pages/stacks-message-signing-request/stacks-message-signing.utils.ts
@@ -13,10 +13,7 @@ import { useWalletType } from '@app/common/use-wallet-type';
 import { createDelay } from '@app/common/utils';
 import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
-import {
-  useIsSignatureRequestValid,
-  useSignatureRequestSearchParams,
-} from '@app/store/signatures/requests.hooks';
+import { useSignatureRequestSearchParams } from '@app/store/signatures/requests.hooks';
 
 const improveUxWithShortDelayAsSigningIsSoFast = createDelay(1000);
 
@@ -42,14 +39,10 @@ export function useStacksMessageSigner() {
   const analytics = useAnalytics();
   const signSoftwareWalletMessage = useMessageSignerStacksSoftwareWallet();
 
-  const validSignatureRequest = useIsSignatureRequestValid();
   const { whenWallet } = useWalletType();
   const ledgerNavigate = useLedgerNavigate();
 
   const [isLoading, setIsLoading] = useState(false);
-
-  if (isDefined(validSignatureRequest) && !validSignatureRequest)
-    throw new Error('Invalid request');
 
   const { requestToken, tabId } = useSignatureRequestSearchParams();
   if (!tabId) throw new Error('Requests can only be made with corresponding tab');

--- a/src/app/store/signatures/requests.hooks.ts
+++ b/src/app/store/signatures/requests.hooks.ts
@@ -6,10 +6,7 @@ import { isString } from '@shared/utils';
 
 import { useDefaultRequestParams } from '@app/common/hooks/use-default-request-search-params';
 import { initialSearchParams } from '@app/common/initial-search-params';
-import {
-  getGenericSignaturePayloadFromToken,
-  verifySignatureRequest,
-} from '@app/common/signature/requests';
+import { getGenericSignaturePayloadFromToken } from '@app/common/signature/requests';
 import { useStacksAccounts } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 export function useSignatureRequestSearchParams() {
@@ -47,24 +44,4 @@ export function useSignatureRequestAccountIndex() {
     return accounts.findIndex(account => account.address === stxAddress); // selected account
   }
   return undefined;
-}
-
-export function useIsSignatureRequestValid() {
-  const accounts = useStacksAccounts();
-  const { origin, requestToken } = useSignatureRequestSearchParams();
-
-  return useAsync(async () => {
-    if (typeof accounts === 'undefined') return;
-    if (!origin || !accounts || !requestToken) return;
-    try {
-      const valid = await verifySignatureRequest({
-        requestToken,
-        accounts,
-        appDomain: origin,
-      });
-      return !!valid;
-    } catch (e) {
-      return false;
-    }
-  }, [accounts, requestToken, origin]).result;
 }


### PR DESCRIPTION
Simple fix for https://github.com/hirosystems/wallet/issues/3702, what do you think about allowing users to create unsecured message signing requests? @kyranjamie 