### PR TITLE
fix(psbt): parse param schema, return error

### DIFF
--- a/src/background/messaging/rpc-methods/sign-psbt.ts
+++ b/src/background/messaging/rpc-methods/sign-psbt.ts
@@ -3,7 +3,11 @@ import * as btc from '@scure/btc-signer';
 import { hexToBytes } from '@stacks/common';
 
 import { RouteUrls } from '@shared/route-urls';
-import { SignPsbtRequest } from '@shared/rpc/methods/sign-psbt';
+import {
+  SignPsbtRequest,
+  getRpcSignPsbtParamErrors,
+  validateRpcSignPsbtParams,
+} from '@shared/rpc/methods/sign-psbt';
 import { makeRpcErrorResponse } from '@shared/rpc/rpc-methods';
 import { ensureArray, isDefined } from '@shared/utils';
 
@@ -25,23 +29,22 @@ function validatePsbt(hex: string) {
 }
 
 export async function rpcSignPsbt(message: SignPsbtRequest, port: chrome.runtime.Port) {
-  if (!message.params || !message.params.hex) {
+  if (!validateRpcSignPsbtParams(message.params)) {
+    const errors = getRpcSignPsbtParamErrors(message.params);
     chrome.tabs.sendMessage(
       getTabIdFromPort(port),
       makeRpcErrorResponse('signPsbt', {
         id: message.id,
-        error: { code: RpcErrorCode.INVALID_PARAMS, message: 'Invalid parameters' },
+        error: {
+          code: RpcErrorCode.INVALID_PARAMS,
+          message:
+            'Invalid parameters: ' +
+            errors.map(e => `Error in path ${e.path}, ${e.message}.`).join(' '),
+        },
       })
     );
     return;
   }
-
-  const params: RequestParams = [
-    ['requestId', message.id],
-    ['hex', message.params.hex],
-    ['publicKey', message.params.publicKey],
-    ['network', message.params.network ?? 'mainnet'],
-  ];
 
   if (!validatePsbt(message.params.hex)) {
     chrome.tabs.sendMessage(
@@ -54,21 +57,28 @@ export async function rpcSignPsbt(message: SignPsbtRequest, port: chrome.runtime
     return;
   }
 
+  const requestParams: RequestParams = [
+    ['requestId', message.id],
+    ['hex', message.params.hex],
+    ['publicKey', message.params.publicKey],
+    ['network', message.params.network ?? 'mainnet'],
+  ];
+
   if (isDefined(message.params.account)) {
-    params.push(['accountIndex', message.params.account.toString()]);
+    requestParams.push(['accountIndex', message.params.account.toString()]);
   }
 
   if (isDefined(message.params.allowedSighash))
     ensureArray(message.params.allowedSighash).forEach(hash =>
-      params.push(['allowedSighash', hash.toString()])
+      requestParams.push(['allowedSighash', hash.toString()])
     );
 
   if (isDefined(message.params.signAtIndex))
     ensureArray(message.params.signAtIndex).forEach(index =>
-      params.push(['signAtIndex', index.toString()])
+      requestParams.push(['signAtIndex', index.toString()])
     );
 
-  const { urlParams, tabId } = makeSearchParamsWithDefaults(port, params);
+  const { urlParams, tabId } = makeSearchParamsWithDefaults(port, requestParams);
 
   const { id } = await triggerRequestWindowOpen(RouteUrls.RpcSignPsbt, urlParams);
   listenForPopupClose({

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,7 +38,9 @@ export enum WalletDefaultNetworkConfigurationIds {
 
 export type DefaultNetworkConfigurations = keyof typeof WalletDefaultNetworkConfigurationIds;
 
-export type NetworkModes = 'mainnet' | 'testnet';
+export const networkModes = ['mainnet', 'testnet'] as const;
+
+export type NetworkModes = (typeof networkModes)[number];
 
 type BitcoinTestnetModes = 'testnet' | 'regtest' | 'signet';
 

--- a/src/shared/rpc/methods/sign-psbt.ts
+++ b/src/shared/rpc/methods/sign-psbt.ts
@@ -1,15 +1,36 @@
 import { DefineRpcMethod, RpcRequest, RpcResponse } from '@btckit/types';
-import { SignatureHash } from '@scure/btc-signer';
+import * as yup from 'yup';
 
-import { NetworkModes } from '@shared/constants';
+import { networkModes } from '@shared/constants';
 
-interface SignPsbtRequestParams {
-  publicKey: string;
-  allowedSighash?: SignatureHash[];
-  hex: string;
-  signAtIndex?: number | number[];
-  network?: NetworkModes;
-  account?: number;
+const rpcSignPsbtValidator = yup.object().shape({
+  publicKey: yup.string().required(),
+  allowedSighash: yup.array().of(yup.number().required()),
+  hex: yup.string().required(),
+  signAtIndex: yup.number().integer().positive(),
+  network: yup.string().oneOf(networkModes),
+  account: yup.number().integer().positive(),
+});
+
+type SignPsbtRequestParams = yup.InferType<typeof rpcSignPsbtValidator>;
+
+export function validateRpcSignPsbtParams(obj: unknown): obj is SignPsbtRequestParams {
+  try {
+    rpcSignPsbtValidator.validateSync(obj, { abortEarly: false });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function getRpcSignPsbtParamErrors(obj: unknown) {
+  try {
+    rpcSignPsbtValidator.validateSync(obj, { abortEarly: false });
+    return [];
+  } catch (e) {
+    if (e instanceof yup.ValidationError) return e.inner;
+    return [];
+  }
 }
 
 export type SignPsbtRequest = RpcRequest<'signPsbt', SignPsbtRequestParams>;


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5322400709).<!-- Sticky Header Marker -->

Closes #3804

This PR adds some additional error handling for PSBT requests. Hopefully this serves as a guide for other RPC requests.

I've utilised a new library for creating the schema we want the params to follow: [`@sinclair/typebox`](https://github.com/sinclairzx81/typebox). 



I know we already use Yup which does a similar thing, but I've favoured this one for a few reasons. Here's my thinking why it's worth the cost of introducing another lib:
- ~[The Hiro API team use this lib successfully to make API schemas/docs](https://github.com/hirosystems/token-metadata-api/blob/92373b02a5a49a291a8b92647f82dddf923416ac/src/token-processor/util/types.ts#L8-L21)~
- ~It renders both types and JSON schema, which we can potentially utilise elsewhere (think wrapper libraries etc).~
- ~Yup/Zod are good object schema libraries but they don't follow a standard, JSON schema, which opens up possibilities of other tools we can use~
- ~Yup schemas can create types, but it doesn't support mixed types well (e.g. `yup.mixed().oneOf([...otherTypes])`)~
- ~It has support for tuples that can help address https://github.com/hirosystems/wallet/issues/3542~

Scrap that. It uses `eval` which violates our CSP. Reverting to yup. 