### PR TITLE
fix: remove required payment type from sign msg

### DIFF
--- a/src/shared/rpc/methods/sign-message.ts
+++ b/src/shared/rpc/methods/sign-message.ts
@@ -18,7 +18,7 @@ const rpcSignMessageParamsSchema = yup.object().shape({
   account: accountSchema,
   message: yup.string().required(),
   network: yup.string().oneOf(Object.values(WalletDefaultNetworkConfigurationIds)),
-  paymentType: yup.string<PaymentTypes>().required(),
+  paymentType: yup.string<PaymentTypes>(),
 });
 
 // TODO: Import param types from btckit when updated


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5412709387).<!-- Sticky Header Marker -->

This might break apps previously not sending the `paymentType` as being required bc we provide a default in the docs.