### PR TITLE
fix: dropdown item padding

### DIFF
--- a/src/app/ui/components/dowpdown-menu/dropdown-menu.tsx
+++ b/src/app/ui/components/dowpdown-menu/dropdown-menu.tsx
@@ -72,12 +72,15 @@ const Label: typeof RadixDropdownMenu.Label = forwardRef((props, ref) => (
   <RadixDropdownMenu.Label className={dropdownMenuLabelStyles} ref={ref} {...props} />
 ));
 
+const dropdownItemStyles = css({ p: 'space.03' });
 const Item: typeof RadixDropdownMenu.Item = forwardRef((props, ref) => (
-  <RadixDropdownMenu.Item
-    className={css(itemBaseStyles, itemInteractiveStyles)}
-    ref={ref}
-    {...props}
-  />
+  <styled.div className={dropdownItemStyles}>
+    <RadixDropdownMenu.Item
+      ref={ref}
+      className={css(itemBaseStyles, itemInteractiveStyles)}
+      {...props}
+    />
+  </styled.div>
 ));
 
 const dropdownMenuSeparatorStyles = css({

--- a/src/app/ui/components/item/item-interactive.stories.tsx
+++ b/src/app/ui/components/item/item-interactive.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { styled } from 'leather-styles/jsx';
 
 import { BtcAvatarIcon } from '@app/ui/components/avatar/btc-avatar-icon';
 import { CopyIcon } from '@app/ui/icons/copy-icon';
@@ -21,19 +22,31 @@ const meta: Meta<typeof Component> = {
 export default meta;
 type Story = StoryObj<typeof Component>;
 
+function ExampleInteractiveItemContent() {
+  return (
+    <ItemLayout
+      showChevron
+      flagImg={<BtcAvatarIcon />}
+      titleLeft="Label"
+      captionLeft="Caption"
+      titleRight="1,000.00 ABC"
+      captionRight="$1,000.00"
+    />
+  );
+}
+
 export const ItemInteractive: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`InteractiveItem` has its hover state applied with a before pseudo element, so the content aligns independently from its hover state background.',
+      },
+    },
+  },
   args: {
     onClick: () => {},
-    children: (
-      <ItemLayout
-        showChevron
-        flagImg={<BtcAvatarIcon />}
-        titleLeft="Label"
-        captionLeft="Caption"
-        titleRight="1,000.00 ABC"
-        captionRight="$1,000.00"
-      />
-    ),
+    children: <ExampleInteractiveItemContent />,
   },
 };
 
@@ -69,5 +82,51 @@ export const WithButtons: Story = {
         }
       />
     ),
+  },
+};
+
+export const AlignmentExample: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates the component alignment in combination with its hover state',
+      },
+    },
+  },
+  decorators: [
+    Story => (
+      <styled.div borderLeft="2px solid" borderColor="red.background-secondary" py="space.06">
+        <styled.h1 textStyle="heading.04" mb="space.04">
+          Left aligned header
+        </styled.h1>
+        <Story />
+      </styled.div>
+    ),
+  ],
+  args: {
+    onClick: () => {},
+    children: <ExampleInteractiveItemContent />,
+  },
+};
+
+export const WithPadding: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "In some layouts, it's necessary to contain the bounds of the element's pseudo element hover background. Wrap the component in a div with padding `space.03` to achieve this",
+      },
+    },
+  },
+  decorators: [
+    Story => (
+      <styled.div border="2px solid" borderColor="red.background-secondary" p="space.03">
+        <Story />
+      </styled.div>
+    ),
+  ],
+  args: {
+    onClick: () => {},
+    children: <ExampleInteractiveItemContent />,
   },
 };


### PR DESCRIPTION
> _Building Leather at commit `d2bfd3b`_<!-- Sticky Header Marker -->

Apologies for some of the broken UI as result of migrating `ItemInteractive` to a pseudo background. 

Spacing issues as a result of the pseudo hover element are easily remedied by a padded container. I've added some examples to storybook that help explain the reasoning behind the move. I'm pretty sure we'll have to add way fewer margin properties and generally have a more consistent UI _not_ having to worry about the hover state border padding.

![image](https://github.com/leather-wallet/extension/assets/1618764/29b872d3-5f98-4317-be41-bbc76aec132e)