### PR TITLE
fix(input): mnemonic value state

### DIFF
--- a/src/app/components/secret-key/mnemonic-key/mnemonic-word-input.tsx
+++ b/src/app/components/secret-key/mnemonic-key/mnemonic-word-input.tsx
@@ -23,7 +23,7 @@ export function MnemonicWordInput({
   const [isFocused, setIsFocused] = useState(false);
   const isDirty = useIsFieldDirty(name);
   return (
-    <Input.Root hasError={isDirty && !!meta.error} shrink>
+    <Input.Root hasError={isDirty && !!meta.error} shrink={!!value}>
       <Input.Field
         // Limitation of the animated label is that we cannot detect
         // programatically updated inputs. Here we add an empty place holder to


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7756229262), [Test report](https://leather-wallet.github.io/playwright-reports/fix/mnemonic-entry)<!-- Sticky Header Marker -->

https://github.com/leather-wallet/extension/assets/1618764/c310988d-694c-4930-a631-ec7af00ca9eb

(Still a bug where first input shows error if you use a key replace/paste, but pretty much unnoticeable when it transitions right away)
