### PR TITLE
fix: add default type to button, closes #4333

### DIFF
--- a/src/app/components/button/button.tsx
+++ b/src/app/components/button/button.tsx
@@ -10,9 +10,9 @@ export type ButtonProps = Omit<
   ButtonVariantProps;
 
 export function LeatherButton(props: ButtonProps) {
-  const { children, variant, fullWidth, invert, ...rest } = props;
+  const { children, variant, fullWidth, invert, type = 'button', ...rest } = props;
   return (
-    <StyledButton className={buttonRecipe({ variant, fullWidth, invert })} {...rest}>
+    <StyledButton className={buttonRecipe({ variant, fullWidth, invert })} type={type} {...rest}>
       {children}
     </StyledButton>
   );

--- a/src/app/components/preview-button.tsx
+++ b/src/app/components/preview-button.tsx
@@ -15,6 +15,7 @@ export function PreviewButton({ text = 'Continue', isDisabled, ...props }: Previ
       data-testid={SendCryptoAssetSelectors.PreviewSendTxBtn}
       disabled={isDisabled}
       onClick={() => handleSubmit()}
+      type="submit"
       {...props}
     >
       {text}

--- a/src/app/features/add-network/add-network.tsx
+++ b/src/app/features/add-network/add-network.tsx
@@ -178,6 +178,7 @@ export function AddNetwork() {
                 disabled={loading}
                 aria-busy={loading}
                 data-testid={NetworkSelectors.BtnAddNetwork}
+                type="submit"
               >
                 Add network
               </LeatherButton>

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-send-max-button.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-send-max-button.tsx
@@ -46,7 +46,6 @@ export function BitcoinSendMaxButton({
     >
       <Box>
         <LeatherButton
-          type="button"
           data-testid={SendCryptoAssetSelectors.SendMaxBtn}
           onClick={() => onSendMax()}
           variant="link"

--- a/src/app/pages/swap/components/swap-selected-asset.layout.tsx
+++ b/src/app/pages/swap/components/swap-selected-asset.layout.tsx
@@ -60,7 +60,7 @@ export function SwapSelectedAssetLayout({
       </HStack>
       <SelectedAssetField
         contentLeft={
-          <LeatherButton onClick={onChooseAsset} p="space.02" type="button" variant="ghost">
+          <LeatherButton onClick={onChooseAsset} p="space.02" variant="ghost">
             <HStack>
               {icon && <styled.img src={icon} width="32px" height="32px" alt="Swap asset" />}
               <styled.span textStyle="label.01">{symbol}</styled.span>
@@ -87,7 +87,6 @@ export function SwapSelectedAssetLayout({
             _focus={{ _before: { color: 'unset' } }}
             cursor={onClickHandler ? 'pointer' : 'unset'}
             onClick={onClickHandler ? onClickHandler : noop}
-            type="button"
             variant={onClickHandler ? 'link' : 'text'}
           >
             <styled.span textStyle="caption.02">{value}</styled.span>

--- a/src/app/pages/swap/swap.tsx
+++ b/src/app/pages/swap/swap.tsx
@@ -36,7 +36,11 @@ export function Swap() {
         <SwapSelectedAssets />
       </SwapContentLayout>
       <SwapFooterLayout>
-        <LeatherButton disabled={!(dirty && isValid) || isFetchingExchangeRate} width="100%">
+        <LeatherButton
+          disabled={!(dirty && isValid) || isFetchingExchangeRate}
+          type="submit"
+          width="100%"
+        >
           Review and swap
         </LeatherButton>
       </SwapFooterLayout>


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6660704102).<!-- Sticky Header Marker -->

Add default type button to `LeatherButton` to prevent unexpected submit behavior.