### PR TITLE
Experiment with programatic icon changing

### DIFF
--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -1,5 +1,6 @@
 import { Outlet, useNavigate } from 'react-router-dom';
 
+import { setNewAppIcon, userApprovedNewAppIcon } from '@shared/new-theme/update-app-icon';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useTrackFirstDeposit } from '@app/common/hooks/analytics/transactions-analytics.hooks';
@@ -40,6 +41,23 @@ export function Home() {
       currentAccount={<CurrentAccount />}
       actions={<HomeActions />}
     >
+      <button
+        onClick={async () => {
+          await userApprovedNewAppIcon();
+          await setNewAppIcon();
+        }}
+      >
+        change icon
+      </button>
+      <button
+        onClick={async () => {
+          const { hasApprovedAppIcon } = await chrome.storage.local.get('hasApprovedAppIcon');
+          // eslint-disable-next-line no-console
+          console.log(!!hasApprovedAppIcon);
+        }}
+      >
+        has updated icon?
+      </button>
       <HomeTabs>
         <Outlet context={{ address: stacksAccount?.address }} />
       </HomeTabs>

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -8,6 +8,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { WalletRequests } from '@shared/rpc/rpc-methods';
 import { warnUsersAboutDevToolsDangers } from '@shared/utils/dev-tools-warning-log';
 
+import { setNewAppIcon, userHasApprovedAppIcon } from '../shared/new-theme/update-app-icon';
 import { initContextMenuActions } from './init-context-menus';
 import { internalBackgroundMessageHandler } from './messaging/internal-methods/message-handler';
 import {
@@ -29,11 +30,9 @@ chrome.runtime.onInstalled.addListener(async details => {
   }
 });
 
-// https://bugs.chromium.org/p/chromium/issues/detail?id=1271154#c108
-chrome.runtime.onStartup.addListener(() =>
-  // eslint-disable-next-line no-console
-  console.log('Service Worker startup')
-);
+chrome.runtime.onStartup.addListener(async () => {
+  if (await userHasApprovedAppIcon()) await setNewAppIcon();
+});
 
 //
 // Listen for connection to the content-script - port for two-way communication

--- a/src/shared/new-theme/update-app-icon.ts
+++ b/src/shared/new-theme/update-app-icon.ts
@@ -1,0 +1,14 @@
+const newIconStoreKey = 'hasApprovedAppIcon';
+
+export async function userHasApprovedAppIcon() {
+  const { hasApprovedAppIcon } = await chrome.storage.local.get(newIconStoreKey);
+  return !!hasApprovedAppIcon;
+}
+
+export async function setNewAppIcon() {
+  await chrome.action.setIcon({ path: 'assets/connect-logo/Stacks128w-preview.png' });
+}
+
+export async function userApprovedNewAppIcon() {
+  await chrome.storage.local.set({ [newIconStoreKey]: true });
+}


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5787910599).<!-- Sticky Header Marker -->

Spent a few minutes experimenting with changing the icon, which could be used for notification purposes among other things.

Because the original icon is set in the manifest, it does revert when the user closes their browser. However, we can re-set it again on service worker start up, so users may very briefly see the previous icon before the new one is set. Trying it out, it think it works okay.