### PR TITLE
fix: sip10 token default max length, closes #4930

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -40,6 +40,7 @@ interface AmountFieldProps {
   switchableAmount?: React.JSX.Element;
   tokenSymbol?: string;
   onSetIsSendingMax?(value: boolean): void;
+  tokenMaxLength?: number;
 }
 export function AmountField({
   autoComplete = 'on',
@@ -50,6 +51,7 @@ export function AmountField({
   onSetIsSendingMax,
   switchableAmount,
   tokenSymbol,
+  tokenMaxLength,
 }: AmountFieldProps) {
   const [field, meta, helpers] = useField('amount');
 
@@ -61,7 +63,9 @@ export function AmountField({
 
   const { decimals } = balance;
   const symbol = tokenSymbol || balance.symbol;
-  const maxLength = decimals === 0 ? maxLengthDefault : decimals + 2;
+
+  const maxLength = tokenMaxLength || (decimals === 0 ? maxLengthDefault : decimals + 2);
+
   const fontSizeModifier = (maxFontSize - minFontSize) / maxLength;
   const subtractedLengthToPositionPrefix = 0.5;
 

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form-container.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form-container.tsx
@@ -33,6 +33,7 @@ export function Sip10TokenSendFormContainer({
       }
       tokenSymbol={symbol}
       autoComplete="off"
+      tokenMaxLength={Infinity}
     />
   );
   const selectedAssetField = (


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8216521329), [Test report](https://leather-wallet.github.io/playwright-reports/fix/sip10-max-length)<!-- Sticky Header Marker -->

Set sip10 token max length to Infinity, as we don't know it's decimals and num can be big