### PR TITLE
chore: add improved sentry perf tracking

### DIFF
--- a/src/shared/utils/analytics.ts
+++ b/src/shared/utils/analytics.ts
@@ -1,3 +1,11 @@
+import React from 'react';
+import {
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom';
+
 import { ripemd160 } from '@noble/hashes/ripemd160';
 import { sha256 } from '@noble/hashes/sha256';
 import { base58 } from '@scure/base';
@@ -59,6 +67,13 @@ export function initSentry() {
         startTransactionOnLocationChange: false,
         startTransactionOnPageLoad: false,
         markBackgroundTransactions: false,
+        routingInstrumentation: Sentry.reactRouterV6Instrumentation(
+          React.useEffect,
+          useLocation,
+          useNavigationType,
+          createRoutesFromChildren,
+          matchRoutes
+        ),
       }),
       new Sentry.Feedback({
         colorScheme: 'system',


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7504659835), [Test report](https://leather-wallet.github.io/playwright-reports/fix/add-sentry-performance)<!-- Sticky Header Marker -->

I _think_ this will enable performance metrics in Sentry, but will need to push live before I can tell.