### PR TITLE
chore: deprecation warnings, closes #4928

### DIFF
--- a/src/inpage/inpage.ts
+++ b/src/inpage/inpage.ts
@@ -252,31 +252,67 @@ const provider: HiroWalletProviderOverrides = {
   },
 };
 
+function consoleDeprecationNotice(text: string) {
+  // eslint-disable-next-line no-console
+  console.warn(`Deprecation warning: ${text}`);
+}
+
+function warnAboutDeprecatedProvider(legacyProvider: object) {
+  return Object.fromEntries(
+    Object.entries(legacyProvider).map(([key, value]) => {
+      if (typeof value === 'function') {
+        return [
+          key,
+          (...args: any[]) => {
+            switch (key) {
+              case 'authenticationRequest':
+                consoleDeprecationNotice(
+                  `Use LeatherProvider.request('getAddresses') instead, see docs https://leather.gitbook.io/developers/bitcoin/connect-users/get-addresses`
+                );
+                break;
+              case 'psbtRequest':
+                consoleDeprecationNotice(
+                  `Use LeatherProvider.request('signPsbt') instead, see docs https://leather.gitbook.io/developers/bitcoin/sign-transactions/partially-signed-bitcoin-transactions-psbts`
+                );
+                break;
+              case 'structuredDataSignatureRequest':
+              case 'signatureRequest':
+                consoleDeprecationNotice(`Use LeatherProvider.request('stx_signMessage') instead`);
+                break;
+              default:
+                consoleDeprecationNotice(
+                  'The provider object is deprecated. Use `LeatherProvider` instead'
+                );
+            }
+
+            return value(...args);
+          },
+        ];
+      }
+      return [key, value];
+    })
+  );
+}
+
 try {
-  // Make properties immutable to contend with other wallets that use agressive
-  // "prioritisation" default settings. As wallet use this approach, Leather has
-  // to use it too, resulting in browsers' own internal logic being used to
-  // determine content script exeuction order. A more fair way to contend over
-  // shared provider space.
-  Object.defineProperty(window, 'StacksProvider', { get: () => provider, set: () => {} });
-  Object.defineProperty(window, 'LeatherProvider', { get: () => provider, set: () => {} });
-  Object.defineProperty(window, 'HiroWalletProvider', {
-    get: () => provider,
+  // Makes properties immutable to contend with other wallets that use agressive
+  // "prioritisation" default settings. As other wallet's use this approach,
+  // Leather has to use it too, so that the browsers' own internal logic being
+  // used to determine content script exeuction order. A more fair way to
+  // contend over shared provider space. `StacksProvider` should be considered
+  // deprecated and each wallet use their own provider namespace.
+  Object.defineProperty(window, 'StacksProvider', {
+    get: () => warnAboutDeprecatedProvider(provider),
     set: () => {},
   });
+  Object.defineProperty(window, 'HiroWalletProvider', {
+    get: () => warnAboutDeprecatedProvider(provider),
+    set: () => {},
+  });
+  Object.defineProperty(window, 'LeatherProvider', { get: () => provider, set: () => {} });
 } catch (e) {}
 
+// Legacy product provider objects
 if (typeof window.btc === 'undefined') {
-  (window as any).btc = {
-    request: (window as any).StacksProvider?.request,
-    listen(event: 'accountChange', callback: (arg: any) => void) {
-      function handler(e: MessageEvent) {
-        if (!e.data) return;
-        if ((e as any).event !== event) return;
-        callback((e as any).event);
-      }
-      window.addEventListener('message', handler);
-      return () => window.removeEventListener('message', handler);
-    },
-  };
+  (window as any).btc = warnAboutDeprecatedProvider(provider);
 }


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7873436658), [Test report](https://leather-wallet.github.io/playwright-reports/feat/deprecation-warnings)<!-- Sticky Header Marker -->

This PR wraps non-LeatherProvider methods with a provider deprecation warning. it also logs separate deprecation warnings for methods that have a `.request` alternative.