### PR TITLE
refactor: sending max fees

### DIFF
--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
@@ -31,6 +31,7 @@ export function determineUtxosForSpendAll({
     [addressInfo.type + '_output_count']: 1,
   });
 
+  // Fee has already been deducted from the amount with send all
   const outputs = [{ value: BigInt(amount), address: recipient }];
 
   const fee = Math.ceil(sizeInfo.txVBytes * feeRate);

--- a/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list.ts
+++ b/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list.ts
@@ -11,6 +11,7 @@ import {
   determineUtxosForSpend,
   determineUtxosForSpendAll,
 } from '@app/common/transactions/bitcoin/coinselect/local-coin-selection';
+import { useCurrentNativeSegwitAddressBalance } from '@app/query/bitcoin/balance/bitcoin-balances.query';
 import { UtxoResponseItem } from '@app/query/bitcoin/bitcoin-client';
 import { useAverageBitcoinFeeRates } from '@app/query/bitcoin/fees/fee-estimates.hooks';
 import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
@@ -39,6 +40,7 @@ export function useBitcoinFeesList({
   recipient,
   utxos,
 }: UseBitcoinFeesListArgs) {
+  const balance = useCurrentNativeSegwitAddressBalance();
   const btcMarketData = useCryptoCurrencyMarketData('BTC');
   const { data: feeRates, isLoading } = useAverageBitcoinFeeRates();
 
@@ -51,7 +53,7 @@ export function useBitcoinFeesList({
 
     if (!feeRates || !utxos.length) return [];
 
-    const satAmount = btcToSat(amount).toNumber();
+    const satAmount = isSendingMax ? balance.amount.toNumber() : btcToSat(amount).toNumber();
 
     const determineUtxosDefaultArgs = {
       amount: satAmount,
@@ -104,7 +106,7 @@ export function useBitcoinFeesList({
         feeRate: feeRates.hourFee.toNumber(),
       },
     ];
-  }, [feeRates, utxos, amount, recipient, isSendingMax, btcMarketData]);
+  }, [feeRates, utxos, isSendingMax, balance.amount, amount, recipient, btcMarketData]);
 
   return {
     feesList,

--- a/src/app/features/bitcoin-choose-fee/bitcoin-choose-fee.tsx
+++ b/src/app/features/bitcoin-choose-fee/bitcoin-choose-fee.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { Box, Stack, Text, color } from '@stacks/ui';
 
+import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
 import { Money } from '@shared/models/money.model';
 
 import { formatMoney } from '@app/common/money/format-money';
@@ -19,24 +20,26 @@ import { InsufficientBalanceError } from './components/insufficient-balance-erro
 interface BitcoinChooseFeeProps {
   amount: Money;
   feesList: React.JSX.Element;
+  isLoading: boolean;
   isSendingMax: boolean;
-  showError: boolean;
   onChooseFee({ feeRate, feeValue, time }: OnChooseFeeArgs): Promise<void>;
+  onSetSelectedFeeType(value: BtcFeeType | null): void;
   onValidateBitcoinSpend(value: number): boolean;
   recipient: string;
   recommendedFeeRate: string;
-  isLoading: boolean;
+  showError: boolean;
 }
 export function BitcoinChooseFee({
   amount,
   feesList,
-  isSendingMax,
-  showError,
-  onChooseFee,
-  recipient,
-  onValidateBitcoinSpend,
   isLoading,
+  isSendingMax,
+  onChooseFee,
+  onSetSelectedFeeType,
+  onValidateBitcoinSpend,
+  recipient,
   recommendedFeeRate,
+  showError,
 }: BitcoinChooseFeeProps) {
   const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
   const btcBalance = useNativeSegwitBalance(nativeSegwitSigner.address);
@@ -59,13 +62,15 @@ export function BitcoinChooseFee({
         <ChooseFeeTabs
           customFee={
             <BitcoinCustomFee
-              customFeeInitialValue={customFeeInitialValue}
-              setCustomFeeInitialValue={setCustomFeeInitialValue}
-              onChooseFee={onChooseFee}
               amount={amount.amount.toNumber()}
-              recipient={recipient}
-              onValidateBitcoinSpend={onValidateBitcoinSpend}
+              customFeeInitialValue={customFeeInitialValue}
               hasInsufficientBalanceError={showError}
+              isSendingMax={isSendingMax}
+              onChooseFee={onChooseFee}
+              onSetSelectedFeeType={onSetSelectedFeeType}
+              onValidateBitcoinSpend={onValidateBitcoinSpend}
+              recipient={recipient}
+              setCustomFeeInitialValue={setCustomFeeInitialValue}
             />
           }
           feesList={feesList}

--- a/src/app/features/bitcoin-choose-fee/bitcoin-custom-fee/bitcoin-custom-fee-fiat.tsx
+++ b/src/app/features/bitcoin-choose-fee/bitcoin-custom-fee/bitcoin-custom-fee-fiat.tsx
@@ -8,13 +8,18 @@ import { satToBtc } from '@app/common/money/unit-conversion';
 import { useBitcoinCustomFee } from './hooks/use-bitcoin-custom-fee';
 
 interface BitcoinCustomFeeFiatProps {
-  recipient: string;
   amount: number;
+  isSendingMax: boolean;
+  recipient: string;
 }
 
-export function BitcoinCustomFeeFiat({ recipient, amount }: BitcoinCustomFeeFiatProps) {
+export function BitcoinCustomFeeFiat({
+  amount,
+  isSendingMax,
+  recipient,
+}: BitcoinCustomFeeFiatProps) {
   const [field] = useField('feeRate');
-  const getCustomFeeValues = useBitcoinCustomFee({ amount, recipient });
+  const getCustomFeeValues = useBitcoinCustomFee({ amount, isSendingMax, recipient });
 
   const feeData = useMemo(() => {
     const { fee, fiatFeeValue } = getCustomFeeValues(Number(field.value));

--- a/src/app/features/bitcoin-choose-fee/bitcoin-custom-fee/bitcoin-custom-fee.tsx
+++ b/src/app/features/bitcoin-choose-fee/bitcoin-custom-fee/bitcoin-custom-fee.tsx
@@ -4,6 +4,8 @@ import { Stack, Text } from '@stacks/ui';
 import { Form, Formik } from 'formik';
 import * as yup from 'yup';
 
+import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
+
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { Link } from '@app/components/link';
 import { PreviewButton } from '@app/components/preview-button';
@@ -16,34 +18,39 @@ import { useBitcoinCustomFee } from './hooks/use-bitcoin-custom-fee';
 const feeInputLabel = 'sats/vB';
 
 interface BitcoinCustomFeeProps {
+  amount: number;
+  customFeeInitialValue: string;
+  hasInsufficientBalanceError: boolean;
+  isSendingMax: boolean;
   onChooseFee({ feeRate, feeValue, time, isCustomFee }: OnChooseFeeArgs): Promise<void>;
+  onSetSelectedFeeType(value: BtcFeeType | null): void;
   onValidateBitcoinSpend(value: number): boolean;
   recipient: string;
-  amount: number;
-  hasInsufficientBalanceError: boolean;
-  customFeeInitialValue: string;
   setCustomFeeInitialValue: Dispatch<SetStateAction<string>>;
 }
 export function BitcoinCustomFee({
-  onChooseFee,
-  recipient,
   amount,
-  hasInsufficientBalanceError,
-  onValidateBitcoinSpend,
   customFeeInitialValue,
+  hasInsufficientBalanceError,
+  isSendingMax,
+  onChooseFee,
+  onSetSelectedFeeType,
+  onValidateBitcoinSpend,
+  recipient,
   setCustomFeeInitialValue,
 }: BitcoinCustomFeeProps) {
   const feeInputRef = useRef<HTMLInputElement | null>(null);
-  const getCustomFeeValues = useBitcoinCustomFee({ amount, recipient });
+  const getCustomFeeValues = useBitcoinCustomFee({ amount, isSendingMax, recipient });
 
   const onChooseCustomBtcFee = useCallback(
     async ({ feeRate }: { feeRate: string }) => {
+      onSetSelectedFeeType(null);
       const { fee: feeValue } = getCustomFeeValues(Number(feeRate));
       const isValid = onValidateBitcoinSpend(feeValue);
       if (!isValid) return;
       await onChooseFee({ feeRate: Number(feeRate), feeValue, time: '', isCustomFee: true });
     },
-    [getCustomFeeValues, onValidateBitcoinSpend, onChooseFee]
+    [onSetSelectedFeeType, getCustomFeeValues, onValidateBitcoinSpend, onChooseFee]
   );
 
   const validationSchema = yup.object({
@@ -90,7 +97,11 @@ export function BitcoinCustomFee({
                     }}
                     inputRef={feeInputRef}
                   />
-                  <BitcoinCustomFeeFiat recipient={recipient} amount={amount} />
+                  <BitcoinCustomFeeFiat
+                    amount={amount}
+                    isSendingMax={isSendingMax}
+                    recipient={recipient}
+                  />
                 </Stack>
               </Stack>
 

--- a/src/app/features/bitcoin-choose-fee/hooks/use-validate-bitcoin-spend.ts
+++ b/src/app/features/bitcoin-choose-fee/hooks/use-validate-bitcoin-spend.ts
@@ -2,10 +2,10 @@ import { useState } from 'react';
 
 import { Money, createMoney } from '@shared/models/money.model';
 
-import { sumMoney } from '@app/common/money/calculate-money';
+import { subtractMoney, sumMoney } from '@app/common/money/calculate-money';
 import { useCurrentNativeSegwitAddressBalance } from '@app/query/bitcoin/balance/bitcoin-balances.query';
 
-export function useValidateBitcoinSpend(amount?: Money) {
+export function useValidateBitcoinSpend(amount?: Money, isSendingMax?: boolean) {
   const [showInsufficientBalanceError, setShowInsufficientBalanceError] = useState(false);
   const balance = useCurrentNativeSegwitAddressBalance();
 
@@ -27,7 +27,10 @@ export function useValidateBitcoinSpend(amount?: Money) {
         throw new Error('Amount should be defined to validate total spend');
       }
 
-      const totalSpend = sumMoney([amount, feeAsMoney]);
+      const totalSpend = isSendingMax
+        ? subtractMoney(balance, feeAsMoney)
+        : sumMoney([amount, feeAsMoney]);
+
       if (totalSpend.amount.isGreaterThan(balance.amount)) {
         setShowInsufficientBalanceError(true);
         return false;

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
@@ -76,21 +76,22 @@ export function RpcSendTransferChooseFee() {
   return (
     <BitcoinChooseFee
       amount={amountAsMoney}
-      isLoading={isLoading}
       feesList={
         <BitcoinFeesList
           feesList={feesList}
           onChooseFee={previewTransfer}
           onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
-          onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
+          onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
           selectedFeeType={selectedFeeType}
         />
       }
-      recommendedFeeRate={recommendedFeeRate}
+      isLoading={isLoading}
+      isSendingMax={false}
+      onChooseFee={previewTransfer}
+      onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
       onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
       recipient={address}
-      onChooseFee={previewTransfer}
-      isSendingMax={false}
+      recommendedFeeRate={recommendedFeeRate}
       showError={showInsufficientBalanceError}
     />
   );

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-container.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-container.tsx
@@ -11,7 +11,7 @@ import { useRpcSendTransfer } from './use-rpc-send-transfer';
 
 interface RpcSendTransferContextState {
   selectedFeeType: BtcFeeType;
-  setSelectedFeeType(value: BtcFeeType): void;
+  setSelectedFeeType(value: BtcFeeType | null): void;
 }
 export function useRpcSendTransferState() {
   const context = useOutletContext<RpcSendTransferContextState>();
@@ -19,7 +19,7 @@ export function useRpcSendTransferState() {
 }
 
 export function RpcSendTransferContainer() {
-  const [selectedFeeType, setSelectedFeeType] = useState(BtcFeeType.Low);
+  const [selectedFeeType, setSelectedFeeType] = useState<BtcFeeType | null>(BtcFeeType.Standard);
   const { origin } = useRpcSendTransfer();
 
   useRouteHeader(<PopupHeader displayAddresssBalanceOf="all" />);

--- a/src/app/pages/send/ordinal-inscription/components/send-inscription-container.tsx
+++ b/src/app/pages/send/ordinal-inscription/components/send-inscription-container.tsx
@@ -14,7 +14,7 @@ export interface SendInscriptionContextState {
   feeRates: AverageBitcoinFeeRates;
   inscription: SupportedInscription;
   selectedFeeType: BtcFeeType;
-  setSelectedFeeType(value: BtcFeeType): void;
+  setSelectedFeeType(value: BtcFeeType | null): void;
   utxo: TaprootUtxo;
 }
 export function useSendInscriptionState() {
@@ -24,7 +24,7 @@ export function useSendInscriptionState() {
 }
 
 export function SendInscriptionContainer() {
-  const [selectedFeeType, setSelectedFeeType] = useState(null);
+  const [selectedFeeType, setSelectedFeeType] = useState<BtcFeeType | null>(BtcFeeType.Standard);
 
   return (
     <SendInscriptionLoader>

--- a/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
@@ -42,21 +42,22 @@ export function SendInscriptionChooseFee() {
     <BaseDrawer title="Choose fee" isShowing enableGoBack onClose={() => navigate(-1)}>
       <BitcoinChooseFee
         amount={createMoney(0, 'BTC')}
-        isLoading={isLoading}
         feesList={
           <BitcoinFeesList
             feesList={feesList}
             onChooseFee={previewTransaction}
             onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
-            onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
+            onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
             selectedFeeType={selectedFeeType}
           />
         }
-        recommendedFeeRate={recommendedFeeRate}
-        onChooseFee={previewTransaction}
-        recipient={recipient}
-        onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
+        isLoading={isLoading}
         isSendingMax={false}
+        onChooseFee={previewTransaction}
+        onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
+        onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
+        recipient={recipient}
+        recommendedFeeRate={recommendedFeeRate}
         showError={showInsufficientBalanceError}
       />
     </BaseDrawer>

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/send-bitcoin-asset-container.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/send-bitcoin-asset-container.tsx
@@ -13,6 +13,6 @@ export function useSendBitcoinAssetContextState() {
 }
 
 export function SendBitcoinAssetContainer() {
-  const [selectedFeeType, setSelectedFeeType] = useState(null);
+  const [selectedFeeType, setSelectedFeeType] = useState<BtcFeeType | null>(BtcFeeType.Standard);
   return <Outlet context={{ selectedFeeType, setSelectedFeeType }} />;
 }

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/hooks/use-calculate-max-spend.ts
@@ -30,9 +30,9 @@ export function useCalculateMaxBitcoinSpend() {
       const size = txSizer.calcTxSize({
         input_script: 'p2wpkh',
         input_count: utxos.length,
-        [`${addressTypeWithFallback}_output_count`]: 2,
+        [`${addressTypeWithFallback}_output_count`]: 1,
       });
-      const fee = Math.ceil(size.txVBytes * (feeRate ?? feeRates.hourFee.toNumber()));
+      const fee = Math.ceil(size.txVBytes * (feeRate ?? feeRates.halfHourFee.toNumber()));
 
       const spendableAmount = BigNumber.max(0, balance.amount.minus(fee));
 

--- a/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
@@ -127,21 +127,22 @@ export function BrcChooseFee() {
   ) : (
     <BitcoinChooseFee
       amount={amountAsMoney}
-      isLoading={isLoading}
       feesList={
         <BitcoinFeesList
           feesList={feesList}
           onChooseFee={previewTransaction}
-          onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
+          onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
           onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
           selectedFeeType={selectedFeeType}
         />
       }
-      recommendedFeeRate={recommendedFeeRate}
-      onChooseFee={previewTransaction}
-      recipient={recipient}
-      onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
+      isLoading={isLoading}
       isSendingMax={false}
+      onChooseFee={previewTransaction}
+      onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
+      onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
+      recommendedFeeRate={recommendedFeeRate}
+      recipient={recipient}
       showError={showInsufficientBalanceError}
     />
   );

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
@@ -37,8 +37,10 @@ export function BtcChooseFee() {
   const recommendedFeeRate = feesList[1]?.feeRate.toString() || '';
 
   const { amountAsMoney, onGoBack, previewTransaction } = useBtcChooseFee();
-  const { showInsufficientBalanceError, onValidateBitcoinAmountSpend } =
-    useValidateBitcoinSpend(amountAsMoney);
+  const { showInsufficientBalanceError, onValidateBitcoinAmountSpend } = useValidateBitcoinSpend(
+    amountAsMoney,
+    isSendingMax
+  );
 
   useRouteHeader(<ModalHeader hideActions onGoBack={onGoBack} title="Choose fee" />);
 
@@ -50,16 +52,17 @@ export function BtcChooseFee() {
         <BitcoinFeesList
           feesList={feesList}
           onChooseFee={previewTransaction}
-          onSetSelectedFeeType={(value: BtcFeeType) => setSelectedFeeType(value)}
+          onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
           onValidateBitcoinSpend={onValidateBitcoinAmountSpend}
           selectedFeeType={selectedFeeType}
         />
       }
-      recommendedFeeRate={recommendedFeeRate}
-      onValidateBitcoinSpend={onValidateBitcoinAmountSpend}
-      onChooseFee={previewTransaction}
-      recipient={txValues.recipient}
       isSendingMax={isSendingMax}
+      onChooseFee={previewTransaction}
+      onValidateBitcoinSpend={onValidateBitcoinAmountSpend}
+      onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
+      recipient={txValues.recipient}
+      recommendedFeeRate={recommendedFeeRate}
       showError={showInsufficientBalanceError}
     />
   );

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-choose-fee.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import { logger } from '@shared/logger';
+import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
 import { createMoney } from '@shared/models/money.model';
 import { noop } from '@shared/utils';
 
@@ -29,7 +30,7 @@ export function useBtcChooseFee() {
   return {
     amountAsMoney,
     onGoBack() {
-      setSelectedFeeType(null);
+      setSelectedFeeType(BtcFeeType.Standard);
       navigate(-1);
     },
 
@@ -37,10 +38,7 @@ export function useBtcChooseFee() {
       const resp = generateTx(
         {
           amount: isSendingMax
-            ? createMoney(
-                btcToSat(calcMaxSpend(txValues.recipient, utxos, feeRate).spendableBitcoin),
-                'BTC'
-              )
+            ? calcMaxSpend(txValues.recipient, utxos, feeRate).amount
             : amountAsMoney,
           recipient: txValues.recipient,
         },


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5416502837).<!-- Sticky Header Marker -->

This PR fixes fees when sending max. Now, the user isn't prevented from selecting the highest fee, instead the fee is subtracted from the total balance and reduces the amount being sent. The same has been done for custom fees here.

I changed the initial send max calc to be based on the `Standard` fee, instead of `Low`, and I set it as the state default so that it is `selected` when the user moves to the choose fee screen. Hopefully this clarifies how the amount at the top has been calculated. I changed to `Standard` here bc it is what the custom input uses as a default, so I thought it made more sense for them to match.

![Screen Shot 2023-06-29 at 2 54 39 PM](https://github.com/hirosystems/wallet/assets/6493321/18ab5475-3288-482f-820e-025332dd7b7a)

Let me know if this doesn't seem correct. cc @mica000 