### PR TITLE
feat: return addresses of regtest and signet

### DIFF
--- a/src/app/common/authentication/use-finish-auth-request.ts
+++ b/src/app/common/authentication/use-finish-auth-request.ts
@@ -89,10 +89,14 @@ export function useFinishAuthRequest() {
               p2tr: {
                 mainnet: taprootAccount.mainnet.payment.address,
                 testnet: taprootAccount.testnet.payment.address,
+                regtest: taprootAccount.regtest.payment.address,
+                signet: taprootAccount.signet.payment.address,
               },
               p2wpkh: {
                 mainnet: nativeSegwitAccount.mainnet.payment.address,
                 testnet: nativeSegwitAccount.testnet.payment.address,
+                regtest: nativeSegwitAccount.regtest.payment.address,
+                signet: nativeSegwitAccount.signet.payment.address,
               },
             },
             btcPublicKey: {


### PR DESCRIPTION
This PR
adds regtest and signet addresses to the auth response profile