### PR TITLE
experimental: in page scam warning

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -13,6 +13,7 @@
       }
     ]
   },
+  "scams": [{ "url": "https://apps.apple.com/gb/app/leather-wallet-hiro-bitcoin/id6478242082" }],
   "activeFiatProviders": {
     "coinbase": {
       "availableRegions": "global",

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -28,9 +28,9 @@ const environmentIcons = {
 };
 
 const devCsp =
-  "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; frame-src https://ordinals.com/; frame-ancestors 'none';";
+  "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; frame-src https://ordinals.com/;";
 
-const prodCsp = `default-src 'none'; connect-src *; style-src 'unsafe-inline'; img-src 'self' data: https:; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-src https://ordinals.com/; frame-ancestors 'none';`;
+const prodCsp = `default-src 'none'; connect-src *; style-src 'unsafe-inline'; img-src 'self' data: https:; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-src https://ordinals.com/;`;
 
 const contentSecurityPolicyEnvironment = {
   testing: prodCsp,
@@ -84,7 +84,10 @@ const manifest = {
   content_security_policy: {
     extension_pages: contentSecurityPolicyEnvironment[WALLET_ENVIRONMENT],
   },
-  web_accessible_resources: [{ resources: ['inpage.js'], matches: ['*://*/*'] }],
+  web_accessible_resources: [
+    { resources: ['inpage.js'], matches: ['*://*/*'] },
+    { resources: ['scam-warning.html'], matches: ['*://*/*'] },
+  ],
   action: {
     default_title: 'Leather',
     default_popup: 'popup.html',

--- a/src/app/scam-warning.tsx
+++ b/src/app/scam-warning.tsx
@@ -1,0 +1,21 @@
+import { createRoot } from 'react-dom/client';
+
+import { styled } from 'leather-styles/jsx';
+
+import './index.css';
+
+export function ScamWarningIframe() {
+  return (
+    <styled.h1 textStyle="display.02" mt="space.10">
+      ⚠️ This website is a massive scam ⚠️
+    </styled.h1>
+  );
+}
+
+async function renderApp() {
+  document.getElementById('splash-screen')?.remove();
+  const container = document.getElementById('app');
+  return createRoot(container!).render(<ScamWarningIframe />);
+}
+
+void renderApp();

--- a/src/content-scripts/content-script.ts
+++ b/src/content-scripts/content-script.ts
@@ -137,3 +137,32 @@ function addLeatherToPage() {
 
 // Don't block thread to add Leather to page
 requestAnimationFrame(() => addLeatherToPage());
+
+function addScamWarningToPage() {
+  const url = chrome.runtime.getURL('scam-warning.html');
+  const iframe = document.createElement('iframe');
+  iframe.src = url;
+  iframe.style.left = '0';
+  iframe.style.top = '0';
+  iframe.style.width = '100%';
+  iframe.style.height = '260px';
+  iframe.style.position = 'absolute';
+  iframe.style.border = 'none';
+  iframe.style.zIndex = '9999999999999999999999999999';
+  document.body.appendChild(iframe);
+}
+
+// This function would have to query bg script or somewhere to read the list of
+// known scams.
+function isMassiveScamWebsite(url: string) {
+  const massiveScams = ['leather-wallet-hiro-bitcoin/id6478242082'];
+  return massiveScams.some(scam => url.includes(scam));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  console.log(document.location.href);
+  if (isMassiveScamWebsite(document.location.href)) {
+    console.log('This is a scam website');
+    addScamWarningToPage();
+  }
+});

--- a/test-app/src/components/app.tsx
+++ b/test-app/src/components/app.tsx
@@ -18,6 +18,7 @@ export const App: React.FC = () => {
           {authResponse && <input type="hidden" id="auth-response" value={authResponse} />}
           {appPrivateKey && <input type="hidden" id="app-private-key" value={appPrivateKey} />}
           <Header signOut={handleSignOut} />
+          <iframe src="chrome-extension://kepoednijakempabkblheecenlndgdmb/index.html#/unlock" />
           <Home />
         </Flex>
       </AppContext.Provider>

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -97,6 +97,7 @@ export const config = {
     index: path.join(SRC_ROOT_PATH, 'app', 'index.tsx'),
     'decryption-worker': path.join(SRC_ROOT_PATH, 'shared/workers/decryption-worker.ts'),
     debug: path.join(SRC_ROOT_PATH, '../scripts/debug.js'),
+    scamWarning: path.join(SRC_ROOT_PATH, 'app', 'scam-warning.tsx'),
   },
   output: {
     path: DIST_ROOT_PATH,
@@ -227,6 +228,11 @@ export const config = {
       filename: 'debug.html',
       title: 'Leather—Debugger',
       chunks: ['debug'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'scam-warning.html',
+      template: path.join(SRC_ROOT_PATH, '../', 'public', 'html', 'index.html'),
+      chunks: ['scamWarning'],
     }),
     new GenerateJsonPlugin(
       'manifest.json',


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8174114835), [Test report](https://leather-wallet.github.io/playwright-reports/add-warning)<!-- Sticky Header Marker -->

This PR demos a prototype scam prevention feature that injects content to the page when an extension user visits a known massive scam.

https://github.com/leather-wallet/extension/assets/1618764/17e67c14-0e5c-49af-951d-7663fc24513b

cc/ @mica000 @fabric-8 @markmhendrickson 