### PR TITLE
fix: swap arrow icon

### DIFF
--- a/src/app/pages/swap/components/swap-assets-pair/swap-assets-pair.layout.tsx
+++ b/src/app/pages/swap/components/swap-assets-pair/swap-assets-pair.layout.tsx
@@ -19,7 +19,7 @@ export function SwapAssetsPairLayout({ swapAssetFrom, swapAssetTo }: SwapAssetsP
     >
       {swapAssetFrom}
       <Box height="24px" px="space.04" py="space.01" width="48px">
-        <ArrowDownIcon />
+        <ArrowDownIcon variant="small" />
       </Box>
       {swapAssetTo}
     </Stack>


### PR DESCRIPTION
> Try out Leather build fea546e — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8437104989), [Test report](https://leather-wallet.github.io/playwright-reports/fix/swap-arrow-icon), [Storybook](https://fix-swap-arrow-icon--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/swap-arrow-icon)<!-- Sticky Header Marker -->

Noticed this icon bug testing container work...

![Screenshot 2024-03-22 at 1 13 02 PM](https://github.com/leather-wallet/extension/assets/6493321/6b368e4e-d0f5-4d4c-a233-3f8eb0916691)

I just made it the small variant for now...
![Screenshot 2024-03-26 at 8 48 58 AM](https://github.com/leather-wallet/extension/assets/6493321/03183a2b-a028-4bcd-aa2a-7bdf2a9db2f1)
