### PR TITLE
refactor: rename taproot utxo

### DIFF
--- a/src/app/features/retrieve-taproot-to-native-segwit/use-generate-retrieve-taproot-funds-tx.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/use-generate-retrieve-taproot-funds-tx.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import * as btc from '@scure/btc-signer';
 
+import { extractAddressIndexFromPath } from '@shared/crypto/bitcoin/bitcoin.utils';
 import { Money, createMoney } from '@shared/models/money.model';
 
 import { sumNumbers } from '@app/common/math/helpers';
@@ -35,7 +36,8 @@ export function useGenerateRetrieveTaprootFundsTx() {
       const totalAmount = sumNumbers(uninscribedUtxos.map(utxo => utxo.value));
 
       uninscribedUtxos.forEach(utxo => {
-        const signer = createSigner?.(utxo.addressIndex);
+        const addressIndex = extractAddressIndexFromPath(utxo.derivationPath);
+        const signer = createSigner?.(addressIndex);
         if (!signer) return;
 
         tx.addInput({
@@ -61,7 +63,10 @@ export function useGenerateRetrieveTaprootFundsTx() {
 
       tx.addOutputAddress(recipient, paymentAmount, networkMode);
 
-      uninscribedUtxos.forEach(utxo => createSigner?.(utxo.addressIndex).sign(tx));
+      uninscribedUtxos.forEach(utxo => {
+        const addressIndex = extractAddressIndexFromPath(utxo.derivationPath);
+        return createSigner?.(addressIndex).sign(tx);
+      });
 
       tx.finalize();
       return tx.hex;

--- a/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.ts
+++ b/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.ts
@@ -4,7 +4,7 @@ import { isDefined } from '@shared/utils';
 import { sumNumbers } from '@app/common/math/helpers';
 import { BtcSizeFeeEstimator } from '@app/common/transactions/bitcoin/fees/btc-size-fee-estimator';
 import { createCounter } from '@app/common/utils/counter';
-import { TaprootUtxo, UtxoResponseItem } from '@app/query/bitcoin/bitcoin-client';
+import { UtxoResponseItem, UtxoWithDerivationPath } from '@app/query/bitcoin/bitcoin-client';
 
 const idealInscriptionValue = 10_000;
 
@@ -22,7 +22,7 @@ interface SelectInscriptionCoinFailure {
 type SelectInscriptionCoinResult = SelectInscriptionCoinSuccess | SelectInscriptionCoinFailure;
 
 interface SelectInscriptionTransferCoinsArgs {
-  inscriptionInput: TaprootUtxo;
+  inscriptionInput: UtxoWithDerivationPath;
   nativeSegwitUtxos: UtxoResponseItem[];
   feeRate: number;
   recipient: string;

--- a/src/app/pages/send/ordinal-inscription/components/create-utxo-from-inscription.ts
+++ b/src/app/pages/send/ordinal-inscription/components/create-utxo-from-inscription.ts
@@ -1,8 +1,20 @@
+import { BitcoinNetworkModes } from '@shared/constants';
+import { getNativeSegwitAddressIndexDerivationPath } from '@shared/crypto/bitcoin/p2wpkh-address-gen';
 import { Inscription } from '@shared/models/inscription.model';
 
-import { TaprootUtxo } from '@app/query/bitcoin/bitcoin-client';
+import { UtxoWithDerivationPath } from '@app/query/bitcoin/bitcoin-client';
 
-export function createUtxoFromInscription(inscription: Inscription): TaprootUtxo {
+interface CreateUtxoFromInscriptionArgs {
+  inscription: Inscription;
+  network: BitcoinNetworkModes;
+  accountIndex: number;
+}
+
+export function createUtxoFromInscription({
+  inscription,
+  network,
+  accountIndex,
+}: CreateUtxoFromInscriptionArgs): UtxoWithDerivationPath {
   const { genesis_block_hash, genesis_timestamp, genesis_block_height, value, addressIndex } =
     inscription;
 
@@ -16,6 +28,6 @@ export function createUtxoFromInscription(inscription: Inscription): TaprootUtxo
       block_time: genesis_timestamp,
     },
     value: Number(value),
-    addressIndex,
+    derivationPath: getNativeSegwitAddressIndexDerivationPath(network, accountIndex, addressIndex),
   };
 }

--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-fees-list.ts
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-fees-list.ts
@@ -7,7 +7,7 @@ import { baseCurrencyAmountInQuote } from '@app/common/money/calculate-money';
 import { formatMoneyPadded, i18nFormatCurrency } from '@app/common/money/format-money';
 import { FeesListItem } from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by-address.hooks';
-import { TaprootUtxo } from '@app/query/bitcoin/bitcoin-client';
+import { UtxoWithDerivationPath } from '@app/query/bitcoin/bitcoin-client';
 import { useAverageBitcoinFeeRates } from '@app/query/bitcoin/fees/fee-estimates.hooks';
 import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
 import { useCurrentAccountNativeSegwitSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
@@ -16,7 +16,7 @@ import { selectInscriptionTransferCoins } from '../coinselect/select-inscription
 
 interface UseSendInscriptionFeesListArgs {
   recipient: string;
-  utxo: TaprootUtxo;
+  utxo: UtxoWithDerivationPath;
 }
 export function useSendInscriptionFeesList({ recipient, utxo }: UseSendInscriptionFeesListArgs) {
   const createNativeSegwitSigner = useCurrentAccountNativeSegwitSigner();

--- a/src/app/query/bitcoin/address/utxos-by-address.hooks.ts
+++ b/src/app/query/bitcoin/address/utxos-by-address.hooks.ts
@@ -4,14 +4,14 @@ import { InscriptionResponseItem } from '@shared/models/inscription.model';
 
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
-import { TaprootUtxo, UtxoResponseItem } from '../bitcoin-client';
+import { UtxoResponseItem, UtxoWithDerivationPath } from '../bitcoin-client';
 import { useInscriptionsByAddressQuery } from '../ordinals/inscriptions.query';
 import { useBitcoinPendingTransactionsInputs } from './transactions-by-address.hooks';
 import { useGetUtxosByAddressQuery } from './utxos-by-address.query';
 
 export function filterUtxosWithInscriptions(
   inscriptions: InscriptionResponseItem[],
-  utxos: TaprootUtxo[] | UtxoResponseItem[]
+  utxos: UtxoWithDerivationPath[] | UtxoResponseItem[]
 ) {
   return utxos.filter(
     utxo =>

--- a/src/app/query/bitcoin/balance/btc-taproot-balance.hooks.ts
+++ b/src/app/query/bitcoin/balance/btc-taproot-balance.hooks.ts
@@ -6,7 +6,7 @@ import { sumNumbers } from '@app/common/math/helpers';
 
 import { filterUtxosWithInscriptions } from '../address/utxos-by-address.hooks';
 import { useTaprootAccountUtxosQuery } from '../address/utxos-by-address.query';
-import { TaprootUtxo } from '../bitcoin-client';
+import { UtxoWithDerivationPath } from '../bitcoin-client';
 import { useGetInscriptionsInfiniteQuery } from '../ordinals/inscriptions.query';
 
 export function useCurrentTaprootAccountUninscribedUtxos() {
@@ -19,7 +19,7 @@ export function useCurrentTaprootAccountUninscribedUtxos() {
     return filterUtxosWithInscriptions(
       inscriptions,
       utxos.filter(utxo => utxo.status.confirmed)
-    ) as TaprootUtxo[];
+    ) as UtxoWithDerivationPath[];
   }, [query.data?.pages, utxos]);
 }
 

--- a/src/app/query/bitcoin/bitcoin-client.ts
+++ b/src/app/query/bitcoin/bitcoin-client.ts
@@ -16,8 +16,8 @@ export interface UtxoResponseItem {
   value: number;
 }
 
-export interface TaprootUtxo extends UtxoResponseItem {
-  addressIndex: number;
+export interface UtxoWithDerivationPath extends UtxoResponseItem {
+  derivationPath: string;
 }
 
 class AddressApi {


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7621894730), [Test report](https://leather-wallet.github.io/playwright-reports/refactor/rename-taproot)<!-- Sticky Header Marker -->

`TaprootUtxo` is wrong naming here, since we use it for both ns utxos and taproot utxos, also added derivation path to the interface as it is in `BitcoinInputSigningConfig`