### PR TITLE
fix: keep search params while doing background location redirect

### DIFF
--- a/src/app/routes/hooks/use-background-location-redirect.ts
+++ b/src/app/routes/hooks/use-background-location-redirect.ts
@@ -11,18 +11,21 @@ import { useLocationState } from '@app/common/hooks/use-location-state';
  */
 
 export function useBackgroundLocationRedirect(baseUrl = RouteUrls.Home) {
-  const { pathname, state } = useLocation();
+  const { pathname, state, search } = useLocation();
   const navigate = useNavigate();
   const backgroundLocation = useLocationState('backgroundLocation');
 
   useEffect(() => {
     void (async () => {
       if (backgroundLocation === undefined) {
-        return navigate(pathname, {
-          state: { backgroundLocation: { pathname: baseUrl }, ...state },
-        });
+        return navigate(
+          { pathname, search },
+          {
+            state: { backgroundLocation: { pathname: baseUrl }, ...state },
+          }
+        );
       }
       return false;
     })();
-  }, [backgroundLocation, baseUrl, navigate, pathname, state]);
+  }, [backgroundLocation, baseUrl, navigate, pathname, state, search]);
 }


### PR DESCRIPTION
> Try out this version of Leather — [download extension builds](https://github.com/leather-wallet/extension/actions/runs/7111171123).<!-- Sticky Header Marker -->

A small fix for the useBackgroundLocationRedirect hook. 

The bug: on the pages that utilize both useBackgroundLocationRedirect and search parameters, useBackgroundLocationRedirect would accidentally delete all of the search parameters on that page.

The fix: while doing a redirect, also use a copy of search parameters.