### PR TITLE
feat: support gltf inscription type, closes #5091

### DIFF
--- a/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -48,6 +48,7 @@ export function Inscription({ rawInscription }: InscriptionProps) {
     case 'html':
     case 'svg':
     case 'video':
+    case 'gltf':
       return (
         <CollectibleIframe
           icon={<OrdinalAvatarIcon size="lg" />}

--- a/src/app/query/bitcoin/ordinals/inscription.hooks.ts
+++ b/src/app/query/bitcoin/ordinals/inscription.hooks.ts
@@ -60,6 +60,13 @@ export function convertInscriptionToSupportedInscriptionType(inscription: Inscri
       type: 'video',
       ...inscription,
     }),
+    gltf: () => ({
+      infoUrl: createInscriptionInfoUrl(inscription.id),
+      src: createIframePreviewUrl(inscription.id),
+      title,
+      type: 'gltf',
+      ...inscription,
+    }),
     other: () => ({
       infoUrl: createInscriptionInfoUrl(inscription.id),
       title,


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8341886111), [Test report](https://leather-wallet.github.io/playwright-reports/feat/support-gltf), [Storybook preview](https://65982789c7e2278518f189e7-plikrhcrzg.chromatic.com/)<!-- Sticky Header Marker -->

This pr adds support for gltf inscription type, preview is opened in ordinals.com iframe