### PR TITLE
fix: build hash mismatch

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -13,12 +13,13 @@ jobs:
   set-in-progress-message:
     if: github.repository == 'leather-wallet/extension' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
-    needs:
-      - pre-run
     steps:
+      - name: Make short commit SHA
+        run: echo "SHORT_SHA=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
+
       - uses: kyranjamie/pull-request-fixed-header@v1.0.1
         with:
-          header: '> _Building Leather…_'
+          header: '> _Building Leather at commit `${{ env.SHORT_SHA }}`_'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
@@ -29,16 +30,6 @@ jobs:
     strategy:
       matrix:
         target: [chromium, firefox]
-    env:
-      WALLET_ENVIRONMENT: feature
-      TARGET_BROWSER: ${{ matrix.target }}
-      COINBASE_APP_ID: ${{ secrets.COINBASE_APP_ID }}
-      MOONPAY_API_KEY: ${{ secrets.MOONPAY_API_KEY }}
-      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-      SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY_STAGING }}
-      TRANSAK_API_KEY: ${{ secrets.TRANSAK_API_KEY }}
-      PR_NUMBER: ${{ github.event.number }}
-      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,11 +37,20 @@ jobs:
 
       - uses: ./.github/actions/provision
 
-      - name: Add SHORT_SHA env property with commit short sha
-        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+      - run: echo "SHORT_SHA=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: Build project
         run: yarn build
+        env:
+          WALLET_ENVIRONMENT: feature
+          TARGET_BROWSER: ${{ matrix.target }}
+          COINBASE_APP_ID: ${{ secrets.COINBASE_APP_ID }}
+          MOONPAY_API_KEY: ${{ secrets.MOONPAY_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY_STAGING }}
+          TRANSAK_API_KEY: ${{ secrets.TRANSAK_API_KEY }}
+          PR_NUMBER: ${{ github.event.number }}
+          COMMIT_SHA: ${{ env.SHORT_SHA }}
 
       - uses: actions/upload-artifact@v3
         name: Upload ${{ matrix.target }} Extension Zip

--- a/src/app/features/psbt-signer/components/psbt-signer.layout.tsx
+++ b/src/app/features/psbt-signer/components/psbt-signer.layout.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@stacks/ui';
+import { Stack } from 'leather-styles/jsx';
 
 import { HasChildren } from '@app/common/has-children';
 
@@ -10,7 +10,7 @@ export function PsbtSignerLayout({ children }: HasChildren) {
       overflowY="auto"
       pb="120px"
       px="loose"
-      spacing="base-loose"
+      gap="base-loose"
       width="100%"
     >
       {children}


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6613805599).

This PR ensures the commit hash of the build and download link match that of the commit at which the build was made. 


cc/ @mica000, if you see the 7 letter hash differ from the build download, or id within the app label, LMK

@fbwoolf, plz rebase your PR on these changes when merged