### PR TITLE
tests: publish reports

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -29,7 +29,8 @@ jobs:
       - pre-run
     strategy:
       matrix:
-        target: [chromium, firefox]
+        # Firefox removed while off store
+        target: [chromium]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,7 +66,12 @@ jobs:
       - pre-run
       - build
     steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
       - uses: kyranjamie/pull-request-fixed-header@v1.0.1
         with:
-          header: '> Try out this version of Leather — [download extension builds](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).'
+          header: '> Try out this version of Leather — [Extension build](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}), [Test report](https://leather-wallet.github.io/playwright-reports/${{ steps.extract_branch.outputs.branch }})'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: GH pages
+name: Publish unit test coverage
 
 on:
   push:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Integration Tests
 
 env:
   CI: true
@@ -73,9 +73,55 @@ jobs:
         run: xvfb-run yarn playwright test tests/specs --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=1
         env:
           TEST_ACCOUNT_SECRET_KEY: ${{ secrets.TEST_ACCOUNT_SECRET_KEY }}
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload blob report to GitHub Actions Artifacts
         if: always()
+        uses: actions/upload-artifact@v3
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 10
+          name: all-blob-reports
+          path: blob-report
+          retention-days: 1
+          if-no-files-found: error
+
+  merge-reports:
+    name: Merge reports
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: all-blob-reports
+          path: all-blob-reports
+
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-report--attempt-${{ github.run_attempt }}
+          path: playwright-report
+          retention-days: 14
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.event_name == 'pull_request'
+        with:
+          personal_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          external_repository: leather-wallet/playwright-reports
+          publish_branch: main
+          publish_dir: ./playwright-report
+          destination_dir: ${{ steps.extract_branch.outputs.branch }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: [[process.env.CI ? 'github' : 'list'], ['html', { open: 'never' }]],
+  reporter: [
+    [process.env.CI ? 'github' : 'list'],
+    [process.env.CI ? 'blob' : 'html', { open: 'never' }],
+  ],
   use: {
     trace: 'on-first-retry',
   },


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7141388048), [Test report](https://leather-wallet.github.io/playwright-reports/tests/publish-reports)<!-- Sticky Header Marker -->

These changes merge all the test reports, and [publish them to a separate Github repo](https://github.com/leather-wallet/playwright-reports).

This means they're hosted via Github pages on: `https://leather-wallet.github.io/playwright-reports/ + BRANCH_NAME`.

Thinking about adding a github commenting tool to link to this here. Open to other ideas. See the report for this PR here https://leather-wallet.github.io/playwright-reports/tests/publish-reports/

