### PR TITLE
test: trace on dev

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Run Playwright tests
         run: xvfb-run yarn playwright test tests/specs --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=1
         env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
           TEST_ACCOUNT_SECRET_KEY: ${{ secrets.TEST_ACCOUNT_SECRET_KEY }}
 
       - name: Upload blob report to GitHub Actions Artifacts
@@ -118,7 +119,6 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.event_name == 'pull_request'
         with:
           personal_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           external_repository: leather-wallet/playwright-reports

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+console.log('Branch: ', process.env.GITHUB_HEAD_REF);
+
 /**
  * See https://playwright.dev/docs/test-configuration
  */
@@ -17,7 +19,9 @@ export default defineConfig({
     [process.env.CI ? 'blob' : 'html', { open: 'never' }],
   ],
   use: {
-    trace: 'on-first-retry',
+    // Traces are heavy so we want to use them sparingly, but having full trace
+    // to reference of the latest dev build is useful to inspect.
+    trace: process.env.GITHUB_HEAD_REF === 'dev' ? 'on' : 'on-first-retry',
   },
   projects: [
     {


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7167628820), [Test report](https://leather-wallet.github.io/playwright-reports/test/always-trace-dev)<!-- Sticky Header Marker -->

This enables traces on all tests, even when they don't fail, but only on dev. This means we can always reference the latest dev build, see screenshots/recordings of tests etc