### PR TITLE
fix: improve type loading

### DIFF
--- a/public/html/debug.html
+++ b/public/html/debug.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="mode__full-page light">
   <head>
     <meta charset="UTF-8" />

--- a/public/html/devtool.html
+++ b/public/html/devtool.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="mode__devtool">
   <head>
     <meta charset="UTF-8" />

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="mode__full-page light">
   <!--
     Hello! Thanks for showing interest in our code.
@@ -9,6 +9,34 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link href="/assets/base.css" rel="stylesheet" />
+    <link
+      rel="preload"
+      href="/assets/fonts/diatype/diatype-light.woff2"
+      as="font"
+      crossorigin
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/assets/fonts/diatype/diatype-medium.woff2"
+      as="font"
+      crossorigin
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/assets/fonts/diatype/diatype-regular.woff2"
+      as="font"
+      crossorigin
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/assets/fonts/marche/marche-super-pro.woff2"
+      as="font"
+      crossorigin
+      type="font/woff2"
+    />
   </head>
   <body>
     <div id="app"></div>

--- a/public/html/popup-center.html
+++ b/public/html/popup-center.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="mode__popup-center light">
   <head>
     <meta charset="UTF-8" />

--- a/public/html/popup.html
+++ b/public/html/popup.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="mode__popup light">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6507219043).<!-- Sticky Header Marker -->

Reviewing @fbwoolf's PR prompted me to do this.

Notice how in the first video, you can see the fonts are loaded on demand, when rendered on the page, later in the app lifecycle. As the modal opens, you can see the fallback font, ~9s, before Marche loads.



https://github.com/leather-wallet/extension/assets/1618764/6105e2bd-75c2-4d4f-bd23-38be755b5a66


Here, we add the preload property, so they're all loaded up front. As the font is already available, it doesn't need to use the fallback.

https://github.com/leather-wallet/extension/assets/1618764/0e967b76-5f89-4e07-ae66-b4c9223a7a20

cc/ @fabric-8 @mica000 
