### PR TITLE
fix: increase swap hardcoded fee, closes #4984

### DIFF
--- a/src/app/pages/swap/alex-swap-container.tsx
+++ b/src/app/pages/swap/alex-swap-container.tsx
@@ -18,7 +18,6 @@ import { isDefined, isUndefined } from '@shared/utils';
 import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
 import { useWalletType } from '@app/common/use-wallet-type';
 import { NonceSetter } from '@app/components/nonce-setter';
-import { defaultFeesMinValuesAsMoney } from '@app/query/stacks/fees/fees.utils';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useGenerateStacksContractCallUnsignedTx } from '@app/store/transactions/contract-call.hooks';
 import { useSignStacksTransaction } from '@app/store/transactions/transaction.hooks';
@@ -31,7 +30,11 @@ import { oneHundredMillion, useAlexSwap } from './hooks/use-alex-swap';
 import { useStacksBroadcastSwap } from './hooks/use-stacks-broadcast-swap';
 import { SwapAsset, SwapFormValues } from './hooks/use-swap-form';
 import { SwapContext, SwapProvider } from './swap.context';
-import { migratePositiveBalancesToTop, sortSwappableAssetsBySymbol } from './swap.utils';
+import {
+  defaultSwapFee,
+  migratePositiveBalancesToTop,
+  sortSwappableAssetsBySymbol,
+} from './swap.utils';
 
 export const alexSwapRoutes = generateSwapRoutes(<AlexSwapContainer />);
 
@@ -86,7 +89,7 @@ function AlexSwapContainer() {
     ]);
 
     onSetSwapSubmissionData({
-      fee: isSponsoredByAlex ? '0' : defaultFeesMinValuesAsMoney[1].amount.toString(),
+      fee: isSponsoredByAlex ? '0' : defaultSwapFee.amount.toString(),
       feeCurrency: values.feeCurrency,
       feeType: values.feeType,
       liquidityFee: new BigNumber(Number(lpFee)).dividedBy(oneHundredMillion).toNumber(),

--- a/src/app/pages/swap/components/swap-details/swap-detail.layout.tsx
+++ b/src/app/pages/swap/components/swap-details/swap-detail.layout.tsx
@@ -26,7 +26,7 @@ export function SwapDetailLayout({
         {tooltipLabel ? (
           <BasicTooltip label={tooltipLabel} side="bottom">
             <Box _hover={{ cursor: 'pointer' }} color="ink.text-subdued">
-              <InfoCircleIcon />
+              <InfoCircleIcon variant="small" />
             </Box>
           </BasicTooltip>
         ) : null}

--- a/src/app/pages/swap/components/swap-details/swap-details.tsx
+++ b/src/app/pages/swap/components/swap-details/swap-details.tsx
@@ -28,6 +28,9 @@ function RouteNames(props: { swapSubmissionData: SwapSubmissionData }) {
   });
 }
 
+const sponsoredFeeLabel =
+  'Sponsorship may not apply when you have pending transactions. In such cases, if you choose to proceed, the associated costs will be deducted from your balance.';
+
 export function SwapDetails() {
   const { swapSubmissionData } = useSwapContext();
   const { isTestnet } = useCurrentNetworkState();
@@ -75,11 +78,11 @@ export function SwapDetails() {
       />
       <SwapDetailLayout
         title="Transaction fees"
-        tooltipLabel="Swap transactions are sponsored by default. However, this sponsorship may not apply when you have pending transactions. In such cases, if you choose to proceed, the associated costs will be deducted from your balance."
+        tooltipLabel={swapSubmissionData.sponsored ? sponsoredFeeLabel : undefined}
         value={
           swapSubmissionData.sponsored
             ? 'Sponsored'
-            : microStxToStx(swapSubmissionData.fee).toString()
+            : `${microStxToStx(swapSubmissionData.fee).toString()} STX`
         }
       />
       <SwapDetailLayout

--- a/src/app/pages/swap/swap.utils.ts
+++ b/src/app/pages/swap/swap.utils.ts
@@ -1,4 +1,8 @@
+import { createMoney } from '@shared/models/money.model';
+
 import { SwapAsset } from './hooks/use-swap-form';
+
+export const defaultSwapFee = createMoney(1000000, 'STX');
 
 export function sortSwappableAssetsBySymbol(swappableAssets: SwapAsset[]) {
   return swappableAssets


### PR DESCRIPTION
> Try out this version of Leather — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8347671398), [Test report](https://leather-wallet.github.io/playwright-reports/fix/swap-hardcoded-fee), [Storybook preview](https://65982789c7e2278518f189e7-veoqsowbzg.chromatic.com/)<!-- Sticky Header Marker -->

This PR increases our hardcoded swap fee to 1 STX.