### PR TITLE
fix(auth): wait for sign out to finish before navigating to /get-started

### DIFF
--- a/src/app/pages/sign-out-confirm/sign-out-confirm.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.tsx
@@ -17,8 +17,9 @@ export function SignOutConfirmDrawer() {
   return (
     <SignOutConfirmLayout
       onUserDeleteWallet={() => {
-        navigate(RouteUrls.Onboarding);
-        void signOut();
+        void signOut().finally(() => {
+          navigate(RouteUrls.Onboarding);
+        });
       }}
       onUserSafelyReturnToHomepage={() => navigate(backgroundLocation ?? '..')}
     />


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6890507100).<!-- Sticky Header Marker -->

Wait for sign out promise to finish before navigating out

https://github.com/leather-wallet/extension/assets/22010816/f7c0e393-3c4a-466c-b527-3dd27a610f0e

