### PR TITLE
fix: add update input for tapInternalKey

### DIFF
--- a/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
+++ b/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
@@ -39,7 +39,7 @@ export function usePsbtSigner() {
           // If type taproot, and the tapInternalKey is missing, assume it should
           // be the account publicKey
           if (taprootSigner && witnessOutputScript?.type === 'tr' && !input.tapInternalKey) {
-            input.tapInternalKey = taprootSigner.payment.tapInternalKey;
+            tx.updateInput(idx, { ...input, tapInternalKey: taprootSigner.payment.tapInternalKey });
           }
 
           try {

--- a/test-app/src/components/bitcoin.tsx
+++ b/test-app/src/components/bitcoin.tsx
@@ -139,6 +139,7 @@ function buildTestTaprootPsbtRequestWithIndex(pubKey: Uint8Array): PsbtRequestOp
   tx.addInput({
     index: 0,
     txid: '4f4cc7cb40b04978bd7704798dc1adf55b58196cef616b0fac8181965abc4726',
+    // tapInternalKey: payment.tapInternalKey,
     witnessUtxo: {
       amount: BigInt(1000),
       script: payment.script,


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5716524026).<!-- Sticky Header Marker -->

This PR fixes adding the `tapInternalKey` to the PSBT input. I didn't run into an error testing this, but I'm not sure why bc I did today. It appears we need to call `updateInput()` after adding it.