### PR TITLE
fix: tighten up match rules to not inject script to wordpress, fixes …

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ supports Chromium and Firefox browsers. When you run `yarn dev`, it will compile
 - [Chrome instructions](https://developer.chrome.com/docs/extensions/mv3/faq/#faq-dev-01)
 - [Firefox instructions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#trying_it_out)
 
+Note that to build for 'firefox' you will need to set the `.env` flag `TARGET_BROWSER` in `generate-manifest`
+
 ## Testing
 
 Several testing scripts are available in [`package.json`](./package.json).

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -93,8 +93,9 @@ const manifest = {
   content_scripts: [
     {
       js: ['content-script.js'],
-      matches: ['*://*/*'],
+      matches: ["file://*/*", "http://*/*", "https://*/*"],
       all_frames: true,
+      run_at: "document_start",
     },
   ],
 };


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5833158567).<!-- Sticky Header Marker -->

This PR fixes a reported issue where:
- When a user is editing a wordpress page in Firefox
- Then the Hiro extenstion adds a script tag to the page src in the WYSIWYG editor

I looked into this and it was caused by the introduction of `all_frames: true` [here](https://github.com/hirosystems/wallet/discussions/2263). 

I notice that it was mentioned that MetaMask use this setting so I tested with their add-on and it doesn't inject a script tag in Wordpress. I checked MetaMask src and how they are doing it and applied their logic here. 

This fixes the issue but I'm not sure if we still need to have `all_frames: true` enabled in general? 