### PR TITLE
chore: demo race condition

### DIFF
--- a/src/app/pages/swap/components/swap-amount-field.tsx
+++ b/src/app/pages/swap/components/swap-amount-field.tsx
@@ -6,6 +6,8 @@ import { Stack, styled } from 'leather-styles/jsx';
 import { isDefined, isUndefined } from '@shared/utils';
 
 import { useShowFieldError } from '@app/common/form-utils';
+import { delay } from '@app/common/utils';
+import { createCounter } from '@app/common/utils/counter';
 
 import { SwapFormValues } from '../hooks/use-swap-form';
 import { useSwapContext } from '../swap.context';
@@ -21,6 +23,8 @@ interface SwapAmountFieldProps {
   isDisabled?: boolean;
   name: string;
 }
+const count = createCounter(0);
+
 export function SwapAmountField({ amountAsFiat, isDisabled, name }: SwapAmountFieldProps) {
   const { fetchToAmount, onSetIsSendingMax } = useSwapContext();
   const { setErrors, setFieldValue, values } = useFormikContext<SwapFormValues>();
@@ -28,14 +32,20 @@ export function SwapAmountField({ amountAsFiat, isDisabled, name }: SwapAmountFi
   const showError = useShowFieldError(name) && name === 'swapAmountFrom' && values.swapAssetTo;
 
   async function onChange(event: ChangeEvent<HTMLInputElement>) {
-    const { swapAssetFrom, swapAssetTo } = values;
-    if (isUndefined(swapAssetFrom) || isUndefined(swapAssetTo)) return;
-    onSetIsSendingMax(false);
-    const value = event.currentTarget.value;
-    const toAmount = await fetchToAmount(swapAssetFrom, swapAssetTo, value);
-    await setFieldValue('swapAmountTo', Number(toAmount));
+    console.log('count', count.getValue());
+    await setFieldValue('swapAmountTo', count.getValue() * 2);
     field.onChange(event);
     setErrors({});
+    count.increment();
+
+    if (count.getValue() === 3) {
+      await delay(3000);
+      await setFieldValue('swapAmountTo', 9999999);
+      field.onChange(event);
+      setErrors({});
+      count.increment();
+      return;
+    }
   }
 
   return (

--- a/src/app/pages/swap/hooks/use-alex-swap.tsx
+++ b/src/app/pages/swap/hooks/use-alex-swap.tsx
@@ -73,6 +73,7 @@ export function useAlexSwap() {
     to: SwapAsset,
     fromAmount: string
   ): Promise<string> {
+    console.log('fetchToAmount', from, to, fromAmount);
     const amount = new BigNumber(fromAmount).multipliedBy(oneHundredMillion).dp(0).toString();
     const amountAsBigInt = isNaN(Number(amount)) ? BigInt(0) : BigInt(amount);
     const result = await alexSDK.getAmountTo(from.currency, amountAsBigInt, to.currency);


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6510672024).<!-- Sticky Header Marker -->

@fbwoolf demoing here the race condition issue describe in your PR with a hacky demo that simulates a race condition.

All updates fire immediately, except the third one which takes 3 seconds. Watch how I make 7 updates, stop, and just because the third request took longer, it replaces the form value, even though it's unrelated to the latest input.

With async programming, we cannot guarantee events will finish in the order they started, and the current implementation does. The impact of that is that a user might see an incorrect value, which when considering a swap is critical.

https://github.com/leather-wallet/extension/assets/1618764/8e5b8c21-9d7a-4199-a870-46ca53aee741

Happy to jam on ideas how to fix this, it'll require some kind of event cancelling or debouncing etc. But made this PR to demo that its a bug vs enhancement.