### PR TITLE
fix: ledger routing bug with broadcast error

### DIFF
--- a/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-tx-container.tsx
@@ -134,7 +134,7 @@ export function LedgerSignStacksTxContainer() {
         await hwWalletTxBroadcast({ signedTx });
         navigate(RouteUrls.Home);
       } catch (e) {
-        navigate(RouteUrls.TransactionBroadcastError);
+        ledgerNavigate.toBroadcastErrorStep(e instanceof Error ? e.message : 'Unknown error');
         return;
       }
     } catch (e) {

--- a/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-tx.routes.tsx
+++ b/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-tx.routes.tsx
@@ -12,6 +12,7 @@ import {
   OperationRejected,
   UnsupportedBrowserLayout,
 } from '../../generic-steps';
+import { LedgerBroadcastError } from '../../generic-steps/broadcast-error/broadcast-error';
 import { LedgerSignStacksTxContainer } from './ledger-sign-tx-container';
 import { ApproveSignLedgerTx } from './steps/approve-sign-ledger-tx';
 import { ConnectLedgerSignTx } from './steps/connect-ledger-sign-tx';
@@ -30,5 +31,6 @@ export const ledgerStacksTxSigningRoutes = (
     <Route path={RouteUrls.LedgerPublicKeyMismatch} element={<LedgerPublicKeyMismatch />} />
     <Route path={RouteUrls.LedgerDevicePayloadInvalid} element={<LedgerDeviceInvalidPayload />} />
     <Route path={RouteUrls.LedgerOutdatedAppWarning} element={<ContractPrincipalBugWarning />} />
+    <Route path={RouteUrls.LedgerBroadcastError} element={<LedgerBroadcastError />} />
   </Route>
 );

--- a/src/app/features/ledger/generic-steps/broadcast-error/broadcast-error.layout.tsx
+++ b/src/app/features/ledger/generic-steps/broadcast-error/broadcast-error.layout.tsx
@@ -1,0 +1,34 @@
+import BroadcastError from '@assets/images/unhappy-face-ui.png';
+import { Box, Button, Flex } from '@stacks/ui';
+
+import { Body } from '@app/components/typography';
+
+import { LedgerTitle } from '../../components/ledger-title';
+import { LedgerWrapper } from '../../components/ledger-wrapper';
+
+interface LedgerBroadcastErrorLayoutProps {
+  error: string;
+  onClose(): void;
+}
+export function LedgerBroadcastErrorLayout(props: LedgerBroadcastErrorLayoutProps) {
+  const { error, onClose } = props;
+
+  return (
+    <LedgerWrapper>
+      <Box mb="loose" mt="tight">
+        <img src={BroadcastError} width="242px" />
+      </Box>
+      <LedgerTitle mb="loose" mt="loose" mx="40px">
+        Transaction Broadcast Error
+      </LedgerTitle>
+      <Body mt="base-tight" px="base">
+        Your transaction failed to broadcast {error && <>because of the error: {error}</>}
+      </Body>
+      <Flex mt="base-loose">
+        <Button mode="tertiary" mr="base-tight" onClick={onClose}>
+          Close
+        </Button>
+      </Flex>
+    </LedgerWrapper>
+  );
+}

--- a/src/app/features/ledger/generic-steps/broadcast-error/broadcast-error.tsx
+++ b/src/app/features/ledger/generic-steps/broadcast-error/broadcast-error.tsx
@@ -1,0 +1,20 @@
+import { useLocation } from 'react-router-dom';
+
+import get from 'lodash.get';
+
+import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
+
+import { LedgerBroadcastErrorLayout } from './broadcast-error.layout';
+
+export function LedgerBroadcastError() {
+  const location = useLocation();
+  const ledgerNavigate = useLedgerNavigate();
+  const error = get(location.state, 'error', '');
+
+  return (
+    <LedgerBroadcastErrorLayout
+      error={error}
+      onClose={() => ledgerNavigate.cancelLedgerActionAndReturnHome()}
+    />
+  );
+}

--- a/src/app/features/ledger/hooks/use-ledger-navigate.ts
+++ b/src/app/features/ledger/hooks/use-ledger-navigate.ts
@@ -82,6 +82,10 @@ export function useLedgerNavigate() {
         return navigate(RouteUrls.LedgerDisconnected, { replace: true });
       },
 
+      toBroadcastErrorStep(error: string) {
+        return navigate(RouteUrls.LedgerBroadcastError, { replace: true, state: { error } });
+      },
+
       cancelLedgerAction() {
         return navigate('..', { relative: 'path' });
       },

--- a/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-broadcast-transaction.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-broadcast-transaction.tsx
@@ -60,7 +60,7 @@ export function useStacksBroadcastTransaction(
         })(signedTx);
       } catch (e) {
         navigate(RouteUrls.TransactionBroadcastError, {
-          state: { message: e instanceof Error ? e.message : 'unknown error' },
+          state: { message: e instanceof Error ? e.message : 'Unknown error' },
         });
       } finally {
         setIsBroadcasting(false);

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/use-sip10-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/use-sip10-send-form.tsx
@@ -86,8 +86,8 @@ export function useSip10SendForm({ symbol, contractId }: UseSip10SendFormArgs) {
       whenWallet({
         software: () =>
           sendFormNavigate.toConfirmAndSignStacksSip10Transaction({
-            decimals: assetBalance?.balance.decimals,
-            name: assetBalance?.asset.name,
+            decimals: assetBalance.balance.decimals,
+            name: assetBalance.asset.name,
             tx,
           }),
         ledger: () => ledgerNavigate.toConnectAndSignTransactionStep(tx),

--- a/src/app/query/stacks/balance/stacks-ft-balances.hooks.ts
+++ b/src/app/query/stacks/balance/stacks-ft-balances.hooks.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
+import BigNumber from 'bignumber.js';
+
 import type { StacksFungibleTokenAssetBalance } from '@shared/models/crypto-asset-balance.model';
 
 import { formatContractId } from '@app/common/utils';
@@ -14,6 +16,7 @@ import {
   convertFtBalancesToStacksFungibleTokenAssetBalanceType,
   convertNftBalancesToStacksNonFungibleTokenAssetBalanceType,
   createStacksCryptoCurrencyAssetTypeWrapper,
+  createStacksFtCryptoAssetBalanceTypeWrapper,
 } from './stacks-ft-balances.utils';
 import { parseBalanceResponse } from './stx-balance.hooks';
 import {
@@ -114,7 +117,7 @@ export function useStacksFungibleTokenAssetBalance(contractId: string) {
       toast.error('Unable to find balance by contract id');
       navigate('..');
     }
-    return balance as StacksFungibleTokenAssetBalance;
+    return balance ?? createStacksFtCryptoAssetBalanceTypeWrapper(new BigNumber(0), contractId);
   }, [assetBalances, contractId, navigate]);
 }
 

--- a/src/app/query/stacks/balance/stacks-ft-balances.utils.ts
+++ b/src/app/query/stacks/balance/stacks-ft-balances.utils.ts
@@ -29,7 +29,7 @@ export function createStacksCryptoCurrencyAssetTypeWrapper(
   };
 }
 
-function createStacksFtCryptoAssetBalanceTypeWrapper(
+export function createStacksFtCryptoAssetBalanceTypeWrapper(
   balance: BigNumber,
   contractId: string
 ): StacksFungibleTokenAssetBalance {

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -21,6 +21,7 @@ export enum RouteUrls {
   LedgerDevicePayloadInvalid = 'ledger-payload-invalid',
   LedgerUnsupportedBrowser = 'unsupported-browser',
   LedgerOutdatedAppWarning = 'outdated-app-warning',
+  LedgerBroadcastError = 'transaction-broadcast-error',
 
   // Active wallet routes
   Home = '/',

--- a/test-app/src/components/bitcoin.tsx
+++ b/test-app/src/components/bitcoin.tsx
@@ -223,6 +223,7 @@ export const Bitcoin = () => {
             ?.request('sendTransfer', {
               address: TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
               amount: '10000',
+              network: 'testnet',
             })
             .then(resp => {
               console.log({ sucesss: resp });


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5407213489).<!-- Sticky Header Marker -->

This PR fixes a routing bug with Ledger. The route was breaking when a transaction broadcast errored. I created a new Ledger route step for broadcast errors.

In debugging this, it was hitting an `undefined` asset balance in the sip10 form bc we were type casting the balance as if it were defined, so I proposed a fix here for that too.

<img width="493" alt="Screen Shot 2023-06-28 at 7 26 22 PM" src="https://github.com/hirosystems/wallet/assets/6493321/57b52be8-bd85-4f9c-b2e9-3b9650dfd839">
