### PR TITLE
fix(psbt): allow number array

### DIFF
--- a/src/shared/rpc/methods/sign-psbt.ts
+++ b/src/shared/rpc/methods/sign-psbt.ts
@@ -5,9 +5,14 @@ import { networkModes } from '@shared/constants';
 
 const rpcSignPsbtValidator = yup.object().shape({
   publicKey: yup.string().required(),
-  allowedSighash: yup.array().of(yup.number().required()),
+  allowedSighash: yup
+    .mixed<number | number[]>()
+    // Forcing type as yup doesn't infer it correctly
+    .oneOf<any>([yup.number().integer(), yup.array().of(yup.number().integer())]),
   hex: yup.string().required(),
-  signAtIndex: yup.number().integer(),
+  signAtIndex: yup
+    .mixed<number | number[]>()
+    .oneOf<any>([yup.number().integer(), yup.array().of(yup.number().integer())]),
   network: yup.string().oneOf(networkModes),
   account: yup.number().integer(),
 });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5343267872).<!-- Sticky Header Marker -->

Wasn't allowing to pass an array