### PR TITLE
fix: revert drawer changes from brand audit, closes #4249

### DIFF
--- a/src/app/components/drawer/controlled-drawer.tsx
+++ b/src/app/components/drawer/controlled-drawer.tsx
@@ -17,9 +17,6 @@ export function ControlledDrawer(props: ControlledDrawerProps) {
 
   return (
     <BaseDrawer
-      height="100vh"
-      position={['absolute', 'fixed']}
-      top={['-24px', 0]}
       enableGoBack={enableGoBack}
       icon={icon}
       isShowing={isShowing}

--- a/src/app/features/switch-account-drawer/switch-account-drawer.tsx
+++ b/src/app/features/switch-account-drawer/switch-account-drawer.tsx
@@ -33,11 +33,7 @@ export const SwitchAccountDrawer = memo(() => {
 
   return isShowing && accounts ? (
     <ControlledDrawer title="Select account" isShowing={isShowing} onClose={onClose}>
-      <Box
-        mb={whenWallet({ ledger: 'base', software: '' })}
-        height={['100vh', '100%']}
-        maxHeight={['110vh', 'inherit']}
-      >
+      <Box mb={whenWallet({ ledger: 'base', software: '' })}>
         <SwitchAccountList
           accounts={accounts}
           currentAccountIndex={currentAccountIndex}

--- a/src/app/pages/receive/receive-modal.tsx
+++ b/src/app/pages/receive/receive-modal.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useClipboard } from '@stacks/ui';
 import { HomePageSelectors } from '@tests/selectors/home.selectors';
 import { Box, styled } from 'leather-styles/jsx';
-import { token } from 'leather-styles/tokens';
 import get from 'lodash.get';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -68,13 +67,7 @@ export function ReceiveModal({ type = 'full' }: ReceiveModalProps) {
 
   return (
     <>
-      <BaseDrawer
-        position={['absolute', 'fixed']}
-        top={[token('spacing.space.07'), 0]}
-        title=""
-        isShowing
-        onClose={() => navigate(backgroundLocation ?? '..')}
-      >
+      <BaseDrawer title="" isShowing onClose={() => navigate(backgroundLocation ?? '..')}>
         <Box mx="space.06">
           <styled.h1 mb="space.05" textStyle="heading.03">
             {title}


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6558929273).<!-- Sticky Header Marker -->

I  want to revert some changes I made that re-position modals in the extension view as they are hacky and actually cause some new issues. 

The original issues reported in the brand audit will be fixed by: #4371 

These changes were first introduced [here](https://github.com/leather-wallet/extension/pull/4343)
