### PR TITLE
fix: add border to onboarding form

### DIFF
--- a/src/app/ui/components/containers/headers/header.tsx
+++ b/src/app/ui/components/containers/headers/header.tsx
@@ -42,6 +42,7 @@ export function Header({
       justifyContent="center"
       margin={{ base: 0, md: 'auto' }}
       p={variant === 'bigTitle' ? 'space.05' : 'space.04'}
+      paddingLeft={variant === 'onboarding' ? 0 : undefined}
       bg="transparent"
       maxWidth={{ base: '100vw', md: 'fullPageMaxWidth' }}
       width="100%"

--- a/src/app/ui/pages/two-column.layout.tsx
+++ b/src/app/ui/pages/two-column.layout.tsx
@@ -38,7 +38,8 @@ export function TwoColumnLayout({
           p={{ base: 'space.02', md: 'space.05' }}
           gap="space.04"
           bg="ink.background-primary"
-          borderRadius="xs"
+          border="default"
+          borderRadius="lg"
           width="100%"
           minWidth={{
             base: '100%',


### PR DESCRIPTION
> Try out Leather build 6c11191 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8469797777), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5134/onboarding), [Storybook](https://fix-5134-onboarding--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5134/onboarding)<!-- Sticky Header Marker -->

This PR:
- adds a border to the mnemonic key / onboarding form
- slightly reduces the padding of the back arrow if it's an onboarding page