### PR TITLE
fix: make sure pending transactions have the correct circle colour, c…

### DIFF
--- a/src/app/common/transactions/bitcoin/utils.ts
+++ b/src/app/common/transactions/bitcoin/utils.ts
@@ -9,22 +9,6 @@ import { truncateMiddle } from '@app/ui/utils/truncate-middle';
 
 import { BtcSizeFeeEstimator } from './fees/btc-size-fee-estimator';
 
-type BtcTxStatus = 'pending' | 'success';
-type BtcStatusColorMap = Record<BtcTxStatus, string>;
-
-const statusFromBitcoinTx = (tx: BitcoinTx): BtcTxStatus => {
-  if (tx.status.confirmed) return 'success';
-  return 'pending';
-};
-
-export const getColorFromBitcoinTx = (tx: BitcoinTx) => {
-  const colorMap: BtcStatusColorMap = {
-    pending: 'warning.label',
-    success: 'stacks',
-  };
-  return colorMap[statusFromBitcoinTx(tx)] ?? 'error.label';
-};
-
 export function containsTaprootInput(tx: BitcoinTx) {
   return tx.vin.some(input => input.prevout.scriptpubkey_type === 'v1_p2tr');
 }

--- a/src/app/components/bitcoin-transaction-item/bitcoin-transaction-icon.tsx
+++ b/src/app/components/bitcoin-transaction-item/bitcoin-transaction-icon.tsx
@@ -2,12 +2,11 @@ import { Circle, CircleProps, Flex } from 'leather-styles/jsx';
 
 import { BitcoinTx } from '@shared/models/transactions/bitcoin-transaction.model';
 
-import { getColorFromBitcoinTx, isBitcoinTxInbound } from '@app/common/transactions/bitcoin/utils';
+import { isBitcoinTxInbound } from '@app/common/transactions/bitcoin/utils';
 import { ArrowDownIcon } from '@app/ui/components/icons/arrow-down-icon';
 import { ArrowUpIcon } from '@app/ui/components/icons/arrow-up-icon';
-import { BtcIcon } from '@app/ui/components/icons/btc-icon';
 
-export function TxStatusIcon(props: { address: string; tx: BitcoinTx }) {
+function TxStatusIcon(props: { address: string; tx: BitcoinTx }) {
   const { address, tx } = props;
   if (isBitcoinTxInbound(address, tx)) return <ArrowDownIcon size="xs" />;
   return <ArrowUpIcon size="xs" />;
@@ -16,21 +15,23 @@ export function TxStatusIcon(props: { address: string; tx: BitcoinTx }) {
 interface TransactionIconProps extends CircleProps {
   transaction: BitcoinTx;
   btcAddress: string;
+  icon: React.ReactNode;
 }
 export function BitcoinTransactionIcon({
   transaction,
   btcAddress,
+  icon,
   ...props
 }: TransactionIconProps) {
   return (
     <Flex position="relative">
-      <BtcIcon />
+      {icon}
       <Circle
         bottom="-2px"
         right="-9px"
         position="absolute"
         size="21px"
-        bg={getColorFromBitcoinTx(transaction)}
+        bg={transaction.status.confirmed ? 'stacks' : 'warning.label'}
         color="accent.background-primary"
         border="background"
         {...props}

--- a/src/app/components/bitcoin-transaction-item/bitcoin-transaction-inscription-icon.tsx
+++ b/src/app/components/bitcoin-transaction-item/bitcoin-transaction-inscription-icon.tsx
@@ -1,20 +1,10 @@
-import { Box, Circle, Flex } from 'leather-styles/jsx';
+import { Circle } from 'leather-styles/jsx';
 
 import { SupportedInscription } from '@shared/models/inscription.model';
-import { BitcoinTx } from '@shared/models/transactions/bitcoin-transaction.model';
 
-import { getColorFromBitcoinTx } from '@app/common/transactions/bitcoin/utils';
 import { OrdinalIcon } from '@app/ui/components/icons/ordinal-icon';
 
-import { TxStatusIcon } from './bitcoin-transaction-icon';
-
-interface BitcoinTransactionInscriptionIconProps {
-  inscription: SupportedInscription;
-  transaction: BitcoinTx;
-  btcAddress: string;
-}
-
-function InscriptionIcon({ inscription, ...rest }: { inscription: SupportedInscription }) {
+export function InscriptionIcon({ inscription, ...rest }: { inscription: SupportedInscription }) {
   switch (inscription.type) {
     case 'image':
       return (
@@ -41,31 +31,4 @@ function InscriptionIcon({ inscription, ...rest }: { inscription: SupportedInscr
     default:
       return <OrdinalIcon />;
   }
-}
-
-export function BitcoinTransactionInscriptionIcon({
-  inscription,
-  transaction,
-  btcAddress,
-  ...rest
-}: BitcoinTransactionInscriptionIconProps) {
-  return (
-    <Flex position="relative">
-      <InscriptionIcon inscription={inscription} />
-      <Circle
-        bottom="-2px"
-        right="-9px"
-        position="absolute"
-        size="21px"
-        bg={getColorFromBitcoinTx(transaction)}
-        color="accent.background-primary"
-        border="background"
-        {...rest}
-      >
-        <Box height="13px" width="13px">
-          <TxStatusIcon address={btcAddress} tx={transaction} />
-        </Box>
-      </Circle>
-    </Flex>
-  );
 }

--- a/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item.tsx
+++ b/src/app/components/bitcoin-transaction-item/bitcoin-transaction-item.tsx
@@ -24,12 +24,13 @@ import {
 } from '@app/query/bitcoin/ordinals/inscription.hooks';
 import { useGetInscriptionsByOutputQuery } from '@app/query/bitcoin/ordinals/inscriptions-by-param.query';
 import { useCurrentAccountNativeSegwitAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+import { BtcIcon } from '@app/ui/components/icons/btc-icon';
 
 import { CaptionDotSeparator } from '../caption-dot-separator';
 import { TransactionItemLayout } from '../transaction-item/transaction-item.layout';
 import { BitcoinTransactionCaption } from './bitcoin-transaction-caption';
 import { BitcoinTransactionIcon } from './bitcoin-transaction-icon';
-import { BitcoinTransactionInscriptionIcon } from './bitcoin-transaction-inscription-icon';
+import { InscriptionIcon } from './bitcoin-transaction-inscription-icon';
 import { BitcoinTransactionStatus } from './bitcoin-transaction-status';
 import { BitcoinTransactionValue } from './bitcoin-transaction-value';
 
@@ -86,15 +87,7 @@ export function BitcoinTransactionItem({ transaction, ...rest }: BitcoinTransact
     </CaptionDotSeparator>
   );
   const txValue = <BitcoinTransactionValue>{value}</BitcoinTransactionValue>;
-  const txIcon = inscriptionData ? (
-    <BitcoinTransactionInscriptionIcon
-      inscription={inscriptionData}
-      transaction={transaction}
-      btcAddress={bitcoinAddress}
-    />
-  ) : (
-    <BitcoinTransactionIcon transaction={transaction} btcAddress={bitcoinAddress} />
-  );
+
   const title = inscriptionData ? `Ordinal inscription #${inscriptionData.number}` : 'Bitcoin';
   const increaseFeeButton = (
     <IncreaseFeeButton
@@ -109,7 +102,13 @@ export function BitcoinTransactionItem({ transaction, ...rest }: BitcoinTransact
     <TransactionItemLayout
       openTxLink={openTxLink}
       txCaption={txCaption}
-      txIcon={txIcon}
+      txIcon={
+        <BitcoinTransactionIcon
+          icon={inscriptionData ? <InscriptionIcon inscription={inscriptionData} /> : <BtcIcon />}
+          transaction={transaction}
+          btcAddress={bitcoinAddress}
+        />
+      }
       txStatus={<BitcoinTransactionStatus transaction={transaction} />}
       txTitle={<TransactionTitle title={title} />}
       txValue={txValue}


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7097230549).<!-- Sticky Header Marker -->

This PR adds a fix to us not showing the correct background colour for `Circle` on pending transactions. No colour was being set as per #4591 

![Screenshot 2023-12-04 at 12 01 32](https://github.com/leather-wallet/extension/assets/2938440/7f946319-584a-47b1-a6ef-836e05417a63)

This works but maybe we need to improve it more. I wonder if we even need `getColorFromBitcoinTx` ? Maybe we do if we want to show an error colour? 

Looking at the code and I don't think `feedback-error` will work properly either 

![Screenshot 2023-12-04 at 12 05 24](https://github.com/leather-wallet/extension/assets/2938440/37f7e5c8-9e38-4c1b-849c-65e5e6edf92b)


