### PR TITLE
fix: add color to warning background, closes #4600

### DIFF
--- a/src/app/pages/receive/components/receive-btc-warning.tsx
+++ b/src/app/pages/receive/components/receive-btc-warning.tsx
@@ -2,7 +2,13 @@ import { Flex, styled } from 'leather-styles/jsx';
 
 export function ReceiveBtcModalWarning({ message }: { message: string }) {
   return (
-    <Flex justifyContent="center" bg="yellow.100" minHeight="48px" p="space.05" width="100%">
+    <Flex
+      justifyContent="center"
+      bg="warning.background"
+      minHeight="48px"
+      p="space.05"
+      width="100%"
+    >
       <styled.span textStyle="label.02">{message}</styled.span>
     </Flex>
   );


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7085799758).<!-- Sticky Header Marker -->

This PR adds a BG colour to the Ordinals deposit warning:
![Screenshot 2023-12-04 at 11 16 08](https://github.com/leather-wallet/extension/assets/2938440/c7e9f500-83d1-490b-92ff-65923a719a75)
![Screenshot 2023-12-04 at 11 15 53](https://github.com/leather-wallet/extension/assets/2938440/ad4d0727-f6cb-43b4-8d41-77569a306370)
