### PR TITLE
fix: home action btns hover state

### DIFF
--- a/theme/recipes/button-recipe.ts
+++ b/theme/recipes/button-recipe.ts
@@ -99,7 +99,7 @@ export const buttonRecipe = defineRecipe({
 
       // Ghost button
       ghost: {
-        _hover: { bg: 'brown.2' },
+        _hover: { bg: 'accent.component-background-hover' },
         _focus: { _before: { border: '2px solid', borderColor: 'blue.500' } },
         ...loadingStyles('brown.12'),
       },


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7552643780), [Test report](https://leather-wallet.github.io/playwright-reports/fix/home-action-btns)<!-- Sticky Header Marker -->

Pr to fix home action btns hover state, @mica000 wonder if colour is right here?
![Screenshot 2023-12-25 at 12 07 40](https://github.com/leather-wallet/extension/assets/46521087/33f0f0ab-bdda-4aa9-9541-34abbb247cff)
