### PR TITLE
chore(stories): add stories for flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "react-refresh": "0.14.0",
     "schema-inspector": "2.0.2",
     "speed-measure-webpack-plugin": "1.5.0",
-    "storybook": "7.6.10",
+    "storybook": "7.6.12",
     "stream-browserify": "3.0.0",
     "svg-url-loader": "8.0.0",
     "ts-node": "10.9.2",

--- a/src/app/components/account/account-list-item-layout.tsx
+++ b/src/app/components/account/account-list-item-layout.tsx
@@ -45,7 +45,7 @@ export function AccountListItemLayout(props: AccountListItemLayoutProps) {
       onClick={onSelectAccount}
       {...rest}
     >
-      <Flag align="middle" img={avatar} spacing="space.04" width="100%" mx="space.04">
+      <Flag img={avatar} spacing="space.04" width="100%" mx="space.04">
         <Stack gap="space.01">
           <HStack alignItems="center" justifyContent="space-between">
             <HStack alignItems="center" gap="space.02">

--- a/src/app/components/account/account-list-item-layout.tsx
+++ b/src/app/components/account/account-list-item-layout.tsx
@@ -3,11 +3,11 @@ import { Flex, HStack, Stack, StackProps, styled } from 'leather-styles/jsx';
 
 import { useViewportMinWidth } from '@app/common/hooks/use-media-query';
 import { BulletSeparator } from '@app/ui/components/bullet-separator/bullet-separator';
+import { Flag } from '@app/ui/components/flag/flag';
 import { CheckmarkIcon } from '@app/ui/components/icons/checkmark-icon';
 import { Spinner } from '@app/ui/components/spinner';
 import { truncateMiddle } from '@app/ui/utils/truncate-middle';
 
-import { Flag } from '../layout/flag';
 import { StacksAccountLoader } from '../loaders/stacks-account-loader';
 import { BitcoinNativeSegwitAccountLoader } from './bitcoin-account-loader';
 

--- a/src/app/components/bitcoin-contract-entry-point/bitcoin-contract-entry-point-layout.tsx
+++ b/src/app/components/bitcoin-contract-entry-point/bitcoin-contract-entry-point-layout.tsx
@@ -30,7 +30,7 @@ export function BitcoinContractEntryPointLayout(props: BitcoinContractEntryPoint
 
   return (
     <Flex cursor={cursor} onClick={onClick} outline={0}>
-      <Flag align="middle" img={icon} spacing="space.04" width="100%">
+      <Flag img={icon} spacing="space.04" width="100%">
         <HStack alignItems="center" justifyContent="space-between" width="100%">
           <styled.span textStyle="label.01">Bitcoin Contracts</styled.span>
           <BasicTooltip

--- a/src/app/components/bitcoin-contract-entry-point/bitcoin-contract-entry-point-layout.tsx
+++ b/src/app/components/bitcoin-contract-entry-point/bitcoin-contract-entry-point-layout.tsx
@@ -4,7 +4,7 @@ import { Money } from '@shared/models/money.model';
 
 import { formatBalance } from '@app/common/format-balance';
 import { ftDecimals } from '@app/common/stacks-utils';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
 import { LoadingSpinner } from '../loading-spinner';

--- a/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/components/brc20-token-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/components/brc20-token-asset-item.layout.tsx
@@ -5,7 +5,7 @@ import type { Money } from '@shared/models/money.model';
 import { formatBalance } from '@app/common/format-balance';
 import { AssetCaption } from '@app/components/crypto-assets/components/asset-caption';
 import { usePressable } from '@app/components/item-hover';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 import { Brc20TokenIcon } from '@app/ui/components/icons/brc20-token-icon';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 

--- a/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/components/brc20-token-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/components/brc20-token-asset-item.layout.tsx
@@ -37,7 +37,7 @@ export function Brc20TokenAssetItemLayout({
       asChild
     >
       <Flex onClick={isPressable ? onClick : undefined} {...bind}>
-        <Flag align="middle" img={<Brc20TokenIcon />} spacing="space.04" width="100%">
+        <Flag img={<Brc20TokenIcon />} spacing="space.04" width="100%">
           <HStack alignItems="center" justifyContent="space-between" width="100%">
             <styled.span
               maxWidth="150px"

--- a/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
@@ -57,12 +57,7 @@ export function CryptoCurrencyAssetItemLayout({
 
   return (
     <Flex data-testid={dataTestId} onClick={isPressable ? onClick : undefined} {...bind}>
-      <Flag
-        align="middle"
-        img={isHovered && copyIcon ? copyIcon : icon}
-        spacing="space.04"
-        width="100%"
-      >
+      <Flag img={isHovered && copyIcon ? copyIcon : icon} spacing="space.04" width="100%">
         <AssetRowGrid
           title={
             <styled.span textStyle="label.01">

--- a/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
@@ -7,7 +7,7 @@ import { Money } from '@shared/models/money.model';
 import { formatBalance } from '@app/common/format-balance';
 import { ftDecimals } from '@app/common/stacks-utils';
 import { usePressable } from '@app/components/item-hover';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 import { truncateMiddle } from '@app/ui/utils/truncate-middle';
 

--- a/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.layout.tsx
@@ -40,7 +40,6 @@ export function StacksFungibleTokenAssetItemLayout({
   return (
     <Flex onClick={isPressable ? onClick : undefined} {...bind}>
       <Flag
-        align="middle"
         img={
           <StacksAssetAvatar
             color="white"

--- a/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/stacks/fungible-token-asset/stacks-fungible-token-asset-item.layout.tsx
@@ -6,7 +6,7 @@ import { formatBalance } from '@app/common/format-balance';
 import { ftDecimals } from '@app/common/stacks-utils';
 import { StacksAssetAvatar } from '@app/components/crypto-assets/stacks/components/stacks-asset-avatar';
 import { usePressable } from '@app/components/item-hover';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
 import { AssetCaption } from '../../components/asset-caption';

--- a/src/app/components/inscription-preview-card/inscription-preview-card.tsx
+++ b/src/app/components/inscription-preview-card/inscription-preview-card.tsx
@@ -1,4 +1,5 @@
-import { Flag } from '../../ui/components/flag/flag';
+import { Flag } from '@app/ui/components/flag/flag';
+
 import { InscriptionMetadata } from './components/inscription-metadata';
 
 interface InscriptionPreviewCardProps {
@@ -21,7 +22,6 @@ export function InscriptionPreviewCard({
 }: InscriptionPreviewCardProps) {
   return (
     <Flag
-      align="middle"
       border={hideBorder ? 'unset' : 'default'}
       borderRadius={hideBorder ? 'unset' : 'sm'}
       img={image}

--- a/src/app/components/inscription-preview-card/inscription-preview-card.tsx
+++ b/src/app/components/inscription-preview-card/inscription-preview-card.tsx
@@ -1,4 +1,4 @@
-import { Flag } from '../layout/flag';
+import { Flag } from '../../ui/components/flag/flag';
 import { InscriptionMetadata } from './components/inscription-metadata';
 
 interface InscriptionPreviewCardProps {

--- a/src/app/components/requester-flag.tsx
+++ b/src/app/components/requester-flag.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'leather-styles/jsx';
 
+import { Flag } from '../ui/components/flag/flag';
 import { Favicon } from './favicon';
-import { Flag } from './layout/flag';
 
 interface RequesterFlagProps {
   requester: string;

--- a/src/app/components/requester-flag.tsx
+++ b/src/app/components/requester-flag.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'leather-styles/jsx';
 
-import { Flag } from '../ui/components/flag/flag';
+import { Flag } from '@app/ui/components/flag/flag';
+
 import { Favicon } from './favicon';
 
 interface RequesterFlagProps {
@@ -11,6 +12,7 @@ export function RequesterFlag({ requester }: RequesterFlagProps) {
   return (
     <Flag
       img={<Favicon origin={requester} />}
+      align="top"
       alignItems="center"
       justifyContent="center"
       py="space.04"

--- a/src/app/components/warning-label.tsx
+++ b/src/app/components/warning-label.tsx
@@ -1,9 +1,8 @@
 import { Box, BoxProps, styled } from 'leather-styles/jsx';
 import { token } from 'leather-styles/tokens';
 
+import { Flag } from '@app/ui/components/flag/flag';
 import { ErrorCircleIcon } from '@app/ui/components/icons/error-circle-icon';
-
-import { Flag } from '../ui/components/flag/flag';
 
 interface WarningLabelProps extends BoxProps {
   title?: string;
@@ -12,6 +11,7 @@ export function WarningLabel({ children, title, ...props }: WarningLabelProps) {
   return (
     <Box bg="warning.background" borderRadius="sm" {...props}>
       <Flag
+        align="top"
         color="accent.notification-text"
         img={<ErrorCircleIcon style={{ color: token('colors.warning.label') }} />}
         minHeight="48px"

--- a/src/app/components/warning-label.tsx
+++ b/src/app/components/warning-label.tsx
@@ -3,7 +3,7 @@ import { token } from 'leather-styles/tokens';
 
 import { ErrorCircleIcon } from '@app/ui/components/icons/error-circle-icon';
 
-import { Flag } from './layout/flag';
+import { Flag } from '../ui/components/flag/flag';
 
 interface WarningLabelProps extends BoxProps {
   title?: string;

--- a/src/app/features/current-account/popup-header.tsx
+++ b/src/app/features/current-account/popup-header.tsx
@@ -33,7 +33,6 @@ function PopupHeaderSuspense({ displayAddresssBalanceOf = 'stx' }: PopupHeaderPr
   return (
     <PopupHeaderLayout>
       <Flag
-        align="middle"
         img={
           <CurrentAccountAvatar
             color={token('colors.white')}

--- a/src/app/features/current-account/popup-header.tsx
+++ b/src/app/features/current-account/popup-header.tsx
@@ -5,13 +5,13 @@ import { token } from 'leather-styles/tokens';
 
 import { BtcBalance } from '@app/components/balance-btc';
 import { StxBalance } from '@app/components/balance-stx';
-import { Flag } from '@app/components/layout/flag';
 import { LoadingRectangle } from '@app/components/loading-rectangle';
 import { NetworkModeBadge } from '@app/components/network-mode-badge';
 import { CurrentAccountAvatar } from '@app/features/current-account/current-account-avatar';
 import { CurrentAccountName } from '@app/features/current-account/current-account-name';
 import { useConfigBitcoinEnabled } from '@app/query/common/remote-config/remote-config.query';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+import { Flag } from '@app/ui/components/flag/flag';
 
 interface PopupHeaderLayoutProps {
   children: React.ReactNode;

--- a/src/app/features/message-signer/message-signing-header.tsx
+++ b/src/app/features/message-signer/message-signing-header.tsx
@@ -2,8 +2,8 @@ import { Stack, styled } from 'leather-styles/jsx';
 
 import { addPortSuffix, getUrlHostname } from '@app/common/utils';
 import { Favicon } from '@app/components/favicon';
-import { Flag } from '@app/components/layout/flag';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
+import { Flag } from '@app/ui/components/flag/flag';
 
 interface MessageSigningHeaderProps {
   name?: string;

--- a/src/app/features/message-signer/message-signing-header.tsx
+++ b/src/app/features/message-signer/message-signing-header.tsx
@@ -32,7 +32,7 @@ export function MessageSigningHeader({
     <Stack gap="space.04" pt="space.05">
       <styled.h1 textStyle="heading.03">Sign message</styled.h1>
       {caption && (
-        <Flag align="middle" img={<Favicon origin={origin ?? ''} />} pl="space.02">
+        <Flag img={<Favicon origin={origin ?? ''} />} pl="space.02">
           <styled.span textStyle="label.02" wordBreak="break-word">
             {caption}
             {additionalText}

--- a/src/app/features/pending-brc-20-transfers/pending-brc-20-transfers.tsx
+++ b/src/app/features/pending-brc-20-transfers/pending-brc-20-transfers.tsx
@@ -6,7 +6,6 @@ import { RouteUrls } from '@shared/route-urls';
 import { noop } from '@shared/utils';
 
 import { usePressable } from '@app/components/item-hover';
-import { Flag } from '@app/components/layout/flag';
 import { StatusPending } from '@app/components/status-pending';
 import { StatusReady } from '@app/components/status-ready';
 import { useNativeSegwitBalance } from '@app/query/bitcoin/balance/btc-native-segwit-balance.hooks';
@@ -21,6 +20,7 @@ import {
   usePendingBrc20Transfers,
 } from '@app/store/ordinals/ordinals.slice';
 import { BulletSeparator } from '@app/ui/components/bullet-separator/bullet-separator';
+import { Flag } from '@app/ui/components/flag/flag';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 import { Caption } from '@app/ui/components/typography/caption';
 

--- a/src/app/features/pending-brc-20-transfers/pending-brc-20-transfers.tsx
+++ b/src/app/features/pending-brc-20-transfers/pending-brc-20-transfers.tsx
@@ -130,12 +130,7 @@ function PendingBrcTransfer({ order }: PendingBrcTransferProps) {
       <HStack width="100%" mt="space.02">
         <BulletSeparator>
           <Flex>
-            <Flag
-              ml="space.02"
-              align="middle"
-              spacing="space.02"
-              img={<StatusIcon status={order.status} />}
-            >
+            <Flag ml="space.02" spacing="space.02" img={<StatusIcon status={order.status} />}>
               <StatusLabel status={order.status} />
             </Flag>
           </Flex>

--- a/src/app/features/psbt-signer/components/psbt-inputs-and-outputs/components/psbt-input-output-item.layout.tsx
+++ b/src/app/features/psbt-signer/components/psbt-inputs-and-outputs/components/psbt-input-output-item.layout.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, HStack, styled } from 'leather-styles/jsx';
 
 import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-link';
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 import { CopyIcon } from '@app/ui/components/icons/copy-icon';
 import { Link } from '@app/ui/components/link/link';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';

--- a/src/app/features/psbt-signer/components/psbt-inputs-and-outputs/components/psbt-input-output-item.layout.tsx
+++ b/src/app/features/psbt-signer/components/psbt-inputs-and-outputs/components/psbt-input-output-item.layout.tsx
@@ -27,7 +27,7 @@ export function PsbtInputOutputItemLayout({
   const { handleOpenBitcoinTxLink: handleOpenTxLink } = useBitcoinExplorerLink();
 
   return (
-    <Flag align="middle" img={<></>} mt="space.05" spacing="space.04">
+    <Flag img={<></>} mt="space.05" spacing="space.04">
       <HStack alignItems="center" justifyContent="space-between">
         <Flex alignItems="center">
           <styled.span mr="space.02" textStyle="caption.01">

--- a/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-total-item.tsx
+++ b/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-total-item.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, styled } from 'leather-styles/jsx';
 
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 import { BtcIcon } from '@app/ui/components/icons/btc-icon';
 import { CopyIcon } from '@app/ui/components/icons/copy-icon';
 import { Link } from '@app/ui/components/link/link';

--- a/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-total-item.tsx
+++ b/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-total-item.tsx
@@ -28,7 +28,7 @@ export function PsbtAddressTotalItem({
   const { onCopy, hasCopied } = useClipboard(hoverLabel ?? '');
 
   return (
-    <Flag align="middle" img={image ? image : <BtcIcon />} mt="space.05" spacing="space.04">
+    <Flag img={image ? image : <BtcIcon />} mt="space.05" spacing="space.04">
       <HStack alignItems="center" justifyContent="space-between">
         <styled.span textStyle="label.01">{title ? title : 'Bitcoin'}</styled.span>
         {valueAction ? (

--- a/src/app/features/psbt-signer/components/psbt-request-header.tsx
+++ b/src/app/features/psbt-signer/components/psbt-request-header.tsx
@@ -23,7 +23,7 @@ export function PsbtRequestHeader({ name, origin }: PsbtRequestHeaderProps) {
         transactions you fully understand.
       </styled.p>
       {caption && (
-        <Flag align="middle" img={<Favicon origin={origin} />} pl="space.02">
+        <Flag img={<Favicon origin={origin} />} pl="space.02">
           <styled.span textStyle="label.02" wordBreak="break-word">
             {caption}
           </styled.span>

--- a/src/app/features/psbt-signer/components/psbt-request-header.tsx
+++ b/src/app/features/psbt-signer/components/psbt-request-header.tsx
@@ -1,7 +1,7 @@
 import { Flex, styled } from 'leather-styles/jsx';
 
 import { Favicon } from '@app/components/favicon';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 
 interface PsbtRequestHeaderProps {
   name?: string;

--- a/src/app/features/stacks-transaction-request/page-top.tsx
+++ b/src/app/features/stacks-transaction-request/page-top.tsx
@@ -37,7 +37,7 @@ function PageTopBase() {
         {pageTitle}
       </styled.h1>
       {caption && (
-        <Flag align="middle" img={<Favicon origin={origin ?? ''} />} pl="space.02">
+        <Flag img={<Favicon origin={origin ?? ''} />} pl="space.02">
           <styled.span textStyle="label.02" wordBreak="break-word">
             {caption}
           </styled.span>

--- a/src/app/features/stacks-transaction-request/page-top.tsx
+++ b/src/app/features/stacks-transaction-request/page-top.tsx
@@ -6,10 +6,10 @@ import { Stack, styled } from 'leather-styles/jsx';
 import { useDefaultRequestParams } from '@app/common/hooks/use-default-request-search-params';
 import { addPortSuffix, getUrlHostname } from '@app/common/utils';
 import { Favicon } from '@app/components/favicon';
-import { Flag } from '@app/components/layout/flag';
 import { useStacksTxPageTitle } from '@app/features/stacks-transaction-request/hooks/use-stacks-tx-page-title';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
+import { Flag } from '@app/ui/components/flag/flag';
 
 function PageTopBase() {
   const transactionRequest = useTransactionRequestState();

--- a/src/app/pages/bitcoin-contract-list/components/bitcoin-contract-list-item-layout.tsx
+++ b/src/app/pages/bitcoin-contract-list/components/bitcoin-contract-list-item-layout.tsx
@@ -8,8 +8,8 @@ import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-l
 import { baseCurrencyAmountInQuote } from '@app/common/money/calculate-money';
 import { i18nFormatCurrency } from '@app/common/money/format-money';
 import { satToBtc } from '@app/common/money/unit-conversion';
-import { Flag } from '@app/components/layout/flag';
 import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
+import { Flag } from '@app/ui/components/flag/flag';
 import { BitcoinContractIcon } from '@app/ui/components/icons/bitcoin-contract-icon';
 import { Caption } from '@app/ui/components/typography/caption';
 

--- a/src/app/pages/bitcoin-contract-list/components/bitcoin-contract-list-item-layout.tsx
+++ b/src/app/pages/bitcoin-contract-list/components/bitcoin-contract-list-item-layout.tsx
@@ -45,7 +45,7 @@ export function BitcoinContractListItemLayout({
         })
       }
     >
-      <Flag img={<BitcoinContractIcon />} align="middle" spacing="space.04" width="100%">
+      <Flag img={<BitcoinContractIcon />} spacing="space.04" width="100%">
         <HStack alignItems="center" justifyContent="space-between" width="100%">
           <styled.span textStyle="body.01">{id}</styled.span>
           <styled.span fontVariantNumeric="tabular-nums" textAlign="right" textStyle="body.01">

--- a/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-offer/bitcoin-contract-lock-amount.tsx
+++ b/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-offer/bitcoin-contract-lock-amount.tsx
@@ -5,7 +5,7 @@ import { HStack, styled } from 'leather-styles/jsx';
 import { token } from 'leather-styles/tokens';
 
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 import { ArrowUpIcon } from '@app/ui/components/icons/arrow-up-icon';
 import { BtcIcon } from '@app/ui/components/icons/btc-icon';
 import { CopyIcon } from '@app/ui/components/icons/copy-icon';

--- a/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-offer/bitcoin-contract-lock-amount.tsx
+++ b/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-offer/bitcoin-contract-lock-amount.tsx
@@ -33,7 +33,7 @@ export function BitcoinContractLockAmount({
   const { onCopy, hasCopied } = useClipboard(hoverLabel ?? '');
 
   return (
-    <Flag align="middle" img={image || <BtcIcon />} width="100%">
+    <Flag img={image || <BtcIcon />} width="100%">
       <HStack alignItems="center" justifyContent="space-between">
         <styled.span textStyle="label.01">{title ? title : 'BTC'}</styled.span>
         <styled.span

--- a/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-request-header.tsx
+++ b/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-request-header.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 import { BitcoinContractRequestSelectors } from '@tests/selectors/bitcoin-contract-request.selectors';
 import { Flex } from 'leather-styles/jsx';
 
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 import { Caption } from '@app/ui/components/typography/caption';
 import { Title } from '@app/ui/components/typography/title';
 

--- a/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-request-header.tsx
+++ b/src/app/pages/bitcoin-contract-request/components/bitcoin-contract-request-header.tsx
@@ -22,11 +22,7 @@ function BitcoinContractRequestHeaderBase({
     <Flex flexDirection="column" my="space.05" width="100%">
       <Title mb="space.04">Lock Bitcoin</Title>
       {caption && (
-        <Flag
-          align="middle"
-          img={<img src={counterpartyWalletIcon} height="32px" width="32px" />}
-          pl="space.02"
-        >
+        <Flag img={<img src={counterpartyWalletIcon} height="32px" width="32px" />} pl="space.02">
           <Caption data-testid={BitcoinContractRequestSelectors.BitcoinContractOfferorText}>
             {caption}
           </Caption>

--- a/src/app/pages/receive/components/receive-item.tsx
+++ b/src/app/pages/receive/components/receive-item.tsx
@@ -1,7 +1,7 @@
 import { Flex, HStack, Stack, styled } from 'leather-styles/jsx';
 
-import { Flag } from '@app/components/layout/flag';
 import { Button } from '@app/ui/components/button/button';
+import { Flag } from '@app/ui/components/flag/flag';
 import { CopyIcon } from '@app/ui/components/icons/copy-icon';
 import { QrCodeIcon } from '@app/ui/components/icons/qr-code-icon';
 import { truncateMiddle } from '@app/ui/utils/truncate-middle';

--- a/src/app/pages/receive/components/receive-item.tsx
+++ b/src/app/pages/receive/components/receive-item.tsx
@@ -24,7 +24,7 @@ export function ReceiveItem({
 }: ReceiveItemProps) {
   if (!address) return null;
   return (
-    <Flag align="middle" img={icon} spacing="space.04">
+    <Flag img={icon} spacing="space.04">
       <Flex justifyContent="space-between">
         <Stack gap="space.00">
           <styled.span textStyle="label.02">{title}</styled.span>

--- a/src/app/pages/rpc-send-transfer/components/send-transfer-header.tsx
+++ b/src/app/pages/rpc-send-transfer/components/send-transfer-header.tsx
@@ -17,7 +17,7 @@ export function SendTransferHeader({ amount, origin }: SendTransferHeaderProps) 
         {title}
       </styled.h1>
       {caption && (
-        <Flag align="middle" img={<Favicon origin={origin} />} pl="space.02">
+        <Flag img={<Favicon origin={origin} />} pl="space.02">
           <styled.span textStyle="label.02" wordBreak="break-word">
             {caption}
           </styled.span>

--- a/src/app/pages/rpc-send-transfer/components/send-transfer-header.tsx
+++ b/src/app/pages/rpc-send-transfer/components/send-transfer-header.tsx
@@ -1,7 +1,7 @@
 import { Flex, styled } from 'leather-styles/jsx';
 
 import { Favicon } from '@app/components/favicon';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 
 interface SendTransferHeaderProps {
   amount: string;

--- a/src/app/pages/send/send-crypto-asset-form/components/selected-asset-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/selected-asset-field.tsx
@@ -26,7 +26,7 @@ export function SelectedAssetField({ icon, name, symbol }: SelectedAssetFieldPro
       width="100%"
     >
       <Field as="div" name="symbol">
-        <Flag align="middle" img={icon} spacing="space.03">
+        <Flag img={icon} spacing="space.03">
           <styled.span textStyle="label.01">{name}</styled.span>
         </Flag>
       </Field>

--- a/src/app/pages/send/send-crypto-asset-form/components/selected-asset-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/selected-asset-field.tsx
@@ -2,7 +2,7 @@ import { Field, useField } from 'formik';
 import { Flex, styled } from 'leather-styles/jsx';
 
 import { useOnMount } from '@app/common/hooks/use-on-mount';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 
 interface SelectedAssetFieldProps {
   icon: React.JSX.Element;

--- a/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
@@ -43,7 +43,7 @@ export function SignOutConfirmLayout(props: SignOutConfirmLayoutProps) {
           <styled.div mt="space.05" textStyle="label.02">
             {whenWallet({
               software: (
-                <Flag align="middle" img={<ErrorIcon />} spacing="space.02">
+                <Flag img={<ErrorIcon />} spacing="space.02">
                   If you haven't backed up your Secret Key, you will lose all your funds.
                 </Flag>
               ),

--- a/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
+++ b/src/app/pages/sign-out-confirm/sign-out-confirm.layout.tsx
@@ -5,8 +5,8 @@ import { Box, HStack, styled } from 'leather-styles/jsx';
 import { useThemeSwitcher } from '@app/common/theme-provider';
 import { useWalletType } from '@app/common/use-wallet-type';
 import { BaseDrawer } from '@app/components/drawer/base-drawer';
-import { Flag } from '@app/components/layout/flag';
 import { Button } from '@app/ui/components/button/button';
+import { Flag } from '@app/ui/components/flag/flag';
 import { ErrorIcon } from '@app/ui/components/icons/error-icon';
 
 interface SignOutConfirmLayoutProps {

--- a/src/app/pages/swap/components/swap-assets-pair/swap-asset-item.layout.tsx
+++ b/src/app/pages/swap/components/swap-assets-pair/swap-asset-item.layout.tsx
@@ -1,7 +1,7 @@
 import { SwapSelectors } from '@tests/selectors/swap.selectors';
 import { HStack, styled } from 'leather-styles/jsx';
 
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 
 interface SwapAssetItemLayoutProps {
   caption: string;

--- a/src/app/pages/swap/components/swap-assets-pair/swap-asset-item.layout.tsx
+++ b/src/app/pages/swap/components/swap-assets-pair/swap-asset-item.layout.tsx
@@ -12,7 +12,6 @@ interface SwapAssetItemLayoutProps {
 export function SwapAssetItemLayout({ caption, icon, symbol, value }: SwapAssetItemLayoutProps) {
   return (
     <Flag
-      align="middle"
       img={<styled.img src={icon} width="48px" height="48px" alt="Swap asset" />}
       spacing="space.03"
       width="100%"

--- a/src/app/pages/swap/swap-choose-asset/components/swap-asset-item.layout.tsx
+++ b/src/app/pages/swap/swap-choose-asset/components/swap-asset-item.layout.tsx
@@ -9,7 +9,7 @@ export function SwapAssetItemLayout({
   ...rest
 }: HasChildren & { icon: React.JSX.Element }) {
   return (
-    <Flag align="middle" img={icon} {...rest}>
+    <Flag img={icon} {...rest}>
       <Stack gap="none">{children}</Stack>
     </Flag>
   );

--- a/src/app/pages/swap/swap-choose-asset/components/swap-asset-item.layout.tsx
+++ b/src/app/pages/swap/swap-choose-asset/components/swap-asset-item.layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'leather-styles/jsx';
 
 import { HasChildren } from '@app/common/has-children';
-import { Flag } from '@app/components/layout/flag';
+import { Flag } from '@app/ui/components/flag/flag';
 
 export function SwapAssetItemLayout({
   children,

--- a/src/app/ui/components/flag/flag.stories.tsx
+++ b/src/app/ui/components/flag/flag.stories.tsx
@@ -11,17 +11,14 @@ const meta: Meta<typeof Component> = {
     align: {
       options: ['top', 'middle', 'bottom'],
       control: { type: 'radio' },
-      defaultValue: 'top',
+      defaultValue: 'middle',
     },
   },
   parameters: {
     controls: { include: ['align'] },
   },
   render: ({ children, ...args }) => (
-    <Component
-      {...args}
-      img={<Circle size="52px" backgroundColor="accent.component-background-pressed" />}
-    >
+    <Component {...args} img={<Circle size="40px" backgroundColor="lightModeRed.300" />}>
       {children}
     </Component>
   ),
@@ -33,25 +30,6 @@ type Story = StoryObj<typeof Component>;
 
 export const Flag: Story = {
   args: {
-    children: (
-      <>
-        <Box width="120px" height="16px" backgroundColor="accent.component-background-pressed" />
-        <Box
-          width="80px"
-          height="12px"
-          mt="space.02"
-          backgroundColor="accent.component-background-pressed"
-        />
-      </>
-    ),
-  },
-};
-
-export const FlagAlternate: Story = {
-  args: {
-    align: 'middle',
-    children: (
-      <Box width="120px" height="16px" backgroundColor="accent.component-background-pressed" />
-    ),
+    children: <Box width="300px" height="20px" backgroundColor="lightModeRed.300" />,
   },
 };

--- a/src/app/ui/components/flag/flag.stories.tsx
+++ b/src/app/ui/components/flag/flag.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Box, Circle } from 'leather-styles/jsx';
+
+import { Flag as Component } from './flag';
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+  tags: ['autodocs'],
+  title: 'Layout/Flag',
+  argTypes: {
+    align: {
+      options: ['top', 'middle', 'bottom'],
+      control: { type: 'radio' },
+      defaultValue: 'top',
+    },
+  },
+  parameters: {
+    controls: { include: ['align'] },
+  },
+  render: ({ children, ...args }) => (
+    <Component
+      {...args}
+      img={<Circle size="52px" backgroundColor="accent.component-background-pressed" />}
+    >
+      {children}
+    </Component>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Component>;
+
+export const Flag: Story = {
+  args: {
+    children: (
+      <>
+        <Box width="120px" height="16px" backgroundColor="accent.component-background-pressed" />
+        <Box
+          width="80px"
+          height="12px"
+          mt="space.02"
+          backgroundColor="accent.component-background-pressed"
+        />
+      </>
+    ),
+  },
+};
+
+export const FlagAlternate: Story = {
+  args: {
+    align: 'middle',
+    children: (
+      <Box width="120px" height="16px" backgroundColor="accent.component-background-pressed" />
+    ),
+  },
+};

--- a/src/app/ui/components/flag/flag.tsx
+++ b/src/app/ui/components/flag/flag.tsx
@@ -1,19 +1,24 @@
+import { css } from 'leather-styles/css';
 import { Box, Flex, FlexProps } from 'leather-styles/jsx';
 import { SpacingToken } from 'leather-styles/tokens';
 
-function alignToFlexProp(alignment: FlagAlignment) {
-  return {
-    top: 'start',
-    middle: 'center',
-    bottom: 'end',
-  }[alignment];
-}
+const flagStyles = css({
+  '&[data-align="top"]': {
+    alignItems: 'start',
+  },
+  '&[data-align="middle"]': {
+    alignItems: 'center',
+  },
+  '&[data-align="bottom"]': {
+    alignItems: 'end',
+  },
+});
 
 type FlagAlignment = 'top' | 'middle' | 'bottom';
 
 interface FlagProps extends FlexProps {
   spacing?: SpacingToken;
-  align?: 'top' | 'middle' | 'bottom';
+  align?: FlagAlignment;
   children: React.ReactNode;
   img: React.ReactNode;
 }
@@ -27,7 +32,7 @@ interface FlagProps extends FlexProps {
  */
 export function Flag({ spacing = 'space.02', align = 'top', img, children, ...props }: FlagProps) {
   return (
-    <Flex flexDirection="row" align={alignToFlexProp(align)} width="100%" {...props}>
+    <Flex flexDirection="row" width="100%" data-align={align} className={flagStyles} {...props}>
       <Box mr={spacing}>{img}</Box>
       <Box flex={1}>{children}</Box>
     </Flex>

--- a/src/app/ui/components/flag/flag.tsx
+++ b/src/app/ui/components/flag/flag.tsx
@@ -30,7 +30,13 @@ interface FlagProps extends FlexProps {
  *   1st. Image content
  *   2nd. Body content
  */
-export function Flag({ spacing = 'space.02', align = 'top', img, children, ...props }: FlagProps) {
+export function Flag({
+  spacing = 'space.03',
+  align = 'middle',
+  img,
+  children,
+  ...props
+}: FlagProps) {
   return (
     <Flex flexDirection="row" width="100%" data-align={align} className={flagStyles} {...props}>
       <Box mr={spacing}>{img}</Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5642,15 +5642,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-manager@7.6.10":
-  version "7.6.10"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.10.tgz#fc30b19dd74e6f6ae896d8f4045552c3206c25f9"
-  integrity sha512-f+YrjZwohGzvfDtH8BHzqM3xW0p4vjjg9u7uzRorqUiNIAAKHpfNrZ/WvwPlPYmrpAHt4xX/nXRJae4rFSygPw==
+"@storybook/builder-manager@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.12.tgz#6dd6ed1e0b440d7dd26dc5438e5e765aa464212e"
+  integrity sha512-AJFrtBj0R11OFwwz+2j+ivRzttWXT6LesSGoLnxown24EV9uLQoHtGb7GOA2GyzY5wjUJS9gQBPGHXjvQEfLJA==
   dependencies:
     "@fal-works/esbuild-plugin-global-externals" "^2.1.2"
-    "@storybook/core-common" "7.6.10"
-    "@storybook/manager" "7.6.10"
-    "@storybook/node-logger" "7.6.10"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/manager" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
     "@types/ejs" "^3.1.1"
     "@types/find-cache-dir" "^3.2.1"
     "@yarnpkg/esbuild-plugin-pnp" "^3.0.0-rc.10"
@@ -5720,6 +5720,18 @@
     telejson "^7.2.0"
     tiny-invariant "^1.3.1"
 
+"@storybook/channels@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.6.12.tgz#eafcbb1c26de94ed15db62dd0f8ea88d20154312"
+  integrity sha512-TaPl5Y3lOoVi5kTLgKNRX8xh2sUPekH0Id1l4Ymw+lpgriEY6r60bmkZLysLG1GhlskpQ/da2+S2ap2ht8P2TQ==
+  dependencies:
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-events" "7.6.12"
+    "@storybook/global" "^5.0.0"
+    qs "^6.10.0"
+    telejson "^7.2.0"
+    tiny-invariant "^1.3.1"
+
 "@storybook/channels@7.6.7":
   version "7.6.7"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.6.7.tgz#23a0c59ebfdfbb83e4a49d8d3fafdd25a9a67140"
@@ -5732,23 +5744,23 @@
     telejson "^7.2.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/cli@7.6.10":
-  version "7.6.10"
-  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.10.tgz#2436276c5404b166a9f795fef44bbd75826d9bfe"
-  integrity sha512-pK1MEseMm73OMO2OVoSz79QWX8ymxgIGM8IeZTCo9gImiVRChMNDFYcv8yPWkjuyesY8c15CoO48aR7pdA1OjQ==
+"@storybook/cli@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.12.tgz#f114dc71799eec60cf92c1462c2418ae11711246"
+  integrity sha512-x4sG1oIVERxp+WnWUexVlgaJCFmML0kGi7a5qfx7z4vHMxCV/WG7g1q7mPS/kqStCGEiQdTciCqOEFqlMh9MLw==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@ndelangen/get-tarball" "^3.0.7"
-    "@storybook/codemod" "7.6.10"
-    "@storybook/core-common" "7.6.10"
-    "@storybook/core-events" "7.6.10"
-    "@storybook/core-server" "7.6.10"
-    "@storybook/csf-tools" "7.6.10"
-    "@storybook/node-logger" "7.6.10"
-    "@storybook/telemetry" "7.6.10"
-    "@storybook/types" "7.6.10"
+    "@storybook/codemod" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/core-events" "7.6.12"
+    "@storybook/core-server" "7.6.12"
+    "@storybook/csf-tools" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/telemetry" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/semver" "^7.3.4"
     "@yarnpkg/fslib" "2.10.3"
     "@yarnpkg/libzip" "2.3.0"
@@ -5785,6 +5797,13 @@
   dependencies:
     "@storybook/global" "^5.0.0"
 
+"@storybook/client-logger@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.6.12.tgz#ee571b22e6f31a3d2fd1ad357a5725f46cfb6ded"
+  integrity sha512-hiRv6dXsOttMPqm9SxEuFoAtDe9rs7TUS8XcO5rmJ9BgfwBJsYlHzAxXkazxmvlyZtKL7gMx6m8OYbCdZgUqtA==
+  dependencies:
+    "@storybook/global" "^5.0.0"
+
 "@storybook/client-logger@7.6.7":
   version "7.6.7"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.6.7.tgz#a2cb75a668c09bf091c1925c3403e3f2f8b1e4e1"
@@ -5792,18 +5811,18 @@
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/codemod@7.6.10":
-  version "7.6.10"
-  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.10.tgz#21cc0e69df6f57d567fc27264310f820662d62fa"
-  integrity sha512-pzFR0nocBb94vN9QCJLC3C3dP734ZigqyPmd0ZCDj9Xce2ytfHK3v1lKB6TZWzKAZT8zztauECYxrbo4LVuagw==
+"@storybook/codemod@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.12.tgz#a450327ea43e6684d028968477d5f895c8905c93"
+  integrity sha512-4EI4Ah1cvz6gFkXOS/LGf23oN8LO6ABGpWwPQoMHpIV3wUkFWBwrKFUe/UAQZGptnM0VZRYx4grS82Hluw4XJA==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.10"
-    "@storybook/node-logger" "7.6.10"
-    "@storybook/types" "7.6.10"
+    "@storybook/csf-tools" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/cross-spawn" "^6.0.2"
     cross-spawn "^7.0.3"
     globby "^11.0.2"
@@ -5865,6 +5884,35 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
+"@storybook/core-common@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.6.12.tgz#a42bdcdb5c68aafcf57492666ad99cfe8261e3f9"
+  integrity sha512-kM9YiBBMM2x5v/oylL7gdO1PS4oehgJC21MivS9p5QZ8uuXKtCQ6UQvI3rzaV+1ZzUA4n+I8MyaMrNIQk8KDbw==
+  dependencies:
+    "@storybook/core-events" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/types" "7.6.12"
+    "@types/find-cache-dir" "^3.2.1"
+    "@types/node" "^18.0.0"
+    "@types/node-fetch" "^2.6.4"
+    "@types/pretty-hrtime" "^1.0.0"
+    chalk "^4.1.0"
+    esbuild "^0.18.0"
+    esbuild-register "^3.5.0"
+    file-system-cache "2.3.0"
+    find-cache-dir "^3.0.0"
+    find-up "^5.0.0"
+    fs-extra "^11.1.0"
+    glob "^10.0.0"
+    handlebars "^4.7.7"
+    lazy-universal-dotenv "^4.0.0"
+    node-fetch "^2.0.0"
+    picomatch "^2.3.0"
+    pkg-dir "^5.0.0"
+    pretty-hrtime "^1.0.3"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
+
 "@storybook/core-common@7.6.7":
   version "7.6.7"
   resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.6.7.tgz#69801d7a70b4ed6dab5dec589f612814628d3807"
@@ -5901,6 +5949,13 @@
   dependencies:
     ts-dedent "^2.0.0"
 
+"@storybook/core-events@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.12.tgz#b622a51ee905ca1adb83163a912bb9dcfee3ba4a"
+  integrity sha512-IO4cwk7bBCKH6lLnnIlHO9FwQXt/9CzLUAoZSY9msWsdPppCdKlw8ynJI5YarSNKDBUn8ArIfnRf0Mve0KQr9Q==
+  dependencies:
+    ts-dedent "^2.0.0"
+
 "@storybook/core-events@7.6.7":
   version "7.6.7"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.7.tgz#ee8823090cc4e30fddebe72be29738e4b2e66b11"
@@ -5908,26 +5963,26 @@
   dependencies:
     ts-dedent "^2.0.0"
 
-"@storybook/core-server@7.6.10":
-  version "7.6.10"
-  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.10.tgz#53bf43b8b3c999c87196774a0b92e2e10a434e4c"
-  integrity sha512-2icnqJkn3vwq0eJPP0rNaHd7IOvxYf5q4lSVl2AWTxo/Ae19KhokI6j/2vvS2XQJMGQszwshlIwrZUNsj5p0yw==
+"@storybook/core-server@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.12.tgz#486d022758dc7bbcc088e3d8d454404464f568dc"
+  integrity sha512-tjWifKsDnIc8pvbjVyQrOHef70Gcp93Bg3WwuysB8PGk7lcX2RD9zv44HNIyjxdOLSSv66IGKrOldEBL3hab4w==
   dependencies:
     "@aw-web-design/x-default-browser" "1.4.126"
     "@discoveryjs/json-ext" "^0.5.3"
-    "@storybook/builder-manager" "7.6.10"
-    "@storybook/channels" "7.6.10"
-    "@storybook/core-common" "7.6.10"
-    "@storybook/core-events" "7.6.10"
+    "@storybook/builder-manager" "7.6.12"
+    "@storybook/channels" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/core-events" "7.6.12"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.10"
+    "@storybook/csf-tools" "7.6.12"
     "@storybook/docs-mdx" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager" "7.6.10"
-    "@storybook/node-logger" "7.6.10"
-    "@storybook/preview-api" "7.6.10"
-    "@storybook/telemetry" "7.6.10"
-    "@storybook/types" "7.6.10"
+    "@storybook/manager" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
+    "@storybook/telemetry" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/detect-port" "^1.3.0"
     "@types/node" "^18.0.0"
     "@types/pretty-hrtime" "^1.0.0"
@@ -5985,6 +6040,21 @@
     "@babel/types" "^7.23.0"
     "@storybook/csf" "^0.1.2"
     "@storybook/types" "7.6.10"
+    fs-extra "^11.1.0"
+    recast "^0.23.1"
+    ts-dedent "^2.0.0"
+
+"@storybook/csf-tools@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.6.12.tgz#42ef641a2bcc2feaff167d68ea5b58aebe4f087c"
+  integrity sha512-MdhkYYxSW5I6Jpk34gTkAZsuj9sxe0xdyeUQpNa8CgJxG43F+ehZ6scW/IPjoSG9gCXBUJMekq26UrmbVfsLCQ==
+  dependencies:
+    "@babel/generator" "^7.23.0"
+    "@babel/parser" "^7.23.0"
+    "@babel/traverse" "^7.23.2"
+    "@babel/types" "^7.23.0"
+    "@storybook/csf" "^0.1.2"
+    "@storybook/types" "7.6.12"
     fs-extra "^11.1.0"
     recast "^0.23.1"
     ts-dedent "^2.0.0"
@@ -6074,10 +6144,10 @@
     telejson "^7.2.0"
     ts-dedent "^2.0.0"
 
-"@storybook/manager@7.6.10":
-  version "7.6.10"
-  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.10.tgz#eb1b71c802fbf04353f3bf017dfb102eb0db217e"
-  integrity sha512-Co3sLCbNYY6O4iH2ggmRDLCPWLj03JE5s/DOG8OVoXc6vBwTc/Qgiyrsxxp6BHQnPpM0mxL6aKAxE3UjsW/Nog==
+"@storybook/manager@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.12.tgz#147219c57f4b68d343a9e0ee1563e5214cd09549"
+  integrity sha512-WMWvswJHGiqJFJb98WQMQfZQhLuVtmci4y/VJGQ/Jnq1nJQs76BCtaeGiHcsYmRaAP1HMI4DbzuTSEgca146xw==
 
 "@storybook/mdx2-csf@^1.0.0":
   version "1.1.0"
@@ -6088,6 +6158,11 @@
   version "7.6.10"
   resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.10.tgz#d4c52d04384d2728d6610fb0afff6eb1feb50fd4"
   integrity sha512-ZBuqrv4bjJzKXyfRGFkVIi+z6ekn6rOPoQao4KmsfLNQAUUsEdR8Baw/zMnnU417zw5dSEaZdpuwx75SCQAeOA==
+
+"@storybook/node-logger@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.12.tgz#2232fc45ca8439649d8cb2cefe38f0a97c1aa275"
+  integrity sha512-iS44/EjfF6hLecKzICmcpQoB9bmVi4tXx5gVXnbI5ZyziBibRQcg/U191Njl7wY2ScN/RCQOr8lh5k57rI3Prg==
 
 "@storybook/node-logger@7.6.7", "@storybook/node-logger@^7.0.12":
   version "7.6.7"
@@ -6133,6 +6208,26 @@
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
     "@storybook/types" "7.6.10"
+    "@types/qs" "^6.9.5"
+    dequal "^2.0.2"
+    lodash "^4.17.21"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    synchronous-promise "^2.0.15"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/preview-api@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.6.12.tgz#d431cc76d733c17ba1943a31fc3297de8f40c467"
+  integrity sha512-uSzeMSLnCRROjiofJP0F0niLWL+sboQ5ktHW6BAYoPwprumXduPxKBUVEZNxMbVYoAz9v/kEZmaLauh8LRP2Hg==
+  dependencies:
+    "@storybook/channels" "7.6.12"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-events" "7.6.12"
+    "@storybook/csf" "^0.1.2"
+    "@storybook/global" "^5.0.0"
+    "@storybook/types" "7.6.12"
     "@types/qs" "^6.9.5"
     dequal "^2.0.2"
     lodash "^4.17.21"
@@ -6211,14 +6306,14 @@
     memoizerific "^1.11.3"
     qs "^6.10.0"
 
-"@storybook/telemetry@7.6.10":
-  version "7.6.10"
-  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.10.tgz#31c0edfb9c7005cf9b5922e51ca896218e3d81ea"
-  integrity sha512-p3mOSUtIyy2tF1z6pQXxNh1JzYFcAm97nUgkwLzF07GfEdVAPM+ftRSLFbD93zVvLEkmLTlsTiiKaDvOY/lQWg==
+"@storybook/telemetry@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.12.tgz#8a49317466c98a184cd01ad6c53162ee1c05a626"
+  integrity sha512-eBG3sLb9CZ05pyK2JXBvnaAsxDzbZH57VyhtphhuZmx0DqF/78qIoHs9ebRJpJWV0sL5rtT9vIq8QXpQhDHLWg==
   dependencies:
-    "@storybook/client-logger" "7.6.10"
-    "@storybook/core-common" "7.6.10"
-    "@storybook/csf-tools" "7.6.10"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/csf-tools" "7.6.12"
     chalk "^4.1.0"
     detect-package-manager "^2.0.1"
     fetch-retry "^5.0.2"
@@ -6273,6 +6368,16 @@
   integrity sha512-hcS2HloJblaMpCAj2axgGV+53kgSRYPT0a1PG1IHsZaYQILfHSMmBqM8XzXXYTsgf9250kz3dqFX1l0n3EqMlQ==
   dependencies:
     "@storybook/channels" "7.6.10"
+    "@types/babel__core" "^7.0.0"
+    "@types/express" "^4.7.0"
+    file-system-cache "2.3.0"
+
+"@storybook/types@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.6.12.tgz#af7813e6f4ca31c500f9e28af5f591c8b1ea1b13"
+  integrity sha512-Wsbd+NS10/2yMHQ/26rXHflXam0hm2qufTFiHOX6VXZWxij3slRU88Fnwzp+1QSyjXb0qkEr8dOx7aG00+ItVw==
+  dependencies:
+    "@storybook/channels" "7.6.12"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "2.3.0"
@@ -18924,12 +19029,12 @@ store2@^2.14.2:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
-storybook@7.6.10:
-  version "7.6.10"
-  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.10.tgz#2185d26cd7b43390e3e2c7581586e2f60cdbd9bd"
-  integrity sha512-ypFeGhQTUBBfqSUVZYh7wS5ghn3O2wILCiQc4459SeUpvUn+skcqw/TlrwGSoF5EWjDA7gtRrWDxO3mnlPt5Cw==
+storybook@7.6.12:
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.12.tgz#63a45b2a32f204abb77c8c20ba85ecba21990500"
+  integrity sha512-zcH9CwIsE8N4PX3he5vaJ3mTTWGxu7cxJ/ag9oja/k3N5/IvQjRyIU1TLkRVb28BB8gaLyorpnc4C4aLVGy4WQ==
   dependencies:
-    "@storybook/cli" "7.6.10"
+    "@storybook/cli" "7.6.12"
 
 stream-browserify@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7767991102), [Test report](https://leather-wallet.github.io/playwright-reports/chore/flag-story)<!-- Sticky Header Marker -->

@fabric-8 @mica000 added the `<Flag />` component to storybook. Made a new grouping by "layout". Please check out the storybook, link in the github ui below in actions.

<img width="1800" alt="image" src="https://github.com/leather-wallet/extension/assets/1618764/f24f998e-74f4-451f-8c9f-fcea2b6ec93f">


Examples where we see in UI, so many times

![image](https://github.com/leather-wallet/extension/assets/1618764/8c5ae02f-a7b3-4fdb-a422-f51121da4ea0)
![2024-02-02-000080@2x](https://github.com/leather-wallet/extension/assets/1618764/0174dd15-dc30-423d-bf3b-211e0dcf10de)
![2024-02-02-000081@2x](https://github.com/leather-wallet/extension/assets/1618764/098a5d55-96af-4a07-b842-c936bc304a65)

