### PR TITLE
fix: align text and caption left so it appears correctly in extension…

### DIFF
--- a/src/app/components/crypto-assets/components/asset-row-grid.tsx
+++ b/src/app/components/crypto-assets/components/asset-row-grid.tsx
@@ -9,11 +9,11 @@ interface AssetRowGridProps {
 export function AssetRowGrid({ title, balance, caption, usdBalance }: AssetRowGridProps) {
   return (
     <Grid columns={2} gridTemplateColumns="2fr 1fr" gridTemplateRows={2} gap={0}>
-      <GridItem whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+      <GridItem textAlign="left" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
         {title}
       </GridItem>
       <GridItem textAlign="right">{balance}</GridItem>
-      <GridItem>{caption}</GridItem>
+      <GridItem textAlign="left">{caption}</GridItem>
       {usdBalance && <GridItem>{usdBalance}</GridItem>}
     </Grid>
   );


### PR DESCRIPTION
When fixing https://github.com/leather-wallet/extension/pull/4359 I made a mistake and forgot to left align some text. 

That meant in extension view the text was centreed and looked off:
<img width="396" alt="Screenshot 2023-10-16 at 15 46 13" src="https://github.com/leather-wallet/extension/assets/2938440/0e1bf1b2-ba91-41a4-8f97-8435e5b593c4">

This PR fixes that alignment

<img width="398" alt="Screenshot 2023-10-16 at 15 39 17" src="https://github.com/leather-wallet/extension/assets/2938440/7794a43d-ec46-480a-b629-7cf75ecc312c">
