### PR TITLE
fix: explicitly set background colour of radix dialog to prevent transparency in dark mode

### DIFF
--- a/src/app/features/leather-intro-dialog/leather-intro-steps.tsx
+++ b/src/app/features/leather-intro-dialog/leather-intro-steps.tsx
@@ -3,6 +3,7 @@ import Confetti from 'react-dom-confetti';
 
 import { Dialog } from '@radix-ui/themes';
 import { Inset } from '@radix-ui/themes';
+import { css } from 'leather-styles/css';
 import { Box, Flex, Stack, styled } from 'leather-styles/jsx';
 
 import { HasChildren } from '@app/common/has-children';
@@ -19,7 +20,7 @@ export function LeatherIntroDialog({ children }: HasChildren) {
         // Prevent immediate closing, force interation
         onEscapeKeyDown={e => e.preventDefault()}
         onInteractOutside={e => e.preventDefault()}
-        style={{ maxWidth: '500px' }}
+        className={css({ maxWidth: '500px', backgroundColor: 'accent.background-primary' })}
       >
         {children}
       </Dialog.Content>


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6337494347).<!-- Sticky Header Marker -->

This fixes https://github.com/leather-wallet/extension/issues/4282 

It's the only other place we are using `Dialog` from Radix UI. I should have searched when solving the last issue. 

It comes in from this report in Slack: 
https://trustmachines.slack.com/archives/C05LRS7G44R/p1695847281064189

![image](https://github.com/leather-wallet/extension/assets/2938440/92d2020c-2bff-4053-a74b-7344d5532192)
![Screen Shot 2023-09-27 at 6 12 30 PM](https://github.com/leather-wallet/extension/assets/2938440/be75fb4e-b330-49fc-b0f4-a0eb15d34dbd)
