### PR TITLE
chore: remove @redux-devtools/remote to stop unit tests failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,6 @@
     "@playwright/test": "1.38.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
     "@redux-devtools/cli": "3.0.2",
-    "@redux-devtools/remote": "0.8.1",
     "@schemastore/web-manifest": "0.0.6",
     "@sentry/webpack-plugin": "2.4.0",
     "@stacks/connect-react": "22.2.0",

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -1,6 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { devToolsEnhancer } from '@redux-devtools/remote';
 import { Action, AnyAction, ThunkAction, combineReducers, configureStore } from '@reduxjs/toolkit';
 import { atomWithStore } from 'jotai-redux';
 import {
@@ -83,17 +82,6 @@ export const store = configureStore({
     }),
     broadcastActionTypeToOtherFramesMiddleware,
   ],
-  enhancers:
-    process.env.WALLET_ENVIRONMENT === 'development'
-      ? [
-          devToolsEnhancer({
-            hostname: 'localhost',
-            port: 8000,
-            realtime: true,
-            suppressConnectErrors: false,
-          }),
-        ]
-      : undefined,
 });
 
 export const persistor = persistStore(store);


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6887677633).<!-- Sticky Header Marker -->

This fixes the failing unit tests
https://github.com/leather-wallet/extension/pull/4490#issuecomment-1812791852

I'm not sure if we need `@redux-devtools/remote` though. 

This issue happened when re-adding prism [here](https://github.com/leather-wallet/extension/pull/4490/commits/c865dd40f5ebb37b30079c7dfd16b8da89d24b6c). I'm trying to think how we can solve it. We don't use nanoid.

Here's a [SO](https://stackoverflow.com/questions/72597602/nanoid4-in-codecept-error-err-require-esm-require-of-es-module)

Maybe we should squash and re-write the commits to avoid doing it