### PR TITLE
refactor: add derivation path to `getAddresses` resp

### DIFF
--- a/src/app/components/brc20-tokens-loader.tsx
+++ b/src/app/components/brc20-tokens-loader.tsx
@@ -2,13 +2,13 @@ import {
   Brc20Token,
   useBrc20TokensByAddressQuery,
 } from '@app/query/bitcoin/ordinals/brc20/brc20-tokens.query';
-import { useCurrentAccountTaprootAddressIndexZeroPayment } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
+import { useCurrentAccountTaprootIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 
 interface Brc20TokensLoaderProps {
   children(brc20Tokens: Brc20Token[]): JSX.Element;
 }
 export function Brc20TokensLoader({ children }: Brc20TokensLoaderProps) {
-  const { address: bitcoinAddressTaproot } = useCurrentAccountTaprootAddressIndexZeroPayment();
+  const { address: bitcoinAddressTaproot } = useCurrentAccountTaprootIndexZeroSigner();
   const { data: brc20Tokens } = useBrc20TokensByAddressQuery(bitcoinAddressTaproot);
   if (!bitcoinAddressTaproot || !brc20Tokens) return null;
   return children(brc20Tokens);

--- a/src/app/features/psbt-signer/components/psbt-decoded-request/psbt-decoded-request.tsx
+++ b/src/app/features/psbt-signer/components/psbt-decoded-request/psbt-decoded-request.tsx
@@ -2,7 +2,7 @@ import * as btc from '@scure/btc-signer';
 import { Stack, color } from '@stacks/ui';
 
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
-import { useCurrentAccountTaprootAddressIndexZeroPayment } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
+import { useCurrentAccountTaprootIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 
 import { usePsbtDecodedRequest } from '../../hooks/use-psbt-decoded-request';
 import { DecodedPsbt } from '../../hooks/use-psbt-signer';
@@ -15,7 +15,7 @@ interface PsbtDecodedRequestProps {
 }
 export function PsbtDecodedRequest({ psbt }: PsbtDecodedRequestProps) {
   const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
-  const { address: bitcoinAddressTaproot } = useCurrentAccountTaprootAddressIndexZeroPayment();
+  const { address: bitcoinAddressTaproot } = useCurrentAccountTaprootIndexZeroSigner();
   const unsignedInputs: btc.TransactionInputRequired[] = psbt.global.unsignedTx?.inputs ?? [];
   const unsignedOutputs: btc.TransactionOutputRequired[] = psbt.global.unsignedTx?.outputs ?? [];
 

--- a/src/app/pages/rpc-get-addresses/use-request-accounts.ts
+++ b/src/app/pages/rpc-get-addresses/use-request-accounts.ts
@@ -10,7 +10,7 @@ import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useDefaultRequestParams } from '@app/common/hooks/use-default-request-search-params';
 import { initialSearchParams } from '@app/common/initial-search-params';
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
-import { useCurrentAccountTaprootAddressIndexZeroPayment } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
+import { useCurrentAccountTaprootIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useAppPermissions } from '@app/store/app-permissions/app-permissions.slice';
 
@@ -32,14 +32,15 @@ export function useGetAddresses() {
   const { tabId, origin, requestId } = useRpcRequestParams();
 
   const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
-  const taprootPayment = useCurrentAccountTaprootAddressIndexZeroPayment();
+  const taprootSigner = useCurrentAccountTaprootIndexZeroSigner();
   const stacksAccount = useCurrentStacksAccount();
 
   const taprootAddressResponse: BtcAddress = {
     symbol: 'BTC',
     type: 'p2tr',
-    address: taprootPayment.address,
-    publicKey: bytesToHex(taprootPayment.publicKey),
+    address: taprootSigner.address,
+    publicKey: bytesToHex(taprootSigner.publicKey),
+    derivationPath: taprootSigner.derivationPath,
   };
 
   const nativeSegwitAddressResponse: BtcAddress = {
@@ -47,6 +48,7 @@ export function useGetAddresses() {
     type: 'p2wpkh',
     address: nativeSegwitSigner.address,
     publicKey: bytesToHex(nativeSegwitSigner.publicKey),
+    derivationPath: nativeSegwitSigner.derivationPath,
   };
 
   const stacksAddressResponse = {

--- a/src/app/query/bitcoin/ordinals/brc20/use-brc-20.ts
+++ b/src/app/query/bitcoin/ordinals/brc20/use-brc-20.ts
@@ -1,7 +1,7 @@
 import { useConfigOrdinalsbot } from '@app/query/common/remote-config/remote-config.query';
 import { useAppDispatch } from '@app/store';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
-import { useCurrentAccountTaprootAddressIndexZeroPayment } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
+import { useCurrentAccountTaprootIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import { brc20TransferInitiated } from '@app/store/ordinals/ordinals.slice';
 
@@ -34,7 +34,7 @@ export function useBrc20Transfers() {
   const dispatch = useAppDispatch();
   const currentAccountIndex = useCurrentAccountIndex();
   const ordinalsbotClient = useOrdinalsbotClient();
-  const { address } = useCurrentAccountTaprootAddressIndexZeroPayment();
+  const { address } = useCurrentAccountTaprootIndexZeroSigner();
   const { data: fees } = useAverageBitcoinFeeRates();
 
   return {

--- a/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { bitcoinNetworkModeToCoreNetworkMode } from '@shared/crypto/bitcoin/bitcoin.utils';
@@ -16,18 +17,21 @@ import {
 
 function useNativeSegwitActiveNetworkAccountPrivateKeychain() {
   const network = useCurrentNetwork();
-  return useSelector(
-    whenNetwork(bitcoinNetworkModeToCoreNetworkMode(network.chain.bitcoin.network))({
-      mainnet: selectMainnetNativeSegWitKeychain,
-      testnet: selectTestnetNativeSegWitKeychain,
-    })
+  const selector = useMemo(
+    () =>
+      whenNetwork(bitcoinNetworkModeToCoreNetworkMode(network.chain.bitcoin.network))({
+        mainnet: selectMainnetNativeSegWitKeychain,
+        testnet: selectTestnetNativeSegWitKeychain,
+      }),
+    [network.chain.bitcoin.network]
   );
+  return useSelector(selector);
 }
 
 export function useNativeSegwitCurrentAccountPrivateKeychain() {
   const keychain = useNativeSegwitActiveNetworkAccountPrivateKeychain();
   const currentAccountIndex = useCurrentAccountIndex();
-  return keychain?.(currentAccountIndex);
+  return useMemo(() => keychain?.(currentAccountIndex), [currentAccountIndex, keychain]);
 }
 
 export function useNativeSegwitNetworkSigners() {
@@ -44,13 +48,16 @@ export function useNativeSegwitNetworkSigners() {
 function useNativeSegwitSigner(accountIndex: number) {
   const network = useCurrentNetwork();
   const accountKeychain = useNativeSegwitActiveNetworkAccountPrivateKeychain()?.(accountIndex);
-  if (!accountKeychain) return;
 
-  return bitcoinSignerFactory({
-    accountKeychain,
-    paymentFn: getNativeSegWitPaymentFromAddressIndex,
-    network: network.chain.bitcoin.network,
-  });
+  return useMemo(() => {
+    if (!accountKeychain) return;
+    return bitcoinSignerFactory({
+      accountIndex,
+      accountKeychain,
+      paymentFn: getNativeSegWitPaymentFromAddressIndex,
+      network: network.chain.bitcoin.network,
+    });
+  }, [accountIndex, accountKeychain, network.chain.bitcoin.network]);
 }
 
 export function useCurrentAccountNativeSegwitSigner() {
@@ -60,8 +67,10 @@ export function useCurrentAccountNativeSegwitSigner() {
 
 export function useCurrentAccountNativeSegwitIndexZeroSigner() {
   const signer = useCurrentAccountNativeSegwitSigner();
-  if (!signer) throw new Error('No signer');
-  return signer(0);
+  return useMemo(() => {
+    if (!signer) throw new Error('No signer');
+    return signer(0);
+  }, [signer]);
 }
 
 /**
@@ -69,7 +78,7 @@ export function useCurrentAccountNativeSegwitIndexZeroSigner() {
  */
 export function useCurrentAccountNativeSegwitAddressIndexZero() {
   const signer = useCurrentAccountNativeSegwitSigner();
-  return signer?.(0).payment.address as string;
+  return useMemo(() => signer?.(0).payment.address, [signer]) as string;
 }
 
 /**
@@ -78,12 +87,4 @@ export function useCurrentAccountNativeSegwitAddressIndexZero() {
 export function useNativeSegwitAccountIndexAddressIndexZero(accountIndex: number) {
   const signer = useNativeSegwitSigner(accountIndex)?.(0);
   return signer?.payment.address as string;
-}
-
-/**
- * @deprecated Use signer.publicKeychain directly instead
- */
-export function useCurrentBitcoinNativeSegwitAddressIndexPublicKeychain() {
-  const signer = useCurrentAccountNativeSegwitSigner();
-  return signer?.(0).publicKeychain;
 }

--- a/src/shared/crypto/bitcoin/p2tr-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2tr-address-gen.ts
@@ -11,6 +11,14 @@ function getTaprootAccountDerivationPath(network: BitcoinNetworkModes, accountIn
   return `m/86'/${getBitcoinCoinTypeIndexByNetwork(network)}'/${accountIndex}'`;
 }
 
+export function getTaprootAddressIndexDerivationPath(
+  network: BitcoinNetworkModes,
+  accountIndex: number,
+  addressIndex: number
+) {
+  return getTaprootAccountDerivationPath(network, accountIndex) + `/0/${addressIndex}`;
+}
+
 export function deriveTaprootAccountFromRootKeychain(
   keychain: HDKey,
   network: BitcoinNetworkModes

--- a/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
+++ b/src/shared/crypto/bitcoin/p2wpkh-address-gen.ts
@@ -10,13 +10,21 @@ import {
   getBitcoinCoinTypeIndexByNetwork,
 } from './bitcoin.utils';
 
-function getNativeSegWitAccountDerivationPath(network: BitcoinNetworkModes, accountIndex: number) {
+function getNativeSegwitAccountDerivationPath(network: BitcoinNetworkModes, accountIndex: number) {
   return `m/84'/${getBitcoinCoinTypeIndexByNetwork(network)}'/${accountIndex}'`;
+}
+
+export function getNativeSegwitAddressIndexDerivationPath(
+  network: BitcoinNetworkModes,
+  accountIndex: number,
+  addressIndex: number
+) {
+  return getNativeSegwitAccountDerivationPath(network, accountIndex) + `/0/${addressIndex}`;
 }
 
 export function deriveNativeSegWitAccountKeychain(keychain: HDKey, network: NetworkModes) {
   if (keychain.depth !== DerivationPathDepth.Root) throw new Error('Keychain passed is not a root');
-  return (index: number) => keychain.derive(getNativeSegWitAccountDerivationPath(network, index));
+  return (index: number) => keychain.derive(getNativeSegwitAccountDerivationPath(network, index));
 }
 
 export function getNativeSegWitPaymentFromAddressIndex(


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5289134894).<!-- Sticky Header Marker -->

Ref #3868

The fact that apps can only interact with the wallet on it's current account, if the user doesn't change account post auth, is a critical flaw that renders the feature nigh useless.

There are two parts to solving the problem of not being able to interact correctly with multi-account wallets. First is to let apps know what account the user is on. To do this, we return the derivation path for addresses in `getAddresses`, added in this PR. 

Response is now:

```js
{
    "jsonrpc": "2.0",
    "id": "623b1d3c-e023-4834-be04-1f89aab7f453",
    "result": {
        "addresses": [
            {
                "symbol": "BTC",
                "type": "p2wpkh",
                "address": "bc1qa636dvumfwc40hx3pfsnvtznmxnmcmhqh66yy5",
                "publicKey": "0259bd9c7129f6681eef72a748e22bf6094872cae1f448ec47a3f00d13689d684e",
                "derivationPath": "m/84'/0'/1'/0/0"
            },
            {
                "symbol": "BTC",
                "type": "p2tr",
                "address": "bc1pahnf4ju9p82j9ve4agw76rq7lmyrhrttqm8gtcy627qmfysusvyqc4x5dg",
                "publicKey": "0276f9983aecc3c1da76c20a780007261af1d96e37b630a442ec13b7c54d474dc2",
                "derivationPath": "m/86'/0'/1'/0/0"
            },
            {
                "symbol": "STX",
                "address": "SP3Z6FJ9ZQ2Z30CWTXNKWDFEM0DVMVQECWM3GQWFZ"
            }
        ]
    }
}
```

Second, is to allow apps to specify which account they wish to interact with.

cc/ @314159265359879 @fbwoolf 