### PR TITLE
fix: welcome text and password strength colors

### DIFF
--- a/src/app/pages/onboarding/set-password/components/password-field.tsx
+++ b/src/app/pages/onboarding/set-password/components/password-field.tsx
@@ -4,6 +4,7 @@ import { OnboardingSelectors } from '@tests/selectors/onboarding.selectors';
 import { useField } from 'formik';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
+import { useThemeSwitcher } from '@app/common/theme-provider';
 import { ValidatedPassword } from '@app/common/validation/validate-password';
 import { Input } from '@app/ui/components/input/input';
 import { Caption } from '@app/ui/components/typography/caption';
@@ -20,8 +21,9 @@ interface PasswordFieldProps {
 export function PasswordField({ strengthResult, isDisabled }: PasswordFieldProps) {
   const [field] = useField('password');
   const [showPassword, setShowPassword] = useState(false);
+  const { theme } = useThemeSwitcher();
 
-  const { strengthColor, strengthText } = useMemo(
+  const { strengthColorLightMode, strengthColorDarkMode, strengthText } = useMemo(
     () => getIndicatorsOfPasswordStrength(strengthResult),
     [strengthResult]
   );
@@ -62,7 +64,7 @@ export function PasswordField({ strengthResult, isDisabled }: PasswordFieldProps
       </Box>
       <PasswordStrengthIndicator
         password={field.value}
-        strengthColor={strengthColor}
+        strengthColor={theme === 'light' ? strengthColorLightMode : strengthColorDarkMode}
         strengthResult={strengthResult}
       />
       <Flex alignItems="center">

--- a/src/app/pages/onboarding/set-password/components/password-field.utils.ts
+++ b/src/app/pages/onboarding/set-password/components/password-field.utils.ts
@@ -6,27 +6,33 @@ export const defaultColor = token('colors.ink.background-secondary');
 
 const strengthStyles = {
   [PasswordStrength.NoScore]: {
-    strengthColor: token('colors.red.action-primary-default'),
+    strengthColorLightMode: token('colors.red.background-secondary'),
+    strengthColorDarkMode: token('colors.red.border'),
     strengthText: 'Poor',
   },
   [PasswordStrength.PoorScore]: {
-    strengthColor: token('colors.red.action-primary-default'),
+    strengthColorLightMode: token('colors.red.background-secondary'),
+    strengthColorDarkMode: token('colors.red.border'),
     strengthText: 'Poor',
   },
   [PasswordStrength.WeakScore]: {
-    strengthColor: token('colors.yellow.action-primary-default'),
+    strengthColorLightMode: token('colors.yellow.background-secondary'),
+    strengthColorDarkMode: token('colors.yellow.border'),
     strengthText: 'Weak',
   },
   [PasswordStrength.AverageScore]: {
-    strengthColor: token('colors.yellow.action-primary-default'),
+    strengthColorLightMode: token('colors.yellow.background-secondary'),
+    strengthColorDarkMode: token('colors.yellow.border'),
     strengthText: 'Average',
   },
   [PasswordStrength.StrongScore]: {
-    strengthColor: token('colors.yellow.action-primary-default'),
+    strengthColorLightMode: token('colors.yellow.background-secondary'),
+    strengthColorDarkMode: token('colors.yellow.border'),
     strengthText: 'Average',
   },
   [PasswordStrength.MeetsAllRequirements]: {
-    strengthColor: token('colors.green.action-primary-default'),
+    strengthColorLightMode: token('colors.green.background-secondary'),
+    strengthColorDarkMode: token('colors.green.border'),
     strengthText: 'Strong',
   },
 };

--- a/src/app/pages/onboarding/welcome/welcome.layout.tsx
+++ b/src/app/pages/onboarding/welcome/welcome.layout.tsx
@@ -37,7 +37,7 @@ export function WelcomeLayout({
           flexDir="column"
           flex={[1, 1, 0]}
           justifyContent={['center', '', 'flex-start']}
-          color={['ink.background-primary', '', 'ink.background-secondary']}
+          color={['ink.text-primary', '', 'ink.background-secondary']}
         >
           <Box>
             <styled.h1 textStyle={['heading.03', '', 'display.02', 'display.01']}>


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8054071595), [Test report](https://leather-wallet.github.io/playwright-reports/fix/welcome-text-color)<!-- Sticky Header Marker -->

This PR fixes the welcome text color so we can release. It also temporarily fixes our password strength colors that don't currently work well in dark mode.

![Screenshot 2024-02-26 at 12 42 45 PM](https://github.com/leather-wallet/extension/assets/6493321/0a65451c-d2f5-40c0-b386-3b0d6f0d7d7b)

![Screenshot 2024-02-23 at 2 03 34 PM](https://github.com/leather-wallet/extension/assets/6493321/6b909023-02dd-45fa-ab67-27bbe92b1273)

