### PR TITLE
fix: refactor error label to align icon and make text consistent size

### DIFF
--- a/src/app/components/error-label.tsx
+++ b/src/app/components/error-label.tsx
@@ -1,24 +1,26 @@
 import { FiAlertCircle } from 'react-icons/fi';
 
-import { Box, Stack, StackProps, color } from '@stacks/ui';
+import { css } from 'leather-styles/css';
+import { HStack, HstackProps } from 'leather-styles/jsx';
 
-export function ErrorLabel({ children, ...rest }: StackProps) {
+export function ErrorLabel({ children, ...rest }: HstackProps) {
   return (
-    <Stack
-      spacing="tight"
-      color={color('feedback-error')}
-      isInline
+    <HStack
+      gap="tight"
+      color="error"
       alignItems="flex-start"
       {...rest}
+      textAlign="left"
+      width="100%"
+      textStyle="body.02"
+      className={css({
+        '& svg': {
+          mt: '2px',
+        },
+      })}
     >
-      <Box
-        size="1rem"
-        color={color('feedback-error')}
-        as={FiAlertCircle}
-        position="relative"
-        strokeWidth={1.5}
-      />
-      <Box>{children}</Box>
-    </Stack>
+      <FiAlertCircle size="1rem" />
+      {children}
+    </HStack>
   );
 }

--- a/src/app/components/error-label.tsx
+++ b/src/app/components/error-label.tsx
@@ -1,7 +1,7 @@
-import { FiAlertCircle } from 'react-icons/fi';
-
 import { css } from 'leather-styles/css';
 import { HStack, HstackProps } from 'leather-styles/jsx';
+
+import { AlertIcon } from './icons/alert-icon';
 
 export function ErrorLabel({ children, ...rest }: HstackProps) {
   return (
@@ -19,7 +19,7 @@ export function ErrorLabel({ children, ...rest }: HstackProps) {
         },
       })}
     >
-      <FiAlertCircle size="1rem" />
+      <AlertIcon />
       {children}
     </HStack>
   );

--- a/src/app/components/field-error.tsx
+++ b/src/app/components/field-error.tsx
@@ -31,7 +31,7 @@ export function TextInputFieldError(props: { name: string }) {
     <Flex mb="tight" width="100%">
       <AnimateHeight duration={400} easing="ease-out" height={showHide}>
         <Flex height={openHeight + 'px'}>
-          <ErrorLabel data-testid={SendCryptoAssetSelectors.FormFieldInputErrorLabel} fontSize={1}>
+          <ErrorLabel data-testid={SendCryptoAssetSelectors.FormFieldInputErrorLabel}>
             {meta.error}
           </ErrorLabel>
         </Flex>

--- a/src/app/components/request-password.tsx
+++ b/src/app/components/request-password.tsx
@@ -2,14 +2,13 @@ import { FormEvent, useCallback, useState } from 'react';
 
 import { Input } from '@stacks/ui';
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
-import { Box, Stack, styled } from 'leather-styles/jsx';
+import { Stack, styled } from 'leather-styles/jsx';
 import { token } from 'leather-styles/tokens';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 import { WaitingMessages, useWaitingMessage } from '@app/common/utils/use-waiting-message';
 import { LeatherButton } from '@app/components/button/button';
-import { Text } from '@app/components/typography';
 
 import { ErrorLabel } from './error-label';
 import { buildEnterKeyEvent } from './link';
@@ -79,13 +78,7 @@ export function RequestPassword({ title, caption, onSuccess }: RequestPasswordPr
           value={password}
           width="100%"
         />
-        {error && (
-          <Box>
-            <ErrorLabel>
-              <Text textStyle="caption">{error}</Text>
-            </ErrorLabel>
-          </Box>
-        )}
+        {error && <ErrorLabel>{error}</ErrorLabel>}
       </Stack>
       <LeatherButton
         data-testid={SettingsSelectors.UnlockWalletBtn}

--- a/src/app/features/add-network/add-network.tsx
+++ b/src/app/features/add-network/add-network.tsx
@@ -168,11 +168,7 @@ export function AddNetwork() {
                 data-testid={NetworkSelectors.NetworkKey}
               />
               {error ? (
-                <ErrorLabel>
-                  <Text textStyle="caption" data-testid={NetworkSelectors.ErrorText}>
-                    {error}
-                  </Text>
-                </ErrorLabel>
+                <ErrorLabel data-testid={NetworkSelectors.ErrorText}>{error}</ErrorLabel>
               ) : null}
               <LeatherButton
                 disabled={loading}

--- a/src/app/features/edit-nonce-drawer/components/edit-nonce-field.tsx
+++ b/src/app/features/edit-nonce-drawer/components/edit-nonce-field.tsx
@@ -2,7 +2,7 @@ import { FormEvent, memo } from 'react';
 
 import { Input } from '@stacks/ui';
 import { useField } from 'formik';
-import { Stack, StackProps, styled } from 'leather-styles/jsx';
+import { Stack, StackProps } from 'leather-styles/jsx';
 
 import { ErrorLabel } from '@app/components/error-label';
 
@@ -28,11 +28,7 @@ export const EditNonceField = memo((props: EditNonceFieldProps) => {
         value={field.value}
         width="100%"
       />
-      {meta.error && (
-        <ErrorLabel>
-          <styled.span textStyle="caption.02">{meta.error}</styled.span>
-        </ErrorLabel>
-      )}
+      {meta.error && <ErrorLabel>{meta.error}</ErrorLabel>}
     </Stack>
   );
 });

--- a/src/app/features/increase-fee-drawer/components/increase-fee-field.tsx
+++ b/src/app/features/increase-fee-drawer/components/increase-fee-field.tsx
@@ -61,13 +61,7 @@ export function IncreaseFeeField(props: IncreaseFeeFieldProps): React.JSX.Elemen
           />
         </InputGroup>
       </Stack>
-      {meta.error && (
-        <ErrorLabel>
-          <Text textStyle="caption" lineHeight="18px">
-            {meta.error}
-          </Text>
-        </ErrorLabel>
-      )}
+      {meta.error && <ErrorLabel>{meta.error}</ErrorLabel>}
     </>
   );
 }

--- a/src/app/features/ledger/generic-steps/connect-device/connect-ledger-error.layout.tsx
+++ b/src/app/features/ledger/generic-steps/connect-device/connect-ledger-error.layout.tsx
@@ -50,9 +50,7 @@ export function ConnectLedgerErrorLayout(props: ConnectLedgerErrorLayoutProps) {
           {warningText}
         </WarningLabel>
       ) : (
-        <ErrorLabel fontSize={1} lineHeight={1.4} mt="base">
-          Unable to connect
-        </ErrorLabel>
+        <ErrorLabel>Unable to connect</ErrorLabel>
       )}
       <Stack borderRadius="12px" gap="space.01" textAlign="left" py="space.05">
         <PossibleReasonUnableToConnect text="Check if Ledger Live is open. Close it and try again" />

--- a/src/app/pages/onboarding/sign-in/mnemonic-form.tsx
+++ b/src/app/pages/onboarding/sign-in/mnemonic-form.tsx
@@ -1,6 +1,5 @@
 import { OnboardingSelectors } from '@tests/selectors/onboarding.selectors';
 import { Form, Formik } from 'formik';
-import { css } from 'leather-styles/css';
 import { Flex, styled } from 'leather-styles/jsx';
 
 import { isEmpty } from '@shared/utils';
@@ -89,18 +88,8 @@ export function MnemonicForm({ mnemonic, setMnemonic, twentyFourWordMode }: Mnem
             </SecretKeyGrid>
             <Flex flexDirection="column" justifyContent="center" alignItems="center" gap="space.05">
               {(showMnemonicErrors || error) && (
-                // #4274 TODO migrate ErrorLabel
-                <ErrorLabel
-                  width="100%"
-                  className={css({
-                    '& svg': {
-                      mt: '3px',
-                    },
-                  })}
-                >
-                  <styled.p data-testid={OnboardingSelectors.SignInSeedError} textStyle="caption">
-                    {showMnemonicErrors ? mnemonicErrorMessage : error}
-                  </styled.p>
+                <ErrorLabel data-testid={OnboardingSelectors.SignInSeedError}>
+                  {showMnemonicErrors ? mnemonicErrorMessage : error}
                 </ErrorLabel>
               )}
 

--- a/src/app/pages/send/ordinal-inscription/send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-form.tsx
@@ -55,11 +55,7 @@ export function SendInscriptionForm() {
                   />
                 </Flex>
               </Box>
-              {currentError && (
-                <ErrorLabel textAlign="left" mb="base-loose">
-                  {currentError}
-                </ErrorLabel>
-              )}
+              {currentError && <ErrorLabel>{currentError}</ErrorLabel>}
               <LeatherButton type="submit">Continue</LeatherButton>
             </Box>
           </SendInscriptionFormLoader>


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6747160197).<!-- Sticky Header Marker -->

This PR refactors the `ErrorLabel` component so that the text and icon line up correctly. 

It also standardises the font size and colour we are using

![Screenshot 2023-11-03 at 12 29 40](https://github.com/leather-wallet/extension/assets/2938440/8bceccd7-fadf-4174-b340-5f55abfb9b9a)
![Screenshot 2023-11-03 at 12 27 38](https://github.com/leather-wallet/extension/assets/2938440/99e634c1-288e-42bb-8259-61ee642af9ae)
![Screenshot 2023-11-03 at 12 24 21](https://github.com/leather-wallet/extension/assets/2938440/dafda018-4d16-4aaa-bb40-f43918182fb2)
![Screenshot 2023-11-03 at 12 21 55](https://github.com/leather-wallet/extension/assets/2938440/bc78eb4c-be65-4585-a9f9-2d605f3add8d)
![Screenshot 2023-11-03 at 12 21 46](https://github.com/leather-wallet/extension/assets/2938440/e1341073-de6b-4c77-842c-61c0b94e1fe0)
