### PR TITLE
fix: update manifest default_title to change extension tooltip text

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -82,7 +82,7 @@ const manifest = {
   },
   web_accessible_resources: [{ resources: ['inpage.js'], matches: ['*://*/*'] }],
   action: {
-    default_title: 'Stacks',
+    default_title: 'Hiro Wallet',
     default_popup: 'popup.html',
     default_icon: defaultIconEnvironment[WALLET_ENVIRONMENT],
   },


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5808693446).<!-- Sticky Header Marker -->

This fix updates the extension `action.default_title` to  be `Hiro Wallet` instead of `Stacks` 

![Screenshot 2023-08-09 at 12 57 09](https://github.com/hirosystems/wallet/assets/2938440/593d83c8-1596-4ea4-ae64-1b87f8c02ee6)
