### PR TITLE
Chore: update link to nonce info

### DIFF
--- a/src/app/features/edit-nonce-drawer/edit-nonce-drawer.tsx
+++ b/src/app/features/edit-nonce-drawer/edit-nonce-drawer.tsx
@@ -13,7 +13,7 @@ import { Link } from '@app/ui/components/link/link';
 
 import { EditNonceForm } from './components/edit-nonce-form';
 
-const url = 'https://www.hiro.so/questions/transactions-advanced-settings';
+const url = 'https://leather.gitbook.io/guides/transactions/nonces';
 
 function CustomFeeMessaging() {
   return (


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8342378784), [Test report](https://leather-wallet.github.io/playwright-reports/fix/nonce-info-link), [Storybook preview](https://65982789c7e2278518f189e7-tmhnjpqdbj.chromatic.com/)<!-- Sticky Header Marker -->

currently links to unreachable webpage on hiro.so this fixes that.