### PR TITLE
fix: only run validation on amount field if non empty, closes #3766

### DIFF
--- a/src/app/common/form-utils.ts
+++ b/src/app/common/form-utils.ts
@@ -9,6 +9,7 @@ export function useShowFieldError(name: string) {
   const form = useFormikContext();
   const [_, meta] = useField(name);
   const isDirty = useIsFieldDirty(name);
+  const isFieldInFocus = document.activeElement?.getAttribute('name') === name;
 
-  return (form.submitCount > 0 && meta.error) || (meta.touched && isDirty && meta.error);
+  return (form.submitCount > 0 && meta.error) || (!isFieldInFocus && meta.touched && isDirty && meta.error);
 }

--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -47,6 +47,7 @@ export function btcInsufficientBalanceValidator({
     .typeError(FormErrorMessages.MustBeNumber)
     .test({
       message: FormErrorMessages.InsufficientFunds,
+      skipAbsent: true,
       test(value) {
         if (!value) return false;
         const maxSpend = calcMaxSpend(recipient, utxos);
@@ -64,6 +65,7 @@ export function btcMinimumSpendValidator() {
     .typeError(FormErrorMessages.MustBeNumber)
     .test({
       message: `Minimum is ${satToBtc(minSpendAmountInSats)}`,
+      skipAbsent: true,
       test(value) {
         if (!value) return false;
         const desiredSpend = btcToSat(value);

--- a/src/app/common/validation/forms/currency-validators.ts
+++ b/src/app/common/validation/forms/currency-validators.ts
@@ -20,6 +20,7 @@ function currencyPrecisionValidatorFactory(precision: number, errorMessage: stri
     .typeError(FormErrorMessages.MustBeNumber)
     .test({
       message: errorMessage,
+      skipAbsent: true,
       test(value: unknown) {
         if (!isNumber(value)) return false;
         return countDecimals(value) <= precision;

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -42,7 +42,6 @@ export function BtcSendForm() {
     utxos,
     validationSchema,
   } = useBtcSendForm();
-
   return (
     <Box width="100%" pb="base">
       <Formik
@@ -50,7 +49,7 @@ export function BtcSendForm() {
           ...routeState,
           recipientBnsName: '',
         })}
-        onSubmit={chooseTransactionFee}
+        onSubmit={async values => await chooseTransactionFee(values)}
         validationSchema={validationSchema}
         innerRef={formRef}
         {...defaultSendFormFormikProps}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -83,12 +83,12 @@ export function useBtcSendForm() {
     }),
 
     async chooseTransactionFee(
-      values: BitcoinSendFormValues,
-      formikHelpers: FormikHelpers<BitcoinSendFormValues>
+      values: BitcoinSendFormValues
+      // formikHelpers: FormikHelpers<BitcoinSendFormValues>
     ) {
       logger.debug('btc form values', values);
       // Validate and check high fee warning first
-      await formikHelpers.validateForm();
+      // await formikHelpers.validateForm();
 
       whenWallet({
         software: () => sendFormNavigate.toChooseTransactionFee(isSendingMax, utxos, values),


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5600097360).<!-- Sticky Header Marker -->

This PR adds a check to the amount field validation to make sure the validation only runs if the amount is not empty. 

I added it just for `amount` but this seems to be a problem affecting a lot of fields:
https://github.com/hirosystems/wallet/assets/2938440/7a200628-cbde-4a1e-b438-1538ff1b8947

If users:
* focus and then unfocus on any field, 
* return and enter a value,
* an incorrect validation error is shown before the user blurs again and validation reruns 
