### PR TITLE
ci: sentry release version

### DIFF
--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -48,7 +48,9 @@ config.plugins = [
           // and needs the `project:releases` and `org:read` scopes
           authToken: sentryAuthToken,
 
-          release: packageJson.version,
+          release: {
+            name: packageJson.version,
+          },
         }),
       ]
     : []),

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -39,7 +39,7 @@ config.plugins = [
     ? [
         sentryWebpackPlugin({
           org: 'trust-machines',
-          project: 'hiro-wallet',
+          project: 'leather',
 
           // Specify the directory containing build artifacts
           include: './dist',


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7084389806).<!-- Sticky Header Marker -->

Think an upgrade of Sentry's webpack lib changed their API such that releases returned to being tied to a commit, rather than an attached version number.