### PR TITLE
fix: early return if stamps query returns undefined

### DIFF
--- a/src/app/features/collectibles/components/bitcoin/stamps.tsx
+++ b/src/app/features/collectibles/components/bitcoin/stamps.tsx
@@ -8,11 +8,11 @@ import { Stamp } from './stamp';
 
 export function Stamps() {
   const currentAccountBtcAddress = useCurrentAccountNativeSegwitAddressIndexZero();
-  const { data: stamps } = useStampsByAddressQuery(currentAccountBtcAddress);
+  const { data: stamps = [] } = useStampsByAddressQuery(currentAccountBtcAddress);
   const analytics = useAnalytics();
 
   useEffect(() => {
-    if (!stamps) return;
+    if (!stamps.length) return;
     if (stamps.length > 0) {
       void analytics.track('view_collectibles', {
         stamps_count: stamps.length,
@@ -21,7 +21,7 @@ export function Stamps() {
     }
   }, [analytics, stamps]);
 
-  if (!stamps) return null;
+  if (!stamps.length) return null;
 
   return (
     <>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5259743427).<!-- Sticky Header Marker -->

Fixes bug in prod with Stamps query.

Users report seeing...
<img width="953" alt="Screen Shot 2023-06-13 at 2 05 34 PM" src="https://github.com/hirosystems/wallet/assets/6493321/b59a3d64-e889-429e-a17d-995fa26fcc55">
