### PR TITLE
ci: attempt automating merge back

### DIFF
--- a/.github/workflows/create-version.yml
+++ b/.github/workflows/create-version.yml
@@ -66,3 +66,12 @@ jobs:
         with:
           name: release-notes
           path: release-notes.txt
+
+      - name: Merge main -> dev
+        uses: devmasx/merge-branch@master
+        continue-on-error: true
+        with:
+          type: now
+          from_branch: main
+          target_branch: dev
+          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6484002870).<!-- Sticky Header Marker -->

I have a feeling we tried this before and it didn't work well, but can't recall why. Here we attempt to merge main back into dev after a release, to remove the manual step. 