### PR TITLE
fix: add spam filtering to fungible token assets, closes #4252

### DIFF
--- a/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.tsx
+++ b/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.tsx
@@ -8,6 +8,7 @@ import { Money } from '@shared/models/money.model';
 
 import { getImageCanonicalUri } from '@app/common/crypto-assets/stacks-crypto-asset.utils';
 import { formatContractId, getTicker } from '@app/common/utils';
+import { spamFilter } from '@app/common/utils/spam-filter';
 
 import { StacksFungibleTokenAssetItemLayout } from './stacks-fungible-token-asset-item.layout';
 
@@ -30,16 +31,15 @@ export const StacksFungibleTokenAssetItem = forwardRefWithAs(
       (contractAssetName.includes('::') ? getAssetName(contractAssetName) : contractAssetName);
     const imageCanonicalUri = getImageCanonicalUri(asset.imageCanonicalUri, asset.name);
     const caption = symbol || getTicker(friendlyName);
-
     return (
       <StacksFungibleTokenAssetItemLayout
         avatar={avatar}
         balance={balance}
-        caption={caption}
+        caption={spamFilter(caption)}
         data-testid={dataTestId}
         imageCanonicalUri={imageCanonicalUri}
         ref={ref}
-        title={friendlyName}
+        title={spamFilter(friendlyName)}
         {...rest}
       />
     );


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6380182957).<!-- Sticky Header Marker -->

This PR fixes a bug with not filtering all spam tokens properly. 

Here you can see a spam token:

![Screenshot 2023-10-02 at 13 36 12](https://github.com/leather-wallet/extension/assets/2938440/04a6c37f-c515-4012-bd48-6e1b0d8a6ac0)

I removed it by adding the `spamFilter` to the fungible list items also

![Screenshot 2023-10-02 at 13 35 56](https://github.com/leather-wallet/extension/assets/2938440/8afbd460-b705-4cf2-bba8-d292b220aa68)

