### PR TITLE
fix: swaps min to receive format, closes #4442

### DIFF
--- a/src/app/pages/swap/components/swap-details/swap-details.tsx
+++ b/src/app/pages/swap/components/swap-details/swap-details.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { HStack, styled } from 'leather-styles/jsx';
 
-import { createMoney } from '@shared/models/money.model';
+import { createMoneyFromDecimal } from '@shared/models/money.model';
 import { isDefined, isUndefined } from '@shared/utils';
 
 import { formatMoneyPadded } from '@app/common/money/format-money';
@@ -40,7 +40,7 @@ export function SwapDetails() {
     return null;
 
   const formattedMinToReceive = formatMoneyPadded(
-    createMoney(
+    createMoneyFromDecimal(
       new BigNumber(swapSubmissionData.swapAmountTo).times(1 - swapSubmissionData.slippage),
       swapSubmissionData.swapAssetTo.balance.symbol,
       swapSubmissionData.swapAssetTo.balance.decimals


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6669721469).<!-- Sticky Header Marker -->

Value is already in primary unit here, so this fixes the format issue with minimum to receive in the review...

<img width="554" alt="Screen Shot 2023-10-27 at 11 18 58 AM" src="https://github.com/leather-wallet/extension/assets/6493321/7a359a37-2605-4ef0-96dc-0ec4f248da1d">
