### PR TITLE
ci: push spec files & traces to separate repo

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -115,11 +115,21 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
 
-      - name: Deploy
+      - name: Deploy PR
         uses: peaceiris/actions-gh-pages@v3
+        if: github.event_name == 'pull_request'
         with:
           personal_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           external_repository: leather-wallet/playwright-reports
           publish_branch: main
           publish_dir: ./playwright-report
           destination_dir: ${{ steps.extract_branch.outputs.branch }}
+
+      - name: Deploy specs.leather.io
+        uses: peaceiris/actions-gh-pages@v3
+        if: steps.extract_branch.outputs.branch == 'dev'
+        with:
+          personal_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          external_repository: leather-wallet/specs.leather.io
+          publish_branch: main
+          publish_dir: ./playwright-report


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7199151947), [Test report](https://leather-wallet.github.io/playwright-reports/ci/push-dev-specs)<!-- Sticky Header Marker -->

Publish extension spec files of `dev` with full traces on https://specs.leather.io/

Went for _specs_ because it's a common test lingo, consistent with our current set up, and I figured this is less ambiguous with it being a "test" version of leather.