### PR TITLE
fix: bug with go back action in send flow, #4355

### DIFF
--- a/src/app/features/edit-nonce-drawer/edit-nonce-drawer.tsx
+++ b/src/app/features/edit-nonce-drawer/edit-nonce-drawer.tsx
@@ -37,10 +37,12 @@ export function EditNonceDrawer() {
 
   useOnMount(() => setLoadedNextNonce(values.nonce));
 
-  const onGoBack = useCallback(
-    () => navigate('..' + search, { replace: true }),
-    [navigate, search]
-  );
+  const onGoBack = useCallback(() => {
+    if (search) {
+      return navigate('..' + search, { replace: true });
+    }
+    navigate(-1);
+  }, [navigate, search]);
 
   const onBlur = useCallback(() => validateField('nonce'), [validateField]);
 

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/hooks/use-recipient-select-fields.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-fields/hooks/use-recipient-select-fields.tsx
@@ -21,7 +21,7 @@ export function useRecipientSelectFields() {
 
   const onClickLabelAction = useCallback(() => {
     setSelectedRecipientField(RecipientFieldType.Address);
-    navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts);
+    navigate(RouteUrls.SendCryptoAssetFormRecipientAccounts, { replace: true });
   }, [navigate]);
 
   // Formik does not provide a field reset

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-send-form-confirmation.tsx
@@ -49,7 +49,7 @@ export function StacksSendFormConfirmation() {
     <ModalHeader
       hideActions
       defaultClose
-      onGoBack={() => navigate('../', { relative: 'path' })}
+      onGoBack={() => navigate('../', { relative: 'path', replace: true })}
       title="Review"
     />
   );

--- a/tests/page-object-models/send.page.ts
+++ b/tests/page-object-models/send.page.ts
@@ -87,4 +87,9 @@ export class SendPage {
   async goBack() {
     await this.page.getByTestId(SharedComponentsSelectors.ModalHeaderBackBtn).click();
   }
+
+  async goBackSelectStx() {
+    await this.goBack();
+    await this.selectStxAndGoToSendForm();
+  }
 }

--- a/tests/specs/send/send-stx.spec.ts
+++ b/tests/specs/send/send-stx.spec.ts
@@ -26,11 +26,6 @@ test.describe('send stx', () => {
       sPage = sendPage;
     });
 
-    test.afterEach(async () => {
-      await sPage.page.getByTestId('modal-header-back-button').click();
-      await sPage.selectStxAndGoToSendForm();
-    });
-
     test('that send max button sets available balance minus fee', async () => {
       await sPage.amountInput.fill('.0001');
       await sPage.amountInput.clear();
@@ -38,6 +33,7 @@ test.describe('send stx', () => {
       await sPage.sendMaxButton.click();
       await sPage.amountInput.blur();
       test.expect(await sPage.amountInput.inputValue()).toBeTruthy();
+      await sPage.goBackSelectStx();
     });
 
     test('that empty memo on preview matches default empty value', async () => {
@@ -52,6 +48,7 @@ test.describe('send stx', () => {
         .getByTestId(SharedComponentsSelectors.InfoCardRowValue)
         .innerText();
       test.expect(confirmationMemo).toEqual(emptyMemoPreviewValue);
+      await sPage.goBack();
     });
 
     test('that asset value, recipient, memo and fees on preview match input', async () => {
@@ -84,9 +81,13 @@ test.describe('send stx', () => {
         .getByTestId(SharedComponentsSelectors.InfoCardRowValue)
         .innerText();
       test.expect(confirmationMemo2).toEqual(memo);
+      await sPage.goBack();
     });
 
     test.describe('send form validation', () => {
+      test.afterEach(async () => {
+        await sPage.goBackSelectStx();
+      });
       test('that the amount must be a number', async () => {
         await sPage.amountInput.fill('aaaaaa');
         await sPage.amountInput.blur();
@@ -128,7 +129,6 @@ test.describe('send stx', () => {
         await sPage.previewSendTxButton.click();
         const errorMsg = await sPage.formInputErrorLabel.innerText();
         test.expect(errorMsg).toContain(FormErrorMessages.SameAddress);
-        await sPage.goBack();
       });
 
       test('that valid addresses are accepted', async () => {
@@ -141,6 +141,10 @@ test.describe('send stx', () => {
     });
 
     test.describe('send form preview', () => {
+      test.afterEach(async () => {
+        await sPage.goBack();
+        await sPage.goBackSelectStx();
+      });
       test('that it shows preview of tx details to be confirmed', async () => {
         await sPage.amountInput.fill('0.000001');
         await sPage.recipientInput.fill(TEST_TESTNET_ACCOUNT_2_STX_ADDRESS);


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6714431715).<!-- Sticky Header Marker -->

This pr fIxes problems with go back action in send flow and failing send-stx tests

Closes #4355