### PR TITLE
fix: discord webhook, new org secret

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -45,23 +45,8 @@ jobs:
         if: steps.firefox.outputs.is_new
         uses: Ilshidur/action-discord@f1ed8844d9b33c17221fab0f36672cde39800eed
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_UX_WEBHOOK }}
-          DISCORD_USERNAME: Hiro Team
-          DISCORD_AVATAR: 'https://i.imgur.com/z9Iy6ug.png'
-          DISCORD_EMBEDS: |
-            [{
-              "title": "Leather for Firefox",
-              "url": "https://addons.mozilla.org/en-US/firefox/addon/hiro-wallet/"
-            }]
-        with:
-          args: ':rocket: A new version (${{ steps.firefox.outputs.new_version }}) of the Leather is available on the Firefox Web Store!'
-
-      - name: Firefox Discord notification - userx-notifs
-        if: steps.firefox.outputs.is_new
-        uses: Ilshidur/action-discord@f1ed8844d9b33c17221fab0f36672cde39800eed
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_UX_NOTIFS_WEBHOOK }}
-          DISCORD_USERNAME: Hiro Team
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_LEATHER_WEBHOOK }}
+          DISCORD_USERNAME: Leather Team
           DISCORD_AVATAR: 'https://i.imgur.com/z9Iy6ug.png'
           DISCORD_EMBEDS: |
             [{
@@ -122,28 +107,13 @@ jobs:
         if: steps.chrome.outputs.is_new
         uses: Ilshidur/action-discord@f1ed8844d9b33c17221fab0f36672cde39800eed
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_UX_WEBHOOK }}
-          DISCORD_USERNAME: Hiro Team
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_LEATHER_WEBHOOK }}
+          DISCORD_USERNAME: Leather Team
           DISCORD_AVATAR: 'https://i.imgur.com/z9Iy6ug.png'
           DISCORD_EMBEDS: |
             [{
               "title": "Leather for Chrome",
-              "url": "https://chrome.google.com/webstore/detail/hiro-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj"
-            }]
-        with:
-          args: ':rocket: A new version (${{ steps.chrome.outputs.new_version }}) of the Leather is available on the Chrome Web Store!'
-
-      - name: Chrome Discord notification - userx-notifs
-        if: steps.chrome.outputs.is_new
-        uses: Ilshidur/action-discord@f1ed8844d9b33c17221fab0f36672cde39800eed
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_UX_NOTIFS_WEBHOOK }}
-          DISCORD_USERNAME: Hiro Team
-          DISCORD_AVATAR: 'https://i.imgur.com/z9Iy6ug.png'
-          DISCORD_EMBEDS: |
-            [{
-              "title": "Leather for Chrome",
-              "url": "https://chrome.google.com/webstore/detail/hiro-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj"
+              "url": "https://chrome.google.com/webstore/detail/leather/ldinpeekobnhjjdofggfgjlcehhmanlj"
             }]
         with:
           args: ':rocket: A new version (${{ steps.chrome.outputs.new_version }}) of the Leather is available on the Chrome Web Store!'


### PR DESCRIPTION
> Try out this version of the Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6172908685).<!-- Sticky Header Marker -->

Should fix the failing release job