### PR TITLE
fix: tx calc unhandled errors, closes #4941

### DIFF
--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
@@ -11,6 +11,12 @@ export interface DetermineUtxosForSpendArgs {
   utxos: UtxoResponseItem[];
 }
 
+export class InsufficientFundsError extends Error {
+  constructor() {
+    super('Insufficient funds');
+  }
+}
+
 export function determineUtxosForSpendAll({
   amount,
   feeRate,
@@ -71,7 +77,7 @@ export function determineUtxosForSpend({
     neededUtxos.push(utxo);
   }
 
-  if (!sizeInfo) throw new Error('Transaction size must be defined');
+  if (!sizeInfo) throw new InsufficientFundsError();
 
   const fee = Math.ceil(sizeInfo.txVBytes * feeRate);
 

--- a/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-fiat.tsx
+++ b/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-fiat.tsx
@@ -1,49 +1,18 @@
-import { useMemo } from 'react';
-
-import { useField } from 'formik';
 import { Flex, styled } from 'leather-styles/jsx';
 
-import { createMoney } from '@shared/models/money.model';
-
-import { satToBtc } from '@app/common/money/unit-conversion';
-
-import { useBitcoinCustomFee } from './hooks/use-bitcoin-custom-fee';
-
 interface BitcoinCustomFeeFiatProps {
-  amount: number;
-  isSendingMax: boolean;
-  recipient: string;
+  feeInBtc: string;
+  fiatFeeValue: string;
 }
 
-export function BitcoinCustomFeeFiat({
-  amount,
-  isSendingMax,
-  recipient,
-}: BitcoinCustomFeeFiatProps) {
-  const [field] = useField('feeRate');
-  const getCustomFeeValues = useBitcoinCustomFee({
-    amount: createMoney(amount, 'BTC'),
-    isSendingMax,
-    recipient,
-  });
-
-  const feeData = useMemo(() => {
-    const { fee, fiatFeeValue } = getCustomFeeValues(Number(field.value));
-    const feeInBtc = satToBtc(fee).toString();
-
-    return { fiatFeeValue, feeInBtc };
-  }, [getCustomFeeValues, field.value]);
-
-  const canShow = !feeData.feeInBtc.includes('e') && Number(field.value) > 0;
-  if (!canShow) return null;
-
+export function BitcoinCustomFeeFiat({ feeInBtc, fiatFeeValue }: BitcoinCustomFeeFiatProps) {
   return (
     <Flex justifyContent="space-between">
       <styled.span color="ink.text-subdued" textStyle="body.02">
-        {feeData.fiatFeeValue}
+        {fiatFeeValue}
       </styled.span>
       <styled.span color="ink.text-subdued" textStyle="body.02">
-        {feeData.feeInBtc} BTC
+        {feeInBtc} BTC
       </styled.span>
     </Flex>
   );

--- a/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-input.tsx
+++ b/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-input.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+
+import { useField } from 'formik';
+import { Stack } from 'leather-styles/jsx';
+
+import { createMoney } from '@shared/models/money.model';
+
+import { useOnMount } from '@app/common/hooks/use-on-mount';
+import { satToBtc } from '@app/common/money/unit-conversion';
+import { InsufficientFundsError } from '@app/common/transactions/bitcoin/coinselect/local-coin-selection';
+import { Input } from '@app/ui/components/input/input';
+
+import { ErrorLabel } from '../error-label';
+import { BitcoinCustomFeeFiat } from './bitcoin-custom-fee-fiat';
+import { useBitcoinCustomFee } from './hooks/use-bitcoin-custom-fee';
+
+interface Props {
+  onClick?(): void;
+  amount: number;
+  isSendingMax: boolean;
+  recipient: string;
+  hasInsufficientBalanceError: boolean;
+  errorMessage?: string;
+  setCustomFeeInitialValue?(value: string): void;
+  customFeeInitialValue: string;
+}
+
+const feeInputLabel = 'sats/vB';
+
+export function BitcoinCustomFeeInput({
+  onClick,
+  amount,
+  isSendingMax,
+  recipient,
+  hasInsufficientBalanceError,
+  setCustomFeeInitialValue,
+  customFeeInitialValue,
+}: Props) {
+  const [field] = useField('feeRate');
+
+  const [feeValue, setFeeValue] = useState<null | {
+    fee: number;
+    fiatFeeValue: string;
+  }>(null);
+
+  const getCustomFeeValues = useBitcoinCustomFee({
+    amount: createMoney(amount, 'BTC'),
+    isSendingMax,
+    recipient,
+  });
+  const [unknownError, setUnknownError] = useState(false);
+  const [customInsufficientBalanceError, setCustomInsufficientBalanceError] = useState(false);
+
+  const hasError = hasInsufficientBalanceError || unknownError || customInsufficientBalanceError;
+  const errorMessage =
+    hasInsufficientBalanceError || customInsufficientBalanceError
+      ? 'Insufficient funds'
+      : 'Unknown error';
+
+  function processFeeValue(feeRate: string) {
+    try {
+      const feeValues = getCustomFeeValues(Number(feeRate));
+      setFeeValue(feeValues);
+
+      setUnknownError(false);
+      setCustomInsufficientBalanceError(false);
+    } catch (err) {
+      if (err instanceof InsufficientFundsError) {
+        return setCustomInsufficientBalanceError(true);
+      }
+
+      setUnknownError(true);
+    }
+  }
+
+  function onChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+    setCustomFeeInitialValue?.(e.target.value);
+    processFeeValue(value);
+  }
+
+  useOnMount(() => {
+    processFeeValue(customFeeInitialValue);
+  });
+  return (
+    <Stack gap="space.05">
+      <Stack>
+        <Input.Root hasError={hasError}>
+          <Input.Label>{feeInputLabel}</Input.Label>
+          <Input.Field
+            onClick={onClick}
+            {...field}
+            onChange={e => {
+              field.onChange(e);
+              onChange?.(e);
+            }}
+          />
+        </Input.Root>
+        {hasError && <ErrorLabel>{errorMessage}</ErrorLabel>}
+      </Stack>
+
+      {!hasError && feeValue && (
+        <BitcoinCustomFeeFiat
+          feeInBtc={satToBtc(feeValue.fee).toString()}
+          fiatFeeValue={feeValue.fiatFeeValue}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee.tsx
+++ b/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useCallback, useRef } from 'react';
 
-import { Form, Formik, useField } from 'formik';
+import { Form, Formik } from 'formik';
 import { Stack, styled } from 'leather-styles/jsx';
 import * as yup from 'yup';
 
@@ -9,40 +9,11 @@ import { createMoney } from '@shared/models/money.model';
 
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { PreviewButton } from '@app/components/preview-button';
-import { Input } from '@app/ui/components/input/input';
 import { Link } from '@app/ui/components/link/link';
 
 import { OnChooseFeeArgs } from '../bitcoin-fees-list/bitcoin-fees-list';
-import { BitcoinCustomFeeFiat } from './bitcoin-custom-fee-fiat';
+import { BitcoinCustomFeeInput } from './bitcoin-custom-fee-input';
 import { useBitcoinCustomFee } from './hooks/use-bitcoin-custom-fee';
-
-const feeInputLabel = 'sats/vB';
-
-interface BitcoinCustomFeeInputProps {
-  hasInsufficientBalanceError: boolean;
-  onClick(): void;
-  onChange?(e: React.ChangeEvent<HTMLInputElement>): void;
-}
-function BitcoinCustomFeeInput({
-  hasInsufficientBalanceError,
-  onClick,
-  onChange,
-}: BitcoinCustomFeeInputProps) {
-  const [field] = useField('feeRate');
-  return (
-    <Input.Root hasError={hasInsufficientBalanceError}>
-      <Input.Label>{feeInputLabel}</Input.Label>
-      <Input.Field
-        onClick={onClick}
-        {...field}
-        onChange={e => {
-          field.onChange(e);
-          onChange?.(e);
-        }}
-      />
-    </Input.Root>
-  );
-}
 
 interface BitcoinCustomFeeProps {
   amount: number;
@@ -56,6 +27,7 @@ interface BitcoinCustomFeeProps {
   setCustomFeeInitialValue: Dispatch<SetStateAction<string>>;
   maxCustomFeeRate: number;
 }
+
 export function BitcoinCustomFee({
   amount,
   customFeeInitialValue,
@@ -123,20 +95,17 @@ export function BitcoinCustomFee({
                 </Link>
               </styled.span>
               <BitcoinCustomFeeInput
-                hasInsufficientBalanceError={hasInsufficientBalanceError}
+                amount={amount}
+                isSendingMax={isSendingMax}
                 onClick={async () => {
-                  feeInputRef?.current?.focus();
+                  feeInputRef.current?.focus();
                   await props.setValues({ ...props.values });
                 }}
-                onChange={e => setCustomFeeInitialValue((e.target as HTMLInputElement).value)}
+                customFeeInitialValue={customFeeInitialValue}
+                setCustomFeeInitialValue={setCustomFeeInitialValue}
+                recipient={recipient}
+                hasInsufficientBalanceError={hasInsufficientBalanceError}
               />
-              <Stack gap="space.01">
-                <BitcoinCustomFeeFiat
-                  amount={amount}
-                  isSendingMax={isSendingMax}
-                  recipient={recipient}
-                />
-              </Stack>
             </Stack>
             <PreviewButton isDisabled={!props.values.feeRate} text="Use custom fee" />
           </Stack>

--- a/src/app/features/increase-fee-drawer/components/increase-btc-fee-form.tsx
+++ b/src/app/features/increase-fee-drawer/components/increase-btc-fee-form.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
-import { Formik, useField } from 'formik';
+import { Formik } from 'formik';
 import { Stack } from 'leather-styles/jsx';
 
 import { BitcoinTx } from '@shared/models/transactions/bitcoin-transaction.model';
@@ -10,31 +10,19 @@ import { useBtcAssetBalance } from '@app/common/hooks/balance/btc/use-btc-balanc
 import { formatMoney } from '@app/common/money/format-money';
 import { btcToSat } from '@app/common/money/unit-conversion';
 import { getBitcoinTxValue } from '@app/common/transactions/bitcoin/utils';
-import { BitcoinCustomFeeFiat } from '@app/components/bitcoin-custom-fee/bitcoin-custom-fee-fiat';
+import { BitcoinCustomFeeInput } from '@app/components/bitcoin-custom-fee/bitcoin-custom-fee-input';
 import { BitcoinTransactionItem } from '@app/components/bitcoin-transaction-item/bitcoin-transaction-item';
 import { LoadingSpinner } from '@app/components/loading-spinner';
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
-import { Input } from '@app/ui/components/input/input';
 import { Caption } from '@app/ui/components/typography/caption';
 
 import { useBtcIncreaseFee } from '../hooks/use-btc-increase-fee';
 import { IncreaseFeeActions } from './increase-fee-actions';
 
-const feeInputLabel = 'sats/vB';
-
-function BitcoinFeeIncreaseField() {
-  const [field] = useField('feeRate');
-  return (
-    <Input.Root>
-      <Input.Field placeholder={feeInputLabel} {...field} />
-      <Input.Label>Fee rate</Input.Label>
-    </Input.Root>
-  );
-}
-
 interface IncreaseBtcFeeFormProps {
   btcTx: BitcoinTx;
 }
+
 export function IncreaseBtcFeeForm({ btcTx }: IncreaseBtcFeeFormProps) {
   const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
   const navigate = useNavigate();
@@ -63,13 +51,14 @@ export function IncreaseBtcFeeForm({ btcTx }: IncreaseBtcFeeFormProps) {
         {btcTx && <BitcoinTransactionItem transaction={btcTx} />}
         <Stack gap="space.04">
           <Stack gap="space.01">
-            <BitcoinFeeIncreaseField />
-            <BitcoinCustomFeeFiat
-              recipient={recipient}
-              isSendingMax={false}
+            <BitcoinCustomFeeInput
               amount={Math.abs(
                 btcToSat(getBitcoinTxValue(currentBitcoinAddress, btcTx)).toNumber()
               )}
+              isSendingMax={false}
+              recipient={recipient}
+              hasInsufficientBalanceError={false}
+              customFeeInitialValue={initialFeeRate}
             />
           </Stack>
 

--- a/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.spec.ts
+++ b/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.spec.ts
@@ -1,12 +1,12 @@
 import { sumNumbers } from '@app/common/math/helpers';
 
-import { selectInscriptionTransferCoins } from './select-inscription-coins';
+import { selectTaprootInscriptionTransferCoins } from './select-inscription-coins';
 
-describe(selectInscriptionTransferCoins.name, () => {
+describe(selectTaprootInscriptionTransferCoins.name, () => {
   test('inscription coin selection', () => {
     const inscriptionInputAmount = 1000n;
 
-    const result = selectInscriptionTransferCoins({
+    const result = selectTaprootInscriptionTransferCoins({
       recipient: '',
       inscriptionInput: {
         value: Number(inscriptionInputAmount),
@@ -37,11 +37,11 @@ describe(selectInscriptionTransferCoins.name, () => {
         Number(inscriptionInputAmount)
     );
 
-    expect(result.txFee).toEqual(6765);
+    expect(result.txFee).toEqual(5048);
   });
 
   test('when there are not enough utxo to cover fee', () => {
-    const result = selectInscriptionTransferCoins({
+    const result = selectTaprootInscriptionTransferCoins({
       recipient: '',
       inscriptionInput: {
         value: 1000,

--- a/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.ts
+++ b/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.ts
@@ -6,8 +6,6 @@ import { BtcSizeFeeEstimator } from '@app/common/transactions/bitcoin/fees/btc-s
 import { createCounter } from '@app/common/utils/counter';
 import { UtxoResponseItem, UtxoWithDerivationPath } from '@app/query/bitcoin/bitcoin-client';
 
-const idealInscriptionValue = 10_000;
-
 interface SelectInscriptionCoinSuccess {
   success: true;
   inputs: UtxoResponseItem[];
@@ -28,7 +26,8 @@ interface SelectInscriptionTransferCoinsArgs {
   recipient: string;
   changeAddress: string;
 }
-export function selectInscriptionTransferCoins(
+
+export function selectTaprootInscriptionTransferCoins(
   args: SelectInscriptionTransferCoinsArgs
 ): SelectInscriptionCoinResult {
   const { inscriptionInput, recipient, changeAddress, nativeSegwitUtxos, feeRate } = args;
@@ -51,9 +50,9 @@ export function selectInscriptionTransferCoins(
   const indexCounter = createCounter();
 
   function shouldContinueTryingWithMoreInputs() {
-    const valueOfUtxos = sumNumbers(neededInputs.map(utxo => utxo.value));
+    const neededSumOfInputs = sumNumbers(neededInputs.map(utxo => utxo.value));
     if (indexCounter.getValue() > nativeSegwitUtxos.length) return false;
-    return idealInscriptionValue + txFee > inscriptionInput.value + valueOfUtxos.toNumber();
+    return txFee >= neededSumOfInputs.toNumber();
   }
 
   let utxos = nativeSegwitUtxos

--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
@@ -11,6 +11,7 @@ import { isError } from '@shared/utils';
 import { FormErrorMessages } from '@app/common/error-messages';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { formFeeRowValue } from '@app/common/send/utils';
+import { InsufficientFundsError } from '@app/common/transactions/bitcoin/coinselect/local-coin-selection';
 import {
   btcAddressNetworkValidator,
   btcAddressValidator,
@@ -20,7 +21,7 @@ import { useSignBitcoinTx } from '@app/store/accounts/blockchain/bitcoin/bitcoin
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useSendInscriptionState } from '../components/send-inscription-container';
-import { recipeintFieldName } from '../send-inscription-form';
+import { recipientFieldName } from '../send-inscription-form';
 import { useGenerateUnsignedOrdinalTx } from './use-generate-ordinal-tx';
 
 export function useSendInscriptionForm() {
@@ -65,6 +66,13 @@ export function useSendInscriptionForm() {
         }
       } catch (error) {
         void analytics.track('ordinals_dot_com_unavailable', { error });
+
+        if (error instanceof InsufficientFundsError) {
+          setShowError(
+            'Insufficient funds to cover fee. Deposit some BTC to your Native Segwit address.'
+          );
+          return;
+        }
 
         let message = 'Unable to establish if utxo has multiple inscriptions';
         if (isError(error)) {
@@ -127,7 +135,7 @@ export function useSendInscriptionForm() {
     },
 
     validationSchema: yup.object({
-      [recipeintFieldName]: yup
+      [recipientFieldName]: yup
         .string()
         .required(FormErrorMessages.AddressRequired)
         .concat(btcAddressValidator())

--- a/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
@@ -22,7 +22,7 @@ export function SendInscriptionChooseFee() {
   const navigate = useNavigate();
   const { recipient, selectedFeeType, setSelectedFeeType, utxo, inscription } =
     useSendInscriptionState();
-  const { feesList, isLoading } = useSendInscriptionFeesList({ recipient, utxo });
+  const { feesList, isLoading } = useSendInscriptionFeesList({ recipient, utxo, inscription });
   const recommendedFeeRate = feesList[1]?.feeRate.toString() || '';
 
   const { reviewTransaction } = useSendInscriptionForm();

--- a/src/app/pages/send/ordinal-inscription/send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-form.tsx
@@ -18,7 +18,7 @@ import { useSendInscriptionState } from './components/send-inscription-container
 import { useSendInscriptionForm } from './hooks/use-send-inscription-form';
 import { SendInscriptionFormLoader } from './send-indcription-form-loader';
 
-export const recipeintFieldName = 'recipient';
+export const recipientFieldName = 'recipient';
 
 export function SendInscriptionForm() {
   const navigate = useNavigate();
@@ -30,7 +30,7 @@ export function SendInscriptionForm() {
     <Formik
       validationSchema={validationSchema}
       initialValues={{
-        [recipeintFieldName]: recipient,
+        [recipientFieldName]: recipient,
         inscription,
         feeRate: feeRates.hourFee.toNumber(),
       }}
@@ -49,7 +49,7 @@ export function SendInscriptionForm() {
                 <Flex flexDirection="column" mt="space.05" width="100%">
                   <CollectibleAsset icon={<OrdinalAvatarIcon />} name="Ordinal inscription" />
                   <RecipientAddressTypeField
-                    name={recipeintFieldName}
+                    name={recipientFieldName}
                     label="To"
                     placeholder="Enter recipient address"
                   />

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-address-type-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-address-type-field.tsx
@@ -32,10 +32,12 @@ export function RecipientAddressTypeField({
   return (
     <Box width="100%" position="relative" mb="space.02">
       <Input.Root shrink>
-        <Box pos="absolute" right="space.03" zIndex={15} top="9px">
-          {rightLabel}
-        </Box>
-        <Input.Label>{topInputOverlay}</Input.Label>
+        {rightLabel && (
+          <Box pos="absolute" right="space.03" zIndex={15} top="9px">
+            {rightLabel}
+          </Box>
+        )}
+        {topInputOverlay && <Input.Label>{topInputOverlay}</Input.Label>}
         <Input.Field
           data-testid={SendCryptoAssetSelectors.RecipientFieldInput}
           placeholder="Recipient"

--- a/src/app/pages/send/send-crypto-asset-form/form/brc-20/use-brc20-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc-20/use-brc20-send-form.tsx
@@ -71,7 +71,6 @@ export function useBrc20SendForm({
       .string()
       .concat(btcAddressValidator())
       .concat(btcAddressNetworkValidator(currentNetwork.chain.bitcoin.bitcoinNetwork)),
-    // .concat(notCurrentAddressValidator(currentAccountBtcAddress || '')),
   });
   const { onFormStateChange } = useUpdatePersistedSendFormValues();
 


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8162711334), [Test report](https://leather-wallet.github.io/playwright-reports/fix/tx-size-error)<!-- Sticky Header Marker -->

This pr handles unprocessed fees calc error in bitcoin flows:
- Removes fee variant in fees list, if there is no enough balance for it
- Shows insufficient balance error in custom fee input

Also:
- refactored custom fee input, so we use one component in all flows, including increasing fee
- refactored inscription fees list, so it considers inscription utxo type (NS or Taproot)
