### PR TITLE
fix: send form max amount

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/amount-field.tsx
@@ -14,7 +14,9 @@ import { ErrorLabel } from '@app/components/error-label';
 const amountInputId = 'amount-input';
 const maxFontSize = 48;
 const minFontSize = 22;
-const maxLengthDefault = STX_DECIMALS + 2; // + 1 for decimal char
+// This is set so the font resizing works. We can revisit the design,
+// but this cannot be completely removed or the UI breaks.
+const maxLength = STX_DECIMALS + 12;
 
 interface GetAmountModifiedFontSize {
   amount: string;
@@ -40,7 +42,6 @@ interface AmountFieldProps {
   switchableAmount?: React.JSX.Element;
   tokenSymbol?: string;
   onSetIsSendingMax?(value: boolean): void;
-  tokenMaxLength?: number;
 }
 export function AmountField({
   autoComplete = 'on',
@@ -51,7 +52,6 @@ export function AmountField({
   onSetIsSendingMax,
   switchableAmount,
   tokenSymbol,
-  tokenMaxLength,
 }: AmountFieldProps) {
   const [field, meta, helpers] = useField('amount');
 
@@ -61,10 +61,7 @@ export function AmountField({
   const [previousTextLength, setPreviousTextLength] = useState(1);
   const fieldRef = useRef<HTMLSpanElement>(null);
 
-  const { decimals } = balance;
   const symbol = tokenSymbol || balance.symbol;
-
-  const maxLength = tokenMaxLength || (decimals === 0 ? maxLengthDefault : decimals + 2);
 
   const fontSizeModifier = (maxFontSize - minFontSize) / maxLength;
   const subtractedLengthToPositionPrefix = 0.5;
@@ -130,7 +127,7 @@ export function AmountField({
   // TODO: could be implemented with html using padded label element
   const onClickFocusInput = useCallback(() => {
     if (isSendingMax) {
-      helpers.setValue('');
+      void helpers.setValue('');
       onSetIsSendingMax?.(false);
     }
 
@@ -141,13 +138,8 @@ export function AmountField({
   }, [isSendingMax, helpers, onSetIsSendingMax]);
 
   return (
-    <Stack
-      alignItems="center"
-      px="space.06"
-      gap={['space.04', showError ? 'space.04' : '48px']}
-      width="100%"
-    >
-      <Flex alignItems="center" flexDirection="column" onClick={onClickFocusInput}>
+    <Stack alignItems="center" gap={['space.04', showError ? 'space.04' : '48px']} width="100%">
+      <Flex alignItems="center" flexDirection="column" onClick={onClickFocusInput} width="100%">
         {/* #4476 TODO check these fonts against design */}
         <Flex
           alignItems="center"

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form-container.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks-sip10/sip10-token-send-form-container.tsx
@@ -33,7 +33,6 @@ export function Sip10TokenSendFormContainer({
       }
       tokenSymbol={symbol}
       autoComplete="off"
-      tokenMaxLength={Infinity}
     />
   );
   const selectedAssetField = (


### PR DESCRIPTION
> _Building Leather at commit 4728fff_<!-- Sticky Header Marker -->

This should allow a greater max length for sending STX w/out breaking the font resizing in the current UI designs for the amount input field. We can revisit the design, but there has to be a maxLength set for the auto-resizing code to work. Note, the UI isn't perfectly centered, so we should revisit during the send flow redesign work. cc @fabric-8 

![Screenshot 2024-03-27 at 9 33 14 AM](https://github.com/leather-wallet/extension/assets/6493321/a14cf7cf-55da-419b-ace0-8df3d3258fb5)

SIP-010 fix: cc @alter-eggo is this good?
![Screenshot 2024-03-27 at 9 33 46 AM](https://github.com/leather-wallet/extension/assets/6493321/8b8d5ec4-4f2a-472a-9d15-a08ac6d1db52)

Same for BTC... (I wish) 😆 
![Screenshot 2024-03-27 at 9 34 30 AM](https://github.com/leather-wallet/extension/assets/6493321/f87f77da-cda6-4f95-a132-cbdf80acdbf8)
