### PR TITLE
feat: updated bitcoin-contracts package and rpc params

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "1.0.2",
     "@coinbase/cbpay-js": "1.0.2",
-    "@dlc-link/dlc-tools": "1.0.4",
+    "@dlc-link/dlc-tools": "1.0.7",
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.1.0",
     "@ledgerhq/hw-transport-webusb": "6.27.19",

--- a/src/app/features/asset-list/asset-list.tsx
+++ b/src/app/features/asset-list/asset-list.tsx
@@ -57,7 +57,7 @@ export function AssetsList() {
       })}
 
       {/* Temporary duplication during Ledger Bitcoin feature dev */}
-      {network.chain.bitcoin.bitcoinNetwork === 'testnet' &&
+      {['testnet', 'regtest'].includes(network.chain.bitcoin.bitcoinNetwork) &&
         whenWallet({
           software: <BitcoinContractEntryPoint btcAddress={btcAddress} />,
           ledger: null,

--- a/src/app/pages/bitcoin-contract-request/bitcoin-contract-request.tsx
+++ b/src/app/pages/bitcoin-contract-request/bitcoin-contract-request.tsx
@@ -46,6 +46,7 @@ export function BitcoinContractRequest() {
 
   useOnMount(() => {
     const bitcoinContractOfferJSON = initialSearchParams.get('bitcoinContractOffer');
+    const bitcoinNetwork = initialSearchParams.get('bitcoinNetwork');
     const counterpartyWalletDetailsJSON = initialSearchParams.get('counterpartyWalletDetails');
 
     const bitcoinAccountDetails = getNativeSegwitSigner?.(0);
@@ -54,19 +55,35 @@ export function BitcoinContractRequest() {
 
     const currentBitcoinNetwork = bitcoinAccountDetails.network;
 
+    if (
+      !getNativeSegwitSigner ||
+      !bitcoinContractOfferJSON ||
+      !counterpartyWalletDetailsJSON ||
+      !bitcoinNetwork
+    )
+      return;
+
     if (!['testnet', 'regtest'].includes(currentBitcoinNetwork)) {
       navigate(RouteUrls.BitcoinContractLockError, {
         state: {
           error: new Error('Invalid Network'),
-          title: "Network doesn't support Bitcoin Contracts",
+          title: "Current selected network doesn't support Bitcoin Contracts",
           body: "The wallet's current selected network doesn't support Bitcoin Contracts",
         },
       });
       sendRpcResponse(BitcoinContractResponseStatus.NETWORK_ERROR);
     }
 
-    if (!getNativeSegwitSigner || !bitcoinContractOfferJSON || !counterpartyWalletDetailsJSON)
-      return;
+    if (JSON.parse(bitcoinNetwork) !== currentBitcoinNetwork) {
+      navigate(RouteUrls.BitcoinContractLockError, {
+        state: {
+          error: new Error('Invalid Network'),
+          title: "Current selected network doesn't match offer's network",
+          body: "The wallet's current selected network doesn't match the offer's network",
+        },
+      });
+      sendRpcResponse(BitcoinContractResponseStatus.NETWORK_ERROR);
+    }
 
     const currentBitcoinContractOfferDetails = handleOffer(
       bitcoinContractOfferJSON,

--- a/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-offer/bitcoin-contract-emergency-refund-time.tsx
+++ b/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-offer/bitcoin-contract-emergency-refund-time.tsx
@@ -2,22 +2,22 @@ import { BitcoinContractRequestSelectors } from '@tests/selectors/bitcoin-contra
 import { Flex } from 'leather-styles/jsx';
 import { styled } from 'leather-styles/jsx';
 
-interface BitcoinContractExpirationDateProps {
-  expirationDate: string;
+interface BitcoinContractEmergencyRefundTimeProps {
+  emergencyRefundTime: string;
 }
-export function BitcoinContractExpirationDate({
-  expirationDate,
-}: BitcoinContractExpirationDateProps) {
+export function BitcoinContractEmergencyRefundTime({
+  emergencyRefundTime,
+}: BitcoinContractEmergencyRefundTimeProps) {
   return (
     <Flex gap="space.05" justifyContent="space-between" p="space.05" width="100%">
       <styled.span fontWeight={500} textStyle="body.01">
-        Expiration Date
+        Emergency Refund Time
       </styled.span>
       <styled.span
         data-testid={BitcoinContractRequestSelectors.BitcoinContractExpirationDate}
         textStyle="body.01"
       >
-        {expirationDate}
+        {emergencyRefundTime}
       </styled.span>
     </Flex>
   );

--- a/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-offer/bitcoin-contract-offer-details.tsx
+++ b/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-offer/bitcoin-contract-offer-details.tsx
@@ -1,6 +1,6 @@
 import { SimplifiedBitcoinContract } from '@app/common/hooks/use-bitcoin-contracts';
 
-import { BitcoinContractExpirationDate } from './bitcoin-contract-expiration-date';
+import { BitcoinContractEmergencyRefundTime } from './bitcoin-contract-emergency-refund-time';
 import { BitcoinContractOfferInput } from './bitcoin-contract-offer-input';
 
 interface BitcoinContractOfferDetailsSimpleProps {
@@ -17,8 +17,8 @@ export function BitcoinContractOfferDetailsSimple({
         addressNativeSegwit={bitcoinAddress}
         bitcoinContractOffer={bitcoinContractOffer}
       />
-      <BitcoinContractExpirationDate
-        expirationDate={bitcoinContractOffer.bitcoinContractExpirationDate}
+      <BitcoinContractEmergencyRefundTime
+        emergencyRefundTime={bitcoinContractOffer.bitcoinContractEmergencyRefundTime}
       />
     </>
   );

--- a/src/background/messaging/rpc-methods/accept-bitcoin-contract.ts
+++ b/src/background/messaging/rpc-methods/accept-bitcoin-contract.ts
@@ -20,7 +20,7 @@ export async function rpcAcceptBitcoinContractOffer(
   if (
     !message.params ||
     !message.params.bitcoinContractOffer ||
-    !message.params.attestorURLs ||
+    !message.params.bitcoinNetwork ||
     !message.params.counterpartyWalletDetails
   ) {
     chrome.tabs.sendMessage(
@@ -38,7 +38,7 @@ export async function rpcAcceptBitcoinContractOffer(
 
   const params: RequestParams = [
     ['bitcoinContractOffer', message.params.bitcoinContractOffer],
-    ['attestorURLs', message.params.attestorURLs],
+    ['bitcoinNetwork', message.params.bitcoinNetwork],
     ['counterpartyWalletDetails', message.params.counterpartyWalletDetails],
     ['requestId', message.id],
   ];

--- a/src/shared/rpc/methods/accept-bitcoin-contract.ts
+++ b/src/shared/rpc/methods/accept-bitcoin-contract.ts
@@ -1,9 +1,11 @@
 import { DefineRpcMethod, RpcRequest, RpcResponse } from '@btckit/types';
 import { AllowAdditionalProperties } from '@btckit/types/dist/types/utils';
 
+import { BitcoinNetworkModes } from '@shared/constants';
+
 interface BitcoinContractResponseParams extends AllowAdditionalProperties {
   bitcoinContractOffer: string;
-  attestorURLs: string;
+  bitcoinNetwork: BitcoinNetworkModes;
   counterpartyWalletDetails: string;
 }
 
@@ -16,7 +18,7 @@ export enum BitcoinContractResponseStatus {
   SUCCESS = 'Accepting Bitcoin Contract offer was successful',
   BROADCAST_ERROR = 'There was an error while broadcasting the Bitcoin Contract transaction',
   INTERFACE_ERROR = 'There was an error while interacting with the Bitcoin Contract interface',
-  NETWORK_ERROR = "The wallet's current selected network is not supported",
+  NETWORK_ERROR = "The wallet's current network does not match the one in the Bitcoin Contract offer",
   REJECTED = 'Bitcoin Contract offer was rejected',
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,10 +1036,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dlc-link/dlc-tools@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@dlc-link/dlc-tools/-/dlc-tools-1.0.4.tgz#0b312a130d1cee4fa3e53e0815968b2fd0bfa91b"
-  integrity sha512-hjwZH2xRmnfIz9zJ7C4EV4cDs8Fu7SOmUcr8aBuzVvwOo23DDu0qYuuCOClICiWHUNUhhWMK+gdQgU8LVdhbuQ==
+"@dlc-link/dlc-tools@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@dlc-link/dlc-tools/-/dlc-tools-1.0.7.tgz#4c3e779720a8aa29a6b6b7ba16ea4e904366879c"
+  integrity sha512-lOdYed8hoHK9k62EWT7rQ/+U6RyKiqS0VzhWg8zdP0VEI//WxRBIY4FeYfBKK+UlWSHUh23PPS3g3Yv8XLOWtw==
 
 "@dnd-kit/accessibility@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6955655653).<!-- Sticky Header Marker -->

This PR introduces some improvements on the Bitcoin Contracts:

Updated @dlc-link/dlc-tools package.

Modified acceptBitcoinContract RPC message parameters:
- Removed attestorList (_unnecessary in the new design_).
- Added bitcoinNetwork to ensure wallet compatibility with the offer's network.

Instead of the Expiration Date, the request page will show the Emergency Refund Time of the DLC.