### PR TITLE
ci: reduce shards in tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -79,4 +79,4 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 30
+          retention-days: 10


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5748787187).<!-- Sticky Header Marker -->

Testing a theory. Some jobs are failing because of "Max execution time exceeding 5mins".

~Sharding speeds up tests by reducing tests ran on each job, but at the expense of having many jobs and multiple cache read operations etc. This will hopefully reduce the load on GA and lower number of failures~

Ha. Just saw we (I) added a hardcoded timeout set to 5mins, ffs 🤦🏼‍♂️ 

To be merged on approval.