### PR TITLE
Fix: ledger no request keys context

### DIFF
--- a/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
@@ -1,35 +1,34 @@
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
-import { Outlet, Route, useLocation } from 'react-router-dom';
+import { Route, useLocation } from 'react-router-dom';
 
 import * as btc from '@scure/btc-signer';
 import { hexToBytes } from '@stacks/common';
+import BitcoinApp from 'ledger-bitcoin';
 import get from 'lodash.get';
 
 import { BitcoinInputSigningConfig } from '@shared/crypto/bitcoin/signer-config';
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
-import { isError } from '@shared/utils';
 
-import { useLocationState, useLocationStateWithCache } from '@app/common/hooks/use-location-state';
+import { useLocationStateWithCache } from '@app/common/hooks/use-location-state';
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 import { appEvents } from '@app/common/publish-subscribe';
 import { delay } from '@app/common/utils';
-import { BaseDrawer } from '@app/components/drawer/base-drawer';
+import { ApproveSignLedgerBitcoinTx } from '@app/features/ledger/flows/bitcoin-tx-signing/steps/approve-bitcoin-sign-ledger-tx';
+import { ledgerSignTxRoutes } from '@app/features/ledger/generic-flows/tx-signing/ledger-sign-tx-route-generator';
+import { LedgerTxSigningContext } from '@app/features/ledger/generic-flows/tx-signing/ledger-sign-tx.context';
+import { TxSigningFlow } from '@app/features/ledger/generic-flows/tx-signing/tx-signing-flow';
+import { useLedgerSignTx } from '@app/features/ledger/generic-flows/tx-signing/use-ledger-sign-tx';
+import { useLedgerAnalytics } from '@app/features/ledger/hooks/use-ledger-analytics.hook';
+import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
 import {
-  LedgerTxSigningContext,
-  LedgerTxSigningProvider,
-} from '@app/features/ledger/generic-flows/tx-signing/ledger-sign-tx.context';
-import { useActionCancellableByUser } from '@app/features/ledger/utils/stacks-ledger-utils';
+  connectLedgerBitcoinApp,
+  getBitcoinAppVersion,
+  isBitcoinAppOpen,
+} from '@app/features/ledger/utils/bitcoin-ledger-utils';
 import { useSignLedgerBitcoinTx } from '@app/store/accounts/blockchain/bitcoin/bitcoin.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
-
-import { ledgerSignTxRoutes } from '../../generic-flows/tx-signing/ledger-sign-tx-route-generator';
-import { useLedgerAnalytics } from '../../hooks/use-ledger-analytics.hook';
-import { useLedgerNavigate } from '../../hooks/use-ledger-navigate';
-import { connectLedgerBitcoinApp, getBitcoinAppVersion } from '../../utils/bitcoin-ledger-utils';
-import { checkLockedDeviceError, useLedgerResponseState } from '../../utils/generic-ledger-utils';
-import { ApproveSignLedgerBitcoinTx } from './steps/approve-bitcoin-sign-ledger-tx';
 
 export const ledgerBitcoinTxSigningRoutes = ledgerSignTxRoutes({
   component: <LedgerSignBitcoinTxContainer />,
@@ -44,15 +43,12 @@ function LedgerSignBitcoinTxContainer() {
   const ledgerAnalytics = useLedgerAnalytics();
   useScrollLock(true);
 
-  const canUserCancelAction = useActionCancellableByUser();
   const [unsignedTransactionRaw, setUnsignedTransactionRaw] = useState<null | string>(null);
   const [unsignedTransaction, setUnsignedTransaction] = useState<null | btc.Transaction>(null);
   const signLedger = useSignLedgerBitcoinTx();
   const network = useCurrentNetwork();
 
   const inputsToSign = useLocationStateWithCache<BitcoinInputSigningConfig[]>('inputsToSign');
-
-  const allowUserToGoBack = useLocationState<boolean>('goBack');
 
   useEffect(() => {
     const tx = get(location.state, 'tx');
@@ -64,67 +60,51 @@ function LedgerSignBitcoinTxContainer() {
 
   useEffect(() => () => setUnsignedTransaction(null), []);
 
-  const [latestDeviceResponse, setLatestDeviceResponse] = useLedgerResponseState();
+  const chain = 'bitcoin' as const;
 
-  const [awaitingDeviceConnection, setAwaitingDeviceConnection] = useState(false);
+  const { signTransaction, latestDeviceResponse, awaitingDeviceConnection } =
+    useLedgerSignTx<BitcoinApp>({
+      chain,
+      isAppOpen: isBitcoinAppOpen({ network: network.chain.bitcoin.bitcoinNetwork }),
+      getAppVersion: getBitcoinAppVersion,
+      connectApp: connectLedgerBitcoinApp(network.chain.bitcoin.bitcoinNetwork),
+      async signTransactionWithDevice(bitcoinApp) {
+        if (!inputsToSign) {
+          ledgerNavigate.cancelLedgerAction();
+          toast.error('No input signing config defined');
+          return;
+        }
 
-  if (!inputsToSign) {
-    ledgerNavigate.cancelLedgerAction();
-    toast.error('No input signing config defined');
-    return null;
-  }
+        ledgerNavigate.toDeviceBusyStep('Verifying public key on Ledger…');
 
-  const signTransaction = async () => {
-    setAwaitingDeviceConnection(true);
-
-    try {
-      const bitcoinApp = await connectLedgerBitcoinApp(network.chain.bitcoin.bitcoinNetwork)();
-
-      try {
-        const versionInfo = await getBitcoinAppVersion(bitcoinApp);
-        ledgerAnalytics.trackDeviceVersionInfo(versionInfo);
-        setAwaitingDeviceConnection(false);
-        setLatestDeviceResponse(versionInfo as any);
-      } catch (e) {
-        setLatestDeviceResponse(e as any);
-        logger.error('Unable to get Ledger app version info', e);
-      }
-
-      ledgerNavigate.toDeviceBusyStep('Verifying public key on Ledger…');
-
-      ledgerNavigate.toConnectionSuccessStep('bitcoin');
-      await delay(1200);
-      if (!unsignedTransaction) throw new Error('No unsigned tx');
-
-      ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: false });
-
-      try {
-        const btcTx = await signLedger(bitcoinApp, unsignedTransaction.toPSBT(), inputsToSign);
-
-        if (!btcTx || !unsignedTransactionRaw) throw new Error('No tx returned');
-        ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: true });
+        ledgerNavigate.toConnectionSuccessStep('bitcoin');
         await delay(1200);
-        appEvents.publish('ledgerBitcoinTxSigned', {
-          signedPsbt: btcTx,
-          unsignedPsbt: unsignedTransactionRaw,
-        });
-      } catch (e) {
-        logger.error('Unable to sign tx with ledger', e);
-        ledgerAnalytics.transactionSignedOnLedgerRejected();
-        ledgerNavigate.toOperationRejectedStep();
-      } finally {
-        void bitcoinApp.transport.close();
-      }
-    } catch (e) {
-      if (isError(e) && checkLockedDeviceError(e)) {
-        setLatestDeviceResponse({ deviceLocked: true } as any);
-        return;
-      }
-    }
-  };
+        if (!unsignedTransaction) throw new Error('No unsigned tx');
+
+        ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: false });
+
+        try {
+          const btcTx = await signLedger(bitcoinApp, unsignedTransaction.toPSBT(), inputsToSign);
+
+          if (!btcTx || !unsignedTransactionRaw) throw new Error('No tx returned');
+          ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: true });
+          await delay(1200);
+          appEvents.publish('ledgerBitcoinTxSigned', {
+            signedPsbt: btcTx,
+            unsignedPsbt: unsignedTransactionRaw,
+          });
+        } catch (e) {
+          logger.error('Unable to sign tx with ledger', e);
+          ledgerAnalytics.transactionSignedOnLedgerRejected();
+          ledgerNavigate.toOperationRejectedStep();
+        } finally {
+          void bitcoinApp.transport.close();
+        }
+      },
+    });
 
   const ledgerContextValue: LedgerTxSigningContext = {
-    chain: 'bitcoin',
+    chain,
     transaction: unsignedTransaction,
     signTransaction,
     latestDeviceResponse,
@@ -132,17 +112,10 @@ function LedgerSignBitcoinTxContainer() {
   };
 
   return (
-    <LedgerTxSigningProvider value={ledgerContextValue}>
-      <BaseDrawer
-        enableGoBack={allowUserToGoBack}
-        isShowing
-        isWaitingOnPerformedAction={awaitingDeviceConnection || canUserCancelAction}
-        onClose={ledgerNavigate.cancelLedgerAction}
-        pauseOnClickOutside
-        waitingOnPerformedActionMessage="Ledger device in use"
-      >
-        <Outlet />
-      </BaseDrawer>
-    </LedgerTxSigningProvider>
+    <TxSigningFlow
+      context={ledgerContextValue}
+      awaitingDeviceConnection={awaitingDeviceConnection}
+      closeAction={ledgerNavigate.cancelLedgerAction}
+    />
   );
 }

--- a/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
+++ b/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
@@ -64,6 +64,8 @@ export function LedgerSignJwtContainer() {
   const [jwtPayloadHash, setJwtPayloadHash] = useState<null | string>(null);
   const { origin, tabId } = useDefaultRequestParams();
 
+  const chain = 'stacks';
+
   const signJwtPayload = async () => {
     if (!origin) throw new Error('Cannot sign payload for unknown origin');
 
@@ -97,7 +99,7 @@ export function LedgerSignJwtContainer() {
           setLatestDeviceResponse({ deviceLocked: true } as any);
           return;
         }
-        ledgerNavigate.toErrorStep();
+        ledgerNavigate.toErrorStep(chain);
       },
     });
 

--- a/src/app/features/ledger/flows/request-stacks-keys/ledger-request-stacks-keys.tsx
+++ b/src/app/features/ledger/flows/request-stacks-keys/ledger-request-stacks-keys.tsx
@@ -2,22 +2,23 @@ import toast from 'react-hot-toast';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
+import StacksApp from '@zondax/ledger-stacks';
+import { pullStacksKeysFromLedgerDevice } from 'app/features/ledger/flows/request-stacks-keys/request-stacks-keys.utils';
+
 import { defaultWalletKeyId } from '@shared/utils';
 
+import { ledgerRequestKeysRoutes } from '@app/features/ledger/generic-flows/request-keys/ledger-request-keys-route-generator';
 import { LedgerRequestKeysContext } from '@app/features/ledger/generic-flows/request-keys/ledger-request-keys.context';
+import { RequestKeysFlow } from '@app/features/ledger/generic-flows/request-keys/request-keys-flow';
+import { useRequestLedgerKeys } from '@app/features/ledger/generic-flows/request-keys/use-request-ledger-keys';
 import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
 import {
   connectLedgerStacksApp,
   getStacksAppVersion,
-  isStacksLedgerAppClosed,
+  isStacksAppOpen,
   useActionCancellableByUser,
 } from '@app/features/ledger/utils/stacks-ledger-utils';
 import { stacksKeysSlice } from '@app/store/ledger/stacks/stacks-key.slice';
-
-import { ledgerRequestKeysRoutes } from '../../generic-flows/request-keys/ledger-request-keys-route-generator';
-import { RequestKeysFlow } from '../../generic-flows/request-keys/request-keys-flow';
-import { useRequestLedgerKeys } from '../../generic-flows/request-keys/use-request-ledger-keys';
-import { pullStacksKeysFromLedgerDevice } from './request-stacks-keys.utils';
 
 function LedgerRequestStacksKeys() {
   const navigate = useNavigate();
@@ -26,14 +27,14 @@ function LedgerRequestStacksKeys() {
 
   const dispatch = useDispatch();
 
+  const chain = 'stacks';
+
   const { requestKeys, latestDeviceResponse, awaitingDeviceConnection, outdatedAppVersionWarning } =
-    useRequestLedgerKeys({
-      chain: 'stacks',
+    useRequestLedgerKeys<StacksApp>({
+      chain,
       connectApp: connectLedgerStacksApp,
       getAppVersion: getStacksAppVersion,
-      isAppOpen(resp) {
-        return !isStacksLedgerAppClosed(resp);
-      },
+      isAppOpen: isStacksAppOpen,
       onSuccess() {
         navigate('/', { replace: true });
       },
@@ -45,7 +46,7 @@ function LedgerRequestStacksKeys() {
         });
         if (resp.status === 'failure') {
           toast.error(resp.errorMessage);
-          ledgerNavigate.toErrorStep(resp.errorMessage);
+          ledgerNavigate.toErrorStep(chain, resp.errorMessage);
           return;
         }
         ledgerNavigate.toDeviceBusyStep();

--- a/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
+++ b/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
@@ -64,6 +64,8 @@ function LedgerSignStacksMsg({ account, unsignedMessage }: LedgerSignMsgProps) {
 
   const [awaitingDeviceConnection, setAwaitingDeviceConnection] = useState(false);
 
+  const chain = 'stacks';
+
   async function signMessage() {
     const stacksApp = await prepareLedgerDeviceStacksAppConnection({
       setLoadingState: setAwaitingDeviceConnection,
@@ -72,7 +74,7 @@ function LedgerSignStacksMsg({ account, unsignedMessage }: LedgerSignMsgProps) {
           setLatestDeviceResponse({ deviceLocked: true } as any);
           return;
         }
-        ledgerNavigate.toErrorStep();
+        ledgerNavigate.toErrorStep(chain);
       },
     });
 

--- a/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container.tsx
+++ b/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container.tsx
@@ -1,38 +1,33 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Outlet, Route, useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Route, useLocation, useNavigate } from 'react-router-dom';
 
 import { deserializeTransaction } from '@stacks/transactions';
-import { LedgerError } from '@zondax/ledger-stacks';
+import StacksApp, { LedgerError } from '@zondax/ledger-stacks';
 import get from 'lodash.get';
 
-import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
 import { isError } from '@shared/utils';
 
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 import { appEvents } from '@app/common/publish-subscribe';
 import { delay } from '@app/common/utils';
-import { BaseDrawer } from '@app/components/drawer/base-drawer';
+import { LedgerTxSigningContext } from '@app/features/ledger/generic-flows/tx-signing/ledger-sign-tx.context';
 import {
-  LedgerTxSigningContext,
-  LedgerTxSigningProvider,
-  createWaitForUserToSeeWarningScreen,
-} from '@app/features/ledger/generic-flows/tx-signing/ledger-sign-tx.context';
-import {
+  connectLedgerStacksApp,
   getStacksAppVersion,
+  isStacksAppOpen,
   isVersionOfLedgerStacksAppWithContractPrincipalBug,
-  prepareLedgerDeviceStacksAppConnection,
   signLedgerStacksTransaction,
   signStacksTransactionWithSignature,
-  useActionCancellableByUser,
 } from '@app/features/ledger/utils/stacks-ledger-utils';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 
 import { ledgerSignTxRoutes } from '../../generic-flows/tx-signing/ledger-sign-tx-route-generator';
+import { TxSigningFlow } from '../../generic-flows/tx-signing/tx-signing-flow';
+import { useLedgerSignTx } from '../../generic-flows/tx-signing/use-ledger-sign-tx';
 import { useLedgerAnalytics } from '../../hooks/use-ledger-analytics.hook';
 import { useLedgerNavigate } from '../../hooks/use-ledger-navigate';
 import { useVerifyMatchingLedgerStacksPublicKey } from '../../hooks/use-verify-matching-stacks-public-key';
-import { checkLockedDeviceError, useLedgerResponseState } from '../../utils/generic-ledger-utils';
 import { ApproveSignLedgerStacksTx } from './steps/approve-sign-stacks-ledger-tx';
 
 export const ledgerStacksTxSigningRoutes = ledgerSignTxRoutes({
@@ -44,16 +39,15 @@ export const ledgerStacksTxSigningRoutes = ledgerSignTxRoutes({
 
 function LedgerSignStacksTxContainer() {
   const location = useLocation();
-  const navigate = useNavigate();
   const ledgerNavigate = useLedgerNavigate();
   const ledgerAnalytics = useLedgerAnalytics();
   useScrollLock(true);
   const account = useCurrentStacksAccount();
-  const canUserCancelAction = useActionCancellableByUser();
   const verifyLedgerPublicKey = useVerifyMatchingLedgerStacksPublicKey();
   const [unsignedTx, setUnsignedTx] = useState<null | string>(null);
+  const navigate = useNavigate();
 
-  const hasUserSkippedBuggyAppWarning = useMemo(() => createWaitForUserToSeeWarningScreen(), []);
+  const chain = 'stacks' as const;
 
   useEffect(() => {
     const tx = get(location.state, 'tx');
@@ -62,52 +56,38 @@ function LedgerSignStacksTxContainer() {
 
   useEffect(() => () => setUnsignedTx(null), []);
 
-  const [latestDeviceResponse, setLatestDeviceResponse] = useLedgerResponseState();
-
-  const [awaitingDeviceConnection, setAwaitingDeviceConnection] = useState(false);
-
-  const signTransaction = async () => {
-    if (!account) return;
-
-    const stacksApp = await prepareLedgerDeviceStacksAppConnection({
-      setLoadingState: setAwaitingDeviceConnection,
-      onError(e) {
-        if (isError(e) && checkLockedDeviceError(e)) {
-          setLatestDeviceResponse({ deviceLocked: true } as any);
-          return;
-        }
-        ledgerNavigate.toErrorStep();
-      },
-    });
-
-    try {
-      const versionInfo = await getStacksAppVersion(stacksApp);
-      ledgerAnalytics.trackDeviceVersionInfo(versionInfo);
-      setLatestDeviceResponse(versionInfo);
-
-      if (versionInfo.deviceLocked) {
-        setAwaitingDeviceConnection(false);
-        return;
+  const {
+    signTransaction,
+    latestDeviceResponse,
+    awaitingDeviceConnection,
+    hasUserSkippedBuggyAppWarning,
+  } = useLedgerSignTx<StacksApp>({
+    chain,
+    isAppOpen: isStacksAppOpen,
+    getAppVersion: getStacksAppVersion,
+    connectApp: connectLedgerStacksApp,
+    async passesAdditionalVersionCheck(appVersion) {
+      if (appVersion.chain !== 'stacks') {
+        return true;
       }
 
-      if (versionInfo.returnCode !== LedgerError.NoErrors) {
-        logger.error('Return code from device has error', versionInfo);
-        return;
-      }
-
-      if (isVersionOfLedgerStacksAppWithContractPrincipalBug(versionInfo)) {
+      if (isVersionOfLedgerStacksAppWithContractPrincipalBug(appVersion)) {
         navigate(RouteUrls.LedgerOutdatedAppWarning);
         const response = await hasUserSkippedBuggyAppWarning.wait();
 
         if (response === 'cancelled-operation') {
           ledgerNavigate.cancelLedgerAction();
-          return;
         }
+        return false;
       }
+      return true;
+    },
+    async signTransactionWithDevice(stacksApp) {
+      // TODO: need better handling
+      if (!account) return;
 
       ledgerNavigate.toDeviceBusyStep('Verifying public key on Ledger…');
       await verifyLedgerPublicKey(stacksApp);
-
       ledgerNavigate.toConnectionSuccessStep('stacks');
       await delay(1000);
       if (!unsignedTx) throw new Error('No unsigned tx');
@@ -152,14 +132,8 @@ function LedgerSignStacksTxContainer() {
         ledgerNavigate.toBroadcastErrorStep(isError(e) ? e.message : 'Unknown error');
         return;
       }
-    } catch (e) {
-      ledgerNavigate.toDeviceDisconnectStep();
-    } finally {
-      await stacksApp.transport.close();
-    }
-  };
-
-  const allowUserToGoBack = get(location.state, 'goBack');
+    },
+  });
 
   function closeAction() {
     appEvents.publish('ledgerStacksTxSigningCancelled', { unsignedTx: unsignedTx ?? '' });
@@ -167,7 +141,7 @@ function LedgerSignStacksTxContainer() {
   }
 
   const ledgerContextValue: LedgerTxSigningContext = {
-    chain: 'stacks',
+    chain,
     transaction: unsignedTx ? deserializeTransaction(unsignedTx) : null,
     signTransaction,
     latestDeviceResponse,
@@ -176,17 +150,10 @@ function LedgerSignStacksTxContainer() {
   };
 
   return (
-    <LedgerTxSigningProvider value={ledgerContextValue}>
-      <BaseDrawer
-        enableGoBack={allowUserToGoBack}
-        isShowing
-        isWaitingOnPerformedAction={awaitingDeviceConnection || canUserCancelAction}
-        onClose={closeAction}
-        pauseOnClickOutside
-        waitingOnPerformedActionMessage="Ledger device in use"
-      >
-        <Outlet />
-      </BaseDrawer>
-    </LedgerTxSigningProvider>
+    <TxSigningFlow
+      context={ledgerContextValue}
+      awaitingDeviceConnection={awaitingDeviceConnection}
+      closeAction={closeAction}
+    />
   );
 }

--- a/src/app/features/ledger/generic-flows/tx-signing/tx-signing-flow.tsx
+++ b/src/app/features/ledger/generic-flows/tx-signing/tx-signing-flow.tsx
@@ -1,0 +1,38 @@
+import { Outlet } from 'react-router-dom';
+
+import { useLocationState } from '@app/common/hooks/use-location-state';
+import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
+import { BaseDrawer } from '@app/components/drawer/base-drawer';
+
+import { useActionCancellableByUser } from '../../utils/stacks-ledger-utils';
+import { LedgerTxSigningContext, LedgerTxSigningProvider } from './ledger-sign-tx.context';
+
+interface TxSigningFlowProps {
+  context: LedgerTxSigningContext;
+  awaitingDeviceConnection: boolean;
+  closeAction(): void;
+}
+export function TxSigningFlow({
+  context,
+  awaitingDeviceConnection,
+  closeAction,
+}: TxSigningFlowProps) {
+  useScrollLock(true);
+  const allowUserToGoBack = useLocationState<boolean>('goBack');
+  const canUserCancelAction = useActionCancellableByUser();
+
+  return (
+    <LedgerTxSigningProvider value={context}>
+      <BaseDrawer
+        enableGoBack={allowUserToGoBack}
+        isShowing
+        isWaitingOnPerformedAction={awaitingDeviceConnection || canUserCancelAction}
+        onClose={closeAction}
+        pauseOnClickOutside
+        waitingOnPerformedActionMessage="Ledger device in use"
+      >
+        <Outlet />
+      </BaseDrawer>
+    </LedgerTxSigningProvider>
+  );
+}

--- a/src/app/features/ledger/generic-steps/connect-device/connect-ledger-error.layout.tsx
+++ b/src/app/features/ledger/generic-steps/connect-device/connect-ledger-error.layout.tsx
@@ -1,6 +1,5 @@
 import { Box, Flex, HStack, Stack, styled } from 'leather-styles/jsx';
 
-import { capitalize } from '@app/common/utils';
 import { ErrorLabel } from '@app/components/error-label';
 import { WarningLabel } from '@app/components/warning-label';
 import { ConnectLedgerErr } from '@app/features/ledger/illustrations/ledger-illu-connect-ledger-error';
@@ -10,7 +9,6 @@ import { Link } from '@app/ui/components/link/link';
 
 import { LedgerTitle } from '../../components/ledger-title';
 import { LedgerWrapper } from '../../components/ledger-wrapper';
-import { useLedgerRequestKeysContext } from '../../generic-flows/request-keys/ledger-request-keys.context';
 
 interface PossibleReasonUnableToConnectProps {
   text: string;
@@ -30,12 +28,11 @@ function PossibleReasonUnableToConnect(props: PossibleReasonUnableToConnectProps
 
 interface ConnectLedgerErrorLayoutProps {
   warningText: string | null;
-  onCancelConnectLedger(): void;
   onTryAgain(): void;
+  appName: string;
 }
 export function ConnectLedgerErrorLayout(props: ConnectLedgerErrorLayoutProps) {
-  const { warningText, onTryAgain } = props;
-  const { chain } = useLedgerRequestKeysContext();
+  const { warningText, onTryAgain, appName } = props;
 
   return (
     <LedgerWrapper px="space.07">
@@ -53,9 +50,7 @@ export function ConnectLedgerErrorLayout(props: ConnectLedgerErrorLayoutProps) {
       <Stack borderRadius="md" gap="space.01" textAlign="left" py="space.05">
         <PossibleReasonUnableToConnect text="Check if Ledger Live is open. Close it and try again" />
         <PossibleReasonUnableToConnect text="Ensure you only have one instance of Leather open" />
-        <PossibleReasonUnableToConnect
-          text={`Verify the ${capitalize(chain)} app is installed and open`}
-        />
+        <PossibleReasonUnableToConnect text={`Verify the ${appName} app is installed and open`} />
         <PossibleReasonUnableToConnect text="Check you've approved the browser USB pop up" />
       </Stack>
       <Button width="100%" onClick={onTryAgain}>

--- a/src/app/features/ledger/generic-steps/connect-device/connect-ledger-error.tsx
+++ b/src/app/features/ledger/generic-steps/connect-device/connect-ledger-error.tsx
@@ -1,3 +1,7 @@
+import { SupportedBlockchains } from '@shared/constants';
+
+import { useLocationState } from '@app/common/hooks/use-location-state';
+import { capitalize } from '@app/common/utils';
 import { useLatestLedgerError } from '@app/features/ledger/hooks/use-ledger-latest-route-error.hook';
 
 import { ConnectLedgerErrorLayout } from '../../generic-steps';
@@ -6,11 +10,15 @@ import { useLedgerNavigate } from '../../hooks/use-ledger-navigate';
 export function ConnectLedgerError() {
   const latestLedgerError = useLatestLedgerError();
   const ledgerNavigate = useLedgerNavigate();
+  const chain = useLocationState<SupportedBlockchains>('chain');
+  // TODO: here it would be better to use
+  // the actual app name from LEDGER_APPS_MAP at src/app/features/ledger/utils/generic-ledger-utils.ts
 
+  const appName = capitalize(chain);
   return (
     <ConnectLedgerErrorLayout
       warningText={latestLedgerError}
-      onCancelConnectLedger={() => ledgerNavigate.cancelLedgerAction()}
+      appName={appName}
       onTryAgain={() => ledgerNavigate.toConnectStepAndTryAgain()}
     />
   );

--- a/src/app/features/ledger/hooks/use-ledger-navigate.ts
+++ b/src/app/features/ledger/hooks/use-ledger-navigate.ts
@@ -64,10 +64,10 @@ export function useLedgerNavigate() {
         return navigate(RouteUrls.ConnectLedgerSuccess, { replace: true, state: { chain } });
       },
 
-      toErrorStep(errorMessage?: string) {
+      toErrorStep(chain: SupportedBlockchains, errorMessage?: string) {
         return navigate(RouteUrls.ConnectLedgerError, {
           replace: true,
-          state: { latestLedgerError: errorMessage },
+          state: { latestLedgerError: errorMessage, chain },
         });
       },
 

--- a/src/app/features/ledger/utils/bitcoin-ledger-utils.ts
+++ b/src/app/features/ledger/utils/bitcoin-ledger-utils.ts
@@ -29,8 +29,13 @@ export function connectLedgerBitcoinApp(network: BitcoinNetworkModes) {
   };
 }
 
-export async function getBitcoinAppVersion(app: BitcoinApp) {
-  return app.getAppAndVersion();
+export interface BitcoinAppVersion extends Awaited<ReturnType<BitcoinApp['getAppAndVersion']>> {
+  chain: 'bitcoin';
+}
+
+export async function getBitcoinAppVersion(app: BitcoinApp): Promise<BitcoinAppVersion> {
+  const appVersion = await app.getAppAndVersion();
+  return { chain: 'bitcoin' as const, ...appVersion };
 }
 
 export interface WalletPolicyDetails {
@@ -78,4 +83,13 @@ export function addTaprootInputSignaturesToPsbt(
   signatures.forEach(([index, signature]) =>
     psbt.updateInput(index, { tapKeySig: signature.signature })
   );
+}
+
+export function isBitcoinAppOpen({ network }: { network: BitcoinNetworkModes }) {
+  return function isBitcoinAppOpenByName({ name }: { name: string }) {
+    if (network === 'mainnet') {
+      return name === LEDGER_APPS_MAP.BITCOIN_MAINNET;
+    }
+    return name === LEDGER_APPS_MAP.BITCOIN_TESTNET;
+  };
 }

--- a/src/app/features/ledger/utils/generic-ledger-utils.ts
+++ b/src/app/features/ledger/utils/generic-ledger-utils.ts
@@ -6,8 +6,16 @@ import BitcoinApp from 'ledger-bitcoin';
 import { delay } from '@app/common/utils';
 import { safeAwait } from '@app/common/utils/safe-await';
 
-import { LedgerConnectionErrors } from '../generic-flows/request-keys/use-request-ledger-keys';
 import { getStacksAppVersion } from './stacks-ledger-utils';
+
+export enum LedgerConnectionErrors {
+  FailedToConnect = 'FailedToConnect',
+  AppNotOpen = 'AppNotOpen',
+  AppVersionOutdated = 'AppVersionOutdated',
+  DeviceNotConnected = 'DeviceNotConnected',
+  DeviceLocked = 'DeviceLocked',
+  IncorrectAppOpened = 'INCORRECT_APP_OPENED',
+}
 
 export const LEDGER_APPS_MAP = {
   STACKS: 'Stacks',

--- a/src/app/features/ledger/utils/stacks-ledger-utils.ts
+++ b/src/app/features/ledger/utils/stacks-ledger-utils.ts
@@ -44,12 +44,17 @@ export async function connectLedgerStacksApp() {
   return new StacksApp(transport);
 }
 
-export async function getStacksAppVersion(app: StacksApp) {
-  const resp = await app.getVersion();
-  if (resp.errorMessage !== 'No errors') {
-    throw new Error(resp.errorMessage);
+export interface StacksAppVersion extends Awaited<ReturnType<StacksApp['getVersion']>> {
+  name: 'Stacks';
+  chain: 'stacks';
+}
+
+export async function getStacksAppVersion(app: StacksApp): Promise<StacksAppVersion> {
+  const appVersion = await app.getVersion();
+  if (appVersion.errorMessage !== 'No errors') {
+    throw new Error(appVersion.errorMessage);
   }
-  return { name: 'Stacks', ...resp };
+  return { name: LEDGER_APPS_MAP.STACKS, chain: 'stacks' as const, ...appVersion };
 }
 
 export const prepareLedgerDeviceStacksAppConnection = prepareLedgerDeviceForAppFn(
@@ -109,4 +114,8 @@ export function isVersionOfLedgerStacksAppWithContractPrincipalBug(
     versionFromWhichContractPrincipalBugIsFixed,
     '<'
   );
+}
+
+export function isStacksAppOpen({ name }: { name: string }) {
+  return name === LEDGER_APPS_MAP.STACKS;
 }


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7797558088), [Test report](https://leather-wallet.github.io/playwright-reports/fix/ledger-no-request-keys-context)<!-- Sticky Header Marker -->

- Fixes #4682 and #4786 by using location state for chain name in ledger connect error, as it sometimes doesn't have access to LedgerRequestKeysContext
- Fixes #4863, refactored a good chunk of code into useLedgerSignTx hook and TxSigningFlow provider.


Here's some testing of different scenarios:

https://github.com/leather-wallet/extension/assets/22010816/773cb55d-b17e-45b7-b981-5bb806917872


Note: will squash commits together after approval