### PR TITLE
fix: set onboarding modal background color to fix transparency in dar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you discover a security vulnerability, please use one of the following means 
 - Report the security issue to our [HackerOne program](https://hackerone.com/hiro)
 - Report the security issue directly at [security@hiro.so](mailto:security@hiro.so)
 
-Please note this email is strictly for reporting security vulnerabilities. For support queries, contact [wallet@hiro.so](mailto:wallet@hiro.so). Your efforts to responsibly disclose your findings are sincerely appreciated and will be taken into account to acknowledge your contributions.
+Please note this email is strictly for reporting security vulnerabilities. For support queries, contact [contact@leather.io](mailto:contact@leather.io). Your efforts to responsibly disclose your findings are sincerely appreciated and will be taken into account to acknowledge your contributions.
 
 ### Audit Report
 

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -3,7 +3,7 @@
   <!--
     Hello! Thanks for showing interest in our code.
     Interested in joining our team? To learn more, email us:
-    wallet@hiro.so
+    contact@leather.io
   -->
   <head>
     <meta charset="UTF-8" />

--- a/src/app/pages/onboarding/allow-diagnostics/allow-diagnostics-layout.tsx
+++ b/src/app/pages/onboarding/allow-diagnostics/allow-diagnostics-layout.tsx
@@ -3,6 +3,7 @@ import { FiCheck } from 'react-icons/fi';
 import { Dialog } from '@radix-ui/themes';
 import { OnboardingSelectors } from '@tests/selectors/onboarding.selectors';
 import { Box, Flex, HStack, Stack, styled } from 'leather-styles/jsx';
+import { token } from 'leather-styles/tokens';
 
 import { LeatherButton } from '@app/components/button/button';
 import { LeatherIcon } from '@app/components/icons/leather-icon';
@@ -29,7 +30,14 @@ export function AllowDiagnosticsLayout(props: AllowDiagnosticsLayoutProps) {
   const { onUserAllowDiagnostics, onUserDenyDiagnostics } = props;
   return (
     <Dialog.Root open>
-      <Dialog.Content style={{ width: '500px', marginLeft: '12px', marginRight: '12px' }}>
+      <Dialog.Content
+        style={{
+          width: '500px',
+          marginLeft: token('spacing.space.03'),
+          marginRight: token('spacing.space.03'),
+          backgroundColor: token('colors.accent.background-primary'),
+        }}
+      >
         <LeatherIcon />
         <styled.h1 textStyle="heading.03" mt={['space.05', 'space.08']}>
           Help us improve


### PR DESCRIPTION
> Try out this version of Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6250837444).<!-- Sticky Header Marker -->

This fixes a bug where the initial onboarding modal is transparent in dark mode. 
![Screenshot 2023-09-20 at 16 24 14](https://github.com/leather-wallet/extension/assets/2938440/21592575-08d5-439b-a6bf-a5769fad08a6)

Fix shown here switching between modes:

https://github.com/leather-wallet/extension/assets/2938440/fd9680f9-ef9c-447b-9ed0-d336a02f0372

