### PR TITLE
fix: warning banner, add fake app warning

### DIFF
--- a/src/app/features/hiro-messages/components/in-app-message-item.tsx
+++ b/src/app/features/hiro-messages/components/in-app-message-item.tsx
@@ -6,68 +6,63 @@ import { CloseIcon } from '@app/ui/icons/close-icon';
 interface HiroMessageItemProps extends HiroMessage {
   onDismiss(id: string): void;
 }
-
 export function HiroMessageItem(props: HiroMessageItemProps) {
   const { id, title, text, learnMoreUrl, learnMoreText, img, imgWidth, dismissible, onDismiss } =
     props;
 
   return (
-    <Flex
-      flex={1}
-      flexDirection={['column', null, 'row']}
-      alignItems={[null, null, 'center']}
-      justifyContent="center"
-      position="relative"
-      p="space.04"
-    >
-      {dismissible && (
-        <styled.button
-          position="absolute"
-          p="space.02"
-          top={[0, 0, '50%']}
-          mr="space.02"
-          mt={['space.02', null, 'unset']}
-          transform={[null, null, 'translateY(-50%)']}
-          right={0}
-          borderRadius="lg"
-          _focus={{ outline: '1px solid white' }}
-          onClick={() => onDismiss(id)}
-        >
-          <CloseIcon />
-        </styled.button>
-      )}
-      {img && (
-        <Box mb={['space.03', null, 'unset']}>
-          <img width={imgWidth} src={img} />
-        </Box>
-      )}
-      <Box fontSize="13px" lineHeight="20px">
-        {title && (
-          <styled.span display="block" lineHeight="inherit">
-            {title}
-          </styled.span>
-        )}
-        <styled.span
-          display="inline"
-          fontSize="inherit"
-          ml={[null, null, 'space.04']}
-          mr={['space.02', 'space.04']}
-          lineHeight="inherit"
-        >
-          {text}
-        </styled.span>
-        {learnMoreUrl && (
-          <styled.a
-            display="inline-block"
-            textDecoration="underline"
-            href={learnMoreUrl}
-            whiteSpace="nowrap"
-            target="_blank"
+    <Flex position="relative" py="space.05" px="space.04" width="100%" justifyContent="center">
+      <Flex pos="relative" flexDirection={['column', null, 'row']} width={['100%', null, '884px']}>
+        {dismissible && (
+          <styled.button
+            position="absolute"
+            p="space.02"
+            top={['-16px', null, '50%']}
+            // mr="space.02"
+            mt={['space.02', null, 'unset']}
+            transform={[null, null, 'translateY(-50%)']}
+            right="-space.02"
+            borderRadius="lg"
+            _focus={{ outline: '1px solid white' }}
+            onClick={() => onDismiss(id)}
           >
-            {learnMoreText ? learnMoreText : 'Learn more ↗'}
-          </styled.a>
+            <CloseIcon />
+          </styled.button>
         )}
-      </Box>
+        {img && (
+          <Box mb={['space.03', null, 'unset']}>
+            <img width={imgWidth} src={img} />
+          </Box>
+        )}
+        <Box fontSize="13px" lineHeight="20px">
+          {title && (
+            <styled.span textStyle="label.02" display="block" lineHeight="inherit">
+              {title}
+            </styled.span>
+          )}
+          <styled.span
+            textStyle="caption.02"
+            display="inline-block"
+            fontSize="inherit"
+            mr={['space.02', 'space.04']}
+            mt="space.03"
+            lineHeight="inherit"
+          >
+            {text}
+          </styled.span>
+          {learnMoreUrl && (
+            <styled.a
+              display="inline-block"
+              textDecoration="underline"
+              href={learnMoreUrl}
+              whiteSpace="nowrap"
+              target="_blank"
+            >
+              {learnMoreText ? learnMoreText : 'Learn more ↗'}
+            </styled.a>
+          )}
+        </Box>
+      </Flex>
     </Flex>
   );
 }

--- a/src/app/features/hiro-messages/in-app-messages.tsx
+++ b/src/app/features/hiro-messages/in-app-messages.tsx
@@ -25,7 +25,7 @@ export function InAppMessages(props: FlexProps) {
   }
 
   return (
-    <Flex bg="ink.component-background-default" color="white" {...props}>
+    <Flex bg="ink.non-interactive" {...props}>
       <HiroMessageItem onDismiss={messageId => dismissMessage(messageId)} {...firstMessage} />
     </Flex>
   );

--- a/src/app/query/common/remote-config/remote-config.query.ts
+++ b/src/app/query/common/remote-config/remote-config.query.ts
@@ -69,8 +69,7 @@ const githubWalletConfigRawUrl = `https://raw.githubusercontent.com/${GITHUB_ORG
 }/config/wallet-config.json`;
 
 async function fetchLeatherMessages(): Promise<RemoteConfig> {
-  if ((!BRANCH_NAME && WALLET_ENVIRONMENT !== 'production') || IS_TEST_ENV)
-    return localConfig as RemoteConfig;
+  if (WALLET_ENVIRONMENT !== 'production' || IS_TEST_ENV) return localConfig as RemoteConfig;
   const resp = await axios.get(githubWalletConfigRawUrl);
   return resp.data;
 }


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8110004843), [Test report](https://leather-wallet.github.io/playwright-reports/chore/warning-fake-app)<!-- Sticky Header Marker -->

Styles got broken in colour changes.

cc/ @fabric-8 @mica000 any chance of input on a quick update to this component?

![2024-03-01-000115@2x](https://github.com/leather-wallet/extension/assets/1618764/e7da9547-5e00-43d5-8324-68688f84638d)

![2024-03-01-000116@2x](https://github.com/leather-wallet/extension/assets/1618764/92102f2e-e15e-4000-bfa0-460e4e4ce396)
