### PR TITLE
fix: add ledger routes to BRC-20 tokens

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
+import { Outlet } from 'react-router-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Stack } from 'leather-styles/jsx';
@@ -130,26 +131,29 @@ export function BrcChooseFee() {
       <LoadingSpinner />
     </Stack>
   ) : (
-    <BitcoinChooseFee
-      amount={amountAsMoney}
-      feesList={
-        <BitcoinFeesList
-          feesList={feesList}
-          onChooseFee={previewTransaction}
-          onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
-          onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
-          selectedFeeType={selectedFeeType}
-        />
-      }
-      isLoading={isLoading}
-      isSendingMax={false}
-      onChooseFee={previewTransaction}
-      onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
-      onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
-      recommendedFeeRate={recommendedFeeRate}
-      recipient={recipient}
-      showError={showInsufficientBalanceError}
-      maxRecommendedFeeRate={feesList[0]?.feeRate}
-    />
+    <>
+      <BitcoinChooseFee
+        amount={amountAsMoney}
+        feesList={
+          <BitcoinFeesList
+            feesList={feesList}
+            onChooseFee={previewTransaction}
+            onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
+            onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
+            selectedFeeType={selectedFeeType}
+          />
+        }
+        isLoading={isLoading}
+        isSendingMax={false}
+        onChooseFee={previewTransaction}
+        onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
+        onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
+        recommendedFeeRate={recommendedFeeRate}
+        recipient={recipient}
+        showError={showInsufficientBalanceError}
+        maxRecommendedFeeRate={feesList[0]?.feeRate}
+      />
+      <Outlet />
+    </>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
@@ -71,7 +71,9 @@ export const sendCryptoAssetFormRoutes = (
       <Route path={RouteUrls.SentBtcTxSummary} element={<BtcSentSummary />} />
 
       <Route path={RouteUrls.SendBrc20SendForm} element={<Brc20SendForm />} />
-      <Route path={RouteUrls.SendBrc20ChooseFee} element={<BrcChooseFee />} />
+      <Route path={RouteUrls.SendBrc20ChooseFee} element={<BrcChooseFee />}>
+        {ledgerBitcoinTxSigningRoutes}
+      </Route>
       <Route path={RouteUrls.SendBrc20Confirmation} element={<Brc20SendFormConfirmation />} />
       <Route path={RouteUrls.SentBrc20Summary} element={<Brc20SentSummary />} />
     </Route>


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7144017581), [Test report](https://leather-wallet.github.io/playwright-reports/fix/4635/brc-20-ledger-routes)<!-- Sticky Header Marker -->

This PR adds `ledgerBitcoinTxSigningRoutes` to BRC-20 tokens as requested [here](https://github.com/leather-wallet/extension/pull/4665#pullrequestreview-1772772643)

