### PR TITLE
feat: embed content iframes

### DIFF
--- a/public/html/iframe.html
+++ b/public/html/iframe.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="app">
+      <button onclick="console.log('test me')">test</button>
+    </div>
+    <script>
+      window.addEventListener('message', e => {
+        console.log('listening in child WARNING', e);
+      });
+      window.parent.addEventListener('message', e => {
+        console.log('listening in child WARNING', e);
+      });
+
+      setInterval(() => {
+        window.parent.alert('test');
+        window.postMessage('from dodgy frame');
+      }, 1000);
+    </script>
+  </body>
+</html>

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -31,11 +31,15 @@ const environmentIcons = {
   },
 };
 
+const devCsp =
+  "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; frame-src *; frame-ancestors 'none';";
+
+const prodCsp = `default-src 'none'; connect-src *; style-src 'unsafe-inline'; img-src 'self' data: https:; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-src *; frame-ancestors 'none';`;
+
 const contentSecurityPolicyEnvironment = {
-  testing: `default-src 'none'; connect-src *; style-src 'unsafe-inline'; img-src 'self' data: https:; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';`,
-  development:
-    "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; frame-src 'none'; frame-ancestors 'none';",
-  production: `default-src 'none'; connect-src *; style-src 'unsafe-inline'; img-src 'self' data: https:; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-src 'none'; frame-ancestors 'none';`,
+  testing: prodCsp,
+  development: devCsp,
+  production: prodCsp,
 };
 
 const defaultIconEnvironment = {

--- a/src/app/components/external-content-frame.tsx
+++ b/src/app/components/external-content-frame.tsx
@@ -1,0 +1,27 @@
+//
+//  __          __     _____  _   _ _____ _   _  _____
+//  \ \        / /\   |  __ \| \ | |_   _| \ | |/ ____|
+//   \ \  /\  / /  \  | |__) |  \| | | | |  \| | |  __
+//    \ \/  \/ / /\ \ |  _  /| . ` | | | | . ` | | |_ |
+//     \  /\  / ____ \| | \ \| |\  |_| |_| |\  | |__| |
+//      \/  \/_/    \_\_|  \_\_| \_|_____|_| \_|\_____|
+//
+// The purpose of this iframe is to wrap content from external sources,
+// primarily for use with animated inscriptions. Iframes are dangerous and we
+// need to be very careful with our use of them.
+//
+// Below, we use the sandbox attribute to limit waht they can do, as well as
+// disabling any interaction with pointer events and user selection.
+
+interface ExternalContentFrameProps {
+  src: string;
+}
+export function ExternalContentFrame({ src }: ExternalContentFrameProps) {
+  return (
+    <iframe
+      src={src}
+      sandbox="allow-scripts"
+      style={{ pointerEvents: 'none', userSelect: 'none' }}
+    />
+  );
+}

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -6,6 +7,7 @@ import { useTrackFirstDeposit } from '@app/common/hooks/analytics/transactions-a
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
 import { useOnMount } from '@app/common/hooks/use-on-mount';
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
+import { ExternalContentFrame } from '@app/components/external-content-frame';
 import { Header } from '@app/components/header';
 import { InAppMessages } from '@app/features/hiro-messages/in-app-messages';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
@@ -20,6 +22,7 @@ export function Home() {
   const stacksAccount = useCurrentStacksAccount();
   const navigate = useNavigate();
   useTrackFirstDeposit();
+  const ref = useRef<HTMLIFrameElement>(null);
 
   useRouteHeader(
     <>
@@ -34,6 +37,7 @@ export function Home() {
 
   return (
     <HomeLayout currentAccount={<CurrentAccount />}>
+      <ExternalContentFrame src="https://ordinal.vercel.app/preview/7d9546000f48bcd65be58a45a57c80f75a4851523aebc738d5dac6738ceae2aai0" />
       <HomeTabs>
         <Outlet context={{ address: stacksAccount?.address }} />
       </HomeTabs>


### PR DESCRIPTION
> Try out this version of Leather — download [extension builds](https://github.com/leather-wallet/extension/actions/runs/6312648675).<!-- Sticky Header Marker -->

This PR explores adding `iframe`s to the wallet to display external content. This is a security sensitive task as we need to be very careful allowing user-generated content.

I'm fairly confident that with the `sandbox` attributes in place, and the frame's interaction completely disabled with CSS properties, we can display the content safely. Many of these animated inscriptions do require scripts to run, so we're using the `allow-scripts` sandbox exception.

I've looked into whether any messaging risks are posed, such as weather a frame can either listen for or broadcast `postMessages`. These are blocked as they're cross-origin.



cc/ @janniks 