### PR TITLE
fix: only show errors when field not in focus, closes #3766

### DIFF
--- a/src/app/common/form-utils.ts
+++ b/src/app/common/form-utils.ts
@@ -9,6 +9,10 @@ export function useShowFieldError(name: string) {
   const form = useFormikContext();
   const [_, meta] = useField(name);
   const isDirty = useIsFieldDirty(name);
+  const isFieldInFocus = document.activeElement?.getAttribute('name') === name;
 
-  return (form.submitCount > 0 && meta.error) || (meta.touched && isDirty && meta.error);
+  return (
+    (form.submitCount > 0 && meta.error) ||
+    (!isFieldInFocus && meta.touched && isDirty && meta.error)
+  );
 }


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5600673862).<!-- Sticky Header Marker -->

This PR fixes issue https://github.com/hirosystems/wallet/issues/3766

I tried a few solutions in this PR but this is the cleanest I found.

https://github.com/hirosystems/wallet/pull/4021

The fix makes sure we only show validation errors if a field is invalid and not in focus. 

Otherwise, if a user focuses then unfocuses on a field(`touches` the field) , when they next return an error shows until they un focus and the validation can re-run and clear the error