### PR TITLE
fix(ledger): inscription sends, non-index 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "react-intersection-observer": "9.5.2",
     "react-lottie": "1.2.3",
     "react-redux": "8.1.3",
-    "react-router-dom": "6.16.0",
+    "react-router-dom": "6.20.1",
     "react-virtuoso": "4.6.0",
     "redux-persist": "6.0.0",
     "rxjs": "7.8.1",

--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
@@ -81,7 +81,6 @@ export function useSendInscriptionForm() {
             inscription,
             recipient: values.recipient,
             utxo,
-            backgroundLocation: { pathname: RouteUrls.Home },
           },
         }
       );
@@ -122,7 +121,6 @@ export function useSendInscriptionForm() {
           time,
           feeRowValue,
           signedTx: signedTx.extract(),
-          backgroundLocation: { pathname: RouteUrls.Home },
         },
       });
     },

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -66,13 +66,13 @@ export function AppRoutes() {
 
 export const homePageModalRoutes = (
   <>
-    {sendOrdinalRoutes}
     {settingsRoutes}
     {receiveRoutes}
     {ledgerStacksTxSigningRoutes}
     {ledgerBitcoinTxSigningRoutes}
     {requestBitcoinKeysRoutes}
     {requestStacksKeysRoutes}
+    {sendOrdinalRoutes}
   </>
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3335,10 +3335,10 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
-"@remix-run/router@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.9.0.tgz#9033238b41c4cbe1e961eccb3f79e2c588328cf6"
-  integrity sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==
+"@remix-run/router@1.13.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.13.1.tgz#07e2a8006f23a3bc898b3f317e0a58cc8076b86e"
+  integrity sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q==
 
 "@rjsf/core@^4.2.0":
   version "4.2.3"
@@ -15639,20 +15639,20 @@ react-remove-scroll@2.5.5:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
-react-router-dom@6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.16.0.tgz#86f24658da35eb66727e75ecbb1a029e33ee39d9"
-  integrity sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==
+react-router-dom@6.20.1:
+  version "6.20.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.20.1.tgz#e34f8075b9304221420de3609e072bb349824984"
+  integrity sha512-npzfPWcxfQN35psS7rJgi/EW0Gx6EsNjfdJSAk73U/HqMEJZ2k/8puxfwHFgDQhBGmS3+sjnGbMdMSV45axPQw==
   dependencies:
-    "@remix-run/router" "1.9.0"
-    react-router "6.16.0"
+    "@remix-run/router" "1.13.1"
+    react-router "6.20.1"
 
-react-router@6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.16.0.tgz#abbf3d5bdc9c108c9b822a18be10ee004096fb81"
-  integrity sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==
+react-router@6.20.1:
+  version "6.20.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.20.1.tgz#e8cc326031d235aaeec405bb234af77cf0fe75ef"
+  integrity sha512-ccvLrB4QeT5DlaxSFFYi/KR8UMQ4fcD8zBcR71Zp1kaYTC5oJKYAp1cbavzGrogwxca+ubjkd7XjFZKBW8CxPA==
   dependencies:
-    "@remix-run/router" "1.9.0"
+    "@remix-run/router" "1.13.1"
 
 react-select@^5.3.2:
   version "5.8.0"


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7196670955), [Test report](https://leather-wallet.github.io/playwright-reports/fix/inscription-sends)<!-- Sticky Header Marker -->

Closes #4680

This PR fixes the issue where inscriptions cannot be sent on Ledger. This breaks the fix done recently to show a background to the modal (which broke the routing of this feature).

As discussed on Slack, and is represented in the designs, inscriptions sends doesn't need to be in a modal. It can be its own page. Let's address that next, issue → https://github.com/leather-wallet/extension/issues/4684

In addition, I noticed I hadn't fixed the non-zero address on Ledger (only software). This PR fixes that too, migrating the remaining Ledger code over to the new `BitcoinSigningConfig` pattern.