### PR TITLE
feat: temporary fix for warning and info labels in dark theme 

### DIFF
--- a/src/app/components/warning-label.tsx
+++ b/src/app/components/warning-label.tsx
@@ -11,7 +11,7 @@ export function WarningLabel({ children, title, ...props }: WarningLabelProps) {
   return (
     <Box {...props}>
       <Flag
-        bg="colors.accent.warning"
+        bg="accent.warning"
         borderRadius="10px"
         img={<AlertIcon color={token('colors.yellow.600')} />}
         minHeight="48px"

--- a/theme/semantic-tokens.ts
+++ b/theme/semantic-tokens.ts
@@ -79,7 +79,7 @@ export const semanticTokens = defineSemanticTokens({
         value: { base: '{colors.yellow.100}', _dark: '{colors.yellow.100}' },
       },
       'notification-text': {
-        value: { base: '{colors.lightModeBrown.12}', _dark: '{colors.darkModeBrown.12}' },
+        value: { base: '{colors.lightModeBrown.12}', _dark: '{colors.darkModeBrown.1}' },
       },
     },
     error: {


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6718477220).<!-- Sticky Header Marker -->

<img width="604" alt="Screenshot 2023-11-01 at 05 27 01" src="https://github.com/leather-wallet/extension/assets/46521087/7cd70148-14ea-4985-9012-484c90ddb907">
<img width="500" alt="Screenshot 2023-11-01 at 05 28 30" src="https://github.com/leather-wallet/extension/assets/46521087/8eb3d121-806f-421c-a87d-1defc7a00b21">
