### PR TITLE
fix(wallet): fees warning alignment fix

### DIFF
--- a/src/app/components/fees-row/components/fees-row.layout.tsx
+++ b/src/app/components/fees-row/components/fees-row.layout.tsx
@@ -23,7 +23,7 @@ export function FeesRowLayout(props: FeesRowLayoutProps) {
   const [_, meta] = useField('fee');
 
   return (
-    <HStack gap="space.04" width="100%" {...rest}>
+    <HStack gap="space.04" width="100%" {...rest} flexWrap="wrap">
       <HStack alignItems="center" justifyContent="space-between" position="relative" width="100%">
         <HStack alignItems="center" width="100%">
           <Tooltip label={feesInfo} placement="bottom">
@@ -39,7 +39,7 @@ export function FeesRowLayout(props: FeesRowLayoutProps) {
         {feeField}
       </HStack>
       {isSponsored && <SponsoredLabel />}
-      {!meta.error && fieldWarning && <WarningLabel>{fieldWarning}</WarningLabel>}
+      {!meta.error && fieldWarning && <WarningLabel width="100%" >{fieldWarning}</WarningLabel>}
     </HStack>
   );
 }


### PR DESCRIPTION
Closes https://github.com/leather-wallet/extension/issues/4674

This PR fixes the alignment issue with fees warning, ensuring a proper display on various devices and screen sizes. The previous alignment problem was affecting the user interface, and this fix aims to enhance the visual presentation of the fees warning.