### PR TITLE
fix: gaia profile test

### DIFF
--- a/tests/specs/profile/profile.spec.ts
+++ b/tests/specs/profile/profile.spec.ts
@@ -26,6 +26,7 @@ test.describe('Profile updating', () => {
     const name = profileUpdatingPage.page.getByText('twitter');
     const nameText = await name.innerText();
     test.expect(nameText).toBe('https://twitter.com/twitterHandle');
+    await profileUpdatingPage.page.close();
   });
 
   test('should show an error for invalid profile', async ({ context }) => {
@@ -36,6 +37,23 @@ test.describe('Profile updating', () => {
     );
 
     test.expect(error).toBeTruthy();
+    await profileUpdatingPage.page.close();
+  });
+});
+
+test.describe('Gaia request', () => {
+  let testAppPage: TestAppPage;
+
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage, context }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await onboardingPage.signInWithTestAccount(extensionId);
+    testAppPage = await TestAppPage.openDemoPage(context);
+    await testAppPage.signIn();
+    const accountsPage = await context.waitForEvent('page');
+    await accountsPage.locator('text="Account 2"').click({ force: true });
+    await testAppPage.page.bringToFront();
+    await testAppPage.page.click('text=Profile');
+    await accountsPage.close();
   });
 
   test('should send a signed profile token to gaia', async ({ context }) => {


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8255508814), [Test report](https://leather-wallet.github.io/playwright-reports/fix/profile-tests)<!-- Sticky Header Marker -->

Attempting to fix the profile test. They passed locally by separating the tests and forcing the open pages closed. The last test was getting stuck not even logging into the account (I think).

EDIT: Also, changing the Gaia test to sign into Account 2, bc it appears to get stuck trying to sign into Account 1.