### PR TITLE
chore: improve display of lock screen, closes #4606

### DIFF
--- a/src/app/components/request-password.tsx
+++ b/src/app/components/request-password.tsx
@@ -62,7 +62,7 @@ export function RequestPassword({ title, caption, onSuccess }: RequestPasswordPr
             >
               {title}
             </styled.h1>
-            <styled.p textStyle={['label.01', 'heading.05']} mb="space.06">
+            <styled.p textStyle={['label.01', 'heading.05']} mb="space.06" textAlign="left">
               {(isRunning && waitingMessage) || caption}
             </styled.p>
           </>
@@ -78,7 +78,7 @@ export function RequestPassword({ title, caption, onSuccess }: RequestPasswordPr
             >
               Your password
             </styled.h2>
-            <Stack gap="space.04" alignItems="center">
+            <Stack gap="space.04" alignItems="center" minHeight="100px">
               <styled.input
                 _focus={{ border: 'focus' }}
                 autoCapitalize="off"
@@ -102,7 +102,7 @@ export function RequestPassword({ title, caption, onSuccess }: RequestPasswordPr
                 value={password}
                 width="100%"
               />
-              {error && <ErrorLabel>{error}</ErrorLabel>}
+              {error && <ErrorLabel width="100%">{error}</ErrorLabel>}
             </Stack>
             <LeatherButton
               data-testid={SettingsSelectors.UnlockWalletBtn}

--- a/src/app/components/secret-key/two-column.layout.tsx
+++ b/src/app/components/secret-key/two-column.layout.tsx
@@ -26,7 +26,9 @@ export function TwoColumnLayout({
         gap="space.07"
         mx={['auto', 'space.03', 'space.03', 'space.03']}
       >
-        <styled.div maxWidth="440px">{leftColumn}</styled.div>
+        <styled.div width="390px" textAlign="left">
+          {leftColumn}
+        </styled.div>
       </Flex>
 
       <Flex

--- a/src/app/pages/onboarding/set-password/components/password-field.tsx
+++ b/src/app/pages/onboarding/set-password/components/password-field.tsx
@@ -70,7 +70,7 @@ export function PasswordField({ strengthResult, isDisabled }: PasswordFieldProps
         strengthResult={strengthResult}
       />
       <Flex alignItems="center">
-        <Caption mx="space.04">Password strength:</Caption>
+        <Caption mr="space.02">Password strength:</Caption>
         <Caption>{field.value ? strengthText : '—'}</Caption>
       </Flex>
     </>


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7260526458), [Test report](https://leather-wallet.github.io/playwright-reports/fix/4606/password-alignment)<!-- Sticky Header Marker -->

This PR adds some improvements to the UI of:
- lock screen
- password strength indicator

https://github.com/leather-wallet/extension/assets/2938440/f973e42f-951e-46bf-a42c-14b62b8133d4

![Screenshot 2023-12-18 at 12 31 15](https://github.com/leather-wallet/extension/assets/2938440/44ab353a-d663-4f68-a53b-28767ef66a7c)
