### PR TITLE
fix: sign out and close all tabs on create wallet, closes #4517

### DIFF
--- a/src/app/pages/onboarding/welcome/welcome.layout.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.layout.tsx
@@ -14,16 +14,14 @@ interface WelcomeLayoutProps {
   onStartOnboarding(): void;
   onRestoreWallet(): void;
 }
-export function WelcomeLayout(props: WelcomeLayoutProps): React.JSX.Element {
-  const {
-    tagline,
-    subheader,
-    isGeneratingWallet,
-    onStartOnboarding,
-    onSelectConnectLedger,
-    onRestoreWallet,
-  } = props;
-
+export function WelcomeLayout({
+  tagline,
+  subheader,
+  isGeneratingWallet,
+  onStartOnboarding,
+  onSelectConnectLedger,
+  onRestoreWallet,
+}: WelcomeLayoutProps): React.JSX.Element {
   const isAtleastBreakpointMd = useViewportMinWidth('md');
 
   return (

--- a/src/app/pages/onboarding/welcome/welcome.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.tsx
@@ -24,7 +24,6 @@ export function WelcomePage() {
   const [isGeneratingWallet, setIsGeneratingWallet] = useState(false);
 
   useRouteHeader(<></>);
-
   const startOnboarding = useCallback(async () => {
     if (isPopupMode()) {
       openIndexPageInNewTab(RouteUrls.Onboarding);
@@ -32,6 +31,8 @@ export function WelcomePage() {
       return;
     }
     setIsGeneratingWallet(true);
+    // #4517 signout other tabs on wallet create
+    await keyActions.signOut();
     keyActions.generateWalletKey();
     void analytics.track('generate_new_secret_key');
     if (decodedAuthRequest) {


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/6954676435).<!-- Sticky Header Marker -->

This PR is a small change so that:
- WHEN a user clicks `Create Wallet`
- THEN we initiate a sign out which in turn clears all other tabs

This prevents the UI from being able to have multiple new wallet tabs open