### PR TITLE
fix: handle inscription type svg, ref #4727

### DIFF
--- a/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -40,6 +40,7 @@ export function Inscription({ rawInscription }: InscriptionProps) {
         />
       );
     case 'html':
+    case 'svg':
     case 'video':
       return (
         <CollectibleIframe

--- a/src/app/query/bitcoin/ordinals/inscription.hooks.ts
+++ b/src/app/query/bitcoin/ordinals/inscription.hooks.ts
@@ -11,7 +11,7 @@ export function createInscriptionInfoUrl(id: string) {
   return `https://ordinals.hiro.so/inscription/${id}`;
 }
 
-function createHtmlPreviewUrl(id: string) {
+function createIframePreviewUrl(id: string) {
   return `https://ordinals.com/preview/${id}`;
 }
 
@@ -20,14 +20,14 @@ export function convertInscriptionToSupportedInscriptionType(inscription: Inscri
   return whenInscriptionType<SupportedInscription>(inscription.content_type, {
     audio: () => ({
       infoUrl: createInscriptionInfoUrl(inscription.id),
-      src: createHtmlPreviewUrl(inscription.id),
+      src: createIframePreviewUrl(inscription.id),
       title,
       type: 'audio',
       ...inscription,
     }),
     html: () => ({
       infoUrl: createInscriptionInfoUrl(inscription.id),
-      src: createHtmlPreviewUrl(inscription.id),
+      src: createIframePreviewUrl(inscription.id),
       title,
       type: 'html',
       ...inscription,
@@ -39,6 +39,13 @@ export function convertInscriptionToSupportedInscriptionType(inscription: Inscri
       type: 'image',
       ...inscription,
     }),
+    svg: () => ({
+      infoUrl: createInscriptionInfoUrl(inscription.id),
+      src: createIframePreviewUrl(inscription.id),
+      title,
+      type: 'svg',
+      ...inscription,
+    }),
     text: () => ({
       contentSrc: `${HIRO_INSCRIPTIONS_API_URL}/${inscription.id}/content`,
       infoUrl: createInscriptionInfoUrl(inscription.id),
@@ -48,7 +55,7 @@ export function convertInscriptionToSupportedInscriptionType(inscription: Inscri
     }),
     video: () => ({
       infoUrl: createInscriptionInfoUrl(inscription.id),
-      src: createHtmlPreviewUrl(inscription.id),
+      src: createIframePreviewUrl(inscription.id),
       title,
       type: 'video',
       ...inscription,

--- a/src/shared/models/inscription.model.ts
+++ b/src/shared/models/inscription.model.ts
@@ -35,7 +35,15 @@ export interface Inscription extends InscriptionResponseItem {
  * appropriately and securely. Inscriptions of types not ready to be handled by the
  * app should be classified as "other".
  */
-const supportedInscriptionTypes = ['audio', 'html', 'image', 'text', 'video', 'other'] as const;
+const supportedInscriptionTypes = [
+  'audio',
+  'html',
+  'image',
+  'svg',
+  'text',
+  'video',
+  'other',
+] as const;
 
 type SupportedInscriptionType = (typeof supportedInscriptionTypes)[number];
 
@@ -64,6 +72,11 @@ interface ImageInscription extends BaseSupportedInscription {
   src: string;
 }
 
+interface SvgInscription extends BaseSupportedInscription {
+  type: 'svg';
+  src: string;
+}
+
 interface TextInscription extends BaseSupportedInscription {
   type: 'text';
   contentSrc: string;
@@ -87,6 +100,7 @@ export type SupportedInscription =
   | AudioInscription
   | HtmlInscription
   | ImageInscription
+  | SvgInscription
   | TextInscription
   | VideoInscription
   | OtherInscription;
@@ -105,6 +119,10 @@ export function whenInscriptionType<T>(
 
   if (mimeType.startsWith('image/') && branches.image) {
     return branches.image();
+  }
+
+  if (mimeType.startsWith('image/svg') && branches.svg) {
+    return branches.svg();
   }
 
   if (mimeType.startsWith('text') && branches.text) {


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7260076179), [Test report](https://leather-wallet.github.io/playwright-reports/fix/inscription-type-image-svg)<!-- Sticky Header Marker -->

It was reported in testing that type `image/svg` wasn't rendering (see issue). This adds an inscription type for `image/svg`.