### PR TITLE
fix: update psbt warning copy

### DIFF
--- a/src/app/features/psbt-signer/components/psbt-request-sighash-warning-label.tsx
+++ b/src/app/features/psbt-signer/components/psbt-request-sighash-warning-label.tsx
@@ -1,11 +1,13 @@
 import { WarningLabel } from '@app/components/warning-label';
 
-export function PsbtRequestSighashWarningLabel() {
+interface PsbtRequestSighashWarningLabelProps {
+  origin: string;
+}
+export function PsbtRequestSighashWarningLabel({ origin }: PsbtRequestSighashWarningLabelProps) {
   return (
     <WarningLabel title="Be careful with this transaction" width="100%">
-      The details you see here are not guaranteed. Be sure to fully trust your counterparty, who can
-      later modify this transaction to send or receive other assets from your account, and possibly
-      even drain it.
+      The details of this transaction are not guaranteed and could be modified later. Continue only
+      if you trust {origin}
     </WarningLabel>
   );
 }

--- a/src/app/features/psbt-signer/psbt-signer.tsx
+++ b/src/app/features/psbt-signer/psbt-signer.tsx
@@ -98,7 +98,7 @@ export function PsbtSigner(props: PsbtSignerProps) {
       <PsbtSignerLayout>
         <PsbtRequestHeader name={name} origin={origin} />
         <PsbtRequestDetailsLayout>
-          {isPsbtMutable ? <PsbtRequestSighashWarningLabel /> : null}
+          {isPsbtMutable ? <PsbtRequestSighashWarningLabel origin={origin} /> : null}
           <PsbtRequestDetailsHeader />
           <PsbtInputsOutputsTotals />
           <PsbtInputsAndOutputs />


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7625943717), [Test report](https://leather-wallet.github.io/playwright-reports/fix/psbt-copy)<!-- Sticky Header Marker -->

Tones down the copy a little in PSBT signing flow. 