### PR TITLE
refactor: improve fee estimation

### DIFF
--- a/src/app/common/math/calculate-averages.ts
+++ b/src/app/common/math/calculate-averages.ts
@@ -1,7 +1,10 @@
 import BigNumber from 'bignumber.js';
 
-export function calculateMeanAverage(numbers: BigNumber[]) {
+import { initBigNumber } from './helpers';
+
+export function calculateMeanAverage(numbers: BigNumber[] | number[]) {
   return numbers
+    .map(initBigNumber)
     .reduce((acc, price) => acc.plus(price), new BigNumber(0))
     .dividedBy(numbers.length);
 }

--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -311,3 +311,11 @@ export const parseIfValidPunycode = (s: string) => {
 export function capitalize(val: string) {
   return val.charAt(0).toUpperCase() + val.slice(1);
 }
+
+export function isFulfilled<T>(p: PromiseSettledResult<T>): p is PromiseFulfilledResult<T> {
+  return p.status === 'fulfilled';
+}
+
+export function isRejected<T>(p: PromiseSettledResult<T>): p is PromiseRejectedResult {
+  return p.status === 'rejected';
+}

--- a/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list.ts
+++ b/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list.ts
@@ -38,7 +38,7 @@ export function useBitcoinFeesList({ amount, isSendingMax, recipient }: UseBitco
   const { data: utxos } = useSpendableNativeSegwitUtxos(currentAccountBtcAddress);
 
   const btcMarketData = useCryptoCurrencyMarketData('BTC');
-  const { avgApiFeeRates: feeRates, isLoading } = useAverageBitcoinFeeRates();
+  const { data: feeRates, isLoading } = useAverageBitcoinFeeRates();
 
   const feesList: FeesListItem[] = useMemo(() => {
     function getFiatFeeValue(fee: number) {

--- a/src/app/features/retrieve-taproot-to-native-segwit/use-generate-retrieve-taproot-funds-tx.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/use-generate-retrieve-taproot-funds-tx.tsx
@@ -16,7 +16,7 @@ export function useGenerateRetrieveTaprootFundsTx() {
   const networkMode = useBitcoinScureLibNetworkConfig();
   const uninscribedUtxos = useCurrentTaprootAccountUninscribedUtxos();
   const createSigner = useCurrentAccountTaprootSigner();
-  const { avgApiFeeRates: feeRates } = useAverageBitcoinFeeRates();
+  const { data: feeRates } = useAverageBitcoinFeeRates();
 
   const fee = useMemo(() => {
     if (!feeRates) return createMoney(0, 'BTC');

--- a/src/app/pages/send/ordinal-inscription/components/send-inscription-loader.tsx
+++ b/src/app/pages/send/ordinal-inscription/components/send-inscription-loader.tsx
@@ -13,7 +13,7 @@ interface SendInscriptionLoaderProps {
 }
 export function SendInscriptionLoader({ children }: SendInscriptionLoaderProps) {
   const { inscription } = useSendInscriptionRouteState();
-  const { avgApiFeeRates: feeRates } = useAverageBitcoinFeeRates();
+  const { data: feeRates } = useAverageBitcoinFeeRates();
 
   if (!feeRates) return null;
 

--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-fees-list.ts
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-fees-list.ts
@@ -23,7 +23,7 @@ export function useSendInscriptionFeesList({ recipient, utxo }: UseSendInscripti
   const { data: nativeSegwitUtxos } = useCurrentNativeSegwitUtxos();
 
   const btcMarketData = useCryptoCurrencyMarketData('BTC');
-  const { avgApiFeeRates: feeRates, isLoading } = useAverageBitcoinFeeRates();
+  const { data: feeRates, isLoading } = useAverageBitcoinFeeRates();
 
   const feesList: FeesListItem[] = useMemo(() => {
     function getFiatFeeValue(fee: number) {

--- a/src/app/pages/send/send-crypto-asset-form/components/send-crypto-asset-form.layout.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/send-crypto-asset-form.layout.tsx
@@ -11,7 +11,7 @@ export function SendCryptoAssetFormLayout({ children }: SendCryptoAssetFormLayou
       data-testid={SendCryptoAssetSelectors.SendForm}
       flexDirection="column"
       maxHeight={['calc(100vh - 116px)', 'calc(85vh - 116px)']}
-      overflowY="scroll"
+      overflowY="auto"
       pb={['120px', '48px']}
       pt={['base', '48px']}
       px="loose"

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
@@ -16,7 +16,7 @@ export function useCalculateMaxBitcoinSpend() {
   const currentAccountBtcAddress = useCurrentAccountNativeSegwitAddressIndexZero();
   const balance = useCurrentNativeSegwitAddressBalance();
   const { data: utxos } = useSpendableNativeSegwitUtxos(currentAccountBtcAddress);
-  const { avgApiFeeRates: feeRates } = useAverageBitcoinFeeRates();
+  const { data: feeRates } = useAverageBitcoinFeeRates();
 
   return useCallback(
     (address = '', feeRate?: number) => {

--- a/src/app/query/bitcoin/fees/fee-estimates.query.ts
+++ b/src/app/query/bitcoin/fees/fee-estimates.query.ts
@@ -6,12 +6,11 @@ import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
 import { BitcoinClient } from '../bitcoin-client';
 
 function fetchAllBitcoinFeeEstimates(client: BitcoinClient) {
-  return async () => {
-    return Promise.allSettled([
+  return async () =>
+    Promise.allSettled([
       client.feeEstimatesApi.getFeeEstimatesFromMempoolSpaceApi(),
-      client.feeEstimatesApi.getFeeEstimatesFromEarnApi(),
+      client.feeEstimatesApi.getFeeEstimatesFromBlockcypherApi(),
     ]);
-  };
 }
 
 type FetchAllBitcoinFeeEstimatesResp = Awaited<
@@ -23,7 +22,7 @@ export function useGetAllBitcoinFeeEstimatesQuery<
 >(options?: AppUseQueryConfig<FetchAllBitcoinFeeEstimatesResp, T>) {
   const client = useBitcoinClient();
   return useQuery({
-    queryKey: ['all-bitcoin-fee-estimates'],
+    queryKey: ['average-bitcoin-fee-estimates'],
     queryFn: fetchAllBitcoinFeeEstimates(client),
     staleTime: 1000 * 60,
     refetchOnWindowFocus: false,

--- a/src/app/query/bitcoin/ordinals/brc20/use-brc-20.ts
+++ b/src/app/query/bitcoin/ordinals/brc20/use-brc-20.ts
@@ -35,7 +35,7 @@ export function useBrc20Transfers() {
   const currentAccountIndex = useCurrentAccountIndex();
   const ordinalsbotClient = useOrdinalsbotClient();
   const { address } = useCurrentAccountTaprootAddressIndexZeroPayment();
-  const bitcoinFees = useAverageBitcoinFeeRates();
+  const { data: fees } = useAverageBitcoinFeeRates();
 
   return {
     async initiateTransfer(tick: string, amount: string) {
@@ -47,7 +47,7 @@ export function useBrc20Transfers() {
         file: payload,
         size,
         name: `${tick}-${amount}.txt`,
-        fee: bitcoinFees.avgApiFeeRates?.halfHourFee.toNumber() ?? 10,
+        fee: fees?.halfHourFee.toNumber() ?? 10,
       });
 
       if (order.data.status !== 'ok') throw new Error('Failed to initiate transfer');


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5188613458).<!-- Sticky Header Marker -->

Earn.com's fees were especially high, and users have been complaining. This PR removes earn.com's API for [Blockcypher's](https://api.blockcypher.com/v1/btc/main), which returns seemingly more accurate (lower) fees.

| | Before | After |
|--------|--------|--------|
| Slow | 54 | 26 |
| Medium | 63 | 31 |
| Fast | 102 | 46 |

I've also added fallback fees in case both endpoints fail. If this happens, we use low fees, (5, 10, and 15 sats), and fire an analytics event so we can see if this often happens.