### PR TITLE
Chore: update link to fee info

### DIFF
--- a/src/app/components/fees-row/components/fees-row.layout.tsx
+++ b/src/app/components/fees-row/components/fees-row.layout.tsx
@@ -9,7 +9,7 @@ import { InfoCircleIcon } from '@app/ui/icons/info-circle-icon';
 
 const feesInfo =
   'Higher fees increase the likelihood of your transaction getting confirmed before others. Click to learn more.';
-const url = 'https://hiro.so/questions/fee-estimates';
+const url = 'https://leather.gitbook.io/guides/transactions/fees';
 
 interface FeesRowLayoutProps extends HstackProps {
   feeField: React.JSX.Element;


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8342361921), [Test report](https://leather-wallet.github.io/playwright-reports/fix/fee-info-link), [Storybook preview](https://65982789c7e2278518f189e7-ofuiomruuk.chromatic.com/)<!-- Sticky Header Marker -->

updated link from hiro.so to leather guides gitbook

Closes #5049