### PR TITLE
fix: Prevent submission of sign-in screen when minimum values not yet entered

### DIFF
--- a/src/app/pages/onboarding/sign-in/mnemonic-form.tsx
+++ b/src/app/pages/onboarding/sign-in/mnemonic-form.tsx
@@ -96,7 +96,7 @@ export function MnemonicForm({ mnemonic, setMnemonic, twentyFourWordMode }: Mnem
               <LeatherButton
                 data-testid={OnboardingSelectors.SignInBtn}
                 aria-disabled={isLoading || showMnemonicErrors}
-                disabled={isEmpty(touched) || !isValid}
+                disabled={isEmpty(touched) || !isValid || !hasFormValues}
                 aria-busy={isLoading}
                 width="100%"
                 type="submit"


### PR DESCRIPTION
Closes https://github.com/leather-wallet/extension/issues/4690

This PR fixes a refinement to the sign-in functionality by preventing submission of the button until minimum required values are entered.