### PR TITLE
fix: send inputs in check utxos analytics event

### DIFF
--- a/src/app/query/bitcoin/transaction/use-check-utxos.ts
+++ b/src/app/query/bitcoin/transaction/use-check-utxos.ts
@@ -126,6 +126,7 @@ export function useCheckInscribedUtxos(blockTxAction?: () => void) {
         if (hasInscribedUtxo) {
           void analytics.track('utxos_includes_inscribed_one', {
             txids,
+            inputs,
           });
           preventTransaction();
           return true;
@@ -140,6 +141,7 @@ export function useCheckInscribedUtxos(blockTxAction?: () => void) {
 
         void analytics.track('error_checking_utxos_from_ordinalscom', {
           txids,
+          inputs,
         });
 
         const hasInscribedUtxo = await checkInscribedUtxosByBestinslot({
@@ -152,6 +154,7 @@ export function useCheckInscribedUtxos(blockTxAction?: () => void) {
         if (hasInscribedUtxo) {
           void analytics.track('utxos_includes_inscribed_one', {
             txids,
+            inputs,
           });
           preventTransaction();
           return true;


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8327083461), [Test report](https://leather-wallet.github.io/playwright-reports/fix/check-utxos-analytics), [Storybook preview](https://65982789c7e2278518f189e7-dyipbdwrxo.chromatic.com/)<!-- Sticky Header Marker -->

Just `txids` is not enough to analyse errors