### PR TITLE
fix: change logic to upscale amount in input field

### DIFF
--- a/src/app/common/utils.ts
+++ b/src/app/common/utils.ts
@@ -295,3 +295,14 @@ export function isFulfilled<T>(p: PromiseSettledResult<T>): p is PromiseFulfille
 export function isRejected<T>(p: PromiseSettledResult<T>): p is PromiseRejectedResult {
   return p.status === 'rejected';
 }
+
+interface LinearInterpolation {
+  start: number;
+  end: number;
+  t: number;
+}
+
+// Linear Interpolation
+export function linearInterpolation({ start, end, t }: LinearInterpolation) {
+  return (1 - t) * start + t * end;
+}

--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -5,10 +5,11 @@ import { Box, Flex, Input, Stack, Text, color } from '@stacks/ui';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { useField } from 'formik';
 
-import { STX_DECIMALS } from '@shared/constants';
+import { STX_DECIMALS, TOKEN_NAME_LENGTH } from '@shared/constants';
 import { Money } from '@shared/models/money.model';
 
 import { useShowFieldError } from '@app/common/form-utils';
+import { linearInterpolation } from '@app/common/utils';
 import { figmaTheme } from '@app/common/utils/figma-theme';
 import { ErrorLabel } from '@app/components/error-label';
 
@@ -30,17 +31,6 @@ function getAmountModifiedFontSize(props: GetAmountModifiedFontSize) {
   return amount.length > symbol.length
     ? Math.ceil(fontSize - convertedAmountFontSize)
     : maxFontSize;
-}
-
-interface Lerp {
-  start: number;
-  end: number;
-  t: number;
-}
-
-// Linear Interpolation
-function lerp({ start, end, t }: Lerp) {
-  return (1 - t) * start + t * end;
 }
 
 interface AmountFieldProps {
@@ -76,12 +66,12 @@ export function AmountField({
   const subtractedLengthToPositionPrefix = 0.5;
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (symbol.length <= 4) {
+    if (symbol.length <= TOKEN_NAME_LENGTH) {
       const value = event.currentTarget.value;
 
       const t = value.length / (symbol.length + maxLength);
 
-      const newFontSize = lerp({ start: maxFontSize, end: minFontSize, t });
+      const newFontSize = linearInterpolation({ start: maxFontSize, end: minFontSize, t });
       setFontSize(newFontSize);
     }
 
@@ -90,7 +80,7 @@ export function AmountField({
 
   useEffect(() => {
     // case, when e.g token doesn't have symbol
-    if (symbol.length > 4) setFontSize(minFontSize);
+    if (symbol.length > TOKEN_NAME_LENGTH) setFontSize(minFontSize);
 
     // Copy/paste
     if (field.value.length > symbol.length && field.value.length > previousTextLength + 2) {

--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 
 import { Box, Flex, Input, Stack, Text, color } from '@stacks/ui';
@@ -52,6 +53,7 @@ export function AmountField({
   tokenSymbol,
 }: AmountFieldProps) {
   const [field, meta, helpers] = useField('amount');
+
   const showError = useShowFieldError('amount');
   const [fontSize, setFontSize] = useState(maxFontSize);
   const [previousTextLength, setPreviousTextLength] = useState(1);
@@ -62,19 +64,30 @@ export function AmountField({
   const fontSizeModifier = (maxFontSize - minFontSize) / maxLength;
   const subtractedLengthToPositionPrefix = 0.5;
 
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.value;
+
+    if (value.length <= symbol.length) {
+      setFontSize(maxFontSize);
+    } else if (previousTextLength > value.length) {
+      const textSize = Math.ceil(fontSize + fontSizeModifier);
+      if (fontSize < maxFontSize) {
+        setFontSize(textSize);
+      }
+    } else if (previousTextLength < value.length) {
+      const textSize = Math.ceil(fontSize - fontSizeModifier);
+      if (fontSize > minFontSize) {
+        setFontSize(textSize);
+      }
+    }
+
+    field.onChange(event);
+  };
+
   useEffect(() => {
     // case, when e.g token doesn't have symbol
     if (symbol.length > 4) setFontSize(minFontSize);
 
-    // Typing
-    if (field.value.length === symbol.length) setFontSize(maxFontSize);
-    if (field.value.length > symbol.length && previousTextLength > field.value.length) {
-      const textSize = Math.ceil(fontSize + fontSizeModifier);
-      fontSize < maxFontSize && setFontSize(textSize);
-    } else if (field.value.length > symbol.length && previousTextLength < field.value.length) {
-      const textSize = Math.ceil(fontSize - fontSizeModifier);
-      fontSize > minFontSize && setFontSize(textSize);
-    }
     // Copy/paste
     if (field.value.length > symbol.length && field.value.length > previousTextLength + 2) {
       const modifiedFontSize = getAmountModifiedFontSize({
@@ -139,6 +152,7 @@ export function AmountField({
             fontWeight={500}
             autoComplete={autoComplete}
             {...field}
+            onChange={onChange}
           />
           <Text fontSize={fontSize + 'px'} pl="tight">
             {symbol.toUpperCase()}

--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -32,6 +32,17 @@ function getAmountModifiedFontSize(props: GetAmountModifiedFontSize) {
     : maxFontSize;
 }
 
+interface Lerp {
+  start: number;
+  end: number;
+  t: number;
+}
+
+// Linear Interpolation
+function lerp({ start, end, t }: Lerp) {
+  return (1 - t) * start + t * end;
+}
+
 interface AmountFieldProps {
   autoComplete?: 'on' | 'off';
   autofocus?: boolean;
@@ -65,20 +76,13 @@ export function AmountField({
   const subtractedLengthToPositionPrefix = 0.5;
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const value = event.currentTarget.value;
+    if (symbol.length <= 4) {
+      const value = event.currentTarget.value;
 
-    if (value.length <= symbol.length) {
-      setFontSize(maxFontSize);
-    } else if (previousTextLength > value.length) {
-      const textSize = Math.ceil(fontSize + fontSizeModifier);
-      if (fontSize < maxFontSize) {
-        setFontSize(textSize);
-      }
-    } else if (previousTextLength < value.length) {
-      const textSize = Math.ceil(fontSize - fontSizeModifier);
-      if (fontSize > minFontSize) {
-        setFontSize(textSize);
-      }
+      const t = value.length / (symbol.length + maxLength);
+
+      const newFontSize = lerp({ start: maxFontSize, end: minFontSize, t });
+      setFontSize(newFontSize);
     }
 
     field.onChange(event);

--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Box, Flex, Input, Stack, Text, color } from '@stacks/ui';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
@@ -57,7 +57,9 @@ export function AmountField({
 
   const showError = useShowFieldError('amount');
   const [fontSize, setFontSize] = useState(maxFontSize);
+  const [textSizeInPx, setTextSizeInPx] = useState(0);
   const [previousTextLength, setPreviousTextLength] = useState(1);
+  const fieldRef = useRef<HTMLSpanElement>(null);
 
   const { decimals } = balance;
   const symbol = tokenSymbol || balance.symbol;
@@ -66,9 +68,16 @@ export function AmountField({
   const subtractedLengthToPositionPrefix = 0.5;
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (symbol.length <= TOKEN_NAME_LENGTH) {
-      const value = event.currentTarget.value;
+    const value = event.currentTarget.value;
 
+    /*
+     * If the symbol is not a token (has more than 4 chars) we don't want to
+     * modify the size since we will always use minFontSize to be avoid overflowing.
+     * Since we are using lerp, as soon as we type 1 character we get a new font size
+     * which makes content jump if we type 0 and placeholder is 0. That's why we only update the size
+     * if we have none or more than 1 characters.
+     */
+    if (symbol.length <= TOKEN_NAME_LENGTH && value.length !== 1) {
       const t = value.length / (symbol.length + maxLength);
 
       const newFontSize = linearInterpolation({ start: maxFontSize, end: minFontSize, t });
@@ -98,6 +107,24 @@ export function AmountField({
     );
   }, [field.value, fontSize, fontSizeModifier, isSendingMax, previousTextLength, symbol]);
 
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(entries => {
+      const [text] = entries;
+      const [size] = text?.contentBoxSize;
+      if (size) {
+        const { inlineSize } = size;
+        setTextSizeInPx(inlineSize);
+      }
+    });
+
+    const sizeReference = fieldRef.current;
+
+    if (sizeReference) {
+      resizeObserver.observe(sizeReference);
+    }
+    () => resizeObserver.disconnect();
+  }, []);
+
   // TODO: could be implemented with html using padded label element
   const onClickFocusInput = useCallback(() => {
     if (isSendingMax) {
@@ -125,6 +152,7 @@ export function AmountField({
           justifyContent="center"
           fontWeight={500}
           color={figmaTheme.text}
+          position="relative"
         >
           {isSendingMax ? <Text fontSize={fontSize + 'px'}>~</Text> : null}
           <Input
@@ -141,13 +169,39 @@ export function AmountField({
             placeholder="0"
             px="none"
             textAlign="right"
-            width={!field.value.length ? '1ch' : previousTextLength + 'ch'}
+            /*
+             * We are adding an extra 25px to the variable since there's a transition for width
+             * which makes the content cut momentarily while the width is updated. The 25px serve
+             * as extra space so users don't experience that text cutting.
+             * We are correcting for that extra space with a negative margin so the content is perfectly
+             * centered
+             */
+            width={!field.value?.length ? '1ch' : textSizeInPx + 25 + 'px'}
+            marginInlineStart={!field.value?.length ? 0 : -25 + 'px'}
             autoFocus={autofocus}
             fontWeight={500}
             autoComplete={autoComplete}
             {...field}
             onChange={onChange}
           />
+          {/*
+           * This is what we use to measure the size of the input, it's hidden
+           * and with no pointer events so users can't interact with it
+           */}
+          <Text
+            position="absolute"
+            ref={fieldRef}
+            visibility="hidden"
+            pointerEvents="none"
+            top={0}
+            left={0}
+            letterSpacing={-0.3 + 'px'}
+            fontWeight={500}
+            fontSize={fontSize + 'px'}
+            minWidth={1 + 'ch'}
+          >
+            {field.value}
+          </Text>
           <Text fontSize={fontSize + 'px'} pl="tight">
             {symbol.toUpperCase()}
           </Text>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -166,3 +166,5 @@ export const defaultNetworksKeyedById: Record<
 };
 
 export const DEFAULT_LIST_LIMIT = 50;
+
+export const TOKEN_NAME_LENGTH = 4;


### PR DESCRIPTION
The bug was caused by this logic

```js
if (field.value.length > symbol.length && previousTextLength > field.value.length)
```

If you had a value of length 10, then delete 9 characters this would be evaluated to false  -> `field.value.length > symbol.length` thus not increasing back the size of the text. 

The correct logic is to check if `value.length` is less or equal to the symbol length, if that is true then you can safely use the maxFontSize, then you either check if you are adding text or deleting outside of the safe boundary and increase/decrease font size accordingly 

I also removed this logic from the `useEffect` since having it in there is usually a code smell, I think is better to implement  this on an event handler.

I'm open to any feedback or changes necessary to merge this PR 😀

https://github.com/hirosystems/wallet/assets/20308945/e4f96c7d-5ea8-4323-97ed-21c03fc8bbb9

fixes #3767