### PR TITLE
fix: recipient account margins

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "react-lottie": "1.2.4",
     "react-redux": "8.1.3",
     "react-router-dom": "6.22.1",
-    "react-virtuoso": "4.6.0",
+    "react-virtuoso": "4.7.1",
     "redux-persist": "6.0.0",
     "rxjs": "7.8.1",
     "style-loader": "3.3.4",

--- a/src/app/features/switch-account-drawer/components/switch-account-list.tsx
+++ b/src/app/features/switch-account-drawer/components/switch-account-list.tsx
@@ -23,7 +23,7 @@ export const SwitchAccountList = memo(
         style={{ paddingTop: '24px', height: '70vh' }}
         totalCount={addressesNum}
         itemContent={index => (
-          <Box key={index} m="space.05">
+          <Box key={index} my="space.05" px="space.05">
             <SwitchAccountListItem
               handleClose={handleClose}
               currentAccountIndex={currentAccountIndex}

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/recipient-accounts-drawer.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-drawer/recipient-accounts-drawer.tsx
@@ -23,16 +23,17 @@ export const RecipientAccountsDrawer = memo(() => {
 
   return (
     <BaseDrawer title="My accounts" isShowing onClose={onGoBack}>
-      <Box mb="space.05" mx="space.04">
+      <Box mb="space.05" mx="space.03">
         <Virtuoso
-          height="72px"
           itemContent={index => (
-            <AccountListItem
-              key={index}
-              stacksAccount={stacksAccounts[index]}
-              onClose={onGoBack}
-              index={index}
-            />
+            <Box my="space.05" px="space.03">
+              <AccountListItem
+                key={index}
+                stacksAccount={stacksAccounts[index]}
+                onClose={onGoBack}
+                index={index}
+              />
+            </Box>
           )}
           style={{ paddingTop: '24px', height: '70vh' }}
           totalCount={stacksAddressesNum || btcAddressesNum}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18847,10 +18847,10 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtuoso@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-4.6.0.tgz#402d86363b6fc6408273615bae9be83e4ce73037"
-  integrity sha512-paQbkLA8U6dRe9srltWgPeoFCtNKqUYIcOpUR01JyznzaXWVzgZQE0M9KGi9vMoq8vHvHkGzuxJ6jDCS6uzePg==
+react-virtuoso@4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-4.7.1.tgz#a86dc0336e85f63ebcfc960bec1a83bca1bc75a4"
+  integrity sha512-V1JIZLEwgX7R+YNkbY8dq6NcnIGKGWXe4mnMJJPsA2L4qeFKst0LY3mDk6sBCJyKRbMzYFxTZWyTT4QsA1JvVQ==
 
 react@18.2.0, react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8141790329), [Test report](https://leather-wallet.github.io/playwright-reports/fix/account-list)<!-- Sticky Header Marker -->

Fixes margins on recipient drawer modal.

![image](https://github.com/leather-wallet/extension/assets/1618764/cfd35c1d-905b-4c95-9284-eb842d547c53)

Using pseudo element does have some quirks, just noticed with virtuoso list causing a scroll unless using a padded container. Though still think handling these is better than trying to style consistently with compounding margins.