### PR TITLE
ci: don't run build for dependabot

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -20,8 +20,7 @@ jobs:
 
   update-pull-request-body:
     name: Add links to built extensions
-    # Don't run on forks
-    if: github.repository == 'leather-wallet/extension'
+    if: github.repository == 'leather-wallet/extension' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs:
       - pre-run


### PR DESCRIPTION
> Try out this version of Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6261832548).<!-- Sticky Header Marker -->

Doesn't work for dependabot PRs