### PR TITLE
Use network.chain.bitcoin.url in api hooks (#4330)

### DIFF
--- a/src/app/store/common/api-clients.hooks.ts
+++ b/src/app/store/common/api-clients.hooks.ts
@@ -2,15 +2,9 @@ import { useMemo } from 'react';
 
 import { ChainID } from '@stacks/transactions';
 
-import {
-  BITCOIN_API_BASE_URL_MAINNET,
-  BITCOIN_API_BASE_URL_SIGNET,
-  BITCOIN_API_BASE_URL_TESTNET,
-  HIRO_API_BASE_URL_MAINNET,
-  HIRO_API_BASE_URL_TESTNET,
-} from '@shared/constants';
+import { HIRO_API_BASE_URL_MAINNET, HIRO_API_BASE_URL_TESTNET } from '@shared/constants';
 
-import { whenBitcoinNetwork, whenStacksChainId } from '@app/common/utils';
+import { whenStacksChainId } from '@app/common/utils';
 import { BitcoinClient } from '@app/query/bitcoin/bitcoin-client';
 import { StacksClient } from '@app/query/stacks/stacks-client';
 import { TokenMetadataClient } from '@app/query/stacks/token-metadata-client';
@@ -24,15 +18,7 @@ import { useCurrentNetworkState } from '../networks/networks.hooks';
 
 export function useBitcoinClient() {
   const network = useCurrentNetworkState();
-
-  const baseUrl = whenBitcoinNetwork(network.chain.bitcoin.network)({
-    mainnet: BITCOIN_API_BASE_URL_MAINNET,
-    testnet: BITCOIN_API_BASE_URL_TESTNET,
-    regtest: BITCOIN_API_BASE_URL_TESTNET,
-    signet: BITCOIN_API_BASE_URL_SIGNET,
-  });
-
-  return new BitcoinClient(baseUrl);
+  return new BitcoinClient(network.chain.bitcoin.url);
 }
 
 // Unanchored by default (microblocks)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -150,7 +150,7 @@ const networkSbtcDevenv: NetworkConfiguration = {
     bitcoin: {
       blockchain: 'bitcoin',
       network: 'regtest',
-      url: 'http://localhost:8999/api',
+      url: 'http://localhost:3002',
     },
   },
 };


### PR DESCRIPTION
This PR
* replaces the use of BITCOIN_API_BASE_URL_ in api hooks with network.chain.bitcoin.url
* changes the bitcoin api port to 3002 as used in devnet
* fixes #4330
