### PR TITLE
fix: check broadcast param as string

### DIFF
--- a/src/app/common/psbt/use-psbt-request-params.ts
+++ b/src/app/common/psbt/use-psbt-request-params.ts
@@ -52,7 +52,7 @@ export function useRpcSignPsbtParams() {
       allowedSighash: undefinedIfLengthZero(
         allowedSighash.map(h => Number(h)) as AllowedSighashTypes[]
       ),
-      broadcast,
+      broadcast: broadcast === 'true',
       origin,
       psbtHex,
       requestId,

--- a/src/app/components/generic-error/generic-error.layout.tsx
+++ b/src/app/components/generic-error/generic-error.layout.tsx
@@ -35,7 +35,13 @@ export function GenericErrorLayout(props: GenericErrorProps) {
       <styled.h1 mt="space.05" textStyle="heading.04">
         {title}
       </styled.h1>
-      <styled.h2 mt="space.04" textAlign="center" textStyle="label.02" wordWrap="break-word">
+      <styled.h2
+        mt="space.04"
+        textAlign="center"
+        textStyle="label.02"
+        width="100%"
+        wordWrap="break-word"
+      >
         {body}
       </styled.h2>
       <Box

--- a/src/app/features/current-account/current-account-name.tsx
+++ b/src/app/features/current-account/current-account-name.tsx
@@ -13,9 +13,9 @@ import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/s
 function AccountNameTitle({ children, ...props }: HasChildren & BoxProps) {
   return (
     <Box {...props}>
-      <styled.h1 data-testid={SettingsSelectors.CurrentAccountDisplayName} textStyle="label.01">
+      <styled.span data-testid={SettingsSelectors.CurrentAccountDisplayName} textStyle="label.01">
         {children}
-      </styled.h1>
+      </styled.span>
     </Box>
   );
 }

--- a/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
@@ -30,7 +30,6 @@ interface BroadcastSignedPsbtTxArgs {
 export function useRpcSignPsbt() {
   const analytics = useAnalytics();
   const navigate = useNavigate();
-  // const { addressNativeSegwitTotal, addressTaprootTotal, fee } = usePsbtSignerContext();
   const { allowedSighash, broadcast, origin, psbtHex, requestId, signAtIndex, tabId } =
     useRpcSignPsbtParams();
   const { signPsbt, getPsbtAsTransaction } = usePsbtSigner();
@@ -107,10 +106,17 @@ export function useRpcSignPsbt() {
         makeRpcSuccessResponse('signPsbt', { id: requestId, result: { hex: bytesToHex(psbt) } })
       );
 
-      // Optional args are handle bc we support two request apis,
-      // but only support broadcasting using the rpc request method
+      // Optional args are handled here bc we support two request apis,
+      // but we only support broadcasting using the rpc request method
       if (broadcast && addressNativeSegwitTotal && addressTaprootTotal && fee) {
-        tx.finalize();
+        try {
+          tx.finalize();
+        } catch (e) {
+          return navigate(RouteUrls.RequestError, {
+            state: { message: e instanceof Error ? e.message : '', title: 'Failed to finalize tx' },
+          });
+        }
+
         await broadcastSignedPsbtTx({
           addressNativeSegwitTotal,
           addressTaprootTotal,

--- a/src/background/messaging/rpc-methods/sign-psbt.ts
+++ b/src/background/messaging/rpc-methods/sign-psbt.ts
@@ -67,7 +67,6 @@ export async function rpcSignPsbt(message: SignPsbtRequest, port: chrome.runtime
 
   const requestParams: RequestParams = [
     ['hex', message.params.hex],
-    ['network', message.params.network ?? 'mainnet'],
     ['requestId', message.id],
   ];
 
@@ -82,6 +81,10 @@ export async function rpcSignPsbt(message: SignPsbtRequest, port: chrome.runtime
 
   if (isDefined(message.params.broadcast)) {
     requestParams.push(['broadcast', message.params.broadcast.toString()]);
+  }
+
+  if (isDefined(message.params.network)) {
+    requestParams.push(['network', message.params.network.toString()]);
   }
 
   if (isDefined(message.params.signAtIndex))


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/6038615032).<!-- Sticky Header Marker -->

This PR fixes the ME bug with the popup not closing. They are sending the new `broadcast` param as `false`, but my check was for it being present not as the string `true`. When calling `tx.finalize()` it errored (which makes sense bc we weren't supposed to call it for ME) > didn't close popup > they proceeded to broadcast the tx on their own. I added a try/catch here around finalizing the tx too so that it will route to the error page correctly.

<img width="522" alt="Screen Shot 2023-08-30 at 1 16 14 PM" src="https://github.com/hirosystems/wallet/assets/6493321/39421103-9c31-45e2-98cc-10ff5d227905">

Also, there have been reports of our docs saying the network defaults to the current network, but I noticed here when the rpc method was added, we default to `mainnet` ...so I removed that too.

Fixed a minor UI bug in the `GenericError` component ...and fixed a console error with an `h1` tag.