### PR TITLE
fix: close settings dropdown on click

### DIFF
--- a/src/app/common/hooks/use-onclickoutside.ts
+++ b/src/app/common/hooks/use-onclickoutside.ts
@@ -27,7 +27,11 @@ const getOptions = (event: HandledEventsType) => {
   return;
 };
 
-export function useOnClickOutside(ref: RefObject<HTMLElement>, handler: Handler | null) {
+export function useOnClickOutside(
+  ref: RefObject<HTMLElement>,
+  handler: Handler | null,
+  exceptionIds: string[] = []
+) {
   const noHandler = !handler;
   const handlerRef = useLatest(handler);
 
@@ -38,6 +42,14 @@ export function useOnClickOutside(ref: RefObject<HTMLElement>, handler: Handler 
 
     const listener = (event: PossibleEvent) => {
       if (!ref.current || !handlerRef.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+
+      const clickedElementIsAnException = exceptionIds
+        .map(el => document.getElementById(el))
+        .some(el => el?.contains(event.target as Node));
+
+      if (clickedElementIsAnException) {
         return;
       }
 
@@ -53,5 +65,5 @@ export function useOnClickOutside(ref: RefObject<HTMLElement>, handler: Handler 
         document.removeEventListener(event, listener, getOptions(event) as EventListenerOptions);
       });
     };
-  }, [ref, handlerRef, noHandler]);
+  }, [ref, handlerRef, noHandler, exceptionIds]);
 }

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -71,6 +71,7 @@ export function Header(props: HeaderProps) {
         <NetworkModeBadge />
         {!hideActions && (
           <Button
+            id="settings-menu-btn"
             data-testid={SettingsSelectors.SettingsMenuBtn}
             onClick={() => setIsShowingSettings(!isShowingSettings)}
             variant="ghost"

--- a/src/app/features/settings-dropdown/settings-dropdown.tsx
+++ b/src/app/features/settings-dropdown/settings-dropdown.tsx
@@ -55,7 +55,7 @@ export function SettingsDropdown() {
 
   const isLedger = useHasLedgerKeys();
 
-  useOnClickOutside(ref, isShowingSettings ? handleClose : null);
+  useOnClickOutside(ref, isShowingSettings ? handleClose : null, ['settings-menu-btn']);
 
   // RouteUrls.Activity is nested off / so we need to use a link relative to the route
   const linkRelativeType =


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7854444864), [Test report](https://leather-wallet.github.io/playwright-reports/fix/settings-menu-open)<!-- Sticky Header Marker -->

Currently if you click on settings dropdown icon (when dropdown in opened), it will close and then immediately open dropdown again. 
This pr fixes it
https://github.com/leather-wallet/extension/assets/46521087/2b2ac24c-cf03-4cec-9d4c-571531dceab1

