### PR TITLE
fix: refetch brc20 tokens on window focus

### DIFF
--- a/src/app/query/bitcoin/ordinals/brc20/brc20-tokens.query.ts
+++ b/src/app/query/bitcoin/ordinals/brc20/brc20-tokens.query.ts
@@ -92,7 +92,7 @@ export function useGetBrc20TokensQuery() {
     },
     refetchOnMount: false,
     refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
     staleTime: 5 * 60 * 1000,
   });
 


### PR DESCRIPTION
> Try out Leather build 73eaa22 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8464023119), [Test report](https://leather-wallet.github.io/playwright-reports/fix/4732/refetch-brc-20), [Storybook](https://fix-4732-refetch-brc-20--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/4732/refetch-brc-20)<!-- Sticky Header Marker -->

This change refetches BRC-20 tokens on window focus so we don't need to re-install the wallet for them to appear