### PR TITLE
fix: use grid for asset rows to stop overflow while allowing width, c…

### DIFF
--- a/src/app/components/crypto-assets/components/asset-row-grid.tsx
+++ b/src/app/components/crypto-assets/components/asset-row-grid.tsx
@@ -1,0 +1,20 @@
+import { Grid, GridItem } from 'leather-styles/jsx';
+
+interface AssetRowGridProps {
+  title: React.ReactNode;
+  balance: React.ReactNode;
+  caption: React.ReactNode;
+  usdBalance?: React.ReactNode;
+}
+export function AssetRowGrid({ title, balance, caption, usdBalance }: AssetRowGridProps) {
+  return (
+    <Grid columns={2} gridTemplateColumns="2fr 1fr" gridTemplateRows={2} gap={0}>
+      <GridItem whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+        {title}
+      </GridItem>
+      <GridItem textAlign="right">{balance}</GridItem>
+      <GridItem>{caption}</GridItem>
+      {usdBalance && <GridItem>{usdBalance}</GridItem>}
+    </Grid>
+  );
+}

--- a/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
@@ -2,7 +2,7 @@ import { Flex, StackProps } from '@stacks/ui';
 import { forwardRefWithAs } from '@stacks/ui-core';
 import { truncateMiddle } from '@stacks/ui-utils';
 import { CryptoAssetSelectors } from '@tests/selectors/crypto-asset.selectors';
-import { HStack, styled } from 'leather-styles/jsx';
+import { styled } from 'leather-styles/jsx';
 
 import { CryptoCurrencies } from '@shared/models/currencies.model';
 import { Money } from '@shared/models/money.model';
@@ -12,6 +12,8 @@ import { ftDecimals } from '@app/common/stacks-utils';
 import { usePressable } from '@app/components/item-hover';
 import { Flag } from '@app/components/layout/flag';
 import { Tooltip } from '@app/components/tooltip';
+
+import { AssetRowGrid } from '../components/asset-row-grid';
 
 interface CryptoCurrencyAssetItemLayoutProps extends StackProps {
   balance: Money;
@@ -67,31 +69,35 @@ export const CryptoCurrencyAssetItemLayout = forwardRefWithAs(
         <Flag
           align="middle"
           img={isHovered && copyIcon ? copyIcon : icon}
-          spacing="base"
+          spacing="space.04"
           width="100%"
         >
-          <HStack alignItems="center" justifyContent="space-between" width="100%">
-            <styled.span textStyle="label.01">
-              {isHovered ? truncateMiddle(address, 6) : title}
-            </styled.span>
-            <Tooltip
-              label={formattedBalance.isAbbreviated ? balance.amount.toString() : undefined}
-              placement="left-start"
-            >
-              <styled.span data-testid={title} textStyle="label.01">
-                {formattedBalance.value} {additionalBalanceInfo}
+          <AssetRowGrid
+            title={
+              <styled.span textStyle="label.01">
+                {isHovered ? truncateMiddle(address, 6) : title}
               </styled.span>
-            </Tooltip>
-          </HStack>
-          <HStack alignItems="center" justifyContent="space-between" height="1.25rem" width="100%">
-            <styled.span textStyle="caption.02">{caption}</styled.span>
-            <Flex>
-              {balance.amount.toNumber() > 0 && address ? (
-                <styled.span textStyle="caption.02">{usdBalance}</styled.span>
-              ) : null}
-              {additionalUsdBalanceInfo}
-            </Flex>
-          </HStack>
+            }
+            balance={
+              <Tooltip
+                label={formattedBalance.isAbbreviated ? balance.amount.toString() : undefined}
+                placement="left-start"
+              >
+                <styled.span data-testid={title} textStyle="label.01">
+                  {formattedBalance.value} {additionalBalanceInfo}
+                </styled.span>
+              </Tooltip>
+            }
+            caption={<styled.span textStyle="caption.02">{caption}</styled.span>}
+            usdBalance={
+              <Flex justifyContent="flex-end">
+                {balance.amount.toNumber() > 0 && address ? (
+                  <styled.span textStyle="caption.02">{usdBalance}</styled.span>
+                ) : null}
+                {additionalUsdBalanceInfo}
+              </Flex>
+            }
+          />
         </Flag>
         {component}
       </Flex>

--- a/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.layout.tsx
@@ -1,6 +1,6 @@
 import { BoxProps } from '@stacks/ui';
 import { forwardRefWithAs } from '@stacks/ui-core';
-import { Flex, HStack, styled } from 'leather-styles/jsx';
+import { Flex, styled } from 'leather-styles/jsx';
 
 import type { Money } from '@shared/models/money.model';
 
@@ -12,6 +12,7 @@ import { Flag } from '@app/components/layout/flag';
 import { Tooltip } from '@app/components/tooltip';
 
 import { AssetCaption } from '../../components/asset-caption';
+import { AssetRowGrid } from '../../components/asset-row-grid';
 
 interface StacksFungibleTokenAssetItemLayoutProps extends BoxProps {
   avatar: string;
@@ -45,32 +46,23 @@ export const StacksFungibleTokenAssetItemLayout = forwardRefWithAs(
               {title[0]}
             </StacksAssetAvatar>
           }
-          spacing="base"
+          spacing="space.04"
           width="100%"
         >
-          <HStack alignItems="center" justifyContent="space-between" width="100%">
-            <styled.span
-              maxWidth="150px"
-              overflow="hidden"
-              textAlign="left"
-              textOverflow="ellipsis"
-              textStyle="label.01"
-              whiteSpace="nowrap"
-            >
-              {title}
-            </styled.span>
-            <Tooltip
-              label={formattedBalance.isAbbreviated ? amount : undefined}
-              placement="left-start"
-            >
-              <styled.span data-testid={title} textStyle="label.01">
-                {formattedBalance.value}
-              </styled.span>
-            </Tooltip>
-          </HStack>
-          <HStack alignItems="center" justifyContent="space-between" height="1.25rem" width="100%">
-            <AssetCaption caption={caption} />
-          </HStack>
+          <AssetRowGrid
+            title={<styled.span textStyle="label.01">{title}</styled.span>}
+            balance={
+              <Tooltip
+                label={formattedBalance.isAbbreviated ? amount : undefined}
+                placement="left-start"
+              >
+                <styled.span data-testid={title} textStyle="label.01">
+                  {formattedBalance.value}
+                </styled.span>
+              </Tooltip>
+            }
+            caption={<AssetCaption caption={caption} />}
+          />
           {component}
         </Flag>
       </Flex>


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6532128732).<!-- Sticky Header Marker -->

This PR uses a `Grid` to contain the asset list items so that the title:
- can use the full width available
- will use ellipsis to truncate when needed 

Here's a demo video: 

https://github.com/leather-wallet/extension/assets/2938440/df5239c9-cdf0-4c4d-b532-600e777c6d7a

**Note** In the video I have hardcoded the title to be "You won 2000STX=>www.stxwon.com" for demonstration purposes only. Putting it in line 54 of `StacksFungibleTokenAssetItemLayout`
