### PR TITLE
fix: allow users to click into text input fields when ::before border

### DIFF
--- a/src/app/components/text-input-field.tsx
+++ b/src/app/components/text-input-field.tsx
@@ -2,7 +2,6 @@ import { Ref, useRef } from 'react';
 
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { useField } from 'formik';
-import { css } from 'leather-styles/css';
 import { Box, Flex, FlexProps, HStack, styled } from 'leather-styles/jsx';
 
 import { useShowFieldError } from '@app/common/form-utils';
@@ -59,11 +58,6 @@ export function TextInputField({
         }}
         border="default"
         borderRadius="sm"
-        className={css({
-          '& :has(:focus)::before': {
-            border: '1px solid green',
-          },
-        })}
         cursor="text"
         flexDirection="column"
         justifyContent="center"

--- a/src/app/components/text-input-field.tsx
+++ b/src/app/components/text-input-field.tsx
@@ -61,7 +61,7 @@ export function TextInputField({
         borderRadius="sm"
         className={css({
           '& :has(:focus)::before': {
-            border: '2px solid #bfc6ff',
+            border: '1px solid green',
           },
         })}
         cursor="text"
@@ -124,6 +124,7 @@ export function TextInputField({
           spellCheck="false"
           textStyle="body.02"
           width="100%"
+          zIndex={1}
           {...field}
           onBlur={e => {
             onBlur?.();


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7018074378).<!-- Sticky Header Marker -->

fix: allow users to click into text input fields when `::before` border is triggered



https://github.com/leather-wallet/extension/assets/2938440/ff821a20-5e9b-446f-9f51-0404241507dd

