### PR TITLE
ci: improve publish extensions workflow

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: kyranjamie/pull-request-fixed-header@v1.0.1
         with:
-          header: '> Try out this version of Leather — download [extension builds](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).'
+          header: '> Try out this version of Leather — [download extension builds](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_chrome_extension:

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -23,13 +23,12 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-  build-extension:
+  extract-version:
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.extract_version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/provision
 
       - name: Extract version
         id: extract_version
@@ -38,59 +37,19 @@ jobs:
       - name: Print version
         run: echo ${{ steps.extract_version.outputs.version }}
 
-      - name: Build project
-        run: yarn build
-
-      - uses: actions/upload-artifact@v3
-        name: Upload build artifact
-        with:
-          name: leather-wallet
-          path: dist
-
-  create-github-release:
-    name: Create Github release
-    runs-on: ubuntu-latest
-    needs:
-      - build-extension
-    steps:
-      - name: Download extension build
-        uses: actions/download-artifact@v2
-        with:
-          path: .
-
-      - name: Download release-notes.txt from create-version workflow
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: create-version.yml
-          name: release-notes
-
-      - run: ls -R
-
-      - name: Zip release build
-        run: zip -r leather-wallet.v${{ needs.build-extension.outputs.new_version }}.zip leather-wallet/
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          prerelease: false
-          tag_name: v${{ needs.build-extension.outputs.new_version }}
-          body_path: release-notes.txt
-          files: leather-wallet.v${{ needs.build-extension.outputs.new_version }}.zip
-
-  publish_chrome_extension:
+  publish-chrome-extension:
     name: Publish Chrome extension
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - pre-run
-      - create-github-release
+      - extract-version
     outputs:
       publish_status: ${{ steps.publish-chrome.outputs.publish_status }}
     env:
       TARGET_BROWSER: chromium
     steps:
       - uses: actions/checkout@v4
-
       - uses: ./.github/actions/provision
 
       - name: Build project
@@ -103,7 +62,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         name: Upload build artifact
         with:
-          name: leather-wallet-chrome
+          name: leather-chromium-v${{ needs.extract-version.outputs.new_version }}
           path: dist
 
       - name: Build extension
@@ -121,7 +80,7 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
 
-  publish_firefox_extension:
+  publish-firefox-extension:
     name: Publish Firefox extension
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
@@ -129,12 +88,11 @@ jobs:
       TARGET_BROWSER: firefox
     needs:
       - pre-run
-      - create-github-release
+      - extract-version
     outputs:
       publish_status: ${{ steps.publish-firefox.outputs.publish_status }}
     steps:
       - uses: actions/checkout@v4
-
       - uses: ./.github/actions/provision
 
       - name: Build project
@@ -144,11 +102,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         name: Upload build artifact
         with:
-          name: leather-wallet-firefox
+          name: leather-firefox-v${{ needs.extract-version.outputs.new_version }}
           path: dist
-
-      - name: Build extension
-        run: sh build-ext.sh
 
       - name: Sign and Upload Production Firefox extension
         continue-on-error: true
@@ -160,13 +115,50 @@ jobs:
           WEB_EXT_API_KEY: ${{ secrets.FIREFOX_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.FIREFOX_API_SECRET }}
 
+  create-github-release:
+    name: Create Github release
+    runs-on: ubuntu-latest
+    needs:
+      - extract-version
+      - publish-chrome-extension
+      - publish-firefox-extension
+    steps:
+      - name: Download extension build
+        uses: actions/download-artifact@v3
+        with:
+          path: .
+
+      - name: Download release-notes.txt from create-version workflow
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: create-version.yml
+          name: release-notes
+
+      - name: Zip Firefox build
+        run: zip -r leather-firefox.v${{ needs.extract-version.outputs.new_version }}.zip leather-firefox-v${{ needs.extract-version.outputs.new_version }}
+
+      - name: Zip Chromium build
+        run: zip -r leather-chromium.v${{ needs.extract-version.outputs.new_version }}.zip leather-chromium-v${{ needs.extract-version.outputs.new_version }}
+
+      - run: ls -la .
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: false
+          tag_name: v${{ needs.extract-version.outputs.new_version }}
+          body_path: release-notes.txt
+          files: |
+            leather-chromium.v${{ needs.extract-version.outputs.new_version }}.zip
+            leather-firefox.v${{ needs.extract-version.outputs.new_version }}.zip
+
   post_run:
     runs-on: ubuntu-latest
     needs:
-      - publish_chrome_extension
-      - publish_firefox_extension
+      - publish-chrome-extension
+      - publish-firefox-extension
     steps:
       - name: Publish Statuses
         run: |
-          echo "::warning::Firefox Publish Status: $([[ "${{ needs.publish_firefox_extension.outputs.publish_status }}" = "0" ]] && echo 'SUCCESS' || echo 'FAILED')"
-          echo "::warning::Chrome Publish Status: $([[ "${{ needs.publish_chrome_extension.outputs.publish_status }}" = "0" ]] && echo 'SUCCESS' || echo 'FAILED')"
+          echo "::warning::Firefox Publish Status: $([[ "${{ needs.publish-firefox-extension.outputs.publish_status }}" = "0" ]] && echo 'SUCCESS' || echo 'FAILED')"
+          echo "::warning::Chrome Publish Status: $([[ "${{ needs.publish-chrome-extension.outputs.publish_status }}" = "0" ]] && echo 'SUCCESS' || echo 'FAILED')"


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6299489444).<!-- Sticky Header Marker -->

We're only publishing one file to the Github release. Since MV3, we need separate builds for Chromium and Firefox targets.

In this PR, two separate bundles to uploaded to each release. Further, the order of operations has been reversed: first we publish to stores, then we upload the bundles.

I've tested a duplicate instance of the publish job, but can't be 100% sure it works until we release next. Can merge this post-fixing Firefox release.