### PR TITLE
fix: subtract microblock txs from available balance, closes #3898

### DIFF
--- a/src/app/query/stacks/mempool/mempool.query.ts
+++ b/src/app/query/stacks/mempool/mempool.query.ts
@@ -1,6 +1,7 @@
 import { MempoolTransaction } from '@stacks/stacks-blockchain-api-types';
 import { useQuery } from '@tanstack/react-query';
 
+import { queryClient } from '@app/common/persistence';
 import { safelyFormatHexTxid } from '@app/common/utils/safe-handle-txid';
 import { useStacksClientUnanchored } from '@app/store/common/api-clients.hooks';
 import { useSubmittedTransactionsActions } from '@app/store/submitted-transactions/submitted-transactions.hooks';
@@ -24,6 +25,8 @@ export function useAccountMempoolQuery(address: string) {
     queryKey: ['account-mempool', address],
     queryFn: accountMempoolFetcher,
     onSuccess: data => {
+      void queryClient.invalidateQueries({ queryKey: ['account-microblock'] });
+
       const pendingTxids = (data.results as MempoolTransaction[]).map(tx => tx.tx_id);
       submittedTransactions.map(tx => {
         if (pendingTxids.includes(safelyFormatHexTxid(tx.txId)))
@@ -31,5 +34,6 @@ export function useAccountMempoolQuery(address: string) {
         return;
       });
     },
+    refetchOnWindowFocus: false,
   });
 }

--- a/src/app/query/stacks/microblock/microblock.query.ts
+++ b/src/app/query/stacks/microblock/microblock.query.ts
@@ -24,5 +24,6 @@ export function useCurrentAccountMicroblockBalanceQuery(address: string) {
         'STX'
       );
     },
+    refetchOnWindowFocus: false,
   });
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5411146637).<!-- Sticky Header Marker -->

Seems problems is in cache. Tx changes the status from pending to microblock, but we don't query microblock txs list