### PR TITLE
fix: swap broadcasts, ref #4750

### DIFF
--- a/src/app/pages/swap/alex-swap-container.tsx
+++ b/src/app/pages/swap/alex-swap-container.tsx
@@ -19,7 +19,6 @@ import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
 import { useWalletType } from '@app/common/use-wallet-type';
 import { NonceSetter } from '@app/components/nonce-setter';
 import { defaultFeesMinValues } from '@app/query/stacks/fees/fees.hooks';
-import { useStacksPendingTransactions } from '@app/query/stacks/mempool/mempool.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useGenerateStacksContractCallUnsignedTx } from '@app/store/transactions/contract-call.hooks';
 import { useSignStacksTransaction } from '@app/store/transactions/transaction.hooks';
@@ -43,12 +42,13 @@ function AlexSwapContainer() {
   const currentAccount = useCurrentStacksAccount();
   const generateUnsignedTx = useGenerateStacksContractCallUnsignedTx();
   const signTx = useSignStacksTransaction();
-  const { transactions: pendingTransactions } = useStacksPendingTransactions();
   const { whenWallet } = useWalletType();
 
+  // Setting software to false until we revisit:
+  // https://github.com/leather-wallet/extension/issues/4750
   const isSponsoredByAlex = whenWallet({
     ledger: false,
-    software: !pendingTransactions.length,
+    software: false,
   });
 
   const {

--- a/src/app/pages/swap/components/swap-assets-pair/swap-assets-pair.tsx
+++ b/src/app/pages/swap/components/swap-assets-pair/swap-assets-pair.tsx
@@ -25,7 +25,7 @@ export function SwapAssetsPair() {
         <SwapAssetItemLayout
           caption="You will swap"
           icon={swapAssetFrom.icon}
-          symbol={swapAssetFrom.balance.symbol}
+          symbol={swapAssetFrom.name}
           value={swapAmountFrom}
         />
       }
@@ -33,7 +33,7 @@ export function SwapAssetsPair() {
         <SwapAssetItemLayout
           caption="You will receive"
           icon={swapAssetTo.icon}
-          symbol={swapAssetTo.balance.symbol}
+          symbol={swapAssetTo.name}
           value={swapAmountTo}
         />
       }

--- a/tests/specs/swap/swap.spec.ts
+++ b/tests/specs/swap/swap.spec.ts
@@ -1,6 +1,5 @@
 import { test } from '../../fixtures/fixtures';
 
-const alexSdkPostRoute = 'https://*.alexlab.co/v1/graphql';
 const hiroApiPostRoute = '*/**/v2/transactions';
 
 test.describe('Swaps', () => {
@@ -36,20 +35,11 @@ test.describe('Swaps', () => {
   });
 
   test('that the swap is broadcast', async ({ swapPage }) => {
-    let requestPromise;
-    const isSponsoredSwap = swapPage.page.getByText('Sponsored');
+    const requestPromise = swapPage.page.waitForRequest(hiroApiPostRoute);
 
-    if (isSponsoredSwap) {
-      requestPromise = swapPage.page.waitForRequest(alexSdkPostRoute);
-      await swapPage.page.route(alexSdkPostRoute, async route => {
-        await route.abort();
-      });
-    } else {
-      requestPromise = swapPage.page.waitForRequest(hiroApiPostRoute);
-      await swapPage.page.route(alexSdkPostRoute, async route => {
-        await route.abort();
-      });
-    }
+    await swapPage.page.route(hiroApiPostRoute, async route => {
+      await route.abort();
+    });
 
     await swapPage.inputSwapAmountFrom();
     await swapPage.selectAssetToReceive();


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7449245017), [Test report](https://leather-wallet.github.io/playwright-reports/fix/sponsored-swaps)<!-- Sticky Header Marker -->

This temp fix will broadcast all swaps from the wallet, rather than using sponsored Alex broadcasts while they do some work on their end. See linked issue.