### PR TITLE
fix: adjust padding of numerical slot, closes #4243

### DIFF
--- a/src/app/components/secret-key/mnemonic-key/mnemonic-input-field.tsx
+++ b/src/app/components/secret-key/mnemonic-key/mnemonic-input-field.tsx
@@ -67,7 +67,7 @@ export function InputField({ dataTestId, name, onPaste, onChange, value }: Input
         },
       })}
     >
-      <TextField.Slot>
+      <TextField.Slot className={css({ padding: 'space.00', marginRight: 'space.01' })}>
         {/* // FIXME #4130: - update this color when available in design system */}
         <styled.span textStyle="label.01" color="GrayText">{`${name}.`}</styled.span>
       </TextField.Slot>


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6407576765).<!-- Sticky Header Marker -->

This is a small change to adjust the padding of the input field label as mentioned here: 
https://github.com/leather-wallet/extension/pull/4243#issuecomment-1746780093 

![Screenshot 2023-10-04 at 15 36 13](https://github.com/leather-wallet/extension/assets/2938440/92023f1b-0385-49ec-9693-51c1b2996b60)
