### PR TITLE
chore: refactor setpassword bars to fix bug

### DIFF
--- a/src/app/pages/onboarding/set-password/components/password-bars.tsx
+++ b/src/app/pages/onboarding/set-password/components/password-bars.tsx
@@ -1,0 +1,24 @@
+import { styled } from 'leather-styles/jsx';
+
+interface PasswordStrengthBarsProps {
+  bars: string[];
+}
+export function PasswordStrengthBars({ bars }: PasswordStrengthBarsProps) {
+  return (
+    <styled.div display="flex" flexDirection="row" height="6px">
+      {bars.map((bar: string, index: number) => {
+        return (
+          <styled.span
+            key={index}
+            bg={bar}
+            marginTop="0"
+            marginBottom="0"
+            marginInline={index < bars.length - 1 ? '0 8px' : 0}
+            borderRadius="2px"
+            flexGrow={1}
+          />
+        );
+      })}
+    </styled.div>
+  );
+}

--- a/src/app/pages/onboarding/set-password/components/password-field.tsx
+++ b/src/app/pages/onboarding/set-password/components/password-field.tsx
@@ -61,7 +61,11 @@ export function PasswordField({ strengthResult, isDisabled }: PasswordFieldProps
           {showPassword ? <EyeSlashIcon /> : <EyeIcon />}
         </styled.button>
       </Box>
-      <PasswordStrengthIndicator strengthColor={strengthColor} strengthResult={strengthResult} />
+      <PasswordStrengthIndicator
+        password={field.value}
+        strengthColor={strengthColor}
+        strengthResult={strengthResult}
+      />
       <Flex alignItems="center">
         <Caption mx="space.04">Password strength:</Caption>
         <Caption>{field.value ? strengthText : '—'}</Caption>

--- a/src/app/pages/onboarding/set-password/components/password-field.utils.ts
+++ b/src/app/pages/onboarding/set-password/components/password-field.utils.ts
@@ -1,6 +1,6 @@
 import { PasswordStrength, ValidatedPassword } from '@app/common/validation/validate-password';
 
-export const defaultColor = 'accent.text-subdued';
+export const defaultColor = 'accent.background-secondary';
 
 const strengthStyles = {
   [PasswordStrength.NoScore]: {

--- a/src/app/pages/onboarding/set-password/components/password-strength-indicator.tsx
+++ b/src/app/pages/onboarding/set-password/components/password-strength-indicator.tsx
@@ -1,50 +1,44 @@
 import { useMemo } from 'react';
 
-import { Box, HStack } from 'leather-styles/jsx';
-
 import { createNullArrayOfLength } from '@app/common/utils';
 import { ValidatedPassword } from '@app/common/validation/validate-password';
 
+import { PasswordStrengthBars } from './password-bars';
 import { defaultColor } from './password-field.utils';
 
 function fillArray(amount: number) {
-  return (item: (i: number) => React.JSX.Element) =>
-    createNullArrayOfLength(amount).map((_, i) => item(i));
+  return (item: (i: number) => string) => createNullArrayOfLength(amount).map((_, i) => item(i));
 }
 
 interface PasswordStrengthIndicatorProps {
+  password: string;
   strengthColor: string;
   strengthResult: ValidatedPassword;
 }
-export function PasswordStrengthIndicator(props: PasswordStrengthIndicatorProps) {
-  const { strengthColor, strengthResult } = props;
-
+export function PasswordStrengthIndicator({
+  password,
+  strengthColor,
+  strengthResult,
+}: PasswordStrengthIndicatorProps) {
   const bars = useMemo(() => {
-    if (strengthResult.password.trim() === '')
-      return fillArray(4)(i => <Box key={i} bg={defaultColor} borderRadius="2px" flexGrow={1} />);
+    if (strengthResult.password.trim() === '' || password.trim() === '')
+      return fillArray(4)(() => defaultColor);
 
     if (strengthResult.score === 4 && !strengthResult.meetsAllStrengthRequirements) {
-      return [
-        ...fillArray(3)(i => <Box key={i} bg={strengthColor} borderRadius="2px" flexGrow={1} />),
-        ...fillArray(1)(i => <Box key={i} bg={defaultColor} borderRadius="2px" flexGrow={1} />),
-      ];
+      return [...fillArray(3)(() => strengthColor), ...fillArray(1)(() => defaultColor)];
     }
 
     return [
-      ...fillArray(Math.max(strengthResult.score, 1))(i => (
-        <Box key={i} bg={strengthColor} borderRadius="2px" flexGrow={1} />
-      )),
-      ...fillArray(4 - Math.max(strengthResult.score, 1))(i => (
-        <Box key={i} bg={defaultColor} borderRadius="2px" flexGrow={1} />
-      )),
+      ...fillArray(Math.max(strengthResult.score, 1))(() => strengthColor),
+      ...fillArray(4 - Math.max(strengthResult.score, 1))(() => defaultColor),
     ];
   }, [
+    password,
     strengthColor,
     strengthResult.meetsAllStrengthRequirements,
     strengthResult.password,
     strengthResult.score,
   ]);
 
-  // TODO: This need to be fixed - Pete?
-  return <HStack height="6px">{bars}</HStack>;
+  return <PasswordStrengthBars bars={bars} />;
 }


### PR DESCRIPTION
This PR refactors the `PasswordStrength` indicator to help migrate it and fix bugs found. 

You can see a before + after below with:
- left light mode - current production
- right dark mode - after this change


https://github.com/leather-wallet/extension/assets/2938440/c025b530-4277-4c1e-b854-50abe379333c


