### PR TITLE
Refactor/tx err reporting

### DIFF
--- a/src/app/common/hooks/use-submit-stx-transaction.ts
+++ b/src/app/common/hooks/use-submit-stx-transaction.ts
@@ -5,6 +5,7 @@ import { bytesToHex } from '@stacks/common';
 import { StacksTransaction, broadcastTransaction } from '@stacks/transactions';
 
 import { logger } from '@shared/logger';
+import { isError } from '@shared/utils';
 
 import { getErrorMessage } from '@app/common/get-error-message';
 import { useRefreshAllAccountData } from '@app/common/hooks/account/use-refresh-all-account-data';
@@ -59,7 +60,7 @@ export function useSubmitTransactionCallback({ loadingKey }: UseSubmitTransactio
           }
         } catch (error) {
           logger.error('Transaction callback', { error });
-          onError(error instanceof Error ? error : { name: '', message: '' });
+          onError(isError(error) ? error : { name: '', message: '' });
           setIsIdle();
         }
       },

--- a/src/app/common/utils/safe-await.ts
+++ b/src/app/common/utils/safe-await.ts
@@ -1,4 +1,5 @@
 // TypeScript port of https://github.com/DavidWells/safe-await/
+import { isError } from '@shared/utils';
 
 // Native Error types https://mzl.la/2Veh3TR
 const nativeExceptions = [
@@ -19,7 +20,7 @@ function throwNative(error: Error) {
 export async function safeAwait<T>(promise: Promise<T>, finallyFn?: () => void) {
   return promise
     .then(data => {
-      if (data instanceof Error) {
+      if (isError(data)) {
         throwNative(data);
         return [data] as readonly [Error];
       }

--- a/src/app/features/increase-fee-drawer/hooks/use-btc-increase-fee.ts
+++ b/src/app/features/increase-fee-drawer/hooks/use-btc-increase-fee.ts
@@ -8,6 +8,7 @@ import * as yup from 'yup';
 import { createMoney } from '@shared/models/money.model';
 import { BitcoinTx } from '@shared/models/transactions/bitcoin-transaction.model';
 import { RouteUrls } from '@shared/route-urls';
+import { isError } from '@shared/utils';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useBtcAssetBalance } from '@app/common/hooks/balance/btc/use-btc-balance';
@@ -122,7 +123,7 @@ export function useBtcIncreaseFee(btcTx: BitcoinTx) {
   }
 
   function onError(error: unknown) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const message = isError(error) ? error.message : 'Unknown error';
     toast.error(message);
     navigate(RouteUrls.Home);
   }

--- a/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
@@ -9,6 +9,7 @@ import get from 'lodash.get';
 import { BitcoinInputSigningConfig } from '@shared/crypto/bitcoin/signer-config';
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
+import { isError } from '@shared/utils';
 
 import { useLocationState, useLocationStateWithCache } from '@app/common/hooks/use-location-state';
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
@@ -115,7 +116,7 @@ function LedgerSignBitcoinTxContainer() {
         void bitcoinApp.transport.close();
       }
     } catch (e) {
-      if (e instanceof Error && checkLockedDeviceError(e)) {
+      if (isError(e) && checkLockedDeviceError(e)) {
         setLatestDeviceResponse({ deviceLocked: true } as any);
         return;
       }

--- a/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
+++ b/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
@@ -7,6 +7,7 @@ import get from 'lodash.get';
 
 import { finalizeAuthResponse } from '@shared/actions/finalize-auth-response';
 import { logger } from '@shared/logger';
+import { isError } from '@shared/utils';
 
 import { useGetLegacyAuthBitcoinAddresses } from '@app/common/authentication/use-legacy-auth-bitcoin-addresses';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
@@ -92,7 +93,7 @@ export function LedgerSignJwtContainer() {
     const stacks = await prepareLedgerDeviceStacksAppConnection({
       setLoadingState: setAwaitingDeviceConnection,
       onError(e) {
-        if (e instanceof Error && checkLockedDeviceError(e)) {
+        if (isError(e) && checkLockedDeviceError(e)) {
           setLatestDeviceResponse({ deviceLocked: true } as any);
           return;
         }

--- a/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
+++ b/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
@@ -9,6 +9,7 @@ import get from 'lodash.get';
 import { finalizeMessageSignature } from '@shared/actions/finalize-message-signature';
 import { logger } from '@shared/logger';
 import { UnsignedMessage, whenSignableMessageOfType } from '@shared/signature/signature-types';
+import { isError } from '@shared/utils';
 
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 import { delay } from '@app/common/utils';
@@ -67,7 +68,7 @@ function LedgerSignStacksMsg({ account, unsignedMessage }: LedgerSignMsgProps) {
     const stacksApp = await prepareLedgerDeviceStacksAppConnection({
       setLoadingState: setAwaitingDeviceConnection,
       onError(e) {
-        if (e instanceof Error && checkLockedDeviceError(e)) {
+        if (isError(e) && checkLockedDeviceError(e)) {
           setLatestDeviceResponse({ deviceLocked: true } as any);
           return;
         }

--- a/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container.tsx
+++ b/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container.tsx
@@ -7,6 +7,7 @@ import get from 'lodash.get';
 
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
+import { isError } from '@shared/utils';
 
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 import { appEvents } from '@app/common/publish-subscribe';
@@ -71,7 +72,7 @@ function LedgerSignStacksTxContainer() {
     const stacksApp = await prepareLedgerDeviceStacksAppConnection({
       setLoadingState: setAwaitingDeviceConnection,
       onError(e) {
-        if (e instanceof Error && checkLockedDeviceError(e)) {
+        if (isError(e) && checkLockedDeviceError(e)) {
           setLatestDeviceResponse({ deviceLocked: true } as any);
           return;
         }
@@ -148,7 +149,7 @@ function LedgerSignStacksTxContainer() {
           signedTx,
         });
       } catch (e) {
-        ledgerNavigate.toBroadcastErrorStep(e instanceof Error ? e.message : 'Unknown error');
+        ledgerNavigate.toBroadcastErrorStep(isError(e) ? e.message : 'Unknown error');
         return;
       }
     } catch (e) {

--- a/src/app/features/ledger/generic-flows/request-keys/use-request-ledger-keys.ts
+++ b/src/app/features/ledger/generic-flows/request-keys/use-request-ledger-keys.ts
@@ -4,6 +4,7 @@ import StacksApp from '@zondax/ledger-stacks';
 import AppClient from 'ledger-bitcoin';
 
 import { SupportedBlockchains } from '@shared/constants';
+import { isError } from '@shared/utils';
 
 import { delay } from '@app/common/utils';
 
@@ -73,7 +74,7 @@ export function useRequestLedgerKeys<App extends AppClient | StacksApp>({
       onSuccess?.();
     } catch (e) {
       setAwaitingDeviceConnection(false);
-      if (e instanceof Error && checkLockedDeviceError(e)) {
+      if (isError(e) && checkLockedDeviceError(e)) {
         setLatestDeviceResponse({ deviceLocked: true } as any);
         return;
       }

--- a/src/app/features/psbt-signer/psbt-signer.tsx
+++ b/src/app/features/psbt-signer/psbt-signer.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { getPsbtTxInputs, getPsbtTxOutputs } from '@shared/crypto/bitcoin/bitcoin.utils';
 import { RouteUrls } from '@shared/route-urls';
-import { closeWindow } from '@shared/utils';
+import { closeWindow, isError } from '@shared/utils';
 
 import { useRouteHeader } from '@app/common/hooks/use-route-header';
 import { SignPsbtArgs } from '@app/common/psbt/requests';
@@ -51,7 +51,7 @@ export function PsbtSigner(props: PsbtSignerProps) {
       return getRawPsbt(psbtHex);
     } catch (e) {
       navigate(RouteUrls.RequestError, {
-        state: { message: e instanceof Error ? e.message : '', title: 'Failed request' },
+        state: { message: isError(e) ? e.message : '', title: 'Failed request' },
       });
       return;
     }

--- a/src/app/features/stacks-transaction-request/hooks/use-stacks-broadcast-transaction.tsx
+++ b/src/app/features/stacks-transaction-request/hooks/use-stacks-broadcast-transaction.tsx
@@ -7,7 +7,7 @@ import { StacksTransaction } from '@stacks/transactions';
 import { logger } from '@shared/logger';
 import { CryptoCurrencies } from '@shared/models/currencies.model';
 import { RouteUrls } from '@shared/route-urls';
-import { isString } from '@shared/utils';
+import { isError, isString } from '@shared/utils';
 
 import { LoadingKeys } from '@app/common/hooks/use-loading';
 import { useSubmitTransactionCallback } from '@app/common/hooks/use-submit-stx-transaction';
@@ -56,7 +56,7 @@ export function useStacksBroadcastTransaction(token: CryptoCurrencies, decimals?
         })(signedTx);
       } catch (e) {
         navigate(RouteUrls.TransactionBroadcastError, {
-          state: { message: e instanceof Error ? e.message : 'Unknown error' },
+          state: { message: isError(e) ? e.message : 'Unknown error' },
         });
       } finally {
         setIsBroadcasting(false);

--- a/src/app/pages/psbt-request/use-psbt-request.tsx
+++ b/src/app/pages/psbt-request/use-psbt-request.tsx
@@ -5,6 +5,7 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 
 import { finalizePsbt } from '@shared/actions/finalize-psbt';
 import { RouteUrls } from '@shared/route-urls';
+import { isError } from '@shared/utils';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { usePsbtRequestSearchParams } from '@app/common/psbt/use-psbt-request-params';
@@ -57,7 +58,7 @@ export function usePsbtRequest() {
           });
         } catch (e) {
           return navigate(RouteUrls.RequestError, {
-            state: { message: e instanceof Error ? e.message : '', title: 'Failed to sign' },
+            state: { message: isError(e) ? e.message : '', title: 'Failed to sign' },
           });
         }
       },

--- a/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
@@ -7,7 +7,7 @@ import { bytesToHex } from '@stacks/common';
 import { Money } from '@shared/models/money.model';
 import { RouteUrls } from '@shared/route-urls';
 import { makeRpcErrorResponse, makeRpcSuccessResponse } from '@shared/rpc/rpc-methods';
-import { closeWindow } from '@shared/utils';
+import { closeWindow, isError } from '@shared/utils';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { sumMoney } from '@app/common/money/calculate-money';
@@ -78,7 +78,7 @@ export function useRpcSignPsbt() {
       },
       onError(e) {
         navigate(RouteUrls.RequestError, {
-          state: { message: e instanceof Error ? e.message : '', title: 'Failed to broadcast' },
+          state: { message: isError(e) ? e.message : '', title: 'Failed to broadcast' },
         });
       },
     });
@@ -113,7 +113,7 @@ export function useRpcSignPsbt() {
           } catch (e) {
             return navigate(RouteUrls.RequestError, {
               state: {
-                message: e instanceof Error ? e.message : '',
+                message: isError(e) ? e.message : '',
                 title: 'Failed to finalize tx',
               },
             });
@@ -130,7 +130,7 @@ export function useRpcSignPsbt() {
         closeWindow();
       } catch (e) {
         return navigate(RouteUrls.RequestError, {
-          state: { message: e instanceof Error ? e.message : '', title: 'Failed to sign' },
+          state: { message: isError(e) ? e.message : '', title: 'Failed to sign' },
         });
       }
     },

--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
@@ -6,6 +6,7 @@ import * as yup from 'yup';
 import { logger } from '@shared/logger';
 import { OrdinalSendFormValues } from '@shared/models/form.model';
 import { RouteUrls } from '@shared/route-urls';
+import { isError } from '@shared/utils';
 
 import { FormErrorMessages } from '@app/common/error-messages';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
@@ -66,7 +67,7 @@ export function useSendInscriptionForm() {
         void analytics.track('ordinals_dot_com_unavailable', { error });
 
         let message = 'Unable to establish if utxo has multiple inscriptions';
-        if (error instanceof Error) {
+        if (isError(error)) {
           message = error.message;
         }
         setShowError(message);

--- a/src/app/pages/swap/hooks/use-stacks-broadcast-swap.tsx
+++ b/src/app/pages/swap/hooks/use-stacks-broadcast-swap.tsx
@@ -6,7 +6,7 @@ import { StacksTransaction } from '@stacks/transactions';
 
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
-import { isString } from '@shared/utils';
+import { isError, isString } from '@shared/utils';
 
 import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
 import { useSubmitTransactionCallback } from '@app/common/hooks/use-submit-stx-transaction';
@@ -42,7 +42,7 @@ export function useStacksBroadcastSwap() {
       } catch (e) {
         setIsIdle();
         navigate(RouteUrls.TransactionBroadcastError, {
-          state: { message: e instanceof Error ? e.message : 'Unknown error' },
+          state: { message: isError(e) ? e.message : 'Unknown error' },
         });
       } finally {
         setIsIdle();

--- a/src/app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
+++ b/src/app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react';
 
+import { isError } from '@shared/utils';
+
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { delay } from '@app/common/utils';
 import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
@@ -30,7 +32,10 @@ export function useBitcoinBroadcastTransaction() {
         return txid;
       } catch (e) {
         onError?.(e as Error);
-        void analytics.track('error_broadcasting_transaction', { error: e });
+        void analytics.track('error_broadcasting_transaction', {
+          errorName: isError(e) ? e.name : 'unknown',
+          errorMsg: isError(e) ? e.message : 'unknown',
+        });
         return;
       } finally {
         setIsBroadcasting(false);

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -29,6 +29,10 @@ export function isObject(value: unknown): value is object {
   return typeof value === 'object';
 }
 
+export function isError(value: unknown): value is Error {
+  return value instanceof Error;
+}
+
 export function isEmpty(value: object) {
   return Object.keys(value).length === 0;
 }


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7785923666), [Test report](https://leather-wallet.github.io/playwright-reports/refactor/tx-err-reporting)<!-- Sticky Header Marker -->

![image](https://github.com/leather-wallet/extension/assets/1618764/ca3ed561-e5f7-4967-9fe6-203086a6d9a9)

Unable to ascertain common errors owing to `Error` not being casted to readable string. 

Also includes refactor making `isError` helper. Let's use this instead of repeating `instanceof Error`