### PR TITLE
test: fix playwright select interactive item

### DIFF
--- a/src/app/features/switch-account-drawer/components/switch-account-list.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list.tsx
@@ -23,7 +23,7 @@ export const SwitchAccountList = memo(
         style={{ paddingTop: '24px', height: '70vh' }}
         totalCount={addressesNum}
         itemContent={index => (
-          <Box key={index} mx="space.05">
+          <Box key={index} m="space.05">
             <SwitchAccountListItem
               handleClose={handleClose}
               currentAccountIndex={currentAccountIndex}

--- a/src/app/ui/components/item/item-interactive.tsx
+++ b/src/app/ui/components/item/item-interactive.tsx
@@ -13,7 +13,6 @@ const basePseudoOutlineProps = {
   left: '-space.03',
   bottom: '-space.03',
   right: '-space.03',
-  pointerEvents: 'none',
 };
 
 const focusVisibleStyles = {

--- a/tests/specs/profile/profile.spec.ts
+++ b/tests/specs/profile/profile.spec.ts
@@ -14,7 +14,7 @@ test.describe('Profile updating', () => {
     testAppPage = await TestAppPage.openDemoPage(context);
     await testAppPage.signIn();
     const accountsPage = await context.waitForEvent('page');
-    await accountsPage.locator('text="Account 1"').click();
+    await accountsPage.locator('text="Account 1"').click({ force: true });
     await testAppPage.page.bringToFront();
     await testAppPage.page.click('text=Profile');
     await accountsPage.close();
@@ -25,7 +25,6 @@ test.describe('Profile updating', () => {
     const profileUpdatingPage = new UpdateProfileRequestPage(await context.waitForEvent('page'));
     const name = profileUpdatingPage.page.getByText('twitter');
     const nameText = await name.innerText();
-
     test.expect(nameText).toBe('https://twitter.com/twitterHandle');
   });
 

--- a/tests/specs/transactions/transactions.spec.ts
+++ b/tests/specs/transactions/transactions.spec.ts
@@ -25,7 +25,7 @@ test.describe('Transaction signing', () => {
       context,
     }) => {
       const accountsPage = await context.waitForEvent('page');
-      await accountsPage.locator('text="Account 2"').click();
+      await accountsPage.locator('text="Account 2"').click({ force: true });
       await testAppPage.page.bringToFront();
       await testAppPage.page.click('text=Debugger', {
         timeout: 30000,
@@ -44,7 +44,7 @@ test.describe('Transaction signing', () => {
   test.describe('App initiated STX transfer', () => {
     test('that it broadcasts correctly with given fee and amount', async ({ context }) => {
       const accountsPage = await context.waitForEvent('page');
-      await accountsPage.locator('text="Account 1"').click();
+      await accountsPage.locator('text="Account 1"').click({ force: true });
       await testAppPage.page.bringToFront();
       await testAppPage.page.click('text=Debugger', {
         timeout: 30000,


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8139089858), [Test report](https://leather-wallet.github.io/playwright-reports/fix/item-interactive-clickable)<!-- Sticky Header Marker -->

The `pointer-events: 'none';` fix https://github.com/leather-wallet/extension/pull/5005 had the unintended side effect of the clickable area being smaller than the background, which isn't good.

This PR removes that property, and manages to fix the test using the `click({ force: true })` arg. (Edit: hadn't realised you also used this in your PR @fbwoolf 👍🏼 )

![image](https://github.com/leather-wallet/extension/assets/1618764/15f5abeb-08ce-4a4c-9ee6-e2cbeb7ee64f)

https://playwright.dev/docs/input

Also fixes padding issue on Select account page