### PR TITLE
Fix/3881/header indentation stacks signing

### DIFF
--- a/src/app/components/typography.tsx
+++ b/src/app/components/typography.tsx
@@ -19,50 +19,42 @@ const openSauceMetrics = {
 const h1 = {
   fontMetrics: openSauceMetrics,
   fontSize: 24,
-  leading: 32,
 };
 
 // B2
 const h2 = {
   fontMetrics: openSauceMetrics,
   fontSize: 18,
-  leading: 28,
 };
 // B3
 const h3 = {
   fontMetrics: openSauceMetrics,
   fontSize: 16,
-  leading: 24,
 };
 // C1
 const h4 = {
   fontMetrics: openSauceMetrics,
   fontSize: 14,
-  leading: 20,
 };
 // C2
 const h5 = {
   fontMetrics: openSauceMetrics,
   fontSize: 12,
-  leading: 16,
 };
 
 const c1 = {
   fontMetrics: interMetrics,
   fontSize: 14,
-  leading: 20,
 };
 
 const c2 = {
   fontMetrics: interMetrics,
   fontSize: 12,
-  leading: 16,
 };
 
 const c3 = {
   fontMetrics: interMetrics,
   fontSize: 10,
-  leading: 16,
 };
 
 const captionStyles = (variant?: 'c1' | 'c2' | 'c3') => {

--- a/src/app/features/current-account/current-account-name.tsx
+++ b/src/app/features/current-account/current-account-name.tsx
@@ -26,10 +26,10 @@ const AccountNameSuspense = memo((props: BoxProps) => {
   const currentAccount = useCurrentStacksAccount();
   const name = useCurrentAccountDisplayName();
   if (!currentAccount || typeof currentAccount.index === 'undefined') return null;
+  // FIXME: The name is truncated here with JS but we could just use CSS to do this
   const nameCharLimit = 18;
   const isLong = name.length > nameCharLimit;
   const displayName = truncateString(name, nameCharLimit);
-
   return (
     <AccountNameTitle {...props}>
       <Tooltip label={isLong ? name : undefined}>

--- a/src/app/features/current-account/popup-header.tsx
+++ b/src/app/features/current-account/popup-header.tsx
@@ -35,7 +35,7 @@ function PopupHeaderSuspense({ displayAddresssBalanceOf = 'stx' }: PopupHeaderPr
     <PopupHeaderLayout>
       <Flag align="middle" img={<CurrentAccountAvatar size="24px" fontSize="10px" />}>
         <SpaceBetween>
-          <Stack isInline alignItems="flex-end">
+          <Stack isInline alignItems="center">
             <CurrentAccountName as="h3" />
             {displayAddresssBalanceOf === 'stx' && <CurrentStxAddress fontSize="12px" />}
           </Stack>


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5409919887).<!-- Sticky Header Marker -->

This PR adds a fix to correctly align items in the signature header. 

This fixes the issue as you can see below, but I think we can further improve on it:

![Kapture 2023-06-28 at 14 36 08](https://github.com/hirosystems/wallet/assets/2938440/6929ea9f-16e2-4ad9-a4d6-530e5d6ae7c4)

- You can see that the items move around based on the amounts in the account
- We use JS to truncate the display name
- We could probably refactor this to layout the header with a flexbox / CSS grid and make it less jumpy

I have made two small refactors also in separate commits which I can exclude from here if needed
