### PR TITLE
fix: refactor primary chain

### DIFF
--- a/src/app/features/message-signer/add-network/add-network.tsx
+++ b/src/app/features/message-signer/add-network/add-network.tsx
@@ -27,7 +27,7 @@ import {
  * The **peer** network ID.
  * Not used in signing, but needed to determine the parent of a subnet.
  */
-enum NetworkID {
+enum PeerNetworkID {
   Mainnet = 0x17000000,
   Testnet = 0xff000000,
 }
@@ -81,12 +81,13 @@ export function AddNetwork() {
             const isSubnet = typeof chainInfo.l1_subnet_governing_contract === 'string';
             const isFirstLevelSubnet =
               isSubnet &&
-              (parentNetworkId === NetworkID.Mainnet || parentNetworkId === NetworkID.Testnet);
+              (parentNetworkId === PeerNetworkID.Mainnet ||
+                parentNetworkId === PeerNetworkID.Testnet);
 
             // Currently, only subnets of mainnet and testnet are supported in the wallet
             if (isFirstLevelSubnet) {
               const parentChainId =
-                parentNetworkId === NetworkID.Mainnet ? ChainID.Mainnet : ChainID.Testnet;
+                parentNetworkId === PeerNetworkID.Mainnet ? ChainID.Mainnet : ChainID.Testnet;
               networksActions.addNetwork({
                 chainId: parentChainId, // Used for differentiating control flow in the wallet
                 subnetChainId: chainId, // Used for signing transactions (via the network object, not to be confused with the NetworkConfigurations)

--- a/src/app/query/stacks/rate-limiter.ts
+++ b/src/app/query/stacks/rate-limiter.ts
@@ -15,9 +15,9 @@ const hiroStacksTestnetApiLimiter = new RateLimiter({
 });
 
 export function useHiroApiRateLimiter() {
-  const network = useCurrentNetworkState();
+  const currentNetwork = useCurrentNetworkState();
 
-  return whenStacksChainId(network.chain.stacks.chainId)({
+  return whenStacksChainId(currentNetwork.chain.stacks.chainId)({
     [ChainID.Mainnet]: hiroStacksMainnetApiLimiter,
     [ChainID.Testnet]: hiroStacksTestnetApiLimiter,
   });

--- a/src/app/store/common/api-clients.hooks.ts
+++ b/src/app/store/common/api-clients.hooks.ts
@@ -56,9 +56,9 @@ export function useStacksClientAnchored() {
 }
 
 export function useTokenMetadataClient() {
-  const network = useCurrentNetworkState();
+  const currentNetwork = useCurrentNetworkState();
 
-  const basePath = whenStacksChainId(network.chain.stacks.chainId)({
+  const basePath = whenStacksChainId(currentNetwork.chain.stacks.chainId)({
     [ChainID.Mainnet]: HIRO_API_BASE_URL_MAINNET,
     [ChainID.Testnet]: HIRO_API_BASE_URL_TESTNET,
   });

--- a/src/app/store/networks/networks.hooks.ts
+++ b/src/app/store/networks/networks.hooks.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { StacksMainnet, StacksNetwork, StacksTestnet } from '@stacks/network';
-import { ChainID } from '@stacks/transactions';
+import { StacksNetwork } from '@stacks/network';
+import { ChainID, TransactionVersion } from '@stacks/transactions';
 
 import { NetworkModes } from '@shared/constants';
 
@@ -29,10 +29,16 @@ export function useCurrentStacksNetworkState(): StacksNetwork {
   return useMemo(() => {
     if (!currentNetwork) throw new Error('No current network');
 
-    const stacksNetwork = whenStacksChainId(currentNetwork.chain.stacks.chainId)({
-      [ChainID.Mainnet]: new StacksMainnet({ url: currentNetwork.chain.stacks.url }),
-      [ChainID.Testnet]: new StacksTestnet({ url: currentNetwork.chain.stacks.url }),
+    // todo: these params could be added to the constructor in stacks.js
+    const stacksNetwork = new StacksNetwork({ url: currentNetwork.chain.stacks.url });
+    stacksNetwork.version = whenStacksChainId(currentNetwork.chain.stacks.chainId)({
+      [ChainID.Mainnet]: TransactionVersion.Mainnet,
+      [ChainID.Testnet]: TransactionVersion.Testnet,
     });
+
+    // Use actual chainId on network object, since it's used for signing
+    stacksNetwork.chainId =
+      currentNetwork.chain.stacks.subnetChainId ?? currentNetwork.chain.stacks.chainId;
 
     stacksNetwork.bnsLookupUrl = currentNetwork.chain.stacks.url || '';
     return stacksNetwork;

--- a/src/app/store/networks/networks.hooks.ts
+++ b/src/app/store/networks/networks.hooks.ts
@@ -50,8 +50,8 @@ export function useNetworksActions() {
 
   return useMemo(
     () => ({
-      addNetwork({ chainId, id, name, url }: PersistedNetworkConfiguration) {
-        dispatch(networksActions.addNetwork({ chainId, id, name, url }));
+      addNetwork({ chainId, subnetChainId, id, name, url }: PersistedNetworkConfiguration) {
+        dispatch(networksActions.addNetwork({ chainId, subnetChainId, id, name, url }));
         dispatch(networksActions.changeNetwork(id));
         return;
       },

--- a/src/app/store/networks/networks.utils.ts
+++ b/src/app/store/networks/networks.utils.ts
@@ -50,7 +50,7 @@ export function transformNetworkStateToMultichainStucture(
     Object.entries(state)
       .map(([key, network]) => {
         if (!network) return ['', null];
-        const { id, name, chainId, url } = network;
+        const { id, name, chainId, subnetChainId, url } = network;
         return [
           key,
           {
@@ -61,6 +61,7 @@ export function transformNetworkStateToMultichainStucture(
                 blockchain: 'stacks',
                 url,
                 chainId,
+                subnetChainId,
               },
               bitcoin: {
                 blockchain: 'bitcoin',

--- a/src/app/store/transactions/transaction.ts
+++ b/src/app/store/transactions/transaction.ts
@@ -23,20 +23,20 @@ export function prepareTxDetailsForBroadcast(tx: StacksTransaction) {
 }
 
 export const transactionNetworkVersionState = atom(get => {
-  const chainId = get(currentNetworkAtom)?.chain.stacks.chainId;
+  const currentNetwork = get(currentNetworkAtom);
 
-  const defaultChainId = TransactionVersion.Testnet;
-  if (!chainId) return defaultChainId;
+  if (!currentNetwork.chain.stacks.chainId) return TransactionVersion.Testnet; // default to testnet
 
-  return whenStacksChainId(chainId)({
+  return whenStacksChainId(currentNetwork.chain.stacks.chainId)({
     [ChainID.Mainnet]: TransactionVersion.Mainnet,
     [ChainID.Testnet]: TransactionVersion.Testnet,
   });
 });
 
 export const addressNetworkVersionState = atom(get => {
-  const chainId = get(currentNetworkAtom)?.chain.stacks.chainId;
-  return whenStacksChainId(chainId)({
+  const currentNetwork = get(currentNetworkAtom);
+
+  return whenStacksChainId(currentNetwork.chain.stacks.chainId)({
     [ChainID.Mainnet]: AddressVersion.MainnetSingleSig,
     [ChainID.Testnet]: AddressVersion.TestnetSingleSig,
   });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -59,7 +59,10 @@ interface BitcoinChainConfig extends BaseChainConfig {
 interface StacksChainConfig extends BaseChainConfig {
   blockchain: 'stacks';
   url: string;
+  /** The chainId of the network (or parent network if this is a subnet) */
   chainId: ChainID;
+  /** An additional chainId for subnets. Indicated a subnet if defined and is mainly used for signing */
+  subnetChainId?: ChainID;
 }
 
 export interface NetworkConfiguration {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5610259162).<!-- Sticky Header Marker -->

- refactors for validating subnet and working with the correct chain id in different code paths

### Explanation
I added a "primary" chain id (which is the parent network, if one is available).
The primary chainId/network is the one used for address detection, transaction version etc. (mainly the checks for mainnet/testnet).
The actual chainId is used mainly for signing (and thus is on the network object constructed from the user-provided url.

I hope this makes sense. It will likely not hold up once nested subnets emerge (which isn't too soon I hope)