### PR TITLE
fix: serialize sip10 form memo before displaying it

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-transaction-summary.ts
+++ b/src/app/pages/send/send-crypto-asset-form/family/stacks/hooks/use-stacks-transaction-summary.ts
@@ -1,10 +1,13 @@
+import { bytesToUtf8 } from '@stacks/common';
 import {
+  ClarityType,
   ContractCallPayload,
   IntCV,
   StacksTransaction,
   TokenTransferPayload,
   addressToString,
   cvToString,
+  serializeCV,
 } from '@stacks/transactions';
 import BigNumber from 'bignumber.js';
 
@@ -74,8 +77,9 @@ export function useStacksTransactionSummary(token: CryptoCurrencies) {
     const payload = tx.payload as ContractCallPayload;
     const fee = tx.auth.spendingCondition.fee;
     const txValue = Number((payload.functionArgs[0] as IntCV).value);
-    const memo = cvToString(payload.functionArgs[3]);
-    const memoDisplayText = memo === 'none' ? 'No memo' : memo;
+    const isSome = payload.functionArgs[3].type === ClarityType.OptionalSome;
+    const memo = bytesToUtf8(serializeCV(payload.functionArgs[3]));
+    const memoDisplayText = isSome ? memo : 'No memo';
 
     const sendingValue = formatMoney(
       convertToMoneyTypeWithDefaultOfZero(symbol, txValue, decimals)


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7206724308), [Test report](https://leather-wallet.github.io/playwright-reports/fix/sip10-form-memo)<!-- Sticky Header Marker -->

fixes #4340

Serialize sip10 form memo before displaying it




https://github.com/leather-wallet/extension/assets/22010816/d51531a5-02a3-4230-85ac-8af136760588


