### PR TITLE
ci: contributor automation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Anyone is welcome to help make Leather better. We encourage contributors to let us know via Github issues what they’d like to work on. We’re happy to help get you started.
+
+Leather aims to respond to contributor PRs within 2 working days.
+
+## Bugs
+
+If you’ve found a bug, first check to see if an issue already exists. If so, add a comment to let us know you found it too. Otherwise, open up an issue describing in as much detail as possible how we’d be able to recreate it.
+
+If you’re a developer, feel free to submit a Pull Request with a suggested fix.
+
+## Feature enhancements
+
+There is a long list of features we want to add to Leather, and we’d love help working on them. Please be aware, your work will only be merged if it aligns with Leather’s product roadmap and conforms to Leather’s standards.
+
+## Coding standards
+
+Code contributions must follow the style and patterns already employed by the project. This list of requirements is non-exhaustive. The Leather team might ask for additional changes.
+
+- Code must conform to our linting setup `yarn lint`
+- Code formatting correctly `yarn prettier`
+- Code must be typed properly with Typescript `yarn typecheck`
+
+## Testing
+
+Code should be tested thoroughly. Complex logic must be unit tested. User flows should be covered with integration tests using [Playwright](https://playwright.dev/). 
+
+## Support
+
+The Leather team is happy to help. If you need more involved guidance for your contribution, please allow some additional time for the team to respond to your queries.

--- a/.github/workflows/contributor-advice.yml
+++ b/.github/workflows/contributor-advice.yml
@@ -1,0 +1,33 @@
+name: Contributor automation
+
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  fork-detection:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    # When a fork
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]'
+    steps:
+      - name: Add contributor advice
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.LEATHER_BOT }}
+          body: |
+            Thanks for contributing to Leather! Our team will review your PR and get back to you as soon as possible.
+
+            Please make sure to follow our [Contributor Guidelines][1]
+
+            [1]: https://github.com/leather-wallet/extension/tree/dev/.github/CONTRIBUTING.md
+
+      - name: Add label
+        run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.LEATHER_BOT }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: 'needs:internal-review'


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8262045684), [Test report](https://leather-wallet.github.io/playwright-reports/ci/contrib-comment)<!-- Sticky Header Marker -->

Adds a job that a message to contributor PRs, and a https://github.com/leather-wallet/extension/labels/needs%3Ainternal-review