### PR TITLE
fix: stamps api, closes #4845

### DIFF
--- a/src/app/query/bitcoin/stamps/stamps-by-address.query.ts
+++ b/src/app/query/bitcoin/stamps/stamps-by-address.query.ts
@@ -5,20 +5,70 @@ import { AppUseQueryConfig } from '@app/query/query-config';
 import { QueryPrefixes } from '@app/query/query-prefixes';
 
 export interface Stamp {
-  asset: string;
-  block_index: number;
-  message_index: number;
   stamp: number;
+  block_index: number;
+  cpid: string;
+  asset_longname: string;
+  creator: string;
+  divisible: number;
+  keyburn: number;
+  locked: number;
+  message_index: number;
+  stamp_base64: string;
   stamp_mimetype: string;
   stamp_url: string;
-  timestamp: number;
+  supply: number;
+  timestamp: string;
   tx_hash: string;
   tx_index: number;
+  src_data: string;
+  ident: string;
+  creator_name: string;
+  stamp_gen: string;
+  stamp_hash: string;
+  is_btc_stamp: number;
+  is_reissue: number;
+  file_hash: string;
 }
 
+interface Src20 {
+  id: string;
+  address: string;
+  cpid: string;
+  p: string;
+  tick: string;
+  amt: number;
+  block_time: string;
+  last_update: number;
+}
+
+interface StampsByAddressQueryResponse {
+  page: number;
+  limit: number;
+  totalPages: number;
+  total: number;
+  last_block: number;
+  btc: {
+    address: string;
+    balance: number;
+    txCount: number;
+    unconfirmedBalance: number;
+    unconfirmedTxCount: number;
+  };
+  data: {
+    stamps: Stamp[];
+    src20: Src20[];
+  };
+}
+
+/**
+ * @see https://stampchain.io/docs#/default/get_api_v2_balance__address_
+ */
 async function fetchStampsByAddress(address: string): Promise<Stamp[]> {
-  const resp = await axios.get(`https://stampchain.io/api/stamps?wallet_address=${address}`);
-  return resp.data;
+  const resp = await axios.get<StampsByAddressQueryResponse>(
+    `https://stampchain.io/api/v2/balance/${address}`
+  );
+  return resp.data.data.stamps;
 }
 
 type FetchStampsByAddressResp = Awaited<ReturnType<typeof fetchStampsByAddress>>;


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8022393384), [Test report](https://leather-wallet.github.io/playwright-reports/fix/stamps-api)<!-- Sticky Header Marker -->

Stamps api is updated, so feature is broken. This pr fixes it