### PR TITLE
fix: add array notation lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,7 @@ module.exports = {
     // This rule is off until we can enable tsconfig noUncheckedIndexedAccess
     '@typescript-eslint/no-unnecessary-condition': 'off',
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+    '@typescript-eslint/array-type': ['error'],
     'no-warning-comments': [0],
 
     'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
@pete-watters said array linting rule

Adding this rule to keep us to a single array type notation