### PR TITLE
feat: enable minify of prod build

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -87,7 +87,7 @@ jobs:
     outputs:
       publish_status: ${{ steps.publish-chrome.outputs.publish_status }}
     env:
-      MINIFY_PRODUCTION_BUILD: false
+      MINIFY_PRODUCTION_BUILD: true
       TARGET_BROWSER: chromium
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "dev": "cross-env WALLET_ENVIRONMENT=development concurrently --raw \"node webpack/dev-server.js\" \"redux-devtools --hostname=localhost --port=8000\"",
     "dev:test-app": "webpack serve --config test-app/webpack/webpack.config.dev.js",
-    "build": "cross-env WALLET_ENVIRONMENT=production webpack --config webpack/webpack.config.prod.js",
-    "build:analyze": "cross-env ANALYZE=true WALLET_ENVIRONMENT=production webpack --config webpack/webpack.config.prod.js",
+    "build": "cross-env WALLET_ENVIRONMENT=production MINIFY_PRODUCTION_BUILD=true webpack --config webpack/webpack.config.prod.js",
+    "build:analyze": "cross-env ANALYZE=true WALLET_ENVIRONMENT=production MINIFY_PRODUCTION_BUILD=true webpack --config webpack/webpack.config.prod.js",
     "build:dev": "cross-env WALLET_ENVIRONMENT=development webpack --config webpack/webpack.config.dev.js",
     "build:ext:test": "cross-env WALLET_ENVIRONMENT=production TEST_ENV=true webpack --config webpack/webpack.config.prod.js",
     "build:ext:test:watch": "cross-env WALLET_ENVIRONMENT=production TEST_ENV=true webpack --config webpack/webpack.config.prod.js --watch",

--- a/test-app/webpack/webpack.config.prod.js
+++ b/test-app/webpack/webpack.config.prod.js
@@ -7,7 +7,7 @@ config.optimization = {
   ...config.optimization,
   flagIncludedChunks: false,
   concatenateModules: false,
-  minimize: process.env.WALLET_ENVIRONMENT !== 'testing',
+  minimize: false,
   moduleIds: 'deterministic',
   splitChunks: {
     hidePathInfo: false,

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -15,16 +15,18 @@ config.optimization = {
   ...config.optimization,
   minimize: shouldMinify,
   moduleIds: 'deterministic',
-  splitChunks: {
-    chunks(chunk) {
-      // Only enable code splitting on main bundle
-      return chunk.name === 'index';
-    },
-    hidePathInfo: false,
-    minSize: 10000,
-    maxAsyncRequests: Infinity,
-    maxInitialRequests: Infinity,
-  },
+  splitChunks: shouldMinify
+    ? {
+        chunks(chunk) {
+          // Only enable code splitting on main bundle
+          return chunk.name === 'index';
+        },
+        hidePathInfo: false,
+        minSize: 10000,
+        maxAsyncRequests: Infinity,
+        maxInitialRequests: Infinity,
+      }
+    : false,
   ...(shouldMinify
     ? {
         minimizer: [


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5714239345).<!-- Sticky Header Marker -->

It seems code minifying was turned off, that's why final bundle was 30-90% (for different chunks) higher than it should be

<img width="352" alt="Screenshot 2023-07-31 at 15 08 36" src="https://github.com/hirosystems/wallet/assets/46521087/90194139-9a9a-43bb-bd80-d452cb565e3d">
<img width="352" alt="Screenshot 2023-07-31 at 15 08 53" src="https://github.com/hirosystems/wallet/assets/46521087/b4f43c37-99e1-4f61-8da0-58a2f9f97df8">
