### PR TITLE
fix: collectibles refetch, closes #4413

### DIFF
--- a/src/app/components/brc20-tokens-loader.tsx
+++ b/src/app/components/brc20-tokens-loader.tsx
@@ -1,13 +1,13 @@
 import {
   Brc20Token,
-  useBrc20TokensQuery,
+  useGetBrc20TokensQuery,
 } from '@app/query/bitcoin/ordinals/brc20/brc20-tokens.query';
 
 interface Brc20TokensLoaderProps {
   children(brc20Tokens: Brc20Token[]): React.JSX.Element;
 }
 export function Brc20TokensLoader({ children }: Brc20TokensLoaderProps) {
-  const { data: allBrc20TokensResponse } = useBrc20TokensQuery();
+  const { data: allBrc20TokensResponse } = useGetBrc20TokensQuery();
   const brc20Tokens = allBrc20TokensResponse?.pages
     .flatMap(page => page.brc20Tokens)
     .filter(token => token.length > 0)

--- a/src/app/features/collectibles/hooks/use-is-fetching-collectibles.ts
+++ b/src/app/features/collectibles/hooks/use-is-fetching-collectibles.ts
@@ -9,11 +9,11 @@ function areAnyQueriesFetching(...args: number[]) {
 
 export function useIsFetchingCollectiblesRelatedQuery() {
   // Ordinal inscriptions
-  const n1 = useIsFetching([QueryPrefixes.TaprootAddressUtxosMetadata]);
-  const n2 = useIsFetching([QueryPrefixes.InscriptionFromUtxo]);
+  const n1 = useIsFetching([QueryPrefixes.TaprootAddressUtxos]);
+  const n2 = useIsFetching([QueryPrefixes.InscriptionsByAddress]);
   const n3 = useIsFetching([QueryPrefixes.InscriptionMetadata]);
   const n4 = useIsFetching([QueryPrefixes.OrdinalTextContent]);
-  const n5 = useIsFetching([QueryPrefixes.InscriptionFromTxid]);
+  const n5 = useIsFetching([QueryPrefixes.GetInscriptions]);
 
   // BNS
   const n6 = useIsFetching([QueryPrefixes.BnsNamesByAddress]);

--- a/src/app/query/bitcoin/address/utxos-by-address.query.ts
+++ b/src/app/query/bitcoin/address/utxos-by-address.query.ts
@@ -4,6 +4,7 @@ import { getTaprootAddress } from '@shared/crypto/bitcoin/bitcoin.utils';
 
 import { createCounter } from '@app/common/utils/counter';
 import { AppUseQueryConfig } from '@app/query/query-config';
+import { QueryPrefixes } from '@app/query/query-prefixes';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { useCurrentTaprootAccount } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
@@ -45,7 +46,7 @@ export function useTaprootAccountUtxosQuery() {
   const currentAccountIndex = useCurrentAccountIndex();
 
   return useQuery(
-    ['taproot-address-utxos-metadata', currentAccountIndex, network.id],
+    [QueryPrefixes.TaprootAddressUtxos, currentAccountIndex, network.id],
     async () => {
       let currentNumberOfAddressesWithoutOrdinals = 0;
       const addressIndexCounter = createCounter(0);

--- a/src/app/query/bitcoin/ordinals/brc20/brc20-tokens.query.ts
+++ b/src/app/query/bitcoin/ordinals/brc20/brc20-tokens.query.ts
@@ -60,7 +60,7 @@ async function fetchBrc20TokensByAddress(address: string): Promise<Brc20Token[]>
   });
 }
 
-export function useBrc20TokensQuery() {
+export function useGetBrc20TokensQuery() {
   const network = useCurrentNetwork();
   const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
   const currentBitcoinAddress = nativeSegwitSigner.address;
@@ -79,7 +79,7 @@ export function useBrc20TokensQuery() {
     [createSigner]
   );
   const query = useInfiniteQuery({
-    queryKey: [QueryPrefixes.Brc20InfiniteQuery, currentBitcoinAddress, network.id],
+    queryKey: [QueryPrefixes.GetBrc20Tokens, currentBitcoinAddress, network.id],
     async queryFn({ pageParam }) {
       const fromIndex: number = pageParam?.fromIndex ?? 0;
       let addressesWithoutTokens = pageParam?.addressesWithoutTokens ?? 0;

--- a/src/app/query/bitcoin/ordinals/inscriptions.query.ts
+++ b/src/app/query/bitcoin/ordinals/inscriptions.query.ts
@@ -76,7 +76,7 @@ export function useGetInscriptionsInfiniteQuery() {
   );
 
   const query = useInfiniteQuery({
-    queryKey: [QueryPrefixes.InscriptionsFromApiInfiniteQuery, currentBitcoinAddress, network.id],
+    queryKey: [QueryPrefixes.GetInscriptions, currentBitcoinAddress, network.id],
     async queryFn({ pageParam }: InfiniteQueryPageParam) {
       const responsesArr: InscriptionsQueryResponse[] = [];
       let fromIndex = pageParam?.fromIndex ?? 0;
@@ -179,7 +179,7 @@ export function useGetInscriptionsInfiniteQuery() {
     staleTime: 3 * 60 * 1000,
     refetchOnMount: false,
     refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 
   return query;

--- a/src/app/query/query-prefixes.ts
+++ b/src/app/query/query-prefixes.ts
@@ -5,17 +5,15 @@
 export enum QueryPrefixes {
   Brc20TokenBalance = 'brc20-token-balance',
   OrdinalTextContent = 'ordinal-text-content',
-  TaprootAddressUtxosMetadata = 'taproot-address-utxos-metadata',
-  InscriptionFromUtxo = 'inscription-from-utxo',
+  TaprootAddressUtxos = 'taproot-address-utxos',
   BnsNamesByAddress = 'bns-names-by-address',
   InscriptionsByAddress = 'inscriptions-by-address',
   InscriptionMetadata = 'inscription-metadata',
-  InscriptionFromTxid = 'inscription-from-txid',
-  InscriptionsFromApiInfiniteQuery = 'inscriptions-from-api-infinite-query',
+  GetInscriptions = 'get-inscriptions',
   GetNftMetadata = 'get-nft-metadata',
   GetNftHoldings = 'get-nft-holdings',
 
   StampCollection = 'stamp-collection',
   StampsByAddress = 'stamps-by-address',
-  Brc20InfiniteQuery = 'brc20-infinite-query',
+  GetBrc20Tokens = 'get-brc20-tokens',
 }

--- a/src/app/query/stacks/tokens/non-fungible-tokens/non-fungible-token-metadata.query.ts
+++ b/src/app/query/stacks/tokens/non-fungible-tokens/non-fungible-token-metadata.query.ts
@@ -12,7 +12,7 @@ import { NftAssetResponse } from '../token-metadata.utils';
 import useGetNonFungibleTokenHoldingsQuery from './non-fungible-token-holdings.query';
 
 const queryOptions = {
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
   refetchOnMount: false,
   staleTime: 10 * 1000,
 };


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7226964680), [Test report](https://leather-wallet.github.io/playwright-reports/fix/collectibles-cache)<!-- Sticky Header Marker -->

This PR fixes getting inscriptions to load right away after returning to the gallery after the tx is confirmed. I also revisited/coordinated some outdated `QueryPrefixes`. Are all of the `useIsFetchingCollectiblesRelatedQuery` queries still current after the infinite inscription query implementation? I believe that was implemented very early with inscriptions?

I changed the refetch for Stacks NFTs to false for `onWindowFocus` bc I was seeing some 429s with rate limiting where my NFTs would disappear.

Other than these changes, it appears our forced refetching of collectibles is working as expected during testing.