### PR TITLE
fix: asset list ui bug, ref #4603

### DIFF
--- a/src/app/features/asset-list/components/stacks-fungible-token-asset-list.tsx
+++ b/src/app/features/asset-list/components/stacks-fungible-token-asset-list.tsx
@@ -8,6 +8,7 @@ interface StacksFungibleTokenAssetListProps {
   assetBalances: StacksFungibleTokenAssetBalance[];
 }
 export function StacksFungibleTokenAssetList({ assetBalances }: StacksFungibleTokenAssetListProps) {
+  if (assetBalances.length === 0) return null;
   return (
     <Stack gap="space.05">
       {assetBalances.map(assetBalance => (


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7328467012), [Test report](https://leather-wallet.github.io/playwright-reports/fix/assets-ui-bug)<!-- Sticky Header Marker -->

Fixes problem with double padding