### PR TITLE
fix: firefox manually loaded extension

### DIFF
--- a/src/content-scripts/content-script.ts
+++ b/src/content-scripts/content-script.ts
@@ -128,9 +128,12 @@ document.addEventListener(DomEventName.psbtRequest, ((event: PsbtRequestEvent) =
   });
 }) as EventListener);
 
-window.addEventListener('load', () => {
+function addHiroWalletToPage() {
   const inpage = document.createElement('script');
   inpage.src = chrome.runtime.getURL('inpage.js');
-  inpage.id = 'stacks-wallet-provider';
+  inpage.id = 'hiro-wallet-provider';
   document.body.appendChild(inpage);
-});
+}
+
+// Don't block thread to add Hiro Wallet to page
+requestAnimationFrame(() => addHiroWalletToPage());


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5681525188).<!-- Sticky Header Marker -->

Previously added an event that breaks Firefox from working when the extension is given permission later in the web app's lifecycle.