### PR TITLE
refactor(psbt): support custom account index

### DIFF
--- a/src/app/features/psbt-signer/components/psbt-request-header.tsx
+++ b/src/app/features/psbt-signer/components/psbt-request-header.tsx
@@ -16,8 +16,10 @@ export function PsbtRequestHeader({ origin }: PsbtRequestHeaderProps) {
         Sign transaction
       </Title>
       {caption && (
-        <Flag align="middle" img={<Favicon origin={origin} />} pl="tight">
-          <Caption wordBreak="break-word">{caption}</Caption>
+        <Flag align="top" img={<Favicon origin={origin} />} pl="tight">
+          <Caption wordBreak="break-word" lineHeight={1.3}>
+            {caption}
+          </Caption>
         </Flag>
       )}
     </Flex>

--- a/src/app/features/psbt-signer/components/psbt-request-warning-label.tsx
+++ b/src/app/features/psbt-signer/components/psbt-request-warning-label.tsx
@@ -1,6 +1,6 @@
 import { WarningLabel } from '@app/components/warning-label';
 
-export function PsbtRequestWarningLabel(props: { appName?: string }) {
+export function PsbtRequestAppWarningLabel(props: { appName?: string }) {
   const { appName } = props;
   const title = `Do not proceed unless you trust ${appName ?? 'Unknown'}!`;
 

--- a/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
+++ b/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
@@ -20,8 +20,6 @@ export function usePsbtSigner() {
 
   return useMemo(
     () => ({
-      nativeSegwitSigner,
-      taprootSigner,
       signPsbtAtIndex(allowedSighash: btc.SignatureHash[], idx: number, tx: btc.Transaction) {
         try {
           nativeSegwitSigner?.signIndex(tx, idx, allowedSighash);
@@ -30,6 +28,17 @@ export function usePsbtSigner() {
             taprootSigner?.signIndex(tx, idx, allowedSighash);
           } catch (e2) {
             logger.error('Error signing tx at provided index', e1, e2);
+          }
+        }
+      },
+      signPsbt(tx: btc.Transaction) {
+        try {
+          nativeSegwitSigner?.sign(tx);
+        } catch (e1) {
+          try {
+            taprootSigner?.sign(tx);
+          } catch (e2) {
+            logger.error('Error signing PSBT', e1, e2);
           }
         }
       },

--- a/src/app/features/psbt-signer/psbt-signer.tsx
+++ b/src/app/features/psbt-signer/psbt-signer.tsx
@@ -5,7 +5,7 @@ import { useOnOriginTabClose } from '@app/routes/hooks/use-on-tab-closed';
 import { PsbtDecodedRequest } from './components/psbt-decoded-request/psbt-decoded-request';
 import { PsbtRequestActions } from './components/psbt-request-actions';
 import { PsbtRequestHeader } from './components/psbt-request-header';
-import { PsbtRequestWarningLabel } from './components/psbt-request-warning-label';
+import { PsbtRequestAppWarningLabel } from './components/psbt-request-warning-label';
 import { PsbtRequestLayout } from './components/psbt-request.layout';
 import { DecodedPsbt } from './hooks/use-psbt-signer';
 
@@ -26,7 +26,7 @@ export function PsbtSigner(props: PsbtSignerProps) {
     <>
       <PsbtRequestLayout>
         <PsbtRequestHeader origin={appName} />
-        <PsbtRequestWarningLabel appName={appName} />
+        <PsbtRequestAppWarningLabel appName={appName} />
         <PsbtDecodedRequest psbt={psbt} />
       </PsbtRequestLayout>
       <PsbtRequestActions isLoading={false} onCancel={onCancel} onSignPsbt={onSignPsbt} />

--- a/src/app/pages/psbt-request/use-psbt-request.tsx
+++ b/src/app/pages/psbt-request/use-psbt-request.tsx
@@ -14,13 +14,7 @@ import { usePsbtRequestSearchParams } from '@app/pages/psbt-request/psbt-request
 export function usePsbtRequest() {
   const { requestToken, tabId } = usePsbtRequestSearchParams();
   const [isLoading, setIsLoading] = useState(false);
-  const {
-    signPsbtAtIndex,
-    getDecodedPsbt,
-    nativeSegwitSigner,
-    taprootSigner,
-    getPsbtAsTransaction,
-  } = usePsbtSigner();
+  const { signPsbt, signPsbtAtIndex, getDecodedPsbt, getPsbtAsTransaction } = usePsbtSigner();
   const analytics = useAnalytics();
   return useMemo(() => {
     if (!requestToken) throw new Error('Cannot decode psbt without request token');
@@ -56,15 +50,7 @@ export function usePsbtRequest() {
         if (!isUndefined(indexOrIndexes) && !isUndefined(allowedSighash)) {
           ensureArray(indexOrIndexes).forEach(idx => signPsbtAtIndex(allowedSighash, idx, tx));
         } else {
-          try {
-            nativeSegwitSigner?.sign(tx);
-          } catch (e1) {
-            try {
-              taprootSigner?.sign(tx);
-            } catch (e2) {
-              logger.error('Error signing tx', e1, e2);
-            }
-          }
+          signPsbt(tx);
         }
 
         const psbt = tx.toPSBT();
@@ -85,10 +71,9 @@ export function usePsbtRequest() {
     getDecodedPsbt,
     getPsbtAsTransaction,
     isLoading,
-    nativeSegwitSigner,
     requestToken,
+    signPsbt,
     signPsbtAtIndex,
     tabId,
-    taprootSigner,
   ]);
 }

--- a/src/app/pages/rpc-sign-psbt/rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/rpc-sign-psbt.tsx
@@ -5,7 +5,6 @@ import { RpcErrorCode } from '@btckit/types';
 import { bytesToHex } from '@noble/hashes/utils';
 import * as btc from '@scure/btc-signer';
 
-import { logger } from '@shared/logger';
 import { makeRpcErrorResponse, makeRpcSuccessResponse } from '@shared/rpc/rpc-methods';
 import { isUndefined } from '@shared/utils';
 
@@ -40,13 +39,7 @@ function useRpcSignPsbtParams() {
 
 function useRpcSignPsbt() {
   const { origin, tabId, requestId, psbtHex, allowedSighash, signAtIndex } = useRpcSignPsbtParams();
-  const {
-    signPsbtAtIndex,
-    getDecodedPsbt,
-    nativeSegwitSigner,
-    taprootSigner,
-    getPsbtAsTransaction,
-  } = usePsbtSigner();
+  const { signPsbt, signPsbtAtIndex, getDecodedPsbt, getPsbtAsTransaction } = usePsbtSigner();
 
   const tx = getPsbtAsTransaction(psbtHex);
 
@@ -61,15 +54,7 @@ function useRpcSignPsbt() {
           signPsbtAtIndex(allowedSighash, idx, tx);
         });
       } else {
-        try {
-          nativeSegwitSigner?.sign(tx);
-        } catch (e1) {
-          try {
-            taprootSigner?.sign(tx);
-          } catch (e2) {
-            logger.error('Error signing tx', e1, e2);
-          }
-        }
+        signPsbt(tx);
       }
       const psbt = tx.toPSBT();
 

--- a/src/app/store/keys/key.selectors.ts
+++ b/src/app/store/keys/key.selectors.ts
@@ -2,6 +2,8 @@ import { useSelector } from 'react-redux';
 
 import { createSelector } from '@reduxjs/toolkit';
 
+import { initialSearchParams } from '@app/common/initial-search-params';
+import { initBigNumber } from '@app/common/math/helpers';
 import { RootState } from '@app/store';
 
 import { selectStacksChain } from '../chains/stx-chain.selectors';
@@ -19,6 +21,10 @@ export function useCurrentKeyDetails() {
 }
 
 export const selectCurrentAccountIndex = createSelector(selectStacksChain, state => {
+  const customAccountIndex = initialSearchParams.get('accountIndex');
+  if (customAccountIndex && initBigNumber(customAccountIndex).isInteger()) {
+    return initBigNumber(customAccountIndex).toNumber();
+  }
   return state[defaultKeyId].currentAccountIndex;
 });
 

--- a/src/background/messaging/rpc-methods/sign-psbt.ts
+++ b/src/background/messaging/rpc-methods/sign-psbt.ts
@@ -54,6 +54,10 @@ export async function rpcSignPsbt(message: SignPsbtRequest, port: chrome.runtime
     return;
   }
 
+  if (isDefined(message.params.account)) {
+    params.push(['accountIndex', message.params.account.toString()]);
+  }
+
   if (isDefined(message.params.allowedSighash))
     ensureArray(message.params.allowedSighash).forEach(hash =>
       params.push(['allowedSighash', hash.toString()])

--- a/src/shared/rpc/methods/sign-psbt.ts
+++ b/src/shared/rpc/methods/sign-psbt.ts
@@ -9,6 +9,7 @@ interface SignPsbtRequestParams {
   hex: string;
   signAtIndex?: number | number[];
   network?: NetworkModes;
+  account?: number;
 }
 
 export type SignPsbtRequest = RpcRequest<'signPsbt', SignPsbtRequestParams>;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5310109864).<!-- Sticky Header Marker -->

Fixes #3868

Depends on #3884

This PR allows developers to describe a custom account index they wish to sign a PSBT from. They'll need the user to auth with the latest changes from #3884, in order to know which account to target. Without this, apps can never be certain they are asking the user to sign from the correct account.

Users should likely be warned when apps are trying to perform actions on accounts that are not the current one. For this I've added a hook to determine when this is the case. We should add an additional warning. Haven't put time/effort into copy or UI thinking, for now I've just added some copy when this is the case cc/ @mica000 @markmhx. 

<img width="554" alt="CleanShot 2023-06-16 at 13 23 44@2x" src="https://github.com/hirosystems/wallet/assets/1618764/6567601f-3719-4a92-b120-f64002f2c945">
