### PR TITLE
fix: removes dependancy on two libraries for bip39

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ yarn playwright install --with-deps
 
 Note that the installed browsers are tied to the version of Playwright being used, and it may be necessary to run the above command again in some situations, such as when upgrading Playwright or switching branches. [Read the documentation for more information](https://playwright.dev/docs/cli#install-system-dependencies).
 
+### Integration tests
+
+All integration tests can be run using:
+
+```bash
+yarn test:integration
+```
+
+To run a suite of tests you can use:
+
+```bash
+yarn playwright test specs/TEST.spec.ts
+yarn playwright test tests/specs --shard=3/8
+```
+
+### Unit tests
+
+Unit tests can be run with vitest using:
+
+```bash
+yarn test:unit
+```
+
 ## Production
 
 [See instructions on Hiro.so for installing from source for production usage.](https://www.hiro.so/wallet/install-web-source)

--- a/package.json
+++ b/package.json
@@ -280,7 +280,6 @@
     "babel-loader": "9.1.3",
     "base64-loader": "1.0.0",
     "bip32": "4.0.0",
-    "bip39": "3.1.0",
     "blns": "2.0.4",
     "browserslist": "4.22.0",
     "chrome-webstore-upload-cli": "2.2.2",

--- a/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
+++ b/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { validateMnemonic } from 'bip39';
+import { validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -50,7 +51,7 @@ export function useSignIn() {
         handleSetError('Entering your Secret Key is required.');
       }
 
-      if (!validateMnemonic(parsedKeyInput)) {
+      if (!validateMnemonic(parsedKeyInput, wordlist)) {
         handleSetError();
         return;
       }


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6380887453).<!-- Sticky Header Marker -->

Small change so we only use `"@scure/bip39"`