### PR TITLE
Set semantic release version at 22

### DIFF
--- a/.github/workflows/create-version.yml
+++ b/.github/workflows/create-version.yml
@@ -38,6 +38,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
         with:
+          semantic_version: 22.0.0
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git


### PR DESCRIPTION
> Try out this version of the Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6220945826).<!-- Sticky Header Marker -->

Setting `semantic-release` version to be 22 as it's still failing. 22 is the latest version

I'm not sure if this will work but I found this issue where people tried to fix  it: 
https://github.com/cycjimmy/semantic-release-action/issues/79


`semantic-release` is still failing with:
```
[semantic-release](https://github.com/leather-wallet/extension/actions/runs/6220419405/job/16880954569#step:5:26)
Error: Command failed: npm install @semantic-release/changelog @semantic-release/git @semantic-release/release-notes-generator --no-audit 
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @cycjimmy/semantic-release-action@3.4.2
npm ERR! Found: semantic-release@19.0.5
npm ERR! node_modules/semantic-release
npm ERR!   semantic-release@"^19.0.5" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer semantic-release@">=20.1.0" from @semantic-release/release-notes-generator@11.0.7
npm ERR! node_modules/@semantic-release/release-notes-generator
npm ERR!   @semantic-release/release-notes-generator@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! 
npm ERR! For a full report see:
npm ERR! /home/runner/.npm/_logs/2023-09-18T09_22_02_600Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2023-09-18T09_22_02_600Z-debug-0.log
```


