### PR TITLE
fix: swap duplicate toast, closes #5068

### DIFF
--- a/src/app/common/hooks/use-submit-stx-transaction.ts
+++ b/src/app/common/hooks/use-submit-stx-transaction.ts
@@ -15,6 +15,8 @@ import { useToast } from '@app/features/toasts/use-toast';
 import { useCurrentStacksNetworkState } from '@app/store/networks/networks.hooks';
 import { useSubmittedTransactionsActions } from '@app/store/submitted-transactions/submitted-transactions.hooks';
 
+import { delay } from '../utils';
+
 const timeForApiToUpdate = 250;
 
 interface UseSubmitTransactionArgs {
@@ -52,7 +54,9 @@ export function useSubmitTransactionCallback({ loadingKey }: UseSubmitTransactio
               rawTx: bytesToHex(transaction.serialize()),
               txId: safelyFormatHexTxid(response.txid),
             });
+            await delay(500);
             toast.success('Transaction submitted!');
+            await delay(500);
 
             void analytics.track('broadcast_transaction', { symbol: 'stx' });
             onSuccess(safelyFormatHexTxid(response.txid));

--- a/src/app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit.tsx
@@ -32,13 +32,13 @@ export function RetrieveTaprootToNativeSegwit() {
   const { generateRetrieveTaprootFundsTx, fee } = useGenerateRetrieveTaprootFundsTx();
   const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
 
-  async function handleBroadcastRetieveBitcoinTx() {
+  async function handleBroadcastRetrieveBitcoinTx() {
     const tx = await generateRetrieveTaprootFundsTx({ recipient, fee });
     await broadcastTx({
       tx,
       async onSuccess() {
         await delay(1200);
-        toast.success('Transaction broadcasted succesfully');
+        toast.success('Transaction submitted!');
         await delay(700);
         navigate(RouteUrls.Activity);
         void analytics.track('broadcast_retrieve_taproot_to_native_segwit');
@@ -52,7 +52,7 @@ export function RetrieveTaprootToNativeSegwit() {
   return (
     <RetrieveTaprootToNativeSegwitLayout
       isBroadcasting={isBroadcasting}
-      onApproveTransaction={handleBroadcastRetieveBitcoinTx}
+      onApproveTransaction={handleBroadcastRetrieveBitcoinTx}
       onClose={() => navigate(RouteUrls.Home)}
     >
       <InfoCard mt="space.05">


### PR DESCRIPTION
> Try out Leather build b3dd29b — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8352140539), [Test report](https://leather-wallet.github.io/playwright-reports/fix/swap-success-toast), [Storybook](https://fix-swap-success-toast--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/swap-success-toast)<!-- Sticky Header Marker -->

This PR fixes seeing the duplicate success toast when swapping. I noticed with one of our broadcasts we added a delay around the toast, so doing the same here fixed the issue.