### PR TITLE
test: reenabe dlc tests

### DIFF
--- a/tests/specs/bitcoin-contract-offer-accept/bitcoin-contract-offer-accept.spec.ts
+++ b/tests/specs/bitcoin-contract-offer-accept/bitcoin-contract-offer-accept.spec.ts
@@ -50,7 +50,7 @@ test.describe('Bitcoin Contract Request Test', () => {
     await rejectButton.click();
   }
 
-  test.skip('that the bitcoin contract offer is properly displayed', async ({ page, context }) => {
+  test('that the bitcoin contract offer is properly displayed', async ({ page, context }) => {
     const expectedOfferorName = 'DLC.Link';
     const expectedLockAmount = '0.0001 BTC';
     const expectedExpirationDate = '10/17/2023';
@@ -81,7 +81,7 @@ test.describe('Bitcoin Contract Request Test', () => {
     await popup.close();
   });
 
-  test.skip('that user can reject a bitcoin contract offer', async ({ page, context }) => {
+  test('that user can reject a bitcoin contract offer', async ({ page, context }) => {
     const [result] = await Promise.all([
       initiateOfferRequest(page)(requestParams),
       clickReject(context),
@@ -98,7 +98,7 @@ test.describe('Bitcoin Contract Request Test', () => {
     });
   });
 
-  test.skip(`that user can't accept a bitcoin contract offer without sufficient bitcoin'`, async ({
+  test(`that user can't accept a bitcoin contract offer without sufficient bitcoin'`, async ({
     page,
     context,
   }) => {


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7165882515), [Test report](https://leather-wallet.github.io/playwright-reports/test/reenable-dlc-tests)<!-- Sticky Header Marker -->

Closes #4664

Making PR to enable tests to see if they're fixed per @fbwoolf's comment

cc/ @Polybius93 attempted to reanable but didn't work. See test reports for more info, anything obvious?