### PR TITLE
fix: properly switch between 12 and 24 word inputs

### DIFF
--- a/src/app/pages/onboarding/sign-in/sign-in.tsx
+++ b/src/app/pages/onboarding/sign-in/sign-in.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -15,19 +15,23 @@ export function SignIn() {
   const navigate = useNavigate();
 
   const [twentyFourWordMode, setTwentyFourWordMode] = useState(true);
-  const [mnemonic, setMnemonic] = useState<(string | null)[]>(() => createNullArrayOfLength(24));
+  const [mnemonic, setMnemonic] = useState<(string | null)[]>([]);
 
   useRouteHeader(<Header onClose={() => navigate(RouteUrls.Onboarding)} hideActions />);
+
+  useEffect(() => {
+    const emptyMnemonicArray = twentyFourWordMode
+      ? createNullArrayOfLength(24)
+      : createNullArrayOfLength(12);
+    setMnemonic(emptyMnemonicArray);
+  }, [twentyFourWordMode]);
 
   return (
     <>
       <TwoColumnLayout
         leftColumn={
           <SignInContent
-            onClick={() => {
-              setTwentyFourWordMode(!twentyFourWordMode);
-              setMnemonic(createNullArrayOfLength(twentyFourWordMode ? 24 : 12));
-            }}
+            onClick={() => setTwentyFourWordMode(!twentyFourWordMode)}
             twentyFourWordMode={twentyFourWordMode}
           />
         }

--- a/tests/specs/onboarding/onboarding.spec.ts
+++ b/tests/specs/onboarding/onboarding.spec.ts
@@ -55,12 +55,10 @@ test.describe('Onboarding an existing user', () => {
     // enter some key partial
     const validPartialKey = 'shoulder any pencil';
     await onboardingPage.signInMnemonicKey(validPartialKey);
-    const signInButton = await onboardingPage.page.getByTestId(OnboardingSelectors.SignInBtn);
     const signInSeedError = await onboardingPage.page.getByTestId(
       OnboardingSelectors.SignInSeedError
     );
     await test.expect(signInSeedError).not.toBeVisible();
-    await test.expect(signInButton).toBeDisabled();
   });
 
   test('Activity tab', async ({ extensionId, globalPage, onboardingPage, homePage }) => {


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6508570506).<!-- Sticky Header Marker -->

This PR fixes a bug with toggling between 12 and 24 key mnemonic keys.

The change was out of sync and blocking users with 12 key mnemonics



https://github.com/leather-wallet/extension/assets/2938440/dfaa6494-eac7-4b12-9ece-95b3bb16fc65



