### PR TITLE
fix(psbt): dynamic validation of sighash type

### DIFF
--- a/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
+++ b/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
@@ -20,7 +20,7 @@ export function usePsbtSigner() {
 
   return useMemo(
     () => ({
-      signPsbtAtIndex(allowedSighash: btc.SignatureHash[], idx: number, tx: btc.Transaction) {
+      signPsbtAtIndex(idx: number, tx: btc.Transaction, allowedSighash?: btc.SignatureHash[]) {
         try {
           nativeSegwitSigner?.signIndex(tx, idx, allowedSighash);
         } catch (e1) {

--- a/src/app/pages/psbt-request/use-psbt-request.tsx
+++ b/src/app/pages/psbt-request/use-psbt-request.tsx
@@ -47,8 +47,8 @@ export function usePsbtRequest() {
         const indexOrIndexes = payload?.signAtIndex;
         const allowedSighash = payload?.allowedSighash;
 
-        if (!isUndefined(indexOrIndexes) && !isUndefined(allowedSighash)) {
-          ensureArray(indexOrIndexes).forEach(idx => signPsbtAtIndex(allowedSighash, idx, tx));
+        if (!isUndefined(indexOrIndexes)) {
+          ensureArray(indexOrIndexes).forEach(idx => signPsbtAtIndex(idx, tx, allowedSighash));
         } else {
           signPsbt(tx);
         }

--- a/src/app/pages/rpc-sign-psbt/rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/rpc-sign-psbt.tsx
@@ -49,9 +49,9 @@ function useRpcSignPsbt() {
       return getDecodedPsbt(psbtHex);
     },
     onSignPsbt() {
-      if (!isUndefined(signAtIndex) && !isUndefined(allowedSighash)) {
+      if (!isUndefined(signAtIndex)) {
         signAtIndex.forEach(idx => {
-          signPsbtAtIndex(allowedSighash, idx, tx);
+          signPsbtAtIndex(idx, tx, allowedSighash);
         });
       } else {
         signPsbt(tx);

--- a/src/background/messaging/rpc-methods/sign-psbt.ts
+++ b/src/background/messaging/rpc-methods/sign-psbt.ts
@@ -69,8 +69,8 @@ export async function rpcSignPsbt(message: SignPsbtRequest, port: chrome.runtime
   }
 
   if (isDefined(message.params.allowedSighash))
-    ensureArray(message.params.allowedSighash).forEach(hash =>
-      requestParams.push(['allowedSighash', hash.toString()])
+    message.params.allowedSighash.forEach(hash =>
+      requestParams.push(['allowedSighash', (hash ?? btc.SignatureHash.ALL).toString()])
     );
 
   if (isDefined(message.params.signAtIndex))

--- a/src/shared/rpc/methods/sign-psbt.ts
+++ b/src/shared/rpc/methods/sign-psbt.ts
@@ -1,8 +1,9 @@
 import { DefineRpcMethod, RpcRequest, RpcResponse } from '@btckit/types';
+import * as btc from '@scure/btc-signer';
 import * as yup from 'yup';
 
 import { networkModes } from '@shared/constants';
-import { isDefined, isNumber, isUndefined } from '@shared/utils';
+import { isNumber, isUndefined } from '@shared/utils';
 
 function testIsNumberOrArrayOfNumbers(value: unknown) {
   if (isUndefined(value)) return true;
@@ -12,14 +13,7 @@ function testIsNumberOrArrayOfNumbers(value: unknown) {
 
 const rpcSignPsbtValidator = yup.object().shape({
   publicKey: yup.string().required(),
-  allowedSighash: yup.mixed<number | number[]>().when('signAtIndex', {
-    is: (signAtIndex: unknown) => isDefined(signAtIndex),
-    then: schema =>
-      schema
-        .test(testIsNumberOrArrayOfNumbers)
-        .required('allowedSighash required when signAtIndex is provided'),
-    otherwise: schema => schema.test(testIsNumberOrArrayOfNumbers),
-  }),
+  allowedSighash: yup.array().of(yup.mixed().oneOf(Object.values(btc.SignatureHash))),
   hex: yup.string().required(),
   signAtIndex: yup.mixed<number | number[]>().test(testIsNumberOrArrayOfNumbers),
   network: yup.string().oneOf(networkModes),


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5348881203).<!-- Sticky Header Marker -->

Added additional validation that if sign at index is defined, allowedSighash is required