### PR TITLE
fix: sign out of the wallet before proceeding with ledger sign in

### DIFF
--- a/src/app/pages/onboarding/welcome/welcome.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.tsx
@@ -67,15 +67,22 @@ export function WelcomePage() {
 
   const restoreWallet = pageModeRoutingAction(RouteUrls.SignIn);
 
+  const onSelectConnectLedger = useCallback(async () => {
+    await keyActions.signOut();
+    if (doesBrowserSupportWebUsbApi()) {
+      supportsWebUsbAction();
+    } else {
+      doesNotSupportWebUsbAction();
+    }
+  }, [doesNotSupportWebUsbAction, keyActions, supportsWebUsbAction]);
+
   return (
     <>
       <WelcomeLayout
         tagline="Bitcoin for the rest of us"
         subheader="Leather is the only Bitcoin wallet you need to tap into the emerging Bitcoin economy"
         isGeneratingWallet={isGeneratingWallet}
-        onSelectConnectLedger={() =>
-          doesBrowserSupportWebUsbApi() ? supportsWebUsbAction() : doesNotSupportWebUsbAction()
-        }
+        onSelectConnectLedger={onSelectConnectLedger}
         onStartOnboarding={() => startOnboarding()}
         onRestoreWallet={() => restoreWallet()}
       />


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7670199092), [Test report](https://leather-wallet.github.io/playwright-reports/fix/p1-secret-keys-fix)<!-- Sticky Header Marker -->

Fixes #4868

We should run sign out before proceeding with ledger sign in.

Test:


https://github.com/leather-wallet/extension/assets/22010816/39db5cd2-a447-4e46-bd06-e165ebb2cf01

