### PR TITLE
fix: bitcoin fees tx size calc

### DIFF
--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
@@ -69,7 +69,7 @@ export function determineUtxosForSpend({
     sizeInfo = txSizer.calcTxSize({
       // Only p2wpkh is supported by the wallet
       input_script: 'p2wpkh',
-      input_count: neededUtxos.length + 1,
+      input_count: neededUtxos.length,
       // From the address of the recipient, we infer the output type
       [addressInfo.type + '_output_count']: 2,
     });

--- a/src/app/query/bitcoin/bitcoin-client.ts
+++ b/src/app/query/bitcoin/bitcoin-client.ts
@@ -80,10 +80,10 @@ interface FeeResult {
 class FeeEstimatesApi {
   constructor(public configuration: Configuration) {}
 
-  async getFeeEstimatesFromBlockcypherApi(): Promise<FeeResult> {
+  async getFeeEstimatesFromBlockcypherApi(network: string): Promise<FeeResult> {
     return fetchData({
       errorMsg: 'No fee estimates fetched',
-      url: `https://api.blockcypher.com/v1/btc/main`,
+      url: `https://api.blockcypher.com/v1/btc/${network}`,
     }).then((resp: FeeEstimateEarnApiResponse) => {
       const { low_fee_per_kb, medium_fee_per_kb, high_fee_per_kb } = resp;
       // These fees are in satoshis per kb

--- a/src/app/query/bitcoin/fees/fee-estimates.query.ts
+++ b/src/app/query/bitcoin/fees/fee-estimates.query.ts
@@ -1,16 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { BitcoinNetworkModes } from '@shared/constants';
+
 import { AppUseQueryConfig } from '@app/query/query-config';
 import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
+import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { BitcoinClient } from '../bitcoin-client';
 
-function fetchAllBitcoinFeeEstimates(client: BitcoinClient) {
+function fetchAllBitcoinFeeEstimates(client: BitcoinClient, network: BitcoinNetworkModes) {
   return async () =>
-    Promise.allSettled([
-      client.feeEstimatesApi.getFeeEstimatesFromMempoolSpaceApi(),
-      client.feeEstimatesApi.getFeeEstimatesFromBlockcypherApi(),
-    ]);
+    network === 'mainnet'
+      ? Promise.allSettled([
+          client.feeEstimatesApi.getFeeEstimatesFromMempoolSpaceApi(),
+          client.feeEstimatesApi.getFeeEstimatesFromBlockcypherApi('main'),
+        ])
+      : // Using `allSettled` so we can add more testnet apis to the array
+        Promise.allSettled([client.feeEstimatesApi.getFeeEstimatesFromBlockcypherApi('test3')]);
 }
 
 type FetchAllBitcoinFeeEstimatesResp = Awaited<
@@ -21,9 +27,11 @@ export function useGetAllBitcoinFeeEstimatesQuery<
   T extends unknown = FetchAllBitcoinFeeEstimatesResp,
 >(options?: AppUseQueryConfig<FetchAllBitcoinFeeEstimatesResp, T>) {
   const client = useBitcoinClient();
+  const network = useCurrentNetwork();
+
   return useQuery({
-    queryKey: ['average-bitcoin-fee-estimates'],
-    queryFn: fetchAllBitcoinFeeEstimates(client),
+    queryKey: ['average-bitcoin-fee-estimates', network.chain.bitcoin.bitcoinNetwork],
+    queryFn: fetchAllBitcoinFeeEstimates(client, network.chain.bitcoin.bitcoinNetwork),
     refetchInterval: 2000 * 60,
     ...options,
   });


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7010963604).<!-- Sticky Header Marker -->

This PR fixes the bug reported where the sat/vB were off in bitcoin broadcasted fees. One issue, on testnet specifically, was that we were not querying the fees endpoints using a network other than mainnet. Mempool only returns `1` for all fee estimates on testnet, so I refactored our code to only use Blockcypher api for fees on testnet, though I left the promise as an array so we can add more apis to the calc later if we want an average on testnet.

The main issue though, repro'd on both mainnet and testnet, was that our tx size calc was always adding `1` to the inputs length. I don't know why we did this originally? I removed it here and it fixed the issue.

<img width="300" alt="Screenshot 2023-11-27 at 1 41 50 PM" src="https://github.com/leather-wallet/extension/assets/6493321/030a89df-a5a7-4a77-b009-cd0618398697">

<img width="1172" alt="Screenshot 2023-11-27 at 1 41 25 PM" src="https://github.com/leather-wallet/extension/assets/6493321/d8fec045-3393-4151-9aa0-e0d9e673ae11">

https://blockstream.info/tx/b6b04f57783a3139869dcaef86dd11f353e5ed1419810c4da60402b8255beb88
