### PR TITLE
fix: removes decimals from balances > $1,000

### DIFF
--- a/src/app/common/hooks/balance/use-total-balance.tsx
+++ b/src/app/common/hooks/balance/use-total-balance.tsx
@@ -37,7 +37,10 @@ export function useTotalBalance({ btcAddress, stxAddress }: UseTotalBalanceArgs)
     const totalBalance = { ...stxUsdAmount, amount: stxUsdAmount.amount.plus(btcUsdAmount.amount) };
     return {
       totalBalance,
-      totalUsdBalance: i18nFormatCurrency(totalBalance),
+      totalUsdBalance: i18nFormatCurrency(
+        totalBalance,
+        totalBalance.amount.isGreaterThanOrEqualTo(100_000) ? 0 : 2
+      ),
       isLoading,
     };
   }, [btcBalance, btcMarketData, stxMarketData, isLoading, stxBalance]);

--- a/src/app/common/money/format-money.ts
+++ b/src/app/common/money/format-money.ts
@@ -14,9 +14,13 @@ export function formatMoneyPadded({ amount, symbol, decimals }: Money) {
   return `${amount.shiftedBy(-decimals).toFormat(decimals)} ${symbol}`;
 }
 
-export function i18nFormatCurrency(quantity: Money, locale = 'en-US') {
+export function i18nFormatCurrency(quantity: Money, decimals: number = 2) {
   if (quantity.symbol !== 'USD') throw new Error('Cannot format non-USD amounts');
-  const currencyFormatter = new Intl.NumberFormat(locale, { style: 'currency', currency: 'USD' });
+  const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: decimals,
+  });
 
   const formatted = currencyFormatter.format(
     quantity.amount.shiftedBy(-quantity.decimals).toNumber()


### PR DESCRIPTION
> Try out Leather build af43e49 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8435488669), [Test report](https://leather-wallet.github.io/playwright-reports/fix/truncate-balance-formatting), [Storybook](https://fix-truncate-balance-formatting--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/truncate-balance-formatting)<!-- Sticky Header Marker -->

Been meaning to do this for a while, and think everyone's onboard with this change.

<img width="422" alt="image" src="https://github.com/leather-wallet/extension/assets/1618764/44bda5b5-b96f-4e93-a4e8-73f695e78e61">
