### PR TITLE
fix: svg inscriptions preview

### DIFF
--- a/src/shared/models/inscription.model.ts
+++ b/src/shared/models/inscription.model.ts
@@ -117,12 +117,12 @@ export function whenInscriptionType<T>(
     return branches.html();
   }
 
-  if (mimeType.startsWith('image/') && branches.image) {
-    return branches.image();
-  }
-
   if (mimeType.startsWith('image/svg') && branches.svg) {
     return branches.svg();
+  }
+
+  if (mimeType.startsWith('image/') && branches.image) {
+    return branches.image();
   }
 
   if (mimeType.startsWith('text') && branches.text) {


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7851233973), [Test report](https://leather-wallet.github.io/playwright-reports/fix/svg-inscriptions)<!-- Sticky Header Marker -->

The order of the if statements here was likely causing an issue where inscriptions with type `image/svg` were not displaying the preview in an iframe correctly.