### PR TITLE
feat: add utxos double check for all btc related flows

### DIFF
--- a/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
@@ -4,6 +4,7 @@ import { RpcErrorCode } from '@btckit/types';
 import { hexToBytes } from '@noble/hashes/utils';
 import { bytesToHex } from '@stacks/common';
 
+import { decodeBitcoinTx } from '@shared/crypto/bitcoin/bitcoin.utils';
 import { Money } from '@shared/models/money.model';
 import { RouteUrls } from '@shared/route-urls';
 import { makeRpcErrorResponse, makeRpcSuccessResponse } from '@shared/rpc/rpc-methods';
@@ -54,6 +55,8 @@ export function useRpcSignPsbt() {
 
     await broadcastTx({
       tx,
+      // skip utxos check for psbt txs
+      skipBypassUtxoIdsCheckFor: decodeBitcoinTx(tx).inputs.map(input => bytesToHex(input.txid)),
       async onSuccess(txid) {
         await refetch();
 

--- a/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
@@ -4,7 +4,6 @@ import { bytesToHex } from '@noble/hashes/utils';
 import { Box, Stack } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
-import { decodeBitcoinTx } from '@shared/crypto/bitcoin/bitcoin.utils';
 import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
@@ -13,10 +12,6 @@ import { BaseDrawer } from '@app/components/drawer/base-drawer';
 import { InfoCard, InfoCardRow, InfoCardSeparator } from '@app/components/info-card/info-card';
 import { InscriptionPreview } from '@app/components/inscription-preview-card/components/inscription-preview';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by-address.hooks';
-import {
-  filterOutIntentionalInscriptionsSpend,
-  useCheckInscribedUtxos,
-} from '@app/query/bitcoin/transaction/use-check-utxos';
 import { useAppDispatch } from '@app/store';
 import { inscriptionSent } from '@app/store/ordinals/ordinals.slice';
 import { Button } from '@app/ui/components/button/button';
@@ -45,17 +40,9 @@ export function SendInscriptionReview() {
   const { refetch } = useCurrentNativeSegwitUtxos();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
 
-  const { checkIfUtxosListIncludesInscribed, isLoading } = useCheckInscribedUtxos({
-    // Filer out inscription txid from the check list
-    inputs: filterOutIntentionalInscriptionsSpend({
-      inputs: decodeBitcoinTx(bytesToHex(signedTx)).inputs,
-      inscriptions: [inscription],
-    }),
-  });
-
   async function sendInscription() {
     await broadcastTx({
-      checkForInscribedUtxos: checkIfUtxosListIncludesInscribed,
+      skipBypassUtxoIdsCheckFor: [inscription.tx_id],
       tx: bytesToHex(signedTx),
       async onSuccess(txid: string) {
         void analytics.track('broadcast_ordinal_transaction');
@@ -100,7 +87,7 @@ export function SendInscriptionReview() {
           <InfoCardRow title="Fee" value={feeRowValue} />
         </Stack>
 
-        <Button aria-busy={isLoading || isBroadcasting} width="100%" onClick={sendInscription}>
+        <Button aria-busy={isBroadcasting} width="100%" onClick={sendInscription}>
           Confirm and send transaction
         </Button>
       </InfoCard>

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -28,7 +28,6 @@ import {
 import { ModalHeader } from '@app/components/modal-header';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by-address.hooks';
 import { useBitcoinBroadcastTransaction } from '@app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction';
-import { useCheckInscribedUtxos } from '@app/query/bitcoin/transaction/use-check-utxos';
 import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
 import { Button } from '@app/ui/components/button/button';
 
@@ -75,12 +74,9 @@ export function BtcSendFormConfirmation() {
   );
   const sendingValue = formatMoneyPadded(createMoneyFromDecimal(Number(transferAmount), symbol));
   const summaryFee = formatMoneyPadded(createMoney(Number(fee), symbol));
-  const { checkIfUtxosListIncludesInscribed, isLoading } = useCheckInscribedUtxos({
-    inputs: decodedTx.inputs,
-  });
+
   async function initiateTransaction() {
     await broadcastTx({
-      checkForInscribedUtxos: checkIfUtxosListIncludesInscribed,
       tx: transaction.hex,
       async onSuccess(txid) {
         void analytics.track('broadcast_transaction', {
@@ -161,7 +157,7 @@ export function BtcSendFormConfirmation() {
       </Stack>
 
       <InfoCardFooter>
-        <Button aria-busy={isLoading || isBroadcasting} onClick={initiateTransaction} width="100%">
+        <Button aria-busy={isBroadcasting} onClick={initiateTransaction} width="100%">
           Confirm and send transaction
         </Button>
       </InfoCardFooter>

--- a/src/app/query/bitcoin/transaction/use-check-utxos.ts
+++ b/src/app/query/bitcoin/transaction/use-check-utxos.ts
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 import * as btc from '@scure/btc-signer';
 import { bytesToHex } from '@stacks/common';
 
-import type { SupportedInscription } from '@shared/models/inscription.model';
 import { isUndefined } from '@shared/utils';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
@@ -19,30 +18,25 @@ class PreventTransactionError extends Error {
   }
 }
 
-interface UseCheckInscribedUtxosArgs {
-  inputs: btc.TransactionInput[];
-  blockTxAction?(): void;
-}
-
 interface FilterOutIntentionalInscriptionsSpendArgs {
   inputs: btc.TransactionInput[];
-  inscriptions: SupportedInscription[];
+  intentionalSpendUtxoIds: string[];
 }
-export function filterOutIntentionalInscriptionsSpend({
+export function filterOutIntentionalUtxoSpend({
   inputs,
-  inscriptions,
-}: FilterOutIntentionalInscriptionsSpendArgs) {
+  intentionalSpendUtxoIds,
+}: FilterOutIntentionalInscriptionsSpendArgs): btc.TransactionInput[] {
   return inputs.filter(input => {
     if (!input.txid) throw new Error('Transaction ID is missing in the input');
     const inputTxid = bytesToHex(input.txid);
 
-    return inscriptions.every(inscription => {
-      return inscription.tx_id !== inputTxid;
+    return intentionalSpendUtxoIds.every(id => {
+      return id !== inputTxid;
     });
   });
 }
 
-export function useCheckInscribedUtxos({ inputs, blockTxAction }: UseCheckInscribedUtxosArgs) {
+export function useCheckInscribedUtxos(blockTxAction?: () => void) {
   const client = useBitcoinClient();
   const analytics = useAnalytics();
   const [isLoading, setIsLoading] = useState(false);
@@ -55,73 +49,76 @@ export function useCheckInscribedUtxos({ inputs, blockTxAction }: UseCheckInscri
     );
   }, [blockTxAction]);
 
-  const checkIfUtxosListIncludesInscribed = useCallback(async () => {
-    setIsLoading(true);
-    const txids = inputs.map(input => {
-      if (!input.txid) throw new Error('Transaction ID is missing in the input');
-      return bytesToHex(input.txid);
-    });
-
-    try {
-      // no need to check for inscriptions on testnet
-      if (isTestnet) {
-        return false;
-      }
-
-      if (txids.length === 0) {
-        throw new Error('Utxos list cannot be empty');
-      }
-
-      const responses = await Promise.all(
-        txids.map(id => client.bestinslotInscriptionsApi.getInscriptionsByTransactionId(id))
-      );
-
-      const hasInscribedUtxo = responses.some(resp => {
-        return resp.data.length > 0;
+  const checkIfUtxosListIncludesInscribed = useCallback(
+    async (inputs: btc.TransactionInput[]) => {
+      setIsLoading(true);
+      const txids = inputs.map(input => {
+        if (!input.txid) throw new Error('Transaction ID is missing in the input');
+        return bytesToHex(input.txid);
       });
 
-      if (hasInscribedUtxo) {
-        void analytics.track('utxos_includes_inscribed_one', {
+      try {
+        // no need to check for inscriptions on testnet
+        if (isTestnet) {
+          return false;
+        }
+
+        if (txids.length === 0) {
+          throw new Error('Utxos list cannot be empty');
+        }
+
+        const responses = await Promise.all(
+          txids.map(id => client.bestinslotInscriptionsApi.getInscriptionsByTransactionId(id))
+        );
+
+        const hasInscribedUtxo = responses.some(resp => {
+          return resp.data.length > 0;
+        });
+
+        if (hasInscribedUtxo) {
+          void analytics.track('utxos_includes_inscribed_one', {
+            txids,
+          });
+          preventTransaction();
+          return true;
+        }
+
+        return false;
+      } catch (e) {
+        if (e instanceof PreventTransactionError) {
+          throw e;
+        }
+
+        void analytics.track('error_checking_utxos_from_bestinslot', {
           txids,
         });
-        preventTransaction();
+
+        const ordinalsComResponses = await Promise.all(
+          txids.map(async (id, index) => {
+            const inscriptionIndex = inputs[index].index;
+            if (isUndefined(inscriptionIndex)) {
+              throw new Error('Inscription index is missing in the input');
+            }
+            const num = await getNumberOfInscriptionOnUtxoUsingOrdinalsCom(id, inscriptionIndex);
+            return num > 0;
+          })
+        );
+
+        const hasInscribedUtxo = ordinalsComResponses.some(resp => resp);
+
+        // if there are inscribed utxos in the transaction, and no error => prevent the transaction
+        if (hasInscribedUtxo) {
+          preventTransaction();
+          return true;
+        }
+
         return true;
+      } finally {
+        setIsLoading(false);
       }
-
-      return false;
-    } catch (e) {
-      if (e instanceof PreventTransactionError) {
-        throw e;
-      }
-
-      void analytics.track('error_checking_utxos_from_bestinslot', {
-        txids,
-      });
-
-      const ordinalsComResponses = await Promise.all(
-        txids.map(async (id, index) => {
-          const inscriptionIndex = inputs[index].index;
-          if (isUndefined(inscriptionIndex)) {
-            throw new Error('Inscription index is missing in the input');
-          }
-          const num = await getNumberOfInscriptionOnUtxoUsingOrdinalsCom(id, inscriptionIndex);
-          return num > 0;
-        })
-      );
-
-      const hasInscribedUtxo = ordinalsComResponses.some(resp => resp);
-
-      // if there are inscribed utxos in the transaction, and no error => prevent the transaction
-      if (hasInscribedUtxo) {
-        preventTransaction();
-        return true;
-      }
-
-      return true;
-    } finally {
-      setIsLoading(false);
-    }
-  }, [client.bestinslotInscriptionsApi, inputs, preventTransaction, isTestnet, analytics]);
+    },
+    [analytics, client.bestinslotInscriptionsApi, isTestnet, preventTransaction]
+  );
 
   return {
     checkIfUtxosListIncludesInscribed,


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/7959596534), [Test report](https://leather-wallet.github.io/playwright-reports/feat/prevent-all-flows)<!-- Sticky Header Marker -->

Refactored utxos double check, so it would be much easier to use it in broadcast tx flow