### PR TITLE
test(ledger): activity page loads

### DIFF
--- a/src/app/components/tabs.tsx
+++ b/src/app/components/tabs.tsx
@@ -69,6 +69,7 @@ export function Tabs({
         {tabs.map((tab, index) => (
           <TabButton
             onClick={() => onTabClick(index)}
+            data-testid={`tab-${tab.slug}`}
             isActive={activeTab === index}
             key={tab.slug}
             label={tab.label}

--- a/src/app/features/activity-list/activity-list.tsx
+++ b/src/app/features/activity-list/activity-list.tsx
@@ -17,6 +17,7 @@ import { TransactionList } from './components/transaction-list/transaction-list'
 
 export function ActivityList() {
   const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
+
   const { isInitialLoading: isInitialLoadingBitcoinTransactions, data: bitcoinTransactions } =
     useGetBitcoinTransactionsByAddressQuery(nativeSegwitSigner.address);
   const { data: bitcoinPendingTxs = [] } = useBitcoinPendingTransactions(

--- a/src/app/features/activity-list/activity-list.tsx
+++ b/src/app/features/activity-list/activity-list.tsx
@@ -15,14 +15,21 @@ import { PendingTransactionList } from './components/pending-transaction-list/pe
 import { SubmittedTransactionList } from './components/submitted-transaction-list/submitted-transaction-list';
 import { TransactionList } from './components/transaction-list/transaction-list';
 
-export function ActivityList() {
-  const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
+// TODO: temporary really ugly fix while we address conditional data problem of
+// bitcoin sometimes being undefined
+function useBitcoinAddress() {
+  try {
+    return useCurrentAccountNativeSegwitIndexZeroSigner().address;
+  } catch (e) {
+    return '';
+  }
+}
 
+export function ActivityList() {
+  const bitcoinAddress = useBitcoinAddress();
   const { isInitialLoading: isInitialLoadingBitcoinTransactions, data: bitcoinTransactions } =
-    useGetBitcoinTransactionsByAddressQuery(nativeSegwitSigner.address);
-  const { data: bitcoinPendingTxs = [] } = useBitcoinPendingTransactions(
-    nativeSegwitSigner.address
-  );
+    useGetBitcoinTransactionsByAddressQuery(bitcoinAddress);
+  const { data: bitcoinPendingTxs = [] } = useBitcoinPendingTransactions(bitcoinAddress);
   const {
     isInitialLoading: isInitialLoadingStacksTransactions,
     data: stacksTransactionsWithTransfers,

--- a/tests/page-object-models/home.page.ts
+++ b/tests/page-object-models/home.page.ts
@@ -68,4 +68,8 @@ export class HomePage {
     ).isEnabled();
     await this.page.getByTestId(WalletDefaultNetworkConfigurationIds.testnet).click();
   }
+
+  async clickActivityTab() {
+    await this.page.getByTestId(HomePageSelectors.ActivityTabBtn).click();
+  }
 }

--- a/tests/selectors/home.selectors.ts
+++ b/tests/selectors/home.selectors.ts
@@ -6,4 +6,6 @@ export enum HomePageSelectors {
   ReceiveBtcTaprootQrCodeBtn = 'receive-taproot-qr-code-btn',
   ReceiveStxQrCodeBtn = 'receive-stx-qr-code-btn',
   SendCryptoAssetBtn = 'send-crypto-asset-btn',
+  ActivityTabBtn = 'tab-activity',
+  BalancesTabBtn = 'tab-balances',
 }

--- a/tests/specs/ledger/ledger.spec.ts
+++ b/tests/specs/ledger/ledger.spec.ts
@@ -13,4 +13,11 @@ test.describe('App with Ledger', () => {
     const address = await homePage.getReceiveStxAddress();
     test.expect(address).toEqual('SPSDM5RXY2E3V7JTFYKPFNRPDHG1B85788FKG2KN');
   });
+
+  test('that you can navigate to activity page', async ({ homePage }) => {
+    await homePage.clickActivityTab();
+    const noActivityText = homePage.page.getByText('No activity yet');
+
+    test.expect(await noActivityText.count()).toBeGreaterThan(0);
+  });
 });

--- a/tests/specs/ledger/ledger.spec.ts
+++ b/tests/specs/ledger/ledger.spec.ts
@@ -17,7 +17,6 @@ test.describe('App with Ledger', () => {
   test('that you can navigate to activity page', async ({ homePage }) => {
     await homePage.clickActivityTab();
     const noActivityText = homePage.page.getByText('No activity yet');
-
-    test.expect(await noActivityText.count()).toBeGreaterThan(0);
+    await test.expect(noActivityText).toBeVisible();
   });
 });

--- a/tests/specs/onboarding/onboarding.spec.ts
+++ b/tests/specs/onboarding/onboarding.spec.ts
@@ -31,6 +31,14 @@ test.describe('Onboarding an existing user', () => {
     test.expect(walletState).toEqual(testSoftwareAccountDefaultWalletState);
   });
 
+  test('Activity tab', async ({ extensionId, globalPage, onboardingPage, homePage }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await onboardingPage.signUpNewUser();
+    await homePage.clickActivityTab();
+    const noActivityText = homePage.page.getByText('No activity yet');
+    await test.expect(noActivityText).toBeVisible();
+  });
+
   test.describe('Address generation', () => {
     test.beforeEach(async ({ extensionId, globalPage, onboardingPage }) => {
       await globalPage.setupAndUseApiCalls(extensionId);


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5400905306).<!-- Sticky Header Marker -->

Test to detect failing activity page with Ledger. Horrible quick fix that we should remove asap.

This bug was introduced by using the `useCurrentAccountNativeSegwitIndexZeroSigner` hook in the `<ActivityList />` component. This hook throws if there is no signer, which there isn't in Ledger wallets.

[See notion doc for discussion](https://www.notion.so/trustmachines/Engineering-Sync-80f098a9714e423393d9130ebf0cbb97?pvs=4)

