### PR TITLE
fix issue with empty text display when creating a custom network without a name

### DIFF
--- a/src/app/components/network-mode-badge.tsx
+++ b/src/app/components/network-mode-badge.tsx
@@ -32,7 +32,7 @@ export const NetworkModeBadge = memo((props: FlexProps) => {
       {...props}
     >
       <styled.span color="accent.text-subdued" textStyle="label.03">
-        {name}
+        {!name ? chain.bitcoin.bitcoinNetwork : name}
       </styled.span>
     </Flex>
   );


### PR DESCRIPTION
Closes #4737

This PR addresses the issue where an empty text was displayed when creating a custom network without a name. The fix ensures that the user interface handles custom networks without names correctly. The network badge displays the provided network name if the user creates a custom test network with that name; otherwise, it displays the network that the user has chosen.