### PR TITLE
fix: Improve visual display of unlock screen

### DIFF
--- a/src/app/components/request-password.tsx
+++ b/src/app/components/request-password.tsx
@@ -56,6 +56,7 @@ export function RequestPassword({ title, caption, onSuccess }: RequestPasswordPr
           <>
             <styled.h1
               textStyle={['heading.03', 'heading.03', 'heading.03', 'display.02']}
+              textAlign="left"
               mt="space.00"
               mb="space.06"
             >

--- a/src/app/components/request-password.tsx
+++ b/src/app/components/request-password.tsx
@@ -108,7 +108,7 @@ export function RequestPassword({ title, caption, onSuccess }: RequestPasswordPr
               disabled={isRunning || !!error}
               aria-busy={isRunning}
               onClick={submit}
-              mt="space.05"
+              mt={['space.11', 'space.05']}
             >
               Continue
             </LeatherButton>


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7001460522).<!-- Sticky Header Marker -->

This is a small PR to give more margin to the `Continue` button in extension mode. 

I'll do more work to fix this properly with: https://github.com/leather-wallet/extension/issues/4370