### PR TITLE
fix: add remote config to recover feature

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -88,5 +88,6 @@
     "integrationEnabled": true,
     "mainnetApiUrl": "https://api2.ordinalsbot.com",
     "signetApiUrl": "https://signet.ordinalsbot.com"
-  }
+  },
+  "recoverUninscribedTaprootUtxosFeatureEnabled": false
 }

--- a/config/wallet-config.schema.json
+++ b/config/wallet-config.schema.json
@@ -137,6 +137,10 @@
         "mainnetApiUrl": { "type": "string" },
         "signetApiUrl": { "type": "string" }
       }
+    },
+    "recoverUninscribedTaprootUtxosFeatureEnabled": {
+      "type": "boolean",
+      "description": "Determines whether or not the recover uninscribed taproot utxos feature is enabled"
     }
   },
   "$defs": {

--- a/src/app/debug.ts
+++ b/src/app/debug.ts
@@ -5,6 +5,7 @@ import * as reduxPersist from 'redux-persist';
 import { getLogsFromBrowserStorage } from '@shared/logger-storage';
 import { persistConfig } from '@shared/storage/redux-pesist';
 
+import { queryClient } from './common/persistence';
 import { store } from './store';
 import { stxChainSlice } from './store/chains/stx-chain.slice';
 import { settingsSlice } from './store/settings/settings.slice';
@@ -34,8 +35,11 @@ const debug = {
   resetMessages() {
     store.dispatch(settingsSlice.actions.resetMessages());
   },
-  resetHasApprovedNewBrand() {
-    store.dispatch(settingsSlice.actions.resetHasApprovedNewBrand());
+  clearReactQueryCache() {
+    queryClient.clear();
+  },
+  clearChromeStorage() {
+    chrome.storage.local.clear();
   },
 };
 

--- a/src/app/features/collectibles/components/taproot-balance-displayer.tsx
+++ b/src/app/features/collectibles/components/taproot-balance-displayer.tsx
@@ -1,6 +1,7 @@
 import { formatMoney } from '@app/common/money/format-money';
 import { Tooltip } from '@app/components/tooltip';
 import { useCurrentTaprootAccountBalance } from '@app/query/bitcoin/balance/btc-taproot-balance.hooks';
+import { useRecoverUninscribedTaprootUtxosFeatureEnabled } from '@app/query/common/remote-config/remote-config.query';
 import { LeatherButton } from '@app/ui/components/button';
 
 const taprootSpendNotSupportedYetMsg = `
@@ -13,6 +14,8 @@ interface TaprootBalanceDisplayerProps {
 }
 export function TaprootBalanceDisplayer({ onSelectRetrieveBalance }: TaprootBalanceDisplayerProps) {
   const balance = useCurrentTaprootAccountBalance();
+  const isRecoverFeatureEnabled = useRecoverUninscribedTaprootUtxosFeatureEnabled();
+  if (!isRecoverFeatureEnabled) return null;
   if (balance.amount.isLessThanOrEqualTo(0)) return null;
   return (
     <Tooltip label={taprootSpendNotSupportedYetMsg}>

--- a/src/app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit.tsx
@@ -66,9 +66,7 @@ export function RetrieveTaprootToNativeSegwit() {
               key={utxo.txid}
               title={`Uninscribed UTXO #${i}`}
               value={
-                <ExternalLink
-                  href={`https://ordinals-explorer.generative.xyz/output/${utxo.txid}:${utxo.vout}`}
-                >
+                <ExternalLink href={`https://ordinals.com/output/${utxo.txid}:${utxo.vout}`}>
                   {`${truncateMiddle(utxo.txid, 4)}:${utxo.vout}`} ↗
                 </ExternalLink>
               }

--- a/src/app/query/bitcoin/address/utxos-by-address.query.ts
+++ b/src/app/query/bitcoin/address/utxos-by-address.query.ts
@@ -31,7 +31,7 @@ export function useGetUtxosByAddressQuery<T extends unknown = UtxoResponseItem[]
   });
 }
 
-const stopSearchAfterNumberAddressesWithoutOrdinals = 20;
+const stopSearchAfterNumberAddressesWithoutUtxos = 20;
 
 /**
  * Returns all utxos for the user's current taproot account. The search for
@@ -48,12 +48,10 @@ export function useTaprootAccountUtxosQuery() {
   return useQuery(
     [QueryPrefixes.TaprootAddressUtxos, currentAccountIndex, network.id],
     async () => {
-      let currentNumberOfAddressesWithoutOrdinals = 0;
+      let currentNumberOfAddressesWithoutUtxos = 0;
       const addressIndexCounter = createCounter(0);
       let foundUnspentTransactions: TaprootUtxo[] = [];
-      while (
-        currentNumberOfAddressesWithoutOrdinals < stopSearchAfterNumberAddressesWithoutOrdinals
-      ) {
+      while (currentNumberOfAddressesWithoutUtxos < stopSearchAfterNumberAddressesWithoutUtxos) {
         const address = getTaprootAddress({
           index: addressIndexCounter.getValue(),
           keychain: account?.keychain,
@@ -63,7 +61,7 @@ export function useTaprootAccountUtxosQuery() {
         const unspentTransactions = await client.addressApi.getUtxosByAddress(address);
 
         if (!hasInscriptions(unspentTransactions)) {
-          currentNumberOfAddressesWithoutOrdinals += 1;
+          currentNumberOfAddressesWithoutUtxos += 1;
           addressIndexCounter.increment();
           continue;
         }
@@ -77,7 +75,7 @@ export function useTaprootAccountUtxosQuery() {
           ...foundUnspentTransactions,
         ];
 
-        currentNumberOfAddressesWithoutOrdinals = 0;
+        currentNumberOfAddressesWithoutUtxos = 0;
         addressIndexCounter.increment();
       }
       return foundUnspentTransactions;

--- a/src/app/query/bitcoin/balance/btc-taproot-balance.hooks.ts
+++ b/src/app/query/bitcoin/balance/btc-taproot-balance.hooks.ts
@@ -11,6 +11,7 @@ import { useGetInscriptionsInfiniteQuery } from '../ordinals/inscriptions.query'
 
 export function useCurrentTaprootAccountUninscribedUtxos() {
   const { data: utxos = [] } = useTaprootAccountUtxosQuery();
+
   const query = useGetInscriptionsInfiniteQuery();
 
   return useMemo(() => {

--- a/src/app/query/common/remote-config/remote-config.query.ts
+++ b/src/app/query/common/remote-config/remote-config.query.ts
@@ -128,6 +128,11 @@ export function useConfigBitcoinSendEnabled() {
   });
 }
 
+export function useRecoverUninscribedTaprootUtxosFeatureEnabled() {
+  const config = useRemoteConfig();
+  return get(config, 'recoverUninscribedTaprootUtxosFeatureEnabled', false);
+}
+
 export function useConfigFeeEstimationsMaxEnabled() {
   const config = useRemoteConfig();
   if (isUndefined(config) || isUndefined(config?.feeEstimationsMinMax)) return;


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7532744054), [Test report](https://leather-wallet.github.io/playwright-reports/fix/temp-disbable-recover-feature)<!-- Sticky Header Marker -->

This PR adds the ability to remote disable the ability for users to recover uninscribed funds from their taproot accounts. May be necessary if our API providers go down, for example.