### PR TITLE
fix: fetch brc20 balance from hiro

### DIFF
--- a/src/app/query/bitcoin/bitcoin-client.ts
+++ b/src/app/query/bitcoin/bitcoin-client.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
 
+import { HIRO_API_BASE_URL_MAINNET } from '@shared/constants';
+import { Paginated } from '@shared/models/api-types';
+
 class Configuration {
   constructor(public baseUrl: string) {}
 }
@@ -65,16 +68,17 @@ export interface Brc20Token extends Brc20TokenResponse {
 }
 
 interface Brc20TokenTicker {
-  decimals: number;
-  deploy_incr_number: number;
-  deploy_ts: string;
-  holder_count: number;
-  image_url: string | null;
-  limit_per_mint: string;
-  max_supply: string;
-  mint_progress: number;
-  minted_supply: string;
+  id: string;
+  number: number;
+  block_height: number;
+  tx_id: string;
+  address: string;
   ticker: string;
+  max_supply: string;
+  mint_limit: string;
+  decimals: number;
+  deploy_timestamp: number;
+  minted_supply: string;
   tx_count: number;
 }
 
@@ -134,6 +138,24 @@ class BestinslotApi {
       {
         ...this.defaultOptions,
       }
+    );
+    return resp.data;
+  }
+}
+
+class HiroApi {
+  url = HIRO_API_BASE_URL_MAINNET;
+
+  async getBrc20Balance(address: string) {
+    const resp = await axios.get<Paginated<Brc20TokenResponse[]>>(
+      `${this.url}/ordinals/v1/brc-20/balances/${address}`
+    );
+    return resp.data;
+  }
+
+  async getBrc20TickerData(ticker: string) {
+    const resp = await axios.get<Paginated<Brc20TokenTicker[]>>(
+      `${this.url}/ordinals/v1/brc-20/tokens?ticker=${ticker}`
     );
     return resp.data;
   }
@@ -250,6 +272,7 @@ export class BitcoinClient {
   feeEstimatesApi: FeeEstimatesApi;
   transactionsApi: TransactionsApi;
   BestinslotApi: BestinslotApi;
+  HiroApi: HiroApi;
 
   constructor(basePath: string) {
     this.configuration = new Configuration(basePath);
@@ -257,5 +280,6 @@ export class BitcoinClient {
     this.feeEstimatesApi = new FeeEstimatesApi(this.configuration);
     this.transactionsApi = new TransactionsApi(this.configuration);
     this.BestinslotApi = new BestinslotApi(this.configuration);
+    this.HiroApi = new HiroApi();
   }
 }

--- a/src/app/query/bitcoin/ordinals/brc20/brc20-tokens.query.ts
+++ b/src/app/query/bitcoin/ordinals/brc20/brc20-tokens.query.ts
@@ -12,8 +12,8 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { Brc20Token } from '../../bitcoin-client';
 
-const addressesSimultaneousFetchLimit = 5;
-const stopSearchAfterNumberAddressesWithoutBrc20Tokens = 5;
+const addressesSimultaneousFetchLimit = 3;
+const stopSearchAfterNumberAddressesWithoutBrc20Tokens = 3;
 
 export function useGetBrc20TokensQuery() {
   const network = useCurrentNetwork();
@@ -51,16 +51,18 @@ export function useGetBrc20TokensQuery() {
       }
 
       const brc20TokensPromises = addressesData.map(async address => {
-        const brc20Tokens = await client.BestinslotApi.getBrc20Balance(address);
+        const brc20Tokens = await client.HiroApi.getBrc20Balance(address);
+
         const tickerPromises = await Promise.all(
-          brc20Tokens.data.map(token => {
-            return client.BestinslotApi.getBrc20TickerData(token.ticker);
+          brc20Tokens.results.map(token => {
+            return client.HiroApi.getBrc20TickerData(token.ticker);
           })
         );
-        return brc20Tokens.data.map((token, index) => {
+
+        return brc20Tokens.results.map((token, index) => {
           return {
             ...token,
-            decimals: tickerPromises[index].data.decimals,
+            decimals: tickerPromises[index].results[0].decimals,
             holderAddress: address,
           };
         });


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8204986583), [Test report](https://leather-wallet.github.io/playwright-reports/fix/hiro-api-brc20)<!-- Sticky Header Marker -->

This pr enables fetching brc20 balances and tickers from Hiro Api