### PR TITLE
fix: use light mode background on icons on fund screen

### DIFF
--- a/src/app/pages/fund/components/fund-account-tile.tsx
+++ b/src/app/pages/fund/components/fund-account-tile.tsx
@@ -48,6 +48,7 @@ export function FundAccountTile(props: FundAccountTileProps) {
             height="40px"
             justifyContent="center"
             width="40px"
+            backgroundColor="lightModeBrown.1"
           >
             <img src={icon} width="24px" />
           </Box>


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7207065168), [Test report](https://leather-wallet.github.io/playwright-reports/fix/light-mode-icons)<!-- Sticky Header Marker -->

Fixes #4691 

<img width="1648" alt="lightModeBackgroundIcons" src="https://github.com/leather-wallet/extension/assets/22010816/e8f546de-16d5-4b63-a19d-0201fd78d53e">
