### PR TITLE
fix: fee calculation in for btc txs closes #4455

### DIFF
--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
@@ -69,7 +69,7 @@ export function determineUtxosForSpend({
     sizeInfo = txSizer.calcTxSize({
       // Only p2wpkh is supported by the wallet
       input_script: 'p2wpkh',
-      input_count: neededUtxos.length,
+      input_count: neededUtxos.length + 1,
       // From the address of the recipient, we infer the output type
       [addressInfo.type + '_output_count']: 2,
     });


### PR DESCRIPTION
This PR would fix fee calculation for the `determineUtxosForSpend` function where if there were 1 UTXO it would incorrectly assign input count as 0