### PR TITLE
fix: revert signing logic to try both keys

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "prettier.documentSelectors": ["src/**/*.{ts,tsx}", "*.{js,json}"],
   "vitest.include": ["src/**/*.spec.ts"],
-  "githubPullRequests.ignoredPullRequestBranches": ["dev"]
+  "githubPullRequests.ignoredPullRequestBranches": ["dev"],
+  "typescript.preferences.preferTypeOnlyAutoImports": true
 }


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7143020693), [Test report](https://leather-wallet.github.io/playwright-reports/fix/asigna)<!-- Sticky Header Marker -->

Closes #4645

Reverts signing logic to trying both keys. We need to implement https://github.com/leather-wallet/extension/issues/4658 to move away from this try all approach.

cc/ @fess-v 