### PR TITLE
fix: multi extension loading

### DIFF
--- a/src/content-scripts/content-script.ts
+++ b/src/content-scripts/content-script.ts
@@ -128,8 +128,9 @@ document.addEventListener(DomEventName.psbtRequest, ((event: PsbtRequestEvent) =
   });
 }) as EventListener);
 
-// Inject inpage script (Stacks Provider)
-const inpage = document.createElement('script');
-inpage.src = chrome.runtime.getURL('inpage.js');
-inpage.id = 'stacks-wallet-provider';
-document.body.appendChild(inpage);
+window.addEventListener('load', () => {
+  const inpage = document.createElement('script');
+  inpage.src = chrome.runtime.getURL('inpage.js');
+  inpage.id = 'stacks-wallet-provider';
+  document.body.appendChild(inpage);
+});

--- a/src/shared/inpage-types.ts
+++ b/src/shared/inpage-types.ts
@@ -3,12 +3,12 @@
  */
 export enum DomEventName {
   request = 'request',
-  authenticationRequest = 'stacksAuthenticationRequest',
-  signatureRequest = 'signatureRequest',
-  structuredDataSignatureRequest = 'structuredDataSignatureRequest',
-  transactionRequest = 'stacksTransactionRequest',
-  profileUpdateRequest = 'profileUpdateRequest',
-  psbtRequest = 'psbtRequest',
+  authenticationRequest = 'hiroWalletStacksAuthenticationRequest',
+  signatureRequest = 'hiroWalletSignatureRequest',
+  structuredDataSignatureRequest = 'hiroWalletStructuredDataSignatureRequest',
+  transactionRequest = 'hiroWalletStacksTransactionRequest',
+  profileUpdateRequest = 'hiroWalletProfileUpdateRequest',
+  psbtRequest = 'hiroWalletPsbtRequest',
 }
 
 export interface AuthenticationRequestEventDetails {

--- a/src/shared/message-types.ts
+++ b/src/shared/message-types.ts
@@ -11,18 +11,18 @@ export const MESSAGE_SOURCE = 'stacks-wallet' as const;
 export const CONTENT_SCRIPT_PORT = 'content-script' as const;
 
 export enum ExternalMethods {
-  transactionRequest = 'transactionRequest',
-  transactionResponse = 'transactionResponse',
-  authenticationRequest = 'authenticationRequest',
-  authenticationResponse = 'authenticationResponse',
-  signatureRequest = 'signatureRequest',
-  signatureResponse = 'signatureResponse',
-  structuredDataSignatureRequest = 'structuredDataSignatureRequest',
-  structuredDataSignatureResponse = 'structuredDataSignatureResponse',
-  profileUpdateRequest = 'profileUpdateRequest',
-  profileUpdateResponse = 'profileUpdateResponse',
-  psbtRequest = 'psbtRequest',
-  psbtResponse = 'psbtResponse',
+  transactionRequest = 'hiroWalletTransactionRequest',
+  transactionResponse = 'hiroWalletTransactionResponse',
+  authenticationRequest = 'hiroWalletAuthenticationRequest',
+  authenticationResponse = 'hiroWalletAuthenticationResponse',
+  signatureRequest = 'hiroWalletSignatureRequest',
+  signatureResponse = 'hiroWalletSignatureResponse',
+  structuredDataSignatureRequest = 'hiroWalletStructuredDataSignatureRequest',
+  structuredDataSignatureResponse = 'hiroWalletStructuredDataSignatureResponse',
+  profileUpdateRequest = 'hiroWalletProfileUpdateRequest',
+  profileUpdateResponse = 'hiroWalletProfileUpdateResponse',
+  psbtRequest = 'hiroWalletPsbtRequest',
+  psbtResponse = 'hiroWalletPsbtResponse',
 }
 
 export enum InternalMethods {


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5622851418).<!-- Sticky Header Marker -->

For some reason Xverse uses exactly the same DOM event names as the Hiro Wallet. By prefixing these events with a HiroWallet specific name, we avoid the clash.