### PR TITLE
test: run on localhost, improve reliability

### DIFF
--- a/tests/specs/bitcoin-contract-offer-accept/bitcoin-contract-offer-accept.spec.ts
+++ b/tests/specs/bitcoin-contract-offer-accept/bitcoin-contract-offer-accept.spec.ts
@@ -22,8 +22,7 @@ test.describe('Bitcoin Contract Request Test', () => {
     await homePage.clickSettingsButton();
     await page.getByTestId(SettingsSelectors.ChangeNetworkAction).click();
     await page.locator(`text="Testnet"`).click();
-    await page.goto('https://leather.io');
-    await page.waitForLoadState('networkidle');
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
   });
 
   function initiateOfferRequest(page: Page) {

--- a/tests/specs/message-signing/bip322-message-signing.spec.ts
+++ b/tests/specs/message-signing/bip322-message-signing.spec.ts
@@ -7,7 +7,7 @@ test.describe('Message signing', () =>
     test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page }) => {
       await globalPage.setupAndUseApiCalls(extensionId);
       await onboardingPage.signInWithTestAccount(extensionId);
-      await page.goto('https://leather.io');
+      await page.goto('localhost:3000', { waitUntil: 'networkidle' });
     });
 
     function clickActionButton(context: BrowserContext) {

--- a/tests/specs/rpc-stacks-transaction/transaction-signing.spec.ts
+++ b/tests/specs/rpc-stacks-transaction/transaction-signing.spec.ts
@@ -14,7 +14,7 @@ test.describe('Transaction signing', () => {
   test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);
-    await page.goto('https://leather.io');
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
   });
 
   function checkVisibleContent(context: BrowserContext) {


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7144174629), [Test report](https://leather-wallet.github.io/playwright-reports/test/improve-bip322-tests)<!-- Sticky Header Marker -->

Investigating the BIP-322 tests. Found these strange ones to be unreliable, because they have no external deps.

I'm pretty sure the unreliability of these tests owes to the fact we were loading them on leather.io. These tests only need a website so there's a console to fire `LeatherProvide.request` from, so the local test app is better, because it avoids side effects.

I couldn't replicate the issue using leather.io _provided_ we set the arg for it to wait: 
```ts
await page.goto('https://leather.io', { waitUntil: 'networkidle' });
```

I reckon the test tries to run too fast after the page loads. The page hasn't had time load its resources, and executes it's scripts, or to inject `LeatherProvider` before the test calls `.request`. 