### PR TITLE
fix(popup): avatar circle on stacks transactions

### DIFF
--- a/src/app/features/current-account/current-account-avatar.tsx
+++ b/src/app/features/current-account/current-account-avatar.tsx
@@ -5,10 +5,14 @@ import { CircleProps } from 'leather-styles/jsx';
 import { useCurrentAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { useDrawers } from '@app/common/hooks/use-drawers';
 import { AccountAvatar } from '@app/components/account/account-avatar';
-import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+import { useCurrentAccountIndex } from '@app/store/accounts/account';
+import { useStacksAccounts } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+import { StacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.models';
 
 export const CurrentAccountAvatar = memo((props: CircleProps) => {
-  const currentAccount = useCurrentStacksAccount();
+  const accountIndex = useCurrentAccountIndex();
+  const accounts = useStacksAccounts();
+  const currentAccount = accounts[accountIndex] as StacksAccount | undefined;
   const name = useCurrentAccountDisplayName();
   const { setIsShowingSwitchAccountsState } = useDrawers();
   if (!currentAccount) return null;


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7007934967).<!-- Sticky Header Marker -->

Addresses #4472 

## Bug description

The issue is coming from useCurrentStacksAccount hook. So for the account name (that "Account _X_" title) we’re using the useCurrentAccountDisplayName hook that simply uses useCurrentAccountIndex hook that in most cases just reads default current account index. 

In case of the account circle, we use useCurrentStacksAccount hook, that utilizes 2 hooks to decide on the account index. One is useCurrentAccountIndex (that is most probably a default current account index) and the other one is useTransactionAccountIndex. Now useTransactionAccountIndex searches stxAddress in txPayload, and if finds one, tries to find an account with that stxAddress. It finds one in another account and returns that another account.

Now it finds stxAddress only in stacks related transactions, thus the issue only happens when we sign stacks transactions.

Now, to fix the issue with the account circle i would just use useCurrentAccountIndex together with useStacksAccounts to make the account circle consistent with the name. But the logic behind useCurrentStacksAccount still seems wrong to me 🤔 It is probably going to breed more bugs if we don't refactor it (decouple stx logic from non-stx logic)

## UI test

#### Reproduced bug


https://github.com/leather-wallet/extension/assets/22010816/d6ccffff-59da-45c7-8804-0b8eda233bda

#### Fixed bug


https://github.com/leather-wallet/extension/assets/22010816/6ed42b17-33e4-4a86-98e4-801c20ac02e7

