### PR TITLE
feat: validate mnemonic words individually, closes #4130

### DIFF
--- a/src/app/components/mnemonic-input-field.tsx
+++ b/src/app/components/mnemonic-input-field.tsx
@@ -1,0 +1,75 @@
+import { Flex, FlexProps, Input, color } from '@stacks/ui';
+import { useField } from 'formik';
+import { css } from 'leaf-styles/css';
+
+import { useShowFieldError } from '@app/common/form-utils';
+
+import { TextInputFieldError } from './field-error';
+
+interface MnemonicInputFieldProps extends FlexProps {
+  dataTestId?: string;
+  name: string;
+  onFocus?(e: React.FocusEvent<Element, Element>): void;
+  type: 'text' | 'password';
+  hasError?: boolean;
+}
+export function MnemonicInputField({
+  dataTestId,
+  name,
+  placeholder,
+  type,
+  ...props
+}: MnemonicInputFieldProps) {
+  const [field] = useField(name);
+
+  const showError = useShowFieldError(name);
+  return (
+    <>
+      <Flex
+        _before={{
+          content: '""',
+          position: 'absolute',
+          border: `2px solid ${showError ? '#F7CDCA' : 'transparent'}`,
+          borderRadius: '10px',
+          left: '-1px',
+          right: '-1px',
+          top: '-1px',
+          bottom: '-1px',
+        }}
+        as="label"
+        border="1px solid #DCDDE2"
+        borderRadius="10px"
+        className={css({
+          '& :has(:focus)::before': {
+            border: '2px solid #bfc6ff',
+          },
+        })}
+        flexDirection="column"
+        htmlFor={name}
+        justifyContent="center"
+        px="base"
+        py="base-tight"
+        position="relative"
+        width="100%"
+        {...props}
+      >
+        <Input
+          _disabled={{ bg: color('bg') }}
+          _focus={{ border: 'none' }}
+          autoComplete="off"
+          border="none"
+          data-testid={dataTestId}
+          display="block"
+          fontSize={1}
+          height="24px"
+          id={name}
+          spellCheck="false"
+          type={type}
+          width="100%"
+          {...field}
+        />
+      </Flex>
+      {field.value !== '' && <TextInputFieldError name={name} />}
+    </>
+  );
+}

--- a/src/app/pages/onboarding/sign-in/components/mnemonic-word-input.tsx
+++ b/src/app/pages/onboarding/sign-in/components/mnemonic-word-input.tsx
@@ -1,0 +1,59 @@
+import { Box, color } from '@stacks/ui';
+import { useFocus } from 'use-events';
+
+import { extractPhraseFromString } from '@app/common/utils';
+import { MnemonicInputField } from '@app/components/mnemonic-input-field';
+
+interface MnemonicWordInputProps {
+  index: number;
+  onUpdateWord(word: string): void;
+  onPasteEntireKey(word: string): void;
+}
+export function MnemonicWordInput({
+  index,
+  onUpdateWord,
+  onPasteEntireKey,
+}: MnemonicWordInputProps) {
+  const [isFocused, bind] = useFocus();
+
+  return (
+    <Box
+      position="relative"
+      _after={{
+        content: `"${index + 1}."`,
+        textAlign: 'right',
+        position: 'absolute',
+        top: 0,
+        left: '-22px',
+        lineHeight: '48px',
+        color: color('text-caption'),
+        fontSize: '12px',
+        width: '18px',
+      }}
+    >
+      <MnemonicInputField
+        type={isFocused ? 'text' : 'password'}
+        name={`mnemonic-input-${index}`}
+        autoCapitalize="off"
+        spellCheck={false}
+        data-testid={`mnemonic-input-${index}`}
+        placeholder="none"
+        onPaste={e => {
+          const pasteValue = extractPhraseFromString(e.clipboardData.getData('text'));
+          if (pasteValue.includes(' ')) {
+            e.preventDefault();
+            //assume its a full key
+            onPasteEntireKey(pasteValue);
+          }
+        }}
+        onChange={(e: any) => {
+          e.preventDefault();
+          onUpdateWord(e.target.value);
+        }}
+        px="14px 16px"
+        height="48px"
+        {...bind}
+      />
+    </Box>
+  );
+}

--- a/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
+++ b/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { validateMnemonic } from 'bip39';
+import { validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -51,7 +52,7 @@ export function useSignIn() {
         handleSetError('Entering your Secret Key is required.');
       }
 
-      if (!validateMnemonic(parsedKeyInput)) {
+      if (!validateMnemonic(parsedKeyInput, wordlist)) {
         handleSetError();
         return;
       }

--- a/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
+++ b/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { validateMnemonic } from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+// FIXME - refactor this to use @scure/bip39 and remove dependancy on bip39
+import { validateMnemonic } from 'bip39';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -52,7 +52,7 @@ export function useSignIn() {
         handleSetError('Entering your Secret Key is required.');
       }
 
-      if (!validateMnemonic(parsedKeyInput, wordlist)) {
+      if (!validateMnemonic(parsedKeyInput)) {
         handleSetError();
         return;
       }

--- a/src/app/pages/onboarding/sign-in/utils/mnemonic-validation.ts
+++ b/src/app/pages/onboarding/sign-in/utils/mnemonic-validation.ts
@@ -1,0 +1,24 @@
+import { getDefaultWordlist, wordlists } from 'bip39';
+import * as yup from 'yup';
+
+function isValidMnemonic(word: string): boolean {
+  return wordlists[getDefaultWordlist()].includes(word);
+}
+
+// YUP validation of dynamic field names => https://github.com/jquense/yup/issues/130
+function mapRules<T>(map: Record<string, unknown>, rule: T): Record<string, T> {
+  return Object.keys(map).reduce((newMap, key) => ({ ...newMap, [key]: rule }), {});
+}
+
+// field names are dynamically generated
+const dynamicObjectValue = yup.string().test({
+  message: 'Not a valid BIP39 word',
+  test(value) {
+    if (!value) return false;
+    return isValidMnemonic(value);
+  },
+});
+
+export const validationSchema = yup.lazy(map =>
+  yup.object(mapRules<typeof dynamicObjectValue>(map, dynamicObjectValue))
+);

--- a/src/app/pages/onboarding/sign-in/utils/mnemonic-validation.ts
+++ b/src/app/pages/onboarding/sign-in/utils/mnemonic-validation.ts
@@ -1,8 +1,8 @@
-import { getDefaultWordlist, wordlists } from 'bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 import * as yup from 'yup';
 
 function isValidMnemonic(word: string): boolean {
-  return wordlists[getDefaultWordlist()].includes(word);
+  return wordlist.includes(word);
 }
 
 // YUP validation of dynamic field names => https://github.com/jquense/yup/issues/130

--- a/src/shared/crypto/bitcoin/p2wsh-p2sh-address-gen.spec.ts
+++ b/src/shared/crypto/bitcoin/p2wsh-p2sh-address-gen.spec.ts
@@ -6,6 +6,7 @@ import { base58check } from '@scure/base';
 import { HDKey } from '@scure/bip32';
 import { hashP2WPKH } from '@stacks/transactions';
 import { BIP32Factory } from 'bip32';
+// FIXME - refactor this to use @scure/bip39 and remove dependancy on bip39
 import * as bip39 from 'bip39';
 import * as bitcoin from 'bitcoinjs-lib';
 

--- a/tests-legacy/integration/onboarding/onboarding.spec.ts
+++ b/tests-legacy/integration/onboarding/onboarding.spec.ts
@@ -39,7 +39,7 @@ describe(`Onboarding integration tests`, () => {
     expect(secretKey).not.toBeFalsy();
     expect(secretKey.split(' ').length).toEqual(24);
   });
-
+  // this fails
   it('should be able to login from welcome page then logout', async () => {
     await wallet.clickDenyAnalytics();
     await wallet.clickSignIn();
@@ -79,6 +79,7 @@ describe(`Onboarding integration tests`, () => {
     await wallet.waitForHideOnboardingsStepsButton();
   });
 
+  // this fails
   it('should hide onboarding steps when signing in with an existing secret key', async () => {
     await wallet.clickDenyAnalytics();
     await wallet.clickSignIn();


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/5893147807).<!-- Sticky Header Marker -->

This PR:
- uses `Formik` for the mnemonic key form
- validates each word against the BIP-39 wordlist

Some code is non-optimal but I went for speed and sharing logic. It also doesn't look great so I will try and improve that.

https://github.com/hirosystems/wallet/assets/2938440/3d15b56a-ba96-4e7e-8a1b-4ff398b1475c




You can see above that it works but:
- when there's an error there is a larger gap underneath the fields
- if you press submit and the fields are empty you get a wall of error messages
- when you `Copy + Paste` a full key, it works but it doesn't populate all of the fields visibly
- the error icon and text are not correctly aligned


