### PR TITLE
fix: tx req fee error

### DIFF
--- a/src/app/features/stacks-transaction-request/stacks-transaction-signer.tsx
+++ b/src/app/features/stacks-transaction-request/stacks-transaction-signer.tsx
@@ -93,14 +93,6 @@ export function StacksTransactionSigner({
 
   return (
     <Flex alignItems="center" flexDirection="column" p="loose" width="100%">
-      <PageTop />
-      <RequestingTabClosedWarningMessage />
-      <PostConditionModeWarning />
-      <TransactionError />
-      <PostConditions />
-      {transactionRequest.txType === 'contract_call' && <ContractCallDetails />}
-      {transactionRequest.txType === 'token_transfer' && <StxTransferDetails />}
-      {transactionRequest.txType === 'smart_contract' && <ContractDeployDetails />}
       <Formik
         initialValues={initialValues}
         onSubmit={onSubmit}
@@ -111,6 +103,15 @@ export function StacksTransactionSigner({
       >
         {() => (
           <>
+            <PageTop />
+            <RequestingTabClosedWarningMessage />
+            <PostConditionModeWarning />
+            <TransactionError />
+            <PostConditions />
+            {transactionRequest.txType === 'contract_call' && <ContractCallDetails />}
+            {transactionRequest.txType === 'token_transfer' && <StxTransferDetails />}
+            {transactionRequest.txType === 'smart_contract' && <ContractDeployDetails />}
+
             {!isNonceAlreadySet && <NonceSetter />}
             <FeeForm
               fees={stxFees}

--- a/src/app/pages/transaction-request/transaction-request.tsx
+++ b/src/app/pages/transaction-request/transaction-request.tsx
@@ -106,14 +106,6 @@ function TransactionRequestBase() {
 
   return (
     <Flex alignItems="center" flexDirection="column" p="loose" width="100%">
-      <PageTop />
-      <RequestingTabClosedWarningMessage />
-      <PostConditionModeWarning />
-      <TransactionError />
-      <PostConditions />
-      {transactionRequest.txType === 'contract_call' && <ContractCallDetails />}
-      {transactionRequest.txType === 'token_transfer' && <StxTransferDetails />}
-      {transactionRequest.txType === 'smart_contract' && <ContractDeployDetails />}
       <Formik
         initialValues={initialValues}
         onSubmit={onSubmit}
@@ -124,6 +116,15 @@ function TransactionRequestBase() {
       >
         {() => (
           <>
+            <PageTop />
+            <RequestingTabClosedWarningMessage />
+            <PostConditionModeWarning />
+            <TransactionError />
+            <PostConditions />
+            {transactionRequest.txType === 'contract_call' && <ContractCallDetails />}
+            {transactionRequest.txType === 'token_transfer' && <StxTransferDetails />}
+            {transactionRequest.txType === 'smart_contract' && <ContractDeployDetails />}
+
             <NonceSetter />
             <FeeForm fees={stxFees} />
             <EditNonceButton


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6646153230).<!-- Sticky Header Marker -->

Now shows error if the fee is set higher than available STX... the fee form needed to wrap the error components so it was available to use. I'm not sure why `transaction.fee` was used originally, but our form handles the fee. And, the conversion here was wrong bc the amount is in microstacks.

<img width="463" alt="Screen Shot 2023-10-25 at 3 36 46 PM" src="https://github.com/leather-wallet/extension/assets/6493321/ade5fa6e-edbb-49da-9ea1-e990df9feebc">

<img width="459" alt="Screen Shot 2023-10-25 at 3 37 33 PM" src="https://github.com/leather-wallet/extension/assets/6493321/a0ca64cd-85b8-4687-b5d2-2445dfbb4c5e">
