### PR TITLE
feat: replaced dlc-wasm-wallet with @dlc-link/dlc-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "1.0.2",
     "@coinbase/cbpay-js": "1.0.2",
+    "@dlc-link/dlc-tools": "1.0.1",
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.1.0",
     "@ledgerhq/hw-transport-webusb": "6.27.16",
@@ -187,7 +188,6 @@
     "compare-versions": "4.1.3",
     "css-loader": "6.8.1",
     "dayjs": "1.11.8",
-    "dlc-wasm-wallet": "0.4.7",
     "dompurify": "3.0.4",
     "dotenv": "16.3.1",
     "downshift": "6.1.7",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "1.0.2",
     "@coinbase/cbpay-js": "1.0.2",
-    "@dlc-link/dlc-tools": "1.0.1",
+    "@dlc-link/dlc-tools": "1.0.2",
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.1.0",
     "@ledgerhq/hw-transport-webusb": "6.27.16",

--- a/src/app/common/hooks/use-bitcoin-contracts.ts
+++ b/src/app/common/hooks/use-bitcoin-contracts.ts
@@ -1,8 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 
 import { RpcErrorCode } from '@btckit/types';
+import { JsDLCInterface } from '@dlc-link/dlc-tools';
 import { bytesToHex } from '@stacks/common';
-import { JsDLCInterface } from 'dlc-wasm-wallet';
 
 import { BITCOIN_API_BASE_URL_MAINNET, BITCOIN_API_BASE_URL_TESTNET } from '@shared/constants';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1492,10 +1492,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dlc-link/dlc-tools@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@dlc-link/dlc-tools/-/dlc-tools-1.0.1.tgz#878973c4a31bac653e29dd3a553ba15315473d9a"
-  integrity sha512-1ZT5+7NsIs+uvrWtoLbQzPyBxIrt2UMybBYt3QdpPi5uFM/ilo3Xgr4qUTuEMe9a6CTwd4P/91RSaSGrqWHb6g==
+"@dlc-link/dlc-tools@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@dlc-link/dlc-tools/-/dlc-tools-1.0.2.tgz#fe7531b735a8f7e4bfee6ca9224c9bde99783027"
+  integrity sha512-EAp5Z/bhUzTdxLSOB9PeeSCfdNyNXsi+NJ25NiQcmczJXwczmShjqRIKpZt/WWs2Ahgi0zpIyFmcvFn7IWo/6Q==
 
 "@dnd-kit/accessibility@^3.0.0":
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1492,6 +1492,11 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@dlc-link/dlc-tools@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@dlc-link/dlc-tools/-/dlc-tools-1.0.1.tgz#878973c4a31bac653e29dd3a553ba15315473d9a"
+  integrity sha512-1ZT5+7NsIs+uvrWtoLbQzPyBxIrt2UMybBYt3QdpPi5uFM/ilo3Xgr4qUTuEMe9a6CTwd4P/91RSaSGrqWHb6g==
+
 "@dnd-kit/accessibility@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz#3ccbefdfca595b0a23a5dc57d3de96bc6935641c"
@@ -12046,11 +12051,6 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
-
-dlc-wasm-wallet@0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/dlc-wasm-wallet/-/dlc-wasm-wallet-0.4.7.tgz#5c726ab83bf549d09e4ae8c7827ca63a9cff5060"
-  integrity sha512-Q5ZW3jknqFf99/pNFPE/ETK/Kvoo3M98mACkZJ+s8XVQ4rxRjmNw+9m9HumItdGDLGBNFzCsew1joNrwfkl9Ow==
 
 dlv@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
> Try out this version of Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6310928138).<!-- Sticky Header Marker -->

We've replaced the dlc-wasm-wallet package with the @dlc-link/dlc-tools package. While it maintains the same core functionality, we've added some new features to the wasm code. Additionally, we've moved the package from a temporary user account to our official company account.