### PR TITLE
fix(tooltip): lower delay, don't force button

### DIFF
--- a/src/app/common/theme-provider.tsx
+++ b/src/app/common/theme-provider.tsx
@@ -82,7 +82,7 @@ export function ThemeSwitcherProvider({ children }: ThemeSwitcherProviderProps) 
   return (
     <ThemeContext.Provider value={{ theme, userSelectedTheme, setUserSelectedTheme }}>
       <RadixTheme appearance={theme}>
-        <RadixTooltip.Provider>{children}</RadixTooltip.Provider>
+        <RadixTooltip.Provider delayDuration={300}>{children}</RadixTooltip.Provider>
       </RadixTheme>
     </ThemeContext.Provider>
   );

--- a/src/app/ui/components/tooltip/basic-tooltip.tsx
+++ b/src/app/ui/components/tooltip/basic-tooltip.tsx
@@ -15,7 +15,7 @@ export function BasicTooltip({ children, label, disabled, side }: BasicTooltipPr
   const isDisabled = !label || disabled;
   return (
     <Tooltip.Root>
-      <Tooltip.Trigger>{children}</Tooltip.Trigger>
+      <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
       <Tooltip.Portal>
         <Tooltip.Content hidden={isDisabled} side={side} sideOffset={5}>
           {label}


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7644740661), [Test report](https://leather-wallet.github.io/playwright-reports/fix/tooltip-isues)<!-- Sticky Header Marker -->

Noticed an issue with tooltip where non-interactive elements became buttons, and so had a focus state. Using `asChild` prop removes this. Additionally, I've lowered the delay, the default of 700ms is too slow for our use cases imo.

@pete-watters per comments on needing an issue. Not sure how tiny changes should fit into the flow? In this instance, it's just so much quicker to just make a PR.