### PR TITLE
fix: pr ext build link

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -21,7 +21,7 @@ jobs:
   update-pull-request-body:
     name: Add links to built extensions
     # Don't run on forks
-    if: github.repository == 'hirosystems/wallet' || github.repository == 'hirosystems/wallet-private'
+    if: github.repository == 'leather-wallet/extension'
     runs-on: ubuntu-latest
     needs:
       - pre-run


### PR DESCRIPTION
> Try out this version of the Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6052294072).<!-- Sticky Header Marker -->

Noticed link to build is not being added to new PRs...

<img width="491" alt="Screen Shot 2023-09-01 at 12 10 20 PM" src="https://github.com/leather-wallet/extension/assets/6493321/8ce57afd-86df-438c-8a5b-ed03adcd3e8c">
