### PR TITLE
fix: reduce send form click area

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -137,6 +137,13 @@ export function AmountField({
             fontWeight={500}
             autoComplete={autoComplete}
             {...field}
+            // Custom `onBlur` logic. If value is empty, let's not validate to
+            // avoid unwanted blur interactions such as when interacting with
+            // send max button
+            onBlur={e => {
+              if (!field.value || field.value === '0') return;
+              return field.onBlur(e);
+            }}
           />
           <Text fontSize={fontSize + 'px'} pl="tight">
             {symbol.toUpperCase()}

--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -105,12 +105,11 @@ export function AmountField({
   return (
     <Stack
       alignItems="center"
-      onClick={onClickFocusInput}
       px="extra-loose"
       spacing={['base', meta.error && meta.touched ? 'base' : '48px']}
       width="100%"
     >
-      <Flex alignItems="center" flexDirection="column">
+      <Flex alignItems="center" flexDirection="column" onClick={onClickFocusInput}>
         <Flex
           alignItems="center"
           height="55px"

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-send-max-button.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-send-max-button.tsx
@@ -51,10 +51,7 @@ export function BitcoinSendMaxButton({
         data-testid={SendCryptoAssetSelectors.SendMaxBtn}
         fontSize={0}
         height="32px"
-        onClick={e => {
-          e.stopPropagation();
-          onSendMax();
-        }}
+        onClick={() => onSendMax()}
         mode="tertiary"
         px="base-tight"
         type="button"

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-send-max-button.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-send-max-button.tsx
@@ -51,7 +51,10 @@ export function BitcoinSendMaxButton({
         data-testid={SendCryptoAssetSelectors.SendMaxBtn}
         fontSize={0}
         height="32px"
-        onClick={onSendMax}
+        onClick={e => {
+          e.stopPropagation();
+          onSendMax();
+        }}
         mode="tertiary"
         px="base-tight"
         type="button"

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-send-max.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-send-max.tsx
@@ -28,11 +28,15 @@ export function useSendMax({
 
   return useCallback(() => {
     void analytics.track('select_maximum_amount_for_send');
-    if (balance.amount.isLessThanOrEqualTo(0)) return toast.error(`Zero balance`);
+    if (balance.amount.isLessThanOrEqualTo(0)) {
+      toast.error(`Zero balance`);
+      return;
+    }
     onSetIsSendingMax(!isSendingMax);
-    amountFieldHelpers.setError('');
     feeFieldHelpers.setValue(sendMaxFee);
-    return amountFieldHelpers.setValue(sendMaxBalance);
+    amountFieldHelpers.setValue(sendMaxBalance, false);
+    amountFieldHelpers.setTouched(false, false);
+    amountFieldHelpers.setError(undefined);
   }, [
     amountFieldHelpers,
     analytics,

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -47,8 +47,9 @@ export function useBtcSendForm() {
     formRef,
     isSendingMax,
     onFormStateChange,
-    onSetIsSendingMax: (value: boolean) => setIsSendingMax(value),
-
+    onSetIsSendingMax(value: boolean) {
+      setIsSendingMax(value);
+    },
     validationSchema: yup.object({
       amount: yup
         .number()

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -52,6 +52,7 @@ export function useBtcSendForm() {
     validationSchema: yup.object({
       amount: yup
         .number()
+        .concat(btcMinimumSpendValidator())
         .concat(
           btcAmountPrecisionValidator(formatPrecisionError(btcCryptoCurrencyAssetBalance.balance))
         )
@@ -63,8 +64,7 @@ export function useBtcSendForm() {
             recipient: formRef.current?.values.recipient ?? '',
             calcMaxSpend,
           })
-        )
-        .concat(btcMinimumSpendValidator()),
+        ),
       recipient: yup
         .string()
         .concat(btcAddressValidator())


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5199661255).<!-- Sticky Header Marker -->

This pr reduce send form "click to focus" area, also changes validators order in btc send form

