### PR TITLE
fix: swap test route path

### DIFF
--- a/tests/specs/swap/swap.spec.ts
+++ b/tests/specs/swap/swap.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../../fixtures/fixtures';
 
-const alexSdkPostRoute = '*/**/v1/graphql';
+const alexSdkPostRoute = 'https://*.alexlab.co/v1/graphql';
 
 test.describe('Swaps', () => {
   test.beforeEach(async ({ extensionId, globalPage, homePage, onboardingPage, swapPage }) => {

--- a/tests/specs/swap/swap.spec.ts
+++ b/tests/specs/swap/swap.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../../fixtures/fixtures';
 
-const alexSdkPostRoute = 'https://gql.alexlab.co/v1/graphql';
+const alexSdkPostRoute = '*/**/v1/graphql';
 
 test.describe('Swaps', () => {
   test.beforeEach(async ({ extensionId, globalPage, homePage, onboardingPage, swapPage }) => {


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7167418674), [Test report](https://leather-wallet.github.io/playwright-reports/fix/intercept-broadcast-test)<!-- Sticky Header Marker -->

Route path was actually wrong here causing the test to fail. It should be a post request to: `https://sponsor-tx.alexlab.co/v1/graphql`.