### PR TITLE
fix: enable ff code splitting

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: kyranjamie/pull-request-fixed-header@v1.0.1
         with:
-          header: '> Try out this version of the Leather — download [extension builds](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).'
+          header: '> Try out this version of Leather — download [extension builds](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_chrome_extension:

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -65,7 +65,6 @@ jobs:
     needs:
       - pre-run
     env:
-      MINIFY_PRODUCTION_BUILD: true
       TARGET_BROWSER: firefox
     steps:
       - name: Checkout

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -79,7 +79,6 @@ jobs:
 
       - run: yarn build
         env:
-          MINIFY_PRODUCTION_BUILD: true
           TARGET_BROWSER: firefox
 
       - run: yarn web-ext lint

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,4 +1,4 @@
-# Sends a notification to Discord whenever a new version of the Leather is available in FireFox or Chrome stores
+# Sends a notification to Discord whenever a new version of Leather is available in FireFox or Chrome stores
 
 name: Notify on Release
 on:
@@ -54,7 +54,7 @@ jobs:
               "url": "https://addons.mozilla.org/en-US/firefox/addon/hiro-wallet/"
             }]
         with:
-          args: ':rocket: A new version (${{ steps.firefox.outputs.new_version }}) of the Leather is available on the Firefox Web Store!'
+          args: ':rocket: A new version (${{ steps.firefox.outputs.new_version }}) of Leather is available on the Firefox Web Store!'
 
   chrome-notify:
     runs-on: ubuntu-latest
@@ -116,4 +116,4 @@ jobs:
               "url": "https://chrome.google.com/webstore/detail/leather/ldinpeekobnhjjdofggfgjlcehhmanlj"
             }]
         with:
-          args: ':rocket: A new version (${{ steps.chrome.outputs.new_version }}) of the Leather is available on the Chrome Web Store!'
+          args: ':rocket: A new version (${{ steps.chrome.outputs.new_version }}) of Leather is available on the Chrome Web Store!'

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -87,7 +87,6 @@ jobs:
     outputs:
       publish_status: ${{ steps.publish-chrome.outputs.publish_status }}
     env:
-      MINIFY_PRODUCTION_BUILD: false
       TARGET_BROWSER: chromium
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +126,6 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     env:
-      MINIFY_PRODUCTION_BUILD: true
       TARGET_BROWSER: firefox
     needs:
       - pre-run
@@ -148,9 +146,6 @@ jobs:
         with:
           name: leather-wallet-firefox
           path: dist
-
-      - name: Put generated manifest.json in ./src
-        run: cp dist/manifest.json src/manifest.json
 
       - name: Build extension
         run: sh build-ext.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM debian:buster-slim as builder
 LABEL maintainer="ux@blockstack.com"
 
 ARG NODE_VERSION=12
-ENV MINIFY_PRODUCTION_BUILD=true
 ENV WALLET_ENVIRONMENT="production"
 ENV NODE_VERSION=${NODE_VERSION}
 WORKDIR /src

--- a/src/app/features/leather-intro-dialog/leather-intro-steps.tsx
+++ b/src/app/features/leather-intro-dialog/leather-intro-steps.tsx
@@ -101,7 +101,7 @@ export function LeatherIntroDialogPart2() {
       </Box>
       <styled.span textStyle="caption.02" display="block" textAlign="left" mt="16px">
         Leather Wallet will now be provided by Leather Wallet LLC [a subsidiary of Nassau Machines
-        Inc]. Please review and accept the Leather Wallet{' '}
+        Inc]. Please review and accept Leather Wallet{' '}
         <styled.a href="https://leather.io/terms" textDecoration="underline" target="_blank">
           Terms of Service
         </styled.a>{' '}

--- a/src/app/features/ledger/generic-steps/public-key-mismatch/public-key-mismatch.layout.tsx
+++ b/src/app/features/ledger/generic-steps/public-key-mismatch/public-key-mismatch.layout.tsx
@@ -17,7 +17,7 @@ export function PublicKeyMismatchLayout({ onClose, onTryAgain }: PublicKeyMismat
       </Box>
       <Title mt="extra-loose">Public key does not match</Title>
       <Text mt="base-tight" lineHeight="24px" color={color('text-caption')}>
-        Ensure you're using the same Ledger you used when setting up the Leather
+        Ensure you're using the same Ledger you used when setting up Leather
       </Text>
       <Flex mt="base-loose">
         <Button mode="tertiary" mr="base-tight" onClick={onClose}>

--- a/src/app/features/ledger/generic-steps/unsupported-browser/unsupported-browser.layout.tsx
+++ b/src/app/features/ledger/generic-steps/unsupported-browser/unsupported-browser.layout.tsx
@@ -22,7 +22,7 @@ export function UnsupportedBrowserLayout() {
         mx="extra-loose"
         color={figmaTheme.textSubdued}
       >
-        To connect your Ledger with the Leather try{' '}
+        To connect your Ledger with Leather try{' '}
         <ExternalLink href="https://www.google.com/chrome/">Chrome</ExternalLink> or{' '}
         <ExternalLink href="https://brave.com/download/">Brave</ExternalLink>.
       </Text>

--- a/src/app/pages/unauthorized-request/unauthorized-request.tsx
+++ b/src/app/pages/unauthorized-request/unauthorized-request.tsx
@@ -6,7 +6,7 @@ const body = `The transaction request was not properly authorized by any of your
 const helpTextList = [
   <Box as="li" mt="base" key={1}>
     Sign out of the app and sign back in to re-authenticate into the application. This should help
-    you successfully sign your transaction with the Leather.
+    you successfully sign your transaction with Leather.
   </Box>,
 ];
 const title = 'Unauthorized request';

--- a/src/shared/utils/requests.ts
+++ b/src/shared/utils/requests.ts
@@ -6,7 +6,7 @@ import { decodeToken } from 'jsontokens';
 // to `@stacks/network` had some undesired consequence.
 // As `StacksNetwork` is a class instance, this is auto
 // serialized when being passed across `postMessage`,
-// from the developer's app, to the Leather.
+// from the developer's app, to Leather.
 // `coreApiUrl` now uses a getter, rather than a prop,
 // and `_coreApiUrl` is a private value.
 // To support both `@stacks/network` versions a dev may be using

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -1,11 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const config = require('./webpack.config.base');
 const packageJson = require('../package.json');
-const { EsbuildPlugin } = require('esbuild-loader');
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 const webpack = require('webpack');
 
-const shouldMinify = JSON.parse(process.env.MINIFY_PRODUCTION_BUILD || false);
 const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
 
 config.mode = 'production';
@@ -13,34 +11,18 @@ config.mode = 'production';
 // Basically, disable any code splitting stuff
 config.optimization = {
   ...config.optimization,
-  minimize: shouldMinify,
+  minimize: false,
   moduleIds: 'deterministic',
   splitChunks: {
+    maxSize: process.env.TARGET_BROWSER === 'firefox' ? 3500000 : undefined,
     chunks(chunk) {
-      // Only enable code splitting on main bundle
       return chunk.name === 'index';
-    },
-    cacheGroups: {
-      radixUI: {
-        test: /[\\/]node_modules[\\/]@radix-ui[\\/]/,
-        name: 'radix-ui',
-        chunks: 'all',
-      },
     },
     hidePathInfo: false,
     minSize: 10000,
     maxAsyncRequests: Infinity,
     maxInitialRequests: Infinity,
   },
-  ...(shouldMinify
-    ? {
-        minimizer: [
-          new EsbuildPlugin({
-            target: 'esnext',
-          }),
-        ],
-      }
-    : {}),
 };
 
 config.plugins = [


### PR DESCRIPTION
> Try out this version of Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6233084542).<!-- Sticky Header Marker -->

The set up thus far has been minifying Firefox only as it somewhat supports it, whereas Chrome doesn't. This allowed us to have pretty big bundles, but keep below the 4MB FF limit.

I can't recall, but there was a reason why code splitting was disabled when this was originally put together. The bundling aspect of the project is amongst the oldest code. In this PR, I've removed all minification, but re-enabled bundling, which should allow us to pass the FF review.