### PR TITLE
fix: stacks nfts loading key not unique

### DIFF
--- a/src/app/features/collectibles/components/stacks/stacks-crypto-assets.tsx
+++ b/src/app/features/collectibles/components/stacks/stacks-crypto-assets.tsx
@@ -27,9 +27,9 @@ export function StacksCryptoAssets() {
       {names.map(name => (
         <StacksBnsName bnsName={parseIfValidPunycode(name)} key={name} />
       ))}
-      {stacksNftsMetadataResp.map(nft => {
+      {stacksNftsMetadataResp.map((nft, i) => {
         if (!nft || !nft.metadata) return null;
-        return <StacksNonFungibleTokens key={nft.token_uri} metadata={nft.metadata} />;
+        return <StacksNonFungibleTokens key={i} metadata={nft.metadata} />;
       })}
     </>
   );


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5418007669).<!-- Sticky Header Marker -->

This PR fixes a loading issue with Stacks NFTs not have a unique key. The nft data is all the exact same in the issue address, so I'm not sure how else to generate a unique/stable key besides using the index?