### PR TITLE
Prevent undefined link to explorer for Bitcoin transaction on submitted screen

### DIFF
--- a/src/app/pages/send/sent-summary/btc-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/btc-sent-summary.tsx
@@ -44,7 +44,7 @@ export function BtcSentSummary() {
 
   function onClickLink() {
     void analytics.track('view_transaction_confirmation', { symbol: 'BTC' });
-    handleOpenTxLink(txLink);
+    handleOpenTxLink({ blockchain: txLink.blockchain, txId: txLink.txid });
   }
 
   function onClickCopy() {


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6782729215).<!-- Sticky Header Marker -->

This PR fixes a bug introduced in https://github.com/leather-wallet/extension/pull/4349/ where on the BTC summary screen we are passing `txid` instead of `txId` 

Before:
https://github.com/leather-wallet/extension/assets/2938440/fe4dd814-a65d-4d11-8210-152b99d79957

After:

https://github.com/leather-wallet/extension/assets/2938440/7a71dac6-d2f4-44cb-a240-34ff42a79c4e

