### PR TITLE
fix: add background state for ledger connect modal

### DIFF
--- a/src/app/features/asset-list/components/connect-ledger-asset-button.tsx
+++ b/src/app/features/asset-list/components/connect-ledger-asset-button.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { styled } from 'leather-styles/jsx';
 
 import { SupportedBlockchains } from '@shared/constants';
+import { RouteUrls } from '@shared/route-urls';
 
 import { capitalize } from '@app/common/utils';
 import { immediatelyAttemptLedgerConnection } from '@app/features/ledger/hooks/use-when-reattempt-ledger-connection';
@@ -19,7 +20,10 @@ export function ConnectLedgerAssetBtn({ chain }: ConnectLedgerAssetBtnProps) {
   const onClick = () => {
     navigate(`${chain}/connect-your-ledger`, {
       replace: true,
-      state: { [immediatelyAttemptLedgerConnection]: true },
+      state: {
+        [immediatelyAttemptLedgerConnection]: true,
+        backgroundLocation: { pathname: RouteUrls.Home },
+      },
     });
   };
   return (


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7018633772).<!-- Sticky Header Marker -->

Previously underlay went blank