### PR TITLE
fix: send ordinal routes, closes #4444

### DIFF
--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
@@ -77,9 +77,12 @@ export function useSendInscriptionForm() {
 
       whenWallet({
         software: () =>
-          navigate(RouteUrls.SendOrdinalInscriptionChooseFee, {
-            state: { inscription, recipient: values.recipient, utxo },
-          }),
+          navigate(
+            `/${RouteUrls.SendOrdinalInscription}/${RouteUrls.SendOrdinalInscriptionChooseFee}`,
+            {
+              state: { inscription, recipient: values.recipient, utxo },
+            }
+          ),
         ledger: noop,
       })();
     },
@@ -100,17 +103,20 @@ export function useSendInscriptionForm() {
 
       const { hex } = resp;
       const feeRowValue = formFeeRowValue(values.feeRate, isCustomFee);
-      return navigate(RouteUrls.SendOrdinalInscriptionReview, {
-        state: {
-          fee: feeValue,
-          inscription,
-          utxo,
-          recipient: values.recipient,
-          time,
-          feeRowValue,
-          tx: hex,
-        },
-      });
+      return navigate(
+        `/${RouteUrls.SendOrdinalInscription}/${RouteUrls.SendOrdinalInscriptionReview}`,
+        {
+          state: {
+            fee: feeValue,
+            inscription,
+            utxo,
+            recipient: values.recipient,
+            time,
+            feeRowValue,
+            tx: hex,
+          },
+        }
+      );
     },
 
     validationSchema: yup.object({

--- a/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
@@ -47,7 +47,7 @@ export function SendInscriptionReview() {
         await refetch();
         // Might be a BRC-20 transfer, so we want to remove it from the pending
         dispatch(inscriptionSent({ inscriptionId: inscription.id }));
-        navigate(RouteUrls.SendOrdinalInscriptionSent, {
+        navigate(`/${RouteUrls.SendOrdinalInscription}/${RouteUrls.SendOrdinalInscriptionSent}`, {
           state: {
             inscription,
             recipient,
@@ -58,7 +58,7 @@ export function SendInscriptionReview() {
         });
       },
       onError() {
-        navigate(RouteUrls.SendOrdinalInscriptionError);
+        navigate(`/${RouteUrls.SendOrdinalInscription}/${RouteUrls.SendOrdinalInscriptionError}`);
       },
     });
   }

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -77,11 +77,11 @@ export enum RouteUrls {
 
   // Send ordinal inscriptions
   SendOrdinalInscription = 'send/ordinal-inscription',
-  SendOrdinalInscriptionChooseFee = 'send/ordinal-inscription/choose-fee',
-  SendOrdinalInscriptionReview = 'send/ordinal-inscription/review',
+  SendOrdinalInscriptionChooseFee = 'choose-fee',
+  SendOrdinalInscriptionReview = 'review',
   SendOrdinalInscriptionSummary = 'send/ordinal-inscription/',
-  SendOrdinalInscriptionSent = 'send/ordinal-inscription/sent',
-  SendOrdinalInscriptionError = 'send/ordinal-inscription/error',
+  SendOrdinalInscriptionSent = 'sent',
+  SendOrdinalInscriptionError = 'error',
 
   // Swap routes
   Swap = '/swap',


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6669290341).<!-- Sticky Header Marker -->

This PR fixes some introduced errors with send ordinal routing. 

I got the routes fixed but sending the actual ordinal errors as you can see here: 

https://github.com/leather-wallet/extension/assets/2938440/93c79fa4-4ac4-4118-9707-cf14ecfc469b

