### PR TITLE
fix: use location.state to store background route to prevent unmount

### DIFF
--- a/src/app/common/hooks/use-background-location-redirect.ts
+++ b/src/app/common/hooks/use-background-location-redirect.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { RouteUrls } from '@shared/route-urls';
+
+import { useLocationState } from '@app/common/hooks/use-location-state';
+
+/*
+when modals are opened in a new tab they lose the location.state.backgroundLocation
+ this hook sets the backgroundLocation to be RouteUrls.Home to improve UX
+*/
+export function useBackgroundLocationRedirect() {
+  const { pathname, state } = useLocation();
+  const navigate = useNavigate();
+  const backgroundLocation = useLocationState('backgroundLocation');
+
+  useEffect(() => {
+    void (async () => {
+      switch (true) {
+        // FIXME ReceiveCollectibleOrdinal loses state?.btcAddressTaproot in a new tab
+        // this can be improved to try and fetch btcAddressTaproot
+        case pathname === RouteUrls.ReceiveCollectibleOrdinal && !state?.btcAddressTaproot:
+          return navigate(RouteUrls.Home);
+
+        case backgroundLocation === undefined:
+          return navigate(pathname, {
+            state: { backgroundLocation: { pathname: RouteUrls.Home } },
+          });
+        default:
+          return false;
+      }
+    })();
+  }, [backgroundLocation, navigate, pathname, state]);
+}

--- a/src/app/common/hooks/use-location-state.ts
+++ b/src/app/common/hooks/use-location-state.ts
@@ -5,11 +5,18 @@ import get from 'lodash.get';
 
 import { isUndefined } from '@shared/utils';
 
+
+export function useLocationState(propName: string): string | undefined;
+export function useLocationState(propName: string, defaultValue: string): string;
+export function useLocationState(propName: 'accountIndex'): number;
+export function useLocationState(propName: 'backgroundLocation'): Location;
 export function useLocationState(propName: string, defaultValue?: string) {
   const location = useLocation();
   return get(location, `state.${propName}`, defaultValue);
 }
 
+export function useLocationStateWithCache<T = string>(propName: string): T | undefined;
+export function useLocationStateWithCache<T = string>(propName: string, defaultValue: T): T;
 export function useLocationStateWithCache<T = string>(propName: string, defaultValue?: T) {
   const location = useLocation();
   const [value, setValue] = useState(defaultValue);

--- a/src/app/common/hooks/use-location-state.ts
+++ b/src/app/common/hooks/use-location-state.ts
@@ -5,7 +5,6 @@ import get from 'lodash.get';
 
 import { isUndefined } from '@shared/utils';
 
-
 export function useLocationState(propName: string): string | undefined;
 export function useLocationState(propName: string, defaultValue: string): string;
 export function useLocationState(propName: 'accountIndex'): number;

--- a/src/app/common/hooks/use-location-state.ts
+++ b/src/app/common/hooks/use-location-state.ts
@@ -5,15 +5,11 @@ import get from 'lodash.get';
 
 import { isUndefined } from '@shared/utils';
 
-export function useLocationState(propName: string): string | undefined;
-export function useLocationState(propName: string, defaultValue: string): string;
 export function useLocationState(propName: string, defaultValue?: string) {
   const location = useLocation();
   return get(location, `state.${propName}`, defaultValue);
 }
 
-export function useLocationStateWithCache<T = string>(propName: string): T | undefined;
-export function useLocationStateWithCache<T = string>(propName: string, defaultValue: T): T;
 export function useLocationStateWithCache<T = string>(propName: string, defaultValue?: T) {
   const location = useLocation();
   const [value, setValue] = useState(defaultValue);

--- a/src/app/components/receive/receive-collectible.tsx
+++ b/src/app/components/receive/receive-collectible.tsx
@@ -1,14 +1,14 @@
 import toast from 'react-hot-toast';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import BitcoinStampImg from '@assets/images/bitcoin-stamp.png';
 import { Box, Stack, useClipboard } from '@stacks/ui';
 import { HomePageSelectors } from '@tests/selectors/home.selectors';
-import get from 'lodash.get';
 
 import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
 import { OrdinalIcon } from '@app/components/icons/ordinal-icon';
 import { useZeroIndexTaprootAddress } from '@app/query/bitcoin/ordinals/use-zero-index-taproot-address';
@@ -19,9 +19,9 @@ import { ReceiveCollectibleItem } from './receive-collectible-item';
 
 export function ReceiveCollectible() {
   const analytics = useAnalytics();
-  const location = useLocation();
+  const backgroundLocation = useLocationState('backgroundLocation');
+  const accountIndex = useLocationState('accountIndex');
   const navigate = useNavigate();
-  const accountIndex = get(location.state, 'accountIndex', undefined);
   const btcAddressNativeSegwit = useCurrentAccountNativeSegwitAddressIndexZero();
   const btcAddressTaproot = useZeroIndexTaprootAddress(accountIndex);
 
@@ -54,7 +54,9 @@ export function ReceiveCollectible() {
         data-testid={HomePageSelectors.ReceiveBtcTaprootQrCodeBtn}
         onCopyAddress={() => {
           void analytics.track('select_inscription_to_add_new_collectible');
-          navigate(RouteUrls.ReceiveCollectibleOrdinal, { state: { btcAddressTaproot } });
+          navigate(RouteUrls.ReceiveCollectibleOrdinal, {
+            state: { btcAddressTaproot, backgroundLocation },
+          });
         }}
         title="Ordinal inscription"
       />

--- a/src/app/features/asset-list/asset-list.tsx
+++ b/src/app/features/asset-list/asset-list.tsx
@@ -1,5 +1,4 @@
-import { Outlet } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 
 import { Box, Stack } from '@stacks/ui';
 import { HomePageSelectorsLegacy } from '@tests-legacy/page-objects/home.selectors';

--- a/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -1,9 +1,8 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Inscription as InscriptionType } from '@shared/models/inscription.model';
 import { RouteUrls } from '@shared/route-urls';
 
-import { useLocationState } from '@app/common/hooks/use-location-state';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { OrdinalIconFull } from '@app/components/icons/ordinal-icon-full';
 import { OrdinalMinimalIcon } from '@app/components/icons/ordinal-minimal-icon';
@@ -19,11 +18,11 @@ interface InscriptionProps {
 export function Inscription({ rawInscription }: InscriptionProps) {
   const inscription = convertInscriptionToSupportedInscriptionType(rawInscription);
   const navigate = useNavigate();
-  const backgroundLocation = useLocationState('backgroundLocation');
+  const location = useLocation();
 
   function openSendInscriptionModal() {
     navigate(RouteUrls.SendOrdinalInscription, {
-      state: { inscription, backgroundLocation },
+      state: { inscription, backgroundLocation: location },
     });
   }
 

--- a/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Inscription as InscriptionType } from '@shared/models/inscription.model';
 import { RouteUrls } from '@shared/route-urls';
 
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { OrdinalIconFull } from '@app/components/icons/ordinal-icon-full';
 import { OrdinalMinimalIcon } from '@app/components/icons/ordinal-minimal-icon';
@@ -18,10 +19,11 @@ interface InscriptionProps {
 export function Inscription({ rawInscription }: InscriptionProps) {
   const inscription = convertInscriptionToSupportedInscriptionType(rawInscription);
   const navigate = useNavigate();
+  const backgroundLocation = useLocationState('backgroundLocation');
 
   function openSendInscriptionModal() {
     navigate(RouteUrls.SendOrdinalInscription, {
-      state: { inscription },
+      state: { inscription, backgroundLocation },
     });
   }
 

--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -96,7 +96,6 @@ export function SettingsDropdown() {
               onClick={wrappedCloseCallback(() => {
                 void analytics.track('click_change_theme_menu_item');
                 navigate(RouteUrls.ChangeTheme, {
-                  relative: 'path',
                   state: { backgroundLocation: location },
                 });
               })}
@@ -151,7 +150,6 @@ export function SettingsDropdown() {
               onClick={wrappedCloseCallback(() => {
                 void analytics.track('click_change_network_menu_item');
                 navigate(RouteUrls.SelectNetwork, {
-                  relative: 'path',
                   state: { backgroundLocation: location },
                 });
               })}
@@ -185,7 +183,6 @@ export function SettingsDropdown() {
               color={color('feedback-error')}
               onClick={wrappedCloseCallback(() =>
                 navigate(RouteUrls.SignOutConfirm, {
-                  relative: 'path',
                   state: { backgroundLocation: location },
                 })
               )}

--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -11,6 +11,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useDrawers } from '@app/common/hooks/use-drawers';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { useModifierKey } from '@app/common/hooks/use-modifier-key';
 import { useOnClickOutside } from '@app/common/hooks/use-onclickoutside';
 import { useWalletType } from '@app/common/use-wallet-type';
@@ -47,6 +48,7 @@ export function SettingsDropdown() {
   const key = useCurrentKeyDetails();
   const { isPressed: showAdvancedMenuOptions } = useModifierKey('alt', 120);
   const location = useLocation();
+  const backgroundLocation = useLocationState('backgroundLocation');
 
   const handleClose = useCallback(() => setIsShowingSettings(false), [setIsShowingSettings]);
 
@@ -95,7 +97,10 @@ export function SettingsDropdown() {
               data-testid={SettingsSelectors.ToggleTheme}
               onClick={wrappedCloseCallback(() => {
                 void analytics.track('click_change_theme_menu_item');
-                navigate(RouteUrls.ChangeTheme, { relative: 'path' });
+                navigate(RouteUrls.ChangeTheme, {
+                  relative: 'path',
+                  state: { backgroundLocation },
+                });
               })}
             >
               Change theme
@@ -147,7 +152,10 @@ export function SettingsDropdown() {
               data-testid={SettingsSelectors.ChangeNetworkAction}
               onClick={wrappedCloseCallback(() => {
                 void analytics.track('click_change_network_menu_item');
-                navigate(RouteUrls.SelectNetwork, { relative: 'path' });
+                navigate(RouteUrls.SelectNetwork, {
+                  relative: 'path',
+                  state: { backgroundLocation },
+                });
               })}
             >
               <Flex width="100%" alignItems="center" justifyContent="space-between">
@@ -178,7 +186,10 @@ export function SettingsDropdown() {
             <MenuItem
               color={color('feedback-error')}
               onClick={wrappedCloseCallback(() =>
-                navigate(RouteUrls.SignOutConfirm, { relative: 'path' })
+                navigate(RouteUrls.SignOutConfirm, {
+                  relative: 'path',
+                  state: { backgroundLocation },
+                })
               )}
               data-testid="settings-sign-out"
             >

--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -11,7 +11,6 @@ import { RouteUrls } from '@shared/route-urls';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useDrawers } from '@app/common/hooks/use-drawers';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
-import { useLocationState } from '@app/common/hooks/use-location-state';
 import { useModifierKey } from '@app/common/hooks/use-modifier-key';
 import { useOnClickOutside } from '@app/common/hooks/use-onclickoutside';
 import { useWalletType } from '@app/common/use-wallet-type';
@@ -48,7 +47,6 @@ export function SettingsDropdown() {
   const key = useCurrentKeyDetails();
   const { isPressed: showAdvancedMenuOptions } = useModifierKey('alt', 120);
   const location = useLocation();
-  // const backgroundLocation = useLocationState('backgroundLocation');
 
   const handleClose = useCallback(() => setIsShowingSettings(false), [setIsShowingSettings]);
 

--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -48,7 +48,7 @@ export function SettingsDropdown() {
   const key = useCurrentKeyDetails();
   const { isPressed: showAdvancedMenuOptions } = useModifierKey('alt', 120);
   const location = useLocation();
-  const backgroundLocation = useLocationState('backgroundLocation');
+  // const backgroundLocation = useLocationState('backgroundLocation');
 
   const handleClose = useCallback(() => setIsShowingSettings(false), [setIsShowingSettings]);
 
@@ -99,7 +99,7 @@ export function SettingsDropdown() {
                 void analytics.track('click_change_theme_menu_item');
                 navigate(RouteUrls.ChangeTheme, {
                   relative: 'path',
-                  state: { backgroundLocation },
+                  state: { backgroundLocation: location },
                 });
               })}
             >
@@ -154,7 +154,7 @@ export function SettingsDropdown() {
                 void analytics.track('click_change_network_menu_item');
                 navigate(RouteUrls.SelectNetwork, {
                   relative: 'path',
-                  state: { backgroundLocation },
+                  state: { backgroundLocation: location },
                 });
               })}
             >
@@ -188,7 +188,7 @@ export function SettingsDropdown() {
               onClick={wrappedCloseCallback(() =>
                 navigate(RouteUrls.SignOutConfirm, {
                   relative: 'path',
-                  state: { backgroundLocation },
+                  state: { backgroundLocation: location },
                 })
               )}
               data-testid="settings-sign-out"

--- a/src/app/features/theme-drawer/theme-drawer.tsx
+++ b/src/app/features/theme-drawer/theme-drawer.tsx
@@ -1,15 +1,17 @@
 import { useNavigate } from 'react-router-dom';
 
+import { useBackgroundLocationRedirect } from '@app/common/hooks/use-background-location-redirect';
 import { useLocationState } from '@app/common/hooks/use-location-state';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 
 import { ThemeList } from './theme-list';
 
 export function ThemesDrawer() {
+  useBackgroundLocationRedirect();
   const navigate = useNavigate();
   const backgroundLocation = useLocationState('backgroundLocation');
   return (
-    <BaseDrawer title="Select Theme" isShowing onClose={() => navigate(backgroundLocation || '..')}>
+    <BaseDrawer title="Select Theme" isShowing onClose={() => navigate(backgroundLocation)}>
       <ThemeList />
     </BaseDrawer>
   );

--- a/src/app/features/theme-drawer/theme-drawer.tsx
+++ b/src/app/features/theme-drawer/theme-drawer.tsx
@@ -9,7 +9,7 @@ export function ThemesDrawer() {
   const navigate = useNavigate();
   const backgroundLocation = useLocationState('backgroundLocation');
   return (
-    <BaseDrawer title="Select Theme" isShowing onClose={() => navigate(backgroundLocation)}>
+    <BaseDrawer title="Select Theme" isShowing onClose={() => navigate(backgroundLocation || '..')}>
       <ThemeList />
     </BaseDrawer>
   );

--- a/src/app/features/theme-drawer/theme-drawer.tsx
+++ b/src/app/features/theme-drawer/theme-drawer.tsx
@@ -1,13 +1,15 @@
 import { useNavigate } from 'react-router-dom';
 
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 
 import { ThemeList } from './theme-list';
 
 export function ThemesDrawer() {
   const navigate = useNavigate();
+  const backgroundLocation = useLocationState('backgroundLocation');
   return (
-    <BaseDrawer title="Select Theme" isShowing onClose={() => navigate('..')}>
+    <BaseDrawer title="Select Theme" isShowing onClose={() => navigate(backgroundLocation)}>
       <ThemeList />
     </BaseDrawer>
   );

--- a/src/app/pages/home/components/home-tabs.tsx
+++ b/src/app/pages/home/components/home-tabs.tsx
@@ -16,7 +16,7 @@ interface HomeTabsProps extends StackProps {
 // TODO #4013: Abstract this to generic RouteTab once choose-fee-tab updated
 export function HomeTabs({ children }: HomeTabsProps) {
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const location = useLocation();
   const backgroundLocation = useLocationState('backgroundLocation');
 
   const tabs = useMemo(
@@ -27,9 +27,20 @@ export function HomeTabs({ children }: HomeTabsProps) {
     []
   );
 
-  const path = backgroundLocation ? backgroundLocation.pathname : pathname;
+  // if(pathname === 'receive' && !backgroundLocation){
 
-  const getActiveTab = useCallback(() => tabs.findIndex(tab => tab.slug === path), [tabs, path]);
+  // }
+  // const path = backgroundLocation ? backgroundLocation.pathname : location?.pathname;
+
+  // console.info('home-tabs bg location', backgroundLocation);
+  // console.info('home-tabs location', location);
+
+  // if open new tab and cannot find location then set tab to be first
+  const getActiveTab = useCallback(() => {
+    const path = backgroundLocation ? backgroundLocation.pathname : location?.pathname;
+    const activeTab = tabs.findIndex(tab => tab.slug === path);
+    return activeTab === -1 ? 0 : activeTab;
+  }, [tabs, backgroundLocation, location]);
 
   const setActiveTab = useCallback(
     (index: number) => navigate(tabs[index]?.slug),

--- a/src/app/pages/home/components/home-tabs.tsx
+++ b/src/app/pages/home/components/home-tabs.tsx
@@ -26,20 +26,9 @@ export function HomeTabs({ children }: HomeTabsProps) {
     ],
     []
   );
-
-  // if(pathname === 'receive' && !backgroundLocation){
-
-  // }
-  // const path = backgroundLocation ? backgroundLocation.pathname : location?.pathname;
-
-  // console.info('home-tabs bg location', backgroundLocation);
-  // console.info('home-tabs location', location);
-
-  // if open new tab and cannot find location then set tab to be first
   const getActiveTab = useCallback(() => {
     const path = backgroundLocation ? backgroundLocation.pathname : location?.pathname;
-    const activeTab = tabs.findIndex(tab => tab.slug === path);
-    return activeTab === -1 ? 0 : activeTab;
+    return tabs.findIndex(tab => tab.slug === path);
   }, [tabs, backgroundLocation, location]);
 
   const setActiveTab = useCallback(

--- a/src/app/pages/home/components/home-tabs.tsx
+++ b/src/app/pages/home/components/home-tabs.tsx
@@ -21,8 +21,8 @@ export function HomeTabs({ children }: HomeTabsProps) {
 
   const tabs = useMemo(
     () => [
-      { slug: RouteUrls.Home, label: 'balances' },
-      { slug: RouteUrls.Activity, label: 'activity' },
+      { slug: `${RouteUrls.Home}/${RouteUrls.Assets}`, label: 'balances' },
+      { slug: `${RouteUrls.Home}/${RouteUrls.Activity}`, label: 'activity' },
     ],
     []
   );

--- a/src/app/pages/home/components/home-tabs.tsx
+++ b/src/app/pages/home/components/home-tabs.tsx
@@ -6,6 +6,7 @@ import type { StackProps } from '@stacks/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { LoadingSpinner } from '@app/components/loading-spinner';
 import { Tabs } from '@app/components/tabs';
 
@@ -16,6 +17,7 @@ interface HomeTabsProps extends StackProps {
 export function HomeTabs({ children }: HomeTabsProps) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const backgroundLocation = useLocationState('backgroundLocation');
 
   const tabs = useMemo(
     () => [
@@ -25,16 +27,14 @@ export function HomeTabs({ children }: HomeTabsProps) {
     []
   );
 
-  const getActiveTab = useCallback(
-    () => tabs.findIndex(tab => tab.slug === pathname),
-    [tabs, pathname]
-  );
+  const path = backgroundLocation ? backgroundLocation.pathname : pathname;
+
+  const getActiveTab = useCallback(() => tabs.findIndex(tab => tab.slug === path), [tabs, path]);
 
   const setActiveTab = useCallback(
     (index: number) => navigate(tabs[index]?.slug),
     [navigate, tabs]
   );
-
   return (
     <Stack flexGrow={1} mt="loose" spacing="extra-loose">
       <Tabs

--- a/src/app/pages/home/components/receive-button.tsx
+++ b/src/app/pages/home/components/receive-button.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ButtonProps } from '@stacks/ui';
 import { HomePageSelectors } from '@tests/selectors/home.selectors';
@@ -13,7 +13,9 @@ import { HomeActionButton } from './tx-button';
 
 export function ReceiveButton(props: ButtonProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const isBitcoinEnabled = useConfigBitcoinEnabled();
+  const receivePath = isBitcoinEnabled ? RouteUrls.Receive : RouteUrls.ReceiveStx;
 
   return (
     <HomeActionButton
@@ -21,7 +23,11 @@ export function ReceiveButton(props: ButtonProps) {
       data-testid={HomePageSelectors.ReceiveCryptoAssetBtn}
       icon={QrCodeIcon}
       label="Receive"
-      onClick={() => navigate(isBitcoinEnabled ? RouteUrls.Receive : RouteUrls.ReceiveStx)}
+      onClick={() =>
+        navigate(receivePath, {
+          state: { backgroundLocation: location },
+        })
+      }
       {...props}
     />
   );

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -13,6 +13,7 @@ import { AssetsList } from '@app/features/asset-list/asset-list';
 import { InAppMessages } from '@app/features/hiro-messages/in-app-messages';
 import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggested-first-steps';
 import { HomeActions } from '@app/pages/home/components/home-actions';
+import { settingsModalRoutes } from '@app/routes/app-routes';
 
 import { CurrentAccount } from './components/account-area';
 import { HomeTabs } from './components/home-tabs';
@@ -48,7 +49,9 @@ export function Home() {
         <>
           <Routes location={backgroundLocation || location}>
             <Route path={RouteUrls.Home} element={<AssetsList />} />
-            <Route path={RouteUrls.Activity} element={<ActivityList />} />
+            <Route path={RouteUrls.Activity} element={<ActivityList />}>
+              {settingsModalRoutes}
+            </Route>
           </Routes>
           {backgroundLocation && <Outlet />}
         </>

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -1,16 +1,18 @@
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
 import { useTrackFirstDeposit } from '@app/common/hooks/analytics/transactions-analytics.hooks';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { useOnMount } from '@app/common/hooks/use-on-mount';
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { Header } from '@app/components/header';
+import { ActivityList } from '@app/features/activity-list/activity-list';
+import { AssetsList } from '@app/features/asset-list/asset-list';
 import { InAppMessages } from '@app/features/hiro-messages/in-app-messages';
 import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggested-first-steps';
 import { HomeActions } from '@app/pages/home/components/home-actions';
-import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 import { CurrentAccount } from './components/account-area';
 import { HomeTabs } from './components/home-tabs';
@@ -19,8 +21,10 @@ import { HomeLayout } from './components/home.layout';
 export function Home() {
   const { decodedAuthRequest } = useOnboardingState();
 
-  const stacksAccount = useCurrentStacksAccount();
   const navigate = useNavigate();
+
+  const location = useLocation();
+  const backgroundLocation = useLocationState('backgroundLocation');
   useTrackFirstDeposit();
 
   useRouteHeader(
@@ -41,7 +45,13 @@ export function Home() {
       actions={<HomeActions />}
     >
       <HomeTabs>
-        <Outlet context={{ address: stacksAccount?.address }} />
+        <>
+          <Routes location={backgroundLocation || location}>
+            <Route path={RouteUrls.Home} element={<AssetsList />} />
+            <Route path={RouteUrls.Activity} element={<ActivityList />} />
+          </Routes>
+          {backgroundLocation && <Outlet />}
+        </>
       </HomeTabs>
     </HomeLayout>
   );

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -13,6 +13,7 @@ import { AssetsList } from '@app/features/asset-list/asset-list';
 import { InAppMessages } from '@app/features/hiro-messages/in-app-messages';
 import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggested-first-steps';
 import { HomeActions } from '@app/pages/home/components/home-actions';
+import { homeModalRoutes } from '@app/routes/app-routes';
 
 import { CurrentAccount } from './components/account-area';
 import { HomeTabs } from './components/home-tabs';
@@ -37,7 +38,6 @@ export function Home() {
   useOnMount(() => {
     if (decodedAuthRequest) navigate(RouteUrls.ChooseAccount);
   });
-
   return (
     <HomeLayout
       suggestedFirstSteps={<SuggestedFirstSteps />}
@@ -49,8 +49,7 @@ export function Home() {
           <Routes location={backgroundLocation || location}>
             <Route path={RouteUrls.Home} element={<AssetsList />} />
             <Route path={RouteUrls.Activity} element={<ActivityList />} />
-            {/* If we have an unmatched route go back home e.g. if a new tab is opened */}
-            <Route path="*" element={<Navigate replace to={RouteUrls.Home} />} />
+            {homeModalRoutes}
           </Routes>
           {backgroundLocation && <Outlet />}
         </>

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -1,4 +1,4 @@
-import { Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -47,8 +47,9 @@ export function Home() {
       <HomeTabs>
         <>
           <Routes location={backgroundLocation || location}>
-            <Route path={RouteUrls.Home} element={<AssetsList />} />
+            <Route path={RouteUrls.Assets} element={<AssetsList />} />
             <Route path={RouteUrls.Activity} element={<ActivityList />} />
+            <Route path="*" element={<Navigate replace to={RouteUrls.Assets} />} />
             {homeModalRoutes}
           </Routes>
           {backgroundLocation && <Outlet />}

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -1,4 +1,4 @@
-import { Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -13,7 +13,6 @@ import { AssetsList } from '@app/features/asset-list/asset-list';
 import { InAppMessages } from '@app/features/hiro-messages/in-app-messages';
 import { SuggestedFirstSteps } from '@app/features/suggested-first-steps/suggested-first-steps';
 import { HomeActions } from '@app/pages/home/components/home-actions';
-import { settingsModalRoutes } from '@app/routes/app-routes';
 
 import { CurrentAccount } from './components/account-area';
 import { HomeTabs } from './components/home-tabs';
@@ -49,9 +48,9 @@ export function Home() {
         <>
           <Routes location={backgroundLocation || location}>
             <Route path={RouteUrls.Home} element={<AssetsList />} />
-            <Route path={RouteUrls.Activity} element={<ActivityList />}>
-              {settingsModalRoutes}
-            </Route>
+            <Route path={RouteUrls.Activity} element={<ActivityList />} />
+            {/* If we have an unmatched route go back home e.g. if a new tab is opened */}
+            <Route path="*" element={<Navigate replace to={RouteUrls.Home} />} />
           </Routes>
           {backgroundLocation && <Outlet />}
         </>

--- a/src/app/pages/receive-tokens/components/receive-tokens.layout.tsx
+++ b/src/app/pages/receive-tokens/components/receive-tokens.layout.tsx
@@ -4,8 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Box, Button, Flex, Text, color } from '@stacks/ui';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 
-import { RouteUrls } from '@shared/route-urls';
-
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { AddressDisplayer } from '@app/components/address-displayer/address-displayer';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { Title } from '@app/components/typography';
@@ -23,9 +22,10 @@ interface ReceiveTokensLayoutProps {
 export function ReceiveTokensLayout(props: ReceiveTokensLayoutProps) {
   const { address, accountName, onCopyAddressToClipboard, title, warning, hasSubtitle } = props;
   const navigate = useNavigate();
+  const { pathname } = useLocationState('backgroundLocation');
 
   return (
-    <BaseDrawer title={title} isShowing onClose={() => navigate(RouteUrls.Home)}>
+    <BaseDrawer title={title} isShowing onClose={() => navigate(pathname)}>
       <Flex alignItems="center" flexDirection="column" pb={['loose', '48px']} px="loose">
         {hasSubtitle && (
           <Text color={color('text-caption')} mb="tight" textAlign="left">

--- a/src/app/pages/receive-tokens/components/receive-tokens.layout.tsx
+++ b/src/app/pages/receive-tokens/components/receive-tokens.layout.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Box, Button, Flex, Text, color } from '@stacks/ui';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 
+import { useBackgroundLocationRedirect } from '@app/common/hooks/use-background-location-redirect';
 import { useLocationState } from '@app/common/hooks/use-location-state';
 import { AddressDisplayer } from '@app/components/address-displayer/address-displayer';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
@@ -20,12 +21,13 @@ interface ReceiveTokensLayoutProps {
   hasSubtitle?: boolean;
 }
 export function ReceiveTokensLayout(props: ReceiveTokensLayoutProps) {
+  useBackgroundLocationRedirect();
   const { address, accountName, onCopyAddressToClipboard, title, warning, hasSubtitle } = props;
   const navigate = useNavigate();
-  const { pathname } = useLocationState('backgroundLocation');
+  const backgroundLocation = useLocationState('backgroundLocation');
 
   return (
-    <BaseDrawer title={title} isShowing onClose={() => navigate(pathname)}>
+    <BaseDrawer title={title} isShowing onClose={() => navigate(backgroundLocation?.pathname)}>
       <Flex alignItems="center" flexDirection="column" pb={['loose', '48px']} px="loose">
         {hasSubtitle && (
           <Text color={color('text-caption')} mb="tight" textAlign="left">

--- a/src/app/pages/receive-tokens/receive-btc.tsx
+++ b/src/app/pages/receive-tokens/receive-btc.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import toast from 'react-hot-toast';
 import { useLocation } from 'react-router-dom';
 
@@ -5,6 +6,7 @@ import { useClipboard } from '@stacks/ui';
 import get from 'lodash.get';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useBackgroundLocationRedirect } from '@app/common/hooks/use-background-location-redirect';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { useNativeSegwitAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
@@ -12,6 +14,7 @@ import { ReceiveBtcModalWarning } from './components/receive-btc-warning';
 import { ReceiveTokensLayout } from './components/receive-tokens.layout';
 
 export function ReceiveBtcModal() {
+  useBackgroundLocationRedirect();
   const analytics = useAnalytics();
   const { state } = useLocation();
 
@@ -23,11 +26,11 @@ export function ReceiveBtcModal() {
 
   const { onCopy } = useClipboard(btcAddress);
 
-  function copyToClipboard() {
+  const copyToClipboard = useCallback(() => {
     void analytics.track('copy_btc_address_to_clipboard');
     toast.success('Copied to clipboard!');
     onCopy();
-  }
+  }, [analytics, onCopy]);
 
   return (
     <ReceiveTokensLayout

--- a/src/app/pages/receive-tokens/receive-modal.tsx
+++ b/src/app/pages/receive-tokens/receive-modal.tsx
@@ -38,7 +38,8 @@ export function ReceiveModal() {
     <BaseDrawer
       title="Select asset to receive"
       isShowing
-      onClose={() => navigate(backgroundLocation?.pathname)}
+      // if open in new tab - backgroundLocation?.pathname can be lost
+      onClose={() => navigate(backgroundLocation?.pathname || '..')}
     >
       <Box mx="extra-loose">
         <Caption style={{ fontSize: '14px' }}>Tokens</Caption>

--- a/src/app/pages/receive-tokens/receive-modal.tsx
+++ b/src/app/pages/receive-tokens/receive-modal.tsx
@@ -9,6 +9,7 @@ import { HomePageSelectors } from '@tests/selectors/home.selectors';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { BtcIcon } from '@app/components/icons/btc-icon';
@@ -22,6 +23,7 @@ import { useCurrentAccountStxAddressState } from '@app/store/accounts/blockchain
 export function ReceiveModal() {
   const analytics = useAnalytics();
   const navigate = useNavigate();
+  const backgroundLocation = useLocationState('backgroundLocation');
   const btcAddress = useCurrentAccountNativeSegwitAddressIndexZero();
   const stxAddress = useCurrentAccountStxAddressState();
   const { onCopy: onCopyStacks } = useClipboard(stxAddress);
@@ -31,8 +33,13 @@ export function ReceiveModal() {
     toast.success('Copied to clipboard!');
     copyHandler();
   }
+
   return (
-    <BaseDrawer title="Select asset to receive" isShowing onClose={() => navigate('../')}>
+    <BaseDrawer
+      title="Select asset to receive"
+      isShowing
+      onClose={() => navigate(backgroundLocation?.pathname)}
+    >
       <Box mx="extra-loose">
         <Caption style={{ fontSize: '14px' }}>Tokens</Caption>
 
@@ -49,7 +56,11 @@ export function ReceiveModal() {
                     borderRadius="10px"
                     data-testid={HomePageSelectors.ReceiveBtcNativeSegwitQrCodeBtn}
                     mode="tertiary"
-                    onClick={() => navigate(RouteUrls.ReceiveBtc)}
+                    onClick={() =>
+                      navigate(RouteUrls.ReceiveBtc, {
+                        state: { backgroundLocation },
+                      })
+                    }
                   >
                     <Box color={color('text-caption')} size="14px">
                       <QrCodeIcon />
@@ -79,7 +90,11 @@ export function ReceiveModal() {
                     borderRadius="10px"
                     data-testid={HomePageSelectors.ReceiveStxQrCodeBtn}
                     mode="tertiary"
-                    onClick={() => navigate(RouteUrls.ReceiveStx)}
+                    onClick={() =>
+                      navigate(RouteUrls.ReceiveStx, {
+                        state: { backgroundLocation },
+                      })
+                    }
                   >
                     <Box color={color('text-caption')} size="14px">
                       <QrCodeIcon />

--- a/src/app/pages/receive-tokens/receive-modal.tsx
+++ b/src/app/pages/receive-tokens/receive-modal.tsx
@@ -9,6 +9,7 @@ import { HomePageSelectors } from '@tests/selectors/home.selectors';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useBackgroundLocationRedirect } from '@app/common/hooks/use-background-location-redirect';
 import { useLocationState } from '@app/common/hooks/use-location-state';
 import { StxAvatar } from '@app/components/crypto-assets/stacks/components/stx-avatar';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
@@ -21,6 +22,7 @@ import { useCurrentAccountNativeSegwitAddressIndexZero } from '@app/store/accoun
 import { useCurrentAccountStxAddressState } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 export function ReceiveModal() {
+  useBackgroundLocationRedirect();
   const analytics = useAnalytics();
   const navigate = useNavigate();
   const backgroundLocation = useLocationState('backgroundLocation');
@@ -38,8 +40,7 @@ export function ReceiveModal() {
     <BaseDrawer
       title="Select asset to receive"
       isShowing
-      // if open in new tab - backgroundLocation?.pathname can be lost
-      onClose={() => navigate(backgroundLocation?.pathname || '..')}
+      onClose={() => navigate(backgroundLocation?.pathname)}
     >
       <Box mx="extra-loose">
         <Caption style={{ fontSize: '14px' }}>Tokens</Caption>

--- a/src/app/pages/receive-tokens/receive-stx.tsx
+++ b/src/app/pages/receive-tokens/receive-stx.tsx
@@ -1,24 +1,27 @@
+import { useCallback } from 'react';
 import toast from 'react-hot-toast';
 
 import { useClipboard } from '@stacks/ui';
 
 import { useCurrentAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useBackgroundLocationRedirect } from '@app/common/hooks/use-background-location-redirect';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 import { ReceiveTokensLayout } from './components/receive-tokens.layout';
 
 export function ReceiveStxModal() {
+  useBackgroundLocationRedirect();
   const currentAccount = useCurrentStacksAccount();
   const analytics = useAnalytics();
   const { onCopy } = useClipboard(currentAccount?.address ?? '');
   const accountName = useCurrentAccountDisplayName();
 
-  function copyToClipboard() {
+  const copyToClipboard = useCallback(() => {
     void analytics.track('copy_stx_address_to_clipboard');
     toast.success('Copied to clipboard!');
     onCopy();
-  }
+  }, [analytics, onCopy]);
 
   if (!currentAccount) return null;
 

--- a/src/app/pages/receive/receive-collectible/receive-collectible-ordinal.tsx
+++ b/src/app/pages/receive/receive-collectible/receive-collectible-ordinal.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import toast from 'react-hot-toast';
 import { FiArrowUpRight } from 'react-icons/fi';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -6,6 +7,7 @@ import { Box, Flex, Stack, color, useClipboard } from '@stacks/ui';
 import { truncateMiddle } from '@stacks/ui-utils';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useBackgroundLocationRedirect } from '@app/common/hooks/use-background-location-redirect';
 import { useLocationState } from '@app/common/hooks/use-location-state';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
@@ -16,28 +18,22 @@ import { PrimaryButton } from '@app/components/primary-button';
 import { Caption, Text, Title } from '@app/components/typography';
 
 export function ReceiveCollectibleOrdinal() {
+  useBackgroundLocationRedirect();
   const navigate = useNavigate();
   const analytics = useAnalytics();
   const { state } = useLocation();
   const backgroundLocation = useLocationState('backgroundLocation');
 
-  // if this is opened in a new tab it has no btcAddress so we cannot do anything
-  if (!state) {
-    // TODO implement this more gracefull to simply not load this component at all if no state.btcAdressTaproot
-    navigate('..');
-    console.log('state.btcAddressTaproot', state);
-  }
-
   const { onCopy } = useClipboard(state?.btcAddressTaproot);
 
-  function copyToClipboard() {
+  const copyToClipboard = useCallback(() => {
     void analytics.track('copy_address_to_add_new_inscription');
     toast.success('Copied to clipboard!');
     onCopy();
-  }
+  }, [analytics, onCopy]);
 
   return (
-    <BaseDrawer isShowing onClose={() => navigate(backgroundLocation?.pathname || '..')}>
+    <BaseDrawer isShowing onClose={() => navigate(backgroundLocation.pathname)}>
       <Box mx="extra-loose">
         <Stack alignItems="center" px={['unset', 'base']} spacing="loose" textAlign="center">
           <OrdinalIcon />

--- a/src/app/pages/receive/receive-collectible/receive-collectible-oridinal.tsx
+++ b/src/app/pages/receive/receive-collectible/receive-collectible-oridinal.tsx
@@ -6,6 +6,7 @@ import { Box, Flex, Stack, color, useClipboard } from '@stacks/ui';
 import { truncateMiddle } from '@stacks/ui-utils';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { ErrorLabel } from '@app/components/error-label';
@@ -18,6 +19,7 @@ export function ReceiveCollectibleOrdinal() {
   const navigate = useNavigate();
   const analytics = useAnalytics();
   const { state } = useLocation();
+  const { pathname } = useLocationState('backgroundLocation');
   const { onCopy } = useClipboard(state.btcAddressTaproot);
 
   function copyToClipboard() {
@@ -27,7 +29,7 @@ export function ReceiveCollectibleOrdinal() {
   }
 
   return (
-    <BaseDrawer isShowing onClose={() => navigate('../')}>
+    <BaseDrawer isShowing onClose={() => navigate(pathname)}>
       <Box mx="extra-loose">
         <Stack alignItems="center" px={['unset', 'base']} spacing="loose" textAlign="center">
           <OrdinalIcon />

--- a/src/app/pages/receive/receive-collectible/receive-collectible-oridinal.tsx
+++ b/src/app/pages/receive/receive-collectible/receive-collectible-oridinal.tsx
@@ -19,8 +19,16 @@ export function ReceiveCollectibleOrdinal() {
   const navigate = useNavigate();
   const analytics = useAnalytics();
   const { state } = useLocation();
-  const { pathname } = useLocationState('backgroundLocation');
-  const { onCopy } = useClipboard(state.btcAddressTaproot);
+  const backgroundLocation = useLocationState('backgroundLocation');
+
+  // if this is opened in a new tab it has no btcAddress so we cannot do anything
+  if (!state) {
+    // TODO implement this more gracefull to simply not load this component at all if no state.btcAdressTaproot
+    navigate('..');
+    console.log('state.btcAddressTaproot', state);
+  }
+
+  const { onCopy } = useClipboard(state?.btcAddressTaproot);
 
   function copyToClipboard() {
     void analytics.track('copy_address_to_add_new_inscription');
@@ -29,7 +37,7 @@ export function ReceiveCollectibleOrdinal() {
   }
 
   return (
-    <BaseDrawer isShowing onClose={() => navigate(pathname)}>
+    <BaseDrawer isShowing onClose={() => navigate(backgroundLocation?.pathname || '..')}>
       <Box mx="extra-loose">
         <Stack alignItems="center" px={['unset', 'base']} spacing="loose" textAlign="center">
           <OrdinalIcon />
@@ -84,7 +92,7 @@ export function ReceiveCollectibleOrdinal() {
             difficulty retrieving it
           </Text>
           <Flex sx={{ maxWidth: '100%', flexWrap: 'wrap', justifyContent: 'center' }}>
-            <Caption mt="2px">{truncateMiddle(state.btcAddressTaproot, 6)}</Caption>
+            <Caption mt="2px">{truncateMiddle(state?.btcAddressTaproot, 6)}</Caption>
           </Flex>
         </Stack>
         <PrimaryButton flexGrow={1} my="extra-loose" onClick={copyToClipboard} width="100%">

--- a/src/app/pages/select-network/select-network.tsx
+++ b/src/app/pages/select-network/select-network.tsx
@@ -4,6 +4,7 @@ import { WalletDefaultNetworkConfigurationIds } from '@shared/constants';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useLocationState } from '@app/common/hooks/use-location-state';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { NetworkListLayout } from '@app/pages/select-network/components/network-list.layout';
 import { NetworkListItem } from '@app/pages/select-network/network-list-item';
@@ -20,6 +21,7 @@ export function SelectNetwork() {
   const analytics = useAnalytics();
   const networksActions = useNetworksActions();
   const currentNetwork = useCurrentNetworkState();
+  const backgroundLocation = useLocationState('backgroundLocation');
 
   function addNetwork() {
     void analytics.track('add_network');
@@ -38,7 +40,7 @@ export function SelectNetwork() {
   }
 
   function closeNetworkModal() {
-    navigate('..');
+    navigate(backgroundLocation || '..');
   }
 
   return (

--- a/src/app/pages/select-network/select-network.tsx
+++ b/src/app/pages/select-network/select-network.tsx
@@ -4,6 +4,7 @@ import { WalletDefaultNetworkConfigurationIds } from '@shared/constants';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
+import { useBackgroundLocationRedirect } from '@app/common/hooks/use-background-location-redirect';
 import { useLocationState } from '@app/common/hooks/use-location-state';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { NetworkListLayout } from '@app/pages/select-network/components/network-list.layout';
@@ -16,6 +17,7 @@ import { AddNetworkButton } from './components/add-network-button';
 const defaultNetworkIds = Object.values(WalletDefaultNetworkConfigurationIds) as string[];
 
 export function SelectNetwork() {
+  useBackgroundLocationRedirect();
   const navigate = useNavigate();
   const networks = useNetworks();
   const analytics = useAnalytics();
@@ -40,7 +42,7 @@ export function SelectNetwork() {
   }
 
   function closeNetworkModal() {
-    navigate(backgroundLocation || '..');
+    navigate(backgroundLocation);
   }
 
   return (

--- a/src/app/pages/sign-out-confirm/sign-out-confirm.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.tsx
@@ -2,13 +2,17 @@ import { useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
+import { useBackgroundLocationRedirect } from '@app/common/hooks/use-background-location-redirect';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
+import { useLocationState } from '@app/common/hooks/use-location-state';
 
 import { SignOutConfirmLayout } from './sign-out-confirm.layout';
 
 export function SignOutConfirmDrawer() {
+  useBackgroundLocationRedirect();
   const { signOut } = useKeyActions();
   const navigate = useNavigate();
+  const backgroundLocation = useLocationState('backgroundLocation');
 
   return (
     <SignOutConfirmLayout
@@ -16,7 +20,7 @@ export function SignOutConfirmDrawer() {
         navigate(RouteUrls.Onboarding);
         void signOut();
       }}
-      onUserSafelyReturnToHomepage={() => navigate('..')}
+      onUserSafelyReturnToHomepage={() => navigate(backgroundLocation)}
     />
   );
 }

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -202,32 +202,29 @@ function useAppRoutes() {
         <Route path={RouteUrls.RequestDiagnostics} element={<AllowDiagnosticsPage />} />
 
         <Route
-          path={RouteUrls.Home}
+          path={`${RouteUrls.Home}/*`}
           element={
             <AccountGate>
               <Home />
             </AccountGate>
           }
-        >
-          <Route index element={<AssetsList />} />
-          <Route path={RouteUrls.Activity} element={<ActivityList />} />
+        />
 
-          {requestBitcoinKeysRoutes}
-          {requestStacksKeysRoutes}
-          <Route path={RouteUrls.RetriveTaprootFunds} element={<RetrieveTaprootToNativeSegwit />} />
+        {requestBitcoinKeysRoutes}
+        {requestStacksKeysRoutes}
+        <Route path={RouteUrls.RetriveTaprootFunds} element={<RetrieveTaprootToNativeSegwit />} />
 
-          <Route path={RouteUrls.IncreaseStxFee} element={<IncreaseStxFeeDrawer />}>
-            {ledgerStacksTxSigningRoutes}
-          </Route>
-          <Route path={RouteUrls.IncreaseBtcFee} element={<IncreaseBtcFeeDrawer />} />
-          <Route path={RouteUrls.IncreaseFeeSent} element={<IncreaseFeeSentDrawer />} />
-          <Route path={RouteUrls.ReceiveCollectible} element={<ReceiveCollectibleModal />} />
-
-          {homeModalRoutes}
-          {sendOrdinalRoutes}
-
+        <Route path={RouteUrls.IncreaseStxFee} element={<IncreaseStxFeeDrawer />}>
           {ledgerStacksTxSigningRoutes}
         </Route>
+        <Route path={RouteUrls.IncreaseBtcFee} element={<IncreaseBtcFeeDrawer />} />
+        <Route path={RouteUrls.IncreaseFeeSent} element={<IncreaseFeeSentDrawer />} />
+        <Route path={RouteUrls.ReceiveCollectible} element={<ReceiveCollectibleModal />} />
+
+        {homeModalRoutes}
+        {sendOrdinalRoutes}
+
+        {ledgerStacksTxSigningRoutes}
         <Route
           path={RouteUrls.RpcReceiveBitcoinContractOffer}
           element={
@@ -268,7 +265,6 @@ function useAppRoutes() {
             return { Component: SetPasswordRoute };
           }}
         />
-
         <Route
           path={RouteUrls.SignIn}
           element={
@@ -308,9 +304,7 @@ function useAppRoutes() {
           <Route path={RouteUrls.FundReceiveBtc} element={<ReceiveBtcModal />} />
           {settingsModalRoutes}
         </Route>
-
         {sendCryptoAssetFormRoutes}
-
         <Route
           path={RouteUrls.ViewSecretKey}
           element={
@@ -324,7 +318,6 @@ function useAppRoutes() {
         <Route path={RouteUrls.Unlock} element={<Unlock />}>
           {settingsModalRoutes}
         </Route>
-
         {legacyRequestRoutes}
         {rpcRequestRoutes}
         <Route path={RouteUrls.UnauthorizedRequest} element={<UnauthorizedRequest />} />
@@ -336,7 +329,6 @@ function useAppRoutes() {
             </AccountGate>
           }
         />
-
         {/* Catch-all route redirects to onboarding */}
         <Route path="*" element={<Navigate replace to={RouteUrls.Onboarding} />} />
       </Route>

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -70,6 +70,14 @@ export function AppRoutes() {
   return <RouterProvider router={routes} />;
 }
 
+export const settingsModalRoutes = (
+  <Route>
+    <Route path={RouteUrls.SignOutConfirm} element={<SignOutConfirmDrawer />} />
+    <Route path={RouteUrls.ChangeTheme} element={<ThemesDrawer />} />
+    <Route path={RouteUrls.SelectNetwork} element={<SelectNetwork />} />
+  </Route>
+);
+
 function useAppRoutes() {
   const userHasNotConsentedToDiagnostics = useHasUserRespondedToAnalyticsConsent();
 
@@ -82,14 +90,6 @@ function useAppRoutes() {
         </Route>
       )
     );
-
-  const settingsModalRoutes = (
-    <Route>
-      <Route path={RouteUrls.SignOutConfirm} element={<SignOutConfirmDrawer />} />
-      <Route path={RouteUrls.ChangeTheme} element={<ThemesDrawer />} />
-      <Route path={RouteUrls.SelectNetwork} element={<SelectNetwork />} />
-    </Route>
-  );
 
   const legacyRequestRoutes = (
     <>

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -187,8 +187,9 @@ function useAppRoutes() {
           }
         >
           <Route index element={<AssetsList />} />
-          <Route path={RouteUrls.Activity} element={<ActivityList />} />
-
+          <Route path={RouteUrls.Activity} element={<ActivityList />}>
+            {settingsModalRoutes}
+          </Route>
           {requestBitcoinKeysRoutes}
           {requestStacksKeysRoutes}
           <Route path={RouteUrls.RetriveTaprootFunds} element={<RetrieveTaprootToNativeSegwit />} />

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -69,6 +69,35 @@ export function AppRoutes() {
   const routes = useAppRoutes();
   return <RouterProvider router={routes} />;
 }
+const settingsModalRoutes = (
+  <Route>
+    <Route path={RouteUrls.SignOutConfirm} element={<SignOutConfirmDrawer />} />
+    <Route path={RouteUrls.ChangeTheme} element={<ThemesDrawer />} />
+    <Route path={RouteUrls.SelectNetwork} element={<SelectNetwork />} />
+  </Route>
+);
+
+const sendOrdinalRoutes = (
+  <Route path={RouteUrls.SendOrdinalInscription} element={<SendInscriptionContainer />}>
+    <Route index element={<SendInscriptionForm />} />
+    <Route
+      path={RouteUrls.SendOrdinalInscriptionChooseFee}
+      element={<SendInscriptionChooseFee />}
+    />
+    <Route path={RouteUrls.SendOrdinalInscriptionReview} element={<SendInscriptionReview />} />
+    <Route path={RouteUrls.SendOrdinalInscriptionSent} element={<SendInscriptionSummary />} />
+    <Route path={RouteUrls.SendOrdinalInscriptionError} element={<BroadcastError />} />
+  </Route>
+);
+
+export const homeModalRoutes = (
+  <Route>
+    <Route path={RouteUrls.Receive} element={<ReceiveModal />} />
+    <Route path={RouteUrls.ReceiveCollectibleOrdinal} element={<ReceiveCollectibleOrdinal />} />
+    {sendOrdinalRoutes}
+    {settingsModalRoutes}
+  </Route>
+);
 
 function useAppRoutes() {
   const userHasNotConsentedToDiagnostics = useHasUserRespondedToAnalyticsConsent();
@@ -82,14 +111,6 @@ function useAppRoutes() {
         </Route>
       )
     );
-
-  const settingsModalRoutes = (
-    <Route>
-      <Route path={RouteUrls.SignOutConfirm} element={<SignOutConfirmDrawer />} />
-      <Route path={RouteUrls.ChangeTheme} element={<ThemesDrawer />} />
-      <Route path={RouteUrls.SelectNetwork} element={<SelectNetwork />} />
-    </Route>
-  );
 
   const legacyRequestRoutes = (
     <>
@@ -187,9 +208,8 @@ function useAppRoutes() {
           }
         >
           <Route index element={<AssetsList />} />
-          <Route path={RouteUrls.Activity} element={<ActivityList />}>
-            {settingsModalRoutes}
-          </Route>
+          <Route path={RouteUrls.Activity} element={<ActivityList />} />
+
           {requestBitcoinKeysRoutes}
           {requestStacksKeysRoutes}
           <Route path={RouteUrls.RetriveTaprootFunds} element={<RetrieveTaprootToNativeSegwit />} />
@@ -199,34 +219,13 @@ function useAppRoutes() {
           </Route>
           <Route path={RouteUrls.IncreaseBtcFee} element={<IncreaseBtcFeeDrawer />} />
           <Route path={RouteUrls.IncreaseFeeSent} element={<IncreaseFeeSentDrawer />} />
-
-          <Route path={RouteUrls.Receive} element={<ReceiveModal />} />
           <Route path={RouteUrls.ReceiveCollectible} element={<ReceiveCollectibleModal />} />
-          <Route
-            path={RouteUrls.ReceiveCollectibleOrdinal}
-            element={<ReceiveCollectibleOrdinal />}
-          />
+
           <Route path={RouteUrls.ReceiveStx} element={<ReceiveStxModal />} />
           <Route path={RouteUrls.ReceiveBtc} element={<ReceiveBtcModal />} />
+          {homeModalRoutes}
+          {sendOrdinalRoutes}
 
-          <Route path={RouteUrls.SendOrdinalInscription} element={<SendInscriptionContainer />}>
-            <Route index element={<SendInscriptionForm />} />
-            <Route
-              path={RouteUrls.SendOrdinalInscriptionChooseFee}
-              element={<SendInscriptionChooseFee />}
-            />
-            <Route
-              path={RouteUrls.SendOrdinalInscriptionReview}
-              element={<SendInscriptionReview />}
-            />
-            <Route
-              path={RouteUrls.SendOrdinalInscriptionSent}
-              element={<SendInscriptionSummary />}
-            />
-            <Route path={RouteUrls.SendOrdinalInscriptionError} element={<BroadcastError />} />
-          </Route>
-
-          {settingsModalRoutes}
           {ledgerStacksTxSigningRoutes}
         </Route>
         <Route

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -70,14 +70,6 @@ export function AppRoutes() {
   return <RouterProvider router={routes} />;
 }
 
-export const settingsModalRoutes = (
-  <Route>
-    <Route path={RouteUrls.SignOutConfirm} element={<SignOutConfirmDrawer />} />
-    <Route path={RouteUrls.ChangeTheme} element={<ThemesDrawer />} />
-    <Route path={RouteUrls.SelectNetwork} element={<SelectNetwork />} />
-  </Route>
-);
-
 function useAppRoutes() {
   const userHasNotConsentedToDiagnostics = useHasUserRespondedToAnalyticsConsent();
 
@@ -90,6 +82,14 @@ function useAppRoutes() {
         </Route>
       )
     );
+
+  const settingsModalRoutes = (
+    <Route>
+      <Route path={RouteUrls.SignOutConfirm} element={<SignOutConfirmDrawer />} />
+      <Route path={RouteUrls.ChangeTheme} element={<ThemesDrawer />} />
+      <Route path={RouteUrls.SelectNetwork} element={<SelectNetwork />} />
+    </Route>
+  );
 
   const legacyRequestRoutes = (
     <>

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -39,7 +39,7 @@ import { ReceiveBtcModal } from '@app/pages/receive-tokens/receive-btc';
 import { ReceiveModal } from '@app/pages/receive-tokens/receive-modal';
 import { ReceiveStxModal } from '@app/pages/receive-tokens/receive-stx';
 import { ReceiveCollectibleModal } from '@app/pages/receive/receive-collectible/receive-collectible-modal';
-import { ReceiveCollectibleOrdinal } from '@app/pages/receive/receive-collectible/receive-collectible-oridinal';
+import { ReceiveCollectibleOrdinal } from '@app/pages/receive/receive-collectible/receive-collectible-ordinal';
 import { RequestError } from '@app/pages/request-error/request-error';
 import { RpcGetAddresses } from '@app/pages/rpc-get-addresses/rpc-get-addresses';
 import { rpcSendTransferRoutes } from '@app/pages/rpc-send-transfer/rpc-send-transfer.routes';
@@ -94,6 +94,8 @@ export const homeModalRoutes = (
   <Route>
     <Route path={RouteUrls.Receive} element={<ReceiveModal />} />
     <Route path={RouteUrls.ReceiveCollectibleOrdinal} element={<ReceiveCollectibleOrdinal />} />
+    <Route path={RouteUrls.ReceiveStx} element={<ReceiveStxModal />} />
+    <Route path={RouteUrls.ReceiveBtc} element={<ReceiveBtcModal />} />
     {sendOrdinalRoutes}
     {settingsModalRoutes}
   </Route>
@@ -221,8 +223,6 @@ function useAppRoutes() {
           <Route path={RouteUrls.IncreaseFeeSent} element={<IncreaseFeeSentDrawer />} />
           <Route path={RouteUrls.ReceiveCollectible} element={<ReceiveCollectibleModal />} />
 
-          <Route path={RouteUrls.ReceiveStx} element={<ReceiveStxModal />} />
-          <Route path={RouteUrls.ReceiveBtc} element={<ReceiveBtcModal />} />
           {homeModalRoutes}
           {sendOrdinalRoutes}
 

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -24,9 +24,13 @@ export enum RouteUrls {
   LedgerBroadcastError = 'transaction-broadcast-error',
   LedgerAddMoreKeys = 'add-more-keys',
 
+  // Active wallet routes - home
+  Home = '/home',
+  // Tab nested relative paths
+  Activity = 'activity',
+  Assets = 'assets',
+
   // Active wallet routes
-  Home = '/',
-  Activity = '/activity',
   AddNetwork = '/add-network',
   ChooseAccount = '/choose-account',
   Fund = '/fund',


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5761428470).<!-- Sticky Header Marker -->

This PR makes a change to how we handle modals displayed over routes. 

`location.state` is used to store the background route to prevent it being unmounted by feeding that to the router if available