### PR TITLE
fix: remove query options from btc fees, closes #4198

### DIFF
--- a/src/app/query/bitcoin/fees/fee-estimates.query.ts
+++ b/src/app/query/bitcoin/fees/fee-estimates.query.ts
@@ -25,9 +25,6 @@ export function useGetAllBitcoinFeeEstimatesQuery<
     queryKey: ['average-bitcoin-fee-estimates'],
     queryFn: fetchAllBitcoinFeeEstimates(client),
     refetchInterval: 2000 * 60,
-    staleTime: 1000 * 60,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
     ...options,
   });
 }


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6668576132).<!-- Sticky Header Marker -->

Remove btc fees query options to see if helps refresh fee data producing low fees.