### PR TITLE
refactor: mask secret key sign in

### DIFF
--- a/src/app/pages/onboarding/set-password/set-password.tsx
+++ b/src/app/pages/onboarding/set-password/set-password.tsx
@@ -57,7 +57,7 @@ function SetPasswordPage() {
   const { decodedAuthRequest } = useOnboardingState();
   const analytics = useAnalytics();
 
-  useRouteHeader(<Header hideActions onClose={() => navigate(RouteUrls.BackUpSecretKey)} />);
+  useRouteHeader(<Header hideActions onClose={() => navigate(-1)} />);
 
   useEffect(() => {
     void analytics.page('view', '/set-password');

--- a/src/app/pages/onboarding/sign-in/sign-in.tsx
+++ b/src/app/pages/onboarding/sign-in/sign-in.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { FiEye, FiEyeOff } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
 import YourSecretKey from '@assets/images/onboarding/your-secret-key.png';
@@ -15,6 +17,7 @@ import {
   DESKTOP_VIEWPORT_MIN_WIDTH,
 } from '@app/components/global-styles/full-page-styles';
 import { Header } from '@app/components/header';
+import { Link } from '@app/components/link';
 import { PageTitle } from '@app/components/page-title';
 import { PrimaryButton } from '@app/components/primary-button';
 import { Title } from '@app/components/typography';
@@ -23,6 +26,7 @@ import { useSignIn } from '@app/pages/onboarding/sign-in/hooks/use-sign-in';
 export function SignIn() {
   const { onPaste, submitMnemonicForm, error, isLoading, ref } = useSignIn();
   const navigate = useNavigate();
+  const [isKeyMasked, setIsKeyMasked] = useState(true);
 
   const [desktopViewport] = useMediaQuery(`(min-width: ${DESKTOP_VIEWPORT_MIN_WIDTH})`);
 
@@ -72,7 +76,11 @@ export function SignIn() {
                   ref={ref as any}
                   spellCheck={false}
                   style={{ resize: 'none' }}
-                  value={form.values.secretKey}
+                  value={
+                    isKeyMasked
+                      ? form.values.secretKey.replace(/[^ ]/g, '*')
+                      : form.values.secretKey
+                  }
                   width="100%"
                 />
                 {error && (
@@ -89,6 +97,18 @@ export function SignIn() {
                     </Text>
                   </ErrorLabel>
                 )}
+                <Stack alignItems="center">
+                  <Link
+                    fontSize="14px"
+                    _hover={{ textDecoration: 'none' }}
+                    onClick={() => setIsKeyMasked(!isKeyMasked)}
+                  >
+                    <Stack alignItems="center" isInline spacing="tight">
+                      {isKeyMasked ? <FiEye /> : <FiEyeOff />}
+                      <Text>{isKeyMasked ? 'Show' : 'Hide'} Secret Key</Text>
+                    </Stack>
+                  </Link>
+                </Stack>
               </Stack>
               <PrimaryButton
                 data-testid={OnboardingSelectors.SignInBtn}

--- a/src/app/pages/onboarding/sign-in/sign-in.tsx
+++ b/src/app/pages/onboarding/sign-in/sign-in.tsx
@@ -3,7 +3,7 @@ import { FiEye, FiEyeOff } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
 import YourSecretKey from '@assets/images/onboarding/your-secret-key.png';
-import { Box, Input, Stack, Text, color, useMediaQuery } from '@stacks/ui';
+import { Box, Input, Stack, Text, color, useClipboard, useMediaQuery } from '@stacks/ui';
 import { OnboardingSelectors } from '@tests/selectors/onboarding.selectors';
 import { Form, Formik } from 'formik';
 
@@ -36,6 +36,7 @@ export function SignIn() {
     sanitizedSecretKey,
   } = useSignIn();
   const navigate = useNavigate();
+  const { onCopy } = useClipboard(sanitizedSecretKey);
 
   const [desktopViewport] = useMediaQuery(`(min-width: ${DESKTOP_VIEWPORT_MIN_WIDTH})`);
 
@@ -83,6 +84,7 @@ export function SignIn() {
                   }}
                   onKeyDown={e => e.key === 'Enter' && form.submitForm()}
                   onPaste={onPaste}
+                  onCopy={onCopy}
                   placeholder="Paste or type your Secret Key"
                   ref={ref as any}
                   spellCheck={false}

--- a/src/app/pages/onboarding/sign-in/sign-in.tsx
+++ b/src/app/pages/onboarding/sign-in/sign-in.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ChangeEvent } from 'react';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
@@ -24,9 +24,18 @@ import { Title } from '@app/components/typography';
 import { useSignIn } from '@app/pages/onboarding/sign-in/hooks/use-sign-in';
 
 export function SignIn() {
-  const { onPaste, submitMnemonicForm, error, isLoading, ref } = useSignIn();
+  const {
+    onPaste,
+    submitMnemonicForm,
+    error,
+    isLoading,
+    ref,
+    onChange,
+    toggleKeyMask,
+    isKeyMasked,
+    sanitizedSecretKey,
+  } = useSignIn();
   const navigate = useNavigate();
-  const [isKeyMasked, setIsKeyMasked] = useState(true);
 
   const [desktopViewport] = useMediaQuery(`(min-width: ${DESKTOP_VIEWPORT_MIN_WIDTH})`);
 
@@ -36,7 +45,7 @@ export function SignIn() {
     <CenteredPageContainer>
       <Formik
         initialValues={{ secretKey: '' }}
-        onSubmit={values => submitMnemonicForm(values.secretKey)}
+        onSubmit={_values => submitMnemonicForm(sanitizedSecretKey)}
       >
         {form => (
           <Form>
@@ -69,7 +78,9 @@ export function SignIn() {
                   borderRadius="10px"
                   fontSize="16px"
                   minHeight="168px"
-                  onChange={form.handleChange}
+                  onChange={event => {
+                    onChange(event as ChangeEvent<HTMLInputElement>, form.handleChange);
+                  }}
                   onKeyDown={e => e.key === 'Enter' && form.submitForm()}
                   onPaste={onPaste}
                   placeholder="Paste or type your Secret Key"
@@ -77,9 +88,7 @@ export function SignIn() {
                   spellCheck={false}
                   style={{ resize: 'none' }}
                   value={
-                    isKeyMasked
-                      ? form.values.secretKey.replace(/[^ ]/g, '*')
-                      : form.values.secretKey
+                    isKeyMasked ? form.values.secretKey.replace(/[^ ]/g, '*') : sanitizedSecretKey
                   }
                   width="100%"
                 />
@@ -98,11 +107,7 @@ export function SignIn() {
                   </ErrorLabel>
                 )}
                 <Stack alignItems="center">
-                  <Link
-                    fontSize="14px"
-                    _hover={{ textDecoration: 'none' }}
-                    onClick={() => setIsKeyMasked(!isKeyMasked)}
-                  >
+                  <Link fontSize="14px" _hover={{ textDecoration: 'none' }} onClick={toggleKeyMask}>
                     <Stack alignItems="center" isInline spacing="tight">
                       {isKeyMasked ? <FiEye /> : <FiEyeOff />}
                       <Text>{isKeyMasked ? 'Show' : 'Hide'} Secret Key</Text>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5292600310).<!-- Sticky Header Marker -->

Clone of: https://github.com/hirosystems/wallet/pull/3734

Tested and works well now.

Also, noticed/fixed a bug here in routing from the set password page. It was always going back to `BackUpSecretKeyPage` which isn't desired if onboarding with an existing key.