### PR TITLE
fix: fix typo in text, closes #4461

### DIFF
--- a/src/app/features/increase-fee-drawer/increase-fee-drawer.tsx
+++ b/src/app/features/increase-fee-drawer/increase-fee-drawer.tsx
@@ -26,7 +26,7 @@ export function IncreaseFeeDrawer({ feeForm, onClose, isShowing }: IncreaseFeeDr
           >
             <Caption>
               If your transaction is pending for a long time, its fee might not be high enough to be
-              included in a clock. Update the fee for a higher value and try again.
+              included in a block. Update the fee for a higher value and try again.
             </Caption>
             {feeForm && feeForm}
           </Suspense>


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6721528169).<!-- Sticky Header Marker -->

This fixes a typo in the copy as per #4461 