### PR TITLE
fix: wrong send stx validation msg

### DIFF
--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -73,12 +73,12 @@ export function btcMinimumSpendValidator() {
     });
 }
 
-export function stxAmountValidator() {
+export function stxAmountValidator(availableStxBalance: Money) {
   return yup
     .number()
     .typeError(FormErrorMessages.MustBeNumber)
     .concat(currencyAmountValidator())
-    .concat(stxAmountPrecisionValidator(formatPrecisionError()));
+    .concat(stxAmountPrecisionValidator(formatPrecisionError(availableStxBalance)));
 }
 
 export function stxAvailableBalanceValidator(availableBalance: Money) {

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
@@ -58,7 +58,9 @@ export function useStxSendForm() {
     stxFees,
 
     validationSchema: yup.object({
-      amount: stxAmountValidator().concat(stxAvailableBalanceValidator(availableStxBalance)),
+      amount: stxAmountValidator(availableStxBalance).concat(
+        stxAvailableBalanceValidator(availableStxBalance)
+      ),
       fee: stxFeeValidator(availableStxBalance),
       recipient,
       memo,

--- a/tests/specs/send/send-stx.spec.ts
+++ b/tests/specs/send/send-stx.spec.ts
@@ -8,6 +8,8 @@ import { SendPage } from '@tests/page-object-models/send.page';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { getDisplayerAddress } from '@tests/utils';
 
+import { STX_DECIMALS } from '@shared/constants';
+
 import { FormErrorMessages } from '@app/common/error-messages';
 
 import { test } from '../../fixtures/fixtures';
@@ -106,7 +108,8 @@ test.describe('send stx', () => {
         await sPage.amountInput.fill('0.0000001');
         await sPage.amountInput.blur();
         const errorMsg = await sPage.amountInputErrorLabel.innerText();
-        test.expect(errorMsg).toEqual(FormErrorMessages.MustBePositive);
+        const error = FormErrorMessages.TooMuchPrecision;
+        test.expect(errorMsg).toEqual(error.replace('{decimals}', String(STX_DECIMALS)));
       });
 
       test('that the amount is greater than the available balance', async () => {
@@ -160,7 +163,8 @@ test.describe('send stx', () => {
 
         await sPage.previewSendTxButton.click();
         const errorMsg = await sPage.amountInputErrorLabel.innerText();
-        test.expect(errorMsg).toEqual(FormErrorMessages.MustBePositive);
+        const error = FormErrorMessages.TooMuchPrecision;
+        test.expect(errorMsg).toEqual(error.replace('{decimals}', String(STX_DECIMALS)));
         await sPage.amountInput.fill('0.000001');
         await sPage.previewSendTxButton.click();
         const details = await sPage.confirmationDetails.allInnerTexts();


### PR DESCRIPTION
> Try out Leather build 926a90b — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8456844860), [Test report](https://leather-wallet.github.io/playwright-reports/fix/send-stx-validation-msg), [Storybook](https://fix-send-stx-validation-msg--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/send-stx-validation-msg)<!-- Sticky Header Marker -->

Noticed a flaky test from the validation error msg being wrong on the STX amount input field. I think changing the max length exposed it. It used to say `Cannot not determine decimal precision` bc we weren't passing the Money object to the validator to know the STX decimals.

Fixed...
![Screenshot 2024-03-27 at 12 49 17 PM](https://github.com/leather-wallet/extension/assets/6493321/18700420-b741-4477-bab1-71a696d3aa45)
