### PR TITLE
refactor: pass all sighashTypes to signer

### DIFF
--- a/src/app/common/psbt/use-psbt-request-params.ts
+++ b/src/app/common/psbt/use-psbt-request-params.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { AllowedSighashTypes } from '@shared/rpc/methods/sign-psbt';
 import { ensureArray, undefinedIfLengthZero } from '@shared/utils';
 
 import { useRejectIfLedgerWallet } from '@app/common/rpc-helpers';
@@ -21,9 +20,6 @@ export function usePsbtRequestSearchParams() {
   return useMemo(
     () => ({
       appName: payload?.appDetails?.name,
-      allowedSighash: payload?.allowedSighash
-        ? undefinedIfLengthZero(payload.allowedSighash.map(h => Number(h)) as AllowedSighashTypes[])
-        : undefined,
       origin,
       payload,
       requestToken,
@@ -41,7 +37,6 @@ export function useRpcSignPsbtParams() {
 
   const [searchParams] = useSearchParams();
   const { origin, tabId } = useDefaultRequestParams();
-  const allowedSighash = searchParams.getAll('allowedSighash');
   const broadcast = searchParams.get('broadcast');
   const psbtHex = searchParams.get('hex');
   const requestId = searchParams.get('requestId');
@@ -49,9 +44,6 @@ export function useRpcSignPsbtParams() {
 
   return useMemo(() => {
     return {
-      allowedSighash: undefinedIfLengthZero(
-        allowedSighash.map(h => Number(h)) as AllowedSighashTypes[]
-      ),
       broadcast: broadcast === 'true',
       origin,
       psbtHex,
@@ -59,5 +51,5 @@ export function useRpcSignPsbtParams() {
       signAtIndex: undefinedIfLengthZero(ensureArray(signAtIndex).map(h => Number(h))),
       tabId: tabId ?? 0,
     };
-  }, [allowedSighash, broadcast, origin, psbtHex, requestId, signAtIndex, tabId]);
+  }, [broadcast, origin, psbtHex, requestId, signAtIndex, tabId]);
 }

--- a/src/app/features/psbt-signer/hooks/use-parsed-psbt.tsx
+++ b/src/app/features/psbt-signer/hooks/use-parsed-psbt.tsx
@@ -2,8 +2,6 @@ import { useCallback } from 'react';
 
 import * as btc from '@scure/btc-signer';
 
-import { AllowedSighashTypes } from '@shared/rpc/methods/sign-psbt';
-
 import { subtractMoney } from '@app/common/money/calculate-money';
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentAccountTaprootIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
@@ -15,22 +13,15 @@ import { usePsbtInscriptions } from './use-psbt-inscriptions';
 import { usePsbtTotals } from './use-psbt-totals';
 
 interface UseParsedPsbtArgs {
-  allowedSighash?: AllowedSighashTypes[];
   inputs: btc.TransactionInput[];
   indexesToSign?: number[];
   outputs: btc.TransactionOutput[];
 }
-export function useParsedPsbt({
-  allowedSighash,
-  inputs,
-  indexesToSign,
-  outputs,
-}: UseParsedPsbtArgs) {
+export function useParsedPsbt({ inputs, indexesToSign, outputs }: UseParsedPsbtArgs) {
   const network = useCurrentNetwork();
   const bitcoinAddressNativeSegwit = useCurrentAccountNativeSegwitIndexZeroSigner().address;
   const { address: bitcoinAddressTaproot } = useCurrentAccountTaprootIndexZeroSigner();
   const { isPsbtMutable, parsedInputs } = useParsedInputs({
-    allowedSighash,
     inputs,
     indexesToSign,
   });

--- a/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
+++ b/src/app/features/psbt-signer/hooks/use-psbt-signer.tsx
@@ -4,7 +4,7 @@ import { hexToBytes } from '@noble/hashes/utils';
 import * as btc from '@scure/btc-signer';
 
 import { logger } from '@shared/logger';
-import { AllowedSighashTypes } from '@shared/rpc/methods/sign-psbt';
+import { allSighashTypes } from '@shared/rpc/methods/sign-psbt';
 import { isString, isUndefined } from '@shared/utils';
 
 import { useCurrentAccountNativeSegwitSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
@@ -13,7 +13,6 @@ import { useCurrentAccountTaprootSigner } from '@app/store/accounts/blockchain/b
 export type RawPsbt = ReturnType<typeof btc.RawPSBTV0.decode>;
 
 interface SignPsbtArgs {
-  allowedSighash?: AllowedSighashTypes[];
   inputs: btc.TransactionInput[];
   indexesToSign?: number[];
   tx: btc.Transaction;
@@ -28,7 +27,7 @@ export function usePsbtSigner() {
 
   return useMemo(
     () => ({
-      signPsbt({ allowedSighash, inputs, indexesToSign, tx }: SignPsbtArgs) {
+      signPsbt({ inputs, indexesToSign, tx }: SignPsbtArgs) {
         inputs.forEach((input, idx) => {
           const isSigning = isUndefined(indexesToSign) || indexesToSign.includes(idx);
 
@@ -44,10 +43,10 @@ export function usePsbtSigner() {
           }
 
           try {
-            nativeSegwitSigner?.signIndex(tx, idx, allowedSighash);
+            nativeSegwitSigner?.signIndex(tx, idx, allSighashTypes);
           } catch (e1) {
             try {
-              taprootSigner?.signIndex(tx, idx, allowedSighash);
+              taprootSigner?.signIndex(tx, idx, allSighashTypes);
             } catch (e2) {
               throw new Error(`Unable to sign PSBT at index, ${e1 ?? e2}`);
             }

--- a/src/app/features/psbt-signer/psbt-signer.tsx
+++ b/src/app/features/psbt-signer/psbt-signer.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import * as btc from '@scure/btc-signer';
 
 import { RouteUrls } from '@shared/route-urls';
-import { AllowedSighashTypes } from '@shared/rpc/methods/sign-psbt';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { SignPsbtArgs } from '@app/common/psbt/requests';
@@ -48,7 +47,6 @@ function getPsbtTxOutputs(psbtTx: btc.Transaction) {
 }
 
 interface PsbtSignerProps {
-  allowedSighash?: AllowedSighashTypes[];
   indexesToSign?: number[];
   isBroadcasting?: boolean;
   name?: string;
@@ -58,16 +56,7 @@ interface PsbtSignerProps {
   psbtHex: string;
 }
 export function PsbtSigner(props: PsbtSignerProps) {
-  const {
-    allowedSighash,
-    indexesToSign,
-    isBroadcasting,
-    name,
-    origin,
-    onCancel,
-    onSignPsbt,
-    psbtHex,
-  } = props;
+  const { indexesToSign, isBroadcasting, name, origin, onCancel, onSignPsbt, psbtHex } = props;
   const navigate = useNavigate();
   const { address: addressNativeSegwit } = useCurrentAccountNativeSegwitIndexZeroSigner();
   const { address: addressTaproot } = useCurrentAccountTaprootIndexZeroSigner();
@@ -103,7 +92,6 @@ export function PsbtSigner(props: PsbtSignerProps) {
     psbtOutputs,
     shouldDefaultToAdvancedView,
   } = useParsedPsbt({
-    allowedSighash,
     inputs: psbtTxInputs,
     indexesToSign,
     outputs: psbtTxOutputs,

--- a/src/app/pages/psbt-request/psbt-request.tsx
+++ b/src/app/pages/psbt-request/psbt-request.tsx
@@ -4,22 +4,13 @@ import { PsbtSigner } from '@app/features/psbt-signer/psbt-signer';
 import { usePsbtRequest } from './use-psbt-request';
 
 export function PsbtRequest() {
-  const {
-    allowedSighash,
-    appName,
-    indexesToSign,
-    isLoading,
-    onSignPsbt,
-    onDenyPsbtSigning,
-    origin,
-    psbtHex,
-  } = usePsbtRequest();
+  const { appName, indexesToSign, isLoading, onSignPsbt, onDenyPsbtSigning, origin, psbtHex } =
+    usePsbtRequest();
 
   if (isLoading) return <LoadingSpinner height="600px" />;
 
   return (
     <PsbtSigner
-      allowedSighash={allowedSighash}
       name={appName ?? ''}
       indexesToSign={indexesToSign}
       origin={origin ?? ''}

--- a/src/app/pages/psbt-request/use-psbt-request.tsx
+++ b/src/app/pages/psbt-request/use-psbt-request.tsx
@@ -15,14 +15,13 @@ export function usePsbtRequest() {
   const [isLoading, setIsLoading] = useState(false);
   const analytics = useAnalytics();
   const navigate = useNavigate();
-  const { allowedSighash, appName, origin, payload, requestToken, signAtIndex, tabId } =
+  const { appName, origin, payload, requestToken, signAtIndex, tabId } =
     usePsbtRequestSearchParams();
   const { signPsbt, getRawPsbt, getPsbtAsTransaction } = usePsbtSigner();
 
   return useMemo(() => {
     return {
       appName,
-      allowedSighash,
       indexesToSign: signAtIndex,
       isLoading,
       getRawPsbt,
@@ -43,7 +42,7 @@ export function usePsbtRequest() {
         const tx = getPsbtAsTransaction(payload.hex);
 
         try {
-          signPsbt({ allowedSighash, indexesToSign: signAtIndex, inputs, tx });
+          signPsbt({ indexesToSign: signAtIndex, inputs, tx });
         } catch (e) {
           return navigate(RouteUrls.RequestError, {
             state: { message: e instanceof Error ? e.message : '', title: 'Failed to sign' },
@@ -63,7 +62,6 @@ export function usePsbtRequest() {
     };
   }, [
     appName,
-    allowedSighash,
     signAtIndex,
     isLoading,
     getRawPsbt,

--- a/src/app/pages/rpc-sign-psbt/rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/rpc-sign-psbt.tsx
@@ -3,12 +3,10 @@ import { PsbtSigner } from '@app/features/psbt-signer/psbt-signer';
 import { useRpcSignPsbt } from './use-rpc-sign-psbt';
 
 export function RpcSignPsbt() {
-  const { allowedSighash, indexesToSign, isBroadcasting, onSignPsbt, onCancel, origin, psbtHex } =
-    useRpcSignPsbt();
+  const { indexesToSign, isBroadcasting, onSignPsbt, onCancel, origin, psbtHex } = useRpcSignPsbt();
 
   return (
     <PsbtSigner
-      allowedSighash={allowedSighash}
       indexesToSign={indexesToSign}
       isBroadcasting={isBroadcasting}
       origin={origin}

--- a/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
@@ -30,8 +30,7 @@ interface BroadcastSignedPsbtTxArgs {
 export function useRpcSignPsbt() {
   const analytics = useAnalytics();
   const navigate = useNavigate();
-  const { allowedSighash, broadcast, origin, psbtHex, requestId, signAtIndex, tabId } =
-    useRpcSignPsbtParams();
+  const { broadcast, origin, psbtHex, requestId, signAtIndex, tabId } = useRpcSignPsbtParams();
   const { signPsbt, getPsbtAsTransaction } = usePsbtSigner();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
   const { refetch } = useCurrentNativeSegwitUtxos();
@@ -83,7 +82,6 @@ export function useRpcSignPsbt() {
   }
 
   return {
-    allowedSighash,
     indexesToSign: signAtIndex,
     isBroadcasting,
     origin,
@@ -92,7 +90,7 @@ export function useRpcSignPsbt() {
       const tx = getPsbtAsTransaction(psbtHex);
 
       try {
-        signPsbt({ allowedSighash, indexesToSign: signAtIndex, inputs, tx });
+        signPsbt({ indexesToSign: signAtIndex, inputs, tx });
       } catch (e) {
         return navigate(RouteUrls.RequestError, {
           state: { message: e instanceof Error ? e.message : '', title: 'Failed to sign' },

--- a/src/background/messaging/rpc-methods/sign-psbt.ts
+++ b/src/background/messaging/rpc-methods/sign-psbt.ts
@@ -74,11 +74,6 @@ export async function rpcSignPsbt(message: SignPsbtRequest, port: chrome.runtime
     requestParams.push(['accountIndex', message.params.account.toString()]);
   }
 
-  if (isDefined(message.params.allowedSighash) && message.params.allowedSighash.length)
-    message.params.allowedSighash.forEach((hash: any) =>
-      requestParams.push(['allowedSighash', hash.toString()])
-    );
-
   if (isDefined(message.params.broadcast)) {
     requestParams.push(['broadcast', message.params.broadcast.toString()]);
   }

--- a/src/shared/rpc/methods/sign-psbt.ts
+++ b/src/shared/rpc/methods/sign-psbt.ts
@@ -14,19 +14,21 @@ import {
 
 // TODO: Revisit allowedSighash type if/when fixed in btc-signer
 export type AllowedSighashTypes = SignatureHash | btc.SignatureHash;
+// Pass all sighashTypes through as allowed to btc-signer
+export const allSighashTypes = [
+  btc.SignatureHash.DEFAULT,
+  SignatureHash.ALL,
+  SignatureHash.NONE,
+  SignatureHash.SINGLE,
+  btc.SignatureHash.ANYONECANPAY,
+  SignatureHash.ALL_ANYONECANPAY,
+  SignatureHash.NONE_ANYONECANPAY,
+  SignatureHash.SINGLE_ANYONECANPAY,
+];
 
 const rpcSignPsbtParamsSchema = yup.object().shape({
   account: accountSchema,
-  allowedSighash: yup
-    .array()
-    .of(
-      yup
-        .mixed()
-        .oneOf([
-          ...Object.values(SignatureHash).filter(Number.isInteger),
-          ...Object.values(btc.SignatureHash).filter(Number.isInteger),
-        ])
-    ),
+  allowedSighash: yup.array(),
   broadcast: yup.boolean(),
   hex: yup.string().required(),
   network: yup.string().oneOf(Object.values(WalletDefaultNetworkConfigurationIds)),


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/hirosystems/wallet/actions/runs/6038438695).<!-- Sticky Header Marker -->

This PR removes code for the `allowedSighash` array param and passes all sighashTypes through to the signer library.