### PR TITLE
feat: validate subnet network id

### DIFF
--- a/src/app/features/message-signer/add-network/add-network.tsx
+++ b/src/app/features/message-signer/add-network/add-network.tsx
@@ -31,8 +31,8 @@ interface AddNetworkFormValues {
 const addNetworkFormValues: AddNetworkFormValues = { key: '', name: '', url: '' };
 
 enum NetworkID {
-  Testnet = 0x17000000,
-  Mainnet = 0xff000000,
+  Testnet = 0xff000000,
+  Mainnet = 0x17000000,
 }
 
 export function AddNetwork() {

--- a/src/app/store/accounts/blockchain/stacks/stacks-accounts.ts
+++ b/src/app/store/accounts/blockchain/stacks/stacks-accounts.ts
@@ -72,7 +72,7 @@ const selectStacksWalletState = createSelector(
 
 const softwareAccountsState = atom<SoftwareStacksAccount[] | undefined>(get => {
   const store = get(storeAtom);
-  const addressVersion = get(addressNetworkVersionState);
+  const addressVersion = get(addressNetworkVersionState) || AddressVersion.TestnetSingleSig;
   const accounts = selectStacksWalletState(store);
   if (!accounts) return undefined;
   return accounts.map(account => {

--- a/src/app/store/networks/networks.utils.ts
+++ b/src/app/store/networks/networks.utils.ts
@@ -64,11 +64,12 @@ export function transformNetworkStateToMultichainStucture(
               },
               bitcoin: {
                 blockchain: 'bitcoin',
-                network: ChainID[chainId].toLowerCase(),
-                url: whenStacksChainId(chainId)({
-                  [ChainID.Mainnet]: BITCOIN_API_BASE_URL_MAINNET,
-                  [ChainID.Testnet]: BITCOIN_API_BASE_URL_TESTNET,
-                }),
+                network: ChainID[chainId] ? ChainID[chainId].toLowerCase() : 'testnet',
+                url:
+                  whenStacksChainId(chainId)({
+                    [ChainID.Mainnet]: BITCOIN_API_BASE_URL_MAINNET,
+                    [ChainID.Testnet]: BITCOIN_API_BASE_URL_TESTNET,
+                  }) || BITCOIN_API_BASE_URL_TESTNET,
               },
             },
           },


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5533609498).<!-- Sticky Header Marker -->

## Description

When adding a subnet (such as https://api.subnets.testnet.hiro.so/v2/info), the `parent_network_id` can be validated with the mainnet and testnet ids.

In the future we could have layers 3 (subnets on subnets) so another strategy will be needed to valid the network IDs.

There's also a confusion between NetworkID and ChainID, I'll try to document that before making the PR ready for review
