### PR TITLE
fix: set backgroundLocation for send ordinal, closes #4562

### DIFF
--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
@@ -76,7 +76,14 @@ export function useSendInscriptionForm() {
 
       navigate(
         `/${RouteUrls.SendOrdinalInscription}/${RouteUrls.SendOrdinalInscriptionChooseFee}`,
-        { state: { inscription, recipient: values.recipient, utxo } }
+        {
+          state: {
+            inscription,
+            recipient: values.recipient,
+            utxo,
+            backgroundLocation: { pathname: RouteUrls.Home },
+          },
+        }
       );
     },
 
@@ -115,6 +122,7 @@ export function useSendInscriptionForm() {
           time,
           feeRowValue,
           signedTx: signedTx.extract(),
+          backgroundLocation: { pathname: RouteUrls.Home },
         },
       });
     },


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7085484106).<!-- Sticky Header Marker -->

This PR solves a bug with the background disappearing after choosing `Continue` in the send ordinal flow

I made a change to set `backgroundLocation` to `Home` to solve it



https://github.com/leather-wallet/extension/assets/2938440/526d05e4-323c-45bf-99b1-9312b4abc183

