### PR TITLE
fix validate custom network name field on form submission

### DIFF
--- a/src/app/features/add-network/add-network.tsx
+++ b/src/app/features/add-network/add-network.tsx
@@ -110,6 +110,11 @@ export function AddNetwork() {
         onSubmit={async () => {
           const { name, stacksUrl, bitcoinUrl, key } = formikProps.values;
 
+          if (!name) {
+            setError('Enter a name');
+            return;
+          }
+
           if (!isValidUrl(stacksUrl)) {
             setError('Enter a valid Stacks API URL');
             return;


### PR DESCRIPTION
Closes #4737

This PR addresses and resolves the issue #4737, which focuses on enhancing the validation of the custom network name field in the form.