### PR TITLE
fix: swaps test and others

### DIFF
--- a/tests/page-object-models/swap.page.ts
+++ b/tests/page-object-models/swap.page.ts
@@ -4,27 +4,22 @@ import { createTestSelector } from '@tests/utils';
 
 export class SwapPage {
   readonly page: Page;
-  readonly chooseAssetList: Locator;
-  readonly chooseAssetListItem: Locator;
-  readonly selectAssetBtn: Locator;
-  readonly swapAmountInput: Locator;
   readonly swapBtn: Locator;
   readonly swapDetailsAmount: Locator;
   readonly swapDetailsProtocol: Locator;
   readonly swapDetailsSymbol: Locator;
-  readonly swapReviewBtn: Locator;
+  readonly chooseAssetList = createTestSelector(SwapSelectors.ChooseAssetList);
+  readonly chooseAssetListItem = createTestSelector(SwapSelectors.ChooseAssetListItem);
+  readonly selectAssetBtn = createTestSelector(SwapSelectors.SelectAssetTriggerBtn);
+  readonly swapAmountInput = createTestSelector(SwapSelectors.SwapAmountInput);
+  readonly swapReviewBtn = createTestSelector(SwapSelectors.SwapReviewBtn);
 
   constructor(page: Page) {
     this.page = page;
-    this.chooseAssetList = page.getByTestId(SwapSelectors.ChooseAssetList);
-    this.chooseAssetListItem = page.getByTestId(SwapSelectors.ChooseAssetListItem);
-    this.selectAssetBtn = page.getByTestId(SwapSelectors.SelectAssetTriggerBtn);
-    this.swapAmountInput = page.getByTestId(SwapSelectors.SwapAmountInput);
     this.swapBtn = page.getByTestId(SwapSelectors.SwapBtn);
     this.swapDetailsAmount = page.getByTestId(SwapSelectors.SwapDetailsAmount);
     this.swapDetailsProtocol = page.getByTestId(SwapSelectors.SwapDetailsProtocol);
     this.swapDetailsSymbol = page.getByTestId(SwapSelectors.SwapDetailsSymbol);
-    this.swapReviewBtn = page.getByTestId(SwapSelectors.SwapReviewBtn);
   }
 
   async waitForSwapPageReady() {
@@ -34,11 +29,16 @@ export class SwapPage {
   }
 
   async selectAssetToReceive() {
-    const swapAssetSelectors = await this.selectAssetBtn.all();
+    const swapAssetSelectors = await this.page.locator(this.selectAssetBtn).all();
     await swapAssetSelectors[1].click();
-    await this.chooseAssetList.waitFor();
-    const swapAssets = await this.chooseAssetListItem.all();
+    await this.page.locator(this.chooseAssetList).waitFor();
+    const swapAssets = await this.page.locator(this.chooseAssetListItem).all();
     await swapAssets[0].click();
-    await this.swapReviewBtn.click();
+    await this.page.locator(this.swapReviewBtn).click();
+  }
+
+  async inputSwapAmountFrom() {
+    const swapAmountInputs = await this.page.locator(this.swapAmountInput).all();
+    await swapAmountInputs[0].fill('1');
   }
 }

--- a/tests/specs/rpc-stacks-transaction/transaction-signing.spec.ts
+++ b/tests/specs/rpc-stacks-transaction/transaction-signing.spec.ts
@@ -53,6 +53,7 @@ test.describe('Transaction signing', () => {
     const multiSignatureTxHex = await generateMultisigUnsignedStxTransfer(
       TEST_ACCOUNT_2_STX_ADDRESS,
       amount,
+      100,
       'mainnet',
       [TEST_ACCOUNT_3_PUBKEY, TEST_ACCOUNT_1_PUBKEY],
       2,

--- a/tests/specs/transactions/transactions.spec.ts
+++ b/tests/specs/transactions/transactions.spec.ts
@@ -15,13 +15,6 @@ test.describe('Transaction signing', () => {
 
     testAppPage = await TestAppPage.openDemoPage(context);
     await testAppPage.signIn();
-    const accountsPage = await context.waitForEvent('page');
-    await accountsPage.locator('text="Account 1"').click();
-    await testAppPage.page.bringToFront();
-    await testAppPage.page.click('text=Debugger', {
-      timeout: 30000,
-    });
-    await accountsPage.close();
   });
 
   // These tests often break if ran in parallel
@@ -31,6 +24,14 @@ test.describe('Transaction signing', () => {
     test('that it validates against insufficient funds when performing a contract call', async ({
       context,
     }) => {
+      const accountsPage = await context.waitForEvent('page');
+      await accountsPage.locator('text="Account 2"').click();
+      await testAppPage.page.bringToFront();
+      await testAppPage.page.click('text=Debugger', {
+        timeout: 30000,
+      });
+      await accountsPage.close();
+
       await testAppPage.clickContractCallButton();
       const transactionRequestPage = new TransactionRequestPage(await context.waitForEvent('page'));
       const error =
@@ -42,6 +43,14 @@ test.describe('Transaction signing', () => {
 
   test.describe('App initiated STX transfer', () => {
     test('that it broadcasts correctly with given fee and amount', async ({ context }) => {
+      const accountsPage = await context.waitForEvent('page');
+      await accountsPage.locator('text="Account 1"').click();
+      await testAppPage.page.bringToFront();
+      await testAppPage.page.click('text=Debugger', {
+        timeout: 30000,
+      });
+      await accountsPage.close();
+
       await testAppPage.clickStxTransferButton();
       const transactionRequestPage = new TransactionRequestPage(await context.waitForEvent('page'));
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -45,6 +45,7 @@ export async function generateUnsignedStxTransfer(
 export async function generateMultisigUnsignedStxTransfer(
   recipient: string,
   amount: number,
+  fee: number,
   network: any,
   publicKeys: string[],
   threshold: number,
@@ -53,6 +54,7 @@ export async function generateMultisigUnsignedStxTransfer(
   memo?: string
 ) {
   const options = {
+    fee,
     recipient,
     memo,
     publicKeys,


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7256172772), [Test report](https://leather-wallet.github.io/playwright-reports/fix/swaps-test)<!-- Sticky Header Marker -->

This PR changes to test swaps on mainnet bc we hide swaps on testnet. The broadcast is caught and aborted, so it should be ok. I also just did some clean up of the locators and handled if there happens to be a pending tx (which means we needed to catch the Hiro api post route). 