### PR TITLE
Fix/5133/update borders

### DIFF
--- a/src/app/components/info-card/info-card.tsx
+++ b/src/app/components/info-card/info-card.tsx
@@ -1,25 +1,12 @@
 import { ReactNode } from 'react';
 
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
-import { Box, BoxProps, Flex, FlexProps, HStack, Stack, styled } from 'leather-styles/jsx';
+import { Box, BoxProps, Flex, HStack, Stack, styled } from 'leather-styles/jsx';
 
 import { isString } from '@shared/utils';
 
 import { Button } from '@app/ui/components/button/button';
 import { DashedHr } from '@app/ui/components/hr';
-
-// InfoCard
-interface InfoCardProps extends FlexProps {
-  children: ReactNode;
-}
-/** @deprecated - replace with ui/card */
-export function InfoCard({ children, ...props }: InfoCardProps) {
-  return (
-    <Flex alignItems="center" flexDirection="column" justifyItems="center" width="100%" {...props}>
-      {children}
-    </Flex>
-  );
-}
 
 // InfoCardRow
 interface InfoCardRowProps {

--- a/src/app/features/add-network/add-network.tsx
+++ b/src/app/features/add-network/add-network.tsx
@@ -4,6 +4,7 @@ import { Stack, styled } from 'leather-styles/jsx';
 
 import { ErrorLabel } from '@app/components/error-label';
 import { Button } from '@app/ui/components/button/button';
+import { Card } from '@app/ui/layout/card/card';
 import { Page } from '@app/ui/layout/page/page.layout';
 
 import { AddNetworkForm } from './add-network-form';
@@ -16,42 +17,44 @@ export function AddNetwork() {
     <Page>
       <Formik initialValues={initialFormValues} onSubmit={onSubmit}>
         {() => (
-          <Form data-testid={NetworkSelectors.NetworkPageReady}>
-            <Stack
-              gap="space.05"
-              maxWidth="pageWidth"
-              px={['space.05', 'space.04']}
-              textAlign={['left', 'center']}
-              my="space.05"
-            >
-              <styled.span textStyle="body.02">
-                Use this form to add a new instance of the{' '}
-                <a
-                  href="https://github.com/blockstack/stacks-blockchain-api"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Stacks Blockchain API
-                </a>{' '}
-                or{' '}
-                <a href="https://github.com/Blockstream/esplora" target="_blank" rel="noreferrer">
-                  Bitcoin Blockchain API
-                </a>
-                . Make sure you review and trust the host before you add it.
-              </styled.span>
-              <AddNetworkForm />
-              {error ? (
-                <ErrorLabel data-testid={NetworkSelectors.ErrorText}>{error}</ErrorLabel>
-              ) : null}
-              <Button
-                aria-busy={loading}
-                data-testid={NetworkSelectors.AddNetworkBtn}
-                type="submit"
+          <Card>
+            <Form data-testid={NetworkSelectors.NetworkPageReady}>
+              <Stack
+                gap="space.05"
+                maxWidth="pageWidth"
+                px={['space.05', 'space.04']}
+                textAlign={['left', 'center']}
+                my="space.05"
               >
-                Add network
-              </Button>
-            </Stack>
-          </Form>
+                <styled.span textStyle="body.02">
+                  Use this form to add a new instance of the{' '}
+                  <a
+                    href="https://github.com/blockstack/stacks-blockchain-api"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Stacks Blockchain API
+                  </a>{' '}
+                  or{' '}
+                  <a href="https://github.com/Blockstream/esplora" target="_blank" rel="noreferrer">
+                    Bitcoin Blockchain API
+                  </a>
+                  . Make sure you review and trust the host before you add it.
+                </styled.span>
+                <AddNetworkForm />
+                {error ? (
+                  <ErrorLabel data-testid={NetworkSelectors.ErrorText}>{error}</ErrorLabel>
+                ) : null}
+                <Button
+                  aria-busy={loading}
+                  data-testid={NetworkSelectors.AddNetworkBtn}
+                  type="submit"
+                >
+                  Add network
+                </Button>
+              </Stack>
+            </Form>
+          </Card>
         )}
       </Formik>
     </Page>

--- a/src/app/features/retrieve-taproot-to-native-segwit/components/retrieve-taproot-to-native-segwit.layout.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/components/retrieve-taproot-to-native-segwit.layout.tsx
@@ -6,6 +6,7 @@ import { Callout } from '@app/ui/components/callout/callout';
 import { Dialog } from '@app/ui/components/containers/dialog/dialog';
 import { Footer } from '@app/ui/components/containers/footers/footer';
 import { Header } from '@app/ui/components/containers/headers/header';
+import { Card } from '@app/ui/layout/card/card';
 
 interface RetrieveTaprootToNativeSegwitLayoutProps {
   isBroadcasting: boolean;
@@ -30,29 +31,37 @@ export function RetrieveTaprootToNativeSegwitLayout(
         </Footer>
       }
     >
-      <Flex alignItems="start" flexDirection="column" mx="space.06" textAlign="left">
-        <BtcAvatarIcon />
-        <styled.span mt="space.04" textStyle="label.01">
-          Retrieve Bitcoin deposited to <br /> Taproot addresses
-        </styled.span>
-        <styled.span mt="space.05" textStyle="body.02">
-          Taproot addresses are used by Leather for Ordinal inscriptions, but they can also contain
-          bitcoin.
-        </styled.span>
-        <styled.span mt="space.04" textStyle="body.02">
-          As we don't support tranferring from Taproot addresses yet, you can retrieve funds to your
-          account's main Native SegWit balance here.
-        </styled.span>
-        <styled.span mt="space.04" textStyle="body.02">
-          This transaction may take upwards of 30 minutes to confirm.
-        </styled.span>
-        {children}
-        <Callout variant="warning" mt="space.05" mb="space.05">
-          We recommend you check the URL for each "Uninscribed UTXO" listed above to ensure it
-          displays no inscription. If it does display one, do not proceed with retrieval or you may
-          lose it!
-        </Callout>
-      </Flex>
+      <Card>
+        <Flex
+          alignItems="start"
+          flexDirection="column"
+          mx="space.06"
+          mt="space.05"
+          textAlign="left"
+        >
+          <BtcAvatarIcon />
+          <styled.span mt="space.04" textStyle="label.01">
+            Retrieve Bitcoin deposited to <br /> Taproot addresses
+          </styled.span>
+          <styled.span mt="space.05" textStyle="body.02">
+            Taproot addresses are used by Leather for Ordinal inscriptions, but they can also
+            contain bitcoin.
+          </styled.span>
+          <styled.span mt="space.04" textStyle="body.02">
+            As we don't support tranferring from Taproot addresses yet, you can retrieve funds to
+            your account's main Native SegWit balance here.
+          </styled.span>
+          <styled.span mt="space.04" textStyle="body.02">
+            This transaction may take upwards of 30 minutes to confirm.
+          </styled.span>
+          {children}
+          <Callout variant="warning" mt="space.05" mb="space.05">
+            We recommend you check the URL for each "Uninscribed UTXO" listed above to ensure it
+            displays no inscription. If it does display one, do not proceed with retrieval or you
+            may lose it!
+          </Callout>
+        </Flex>
+      </Card>
     </Dialog>
   );
 }

--- a/src/app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/retrieve-taproot-to-native-segwit.tsx
@@ -8,7 +8,7 @@ import { delay } from '@shared/utils';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { formatMoneyPadded } from '@app/common/money/format-money';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
-import { InfoCard, InfoCardRow, InfoCardSeparator } from '@app/components/info-card/info-card';
+import { InfoCardRow, InfoCardSeparator } from '@app/components/info-card/info-card';
 import { useToast } from '@app/features/toasts/use-toast';
 import {
   useCurrentTaprootAccountBalance,
@@ -55,26 +55,24 @@ export function RetrieveTaprootToNativeSegwit() {
       onApproveTransaction={handleBroadcastRetrieveBitcoinTx}
       onClose={() => navigate(RouteUrls.Home)}
     >
-      <InfoCard mt="space.05">
-        <Stack width="100%">
-          <InfoCardRow title="Your address" value={<FormAddressDisplayer address={recipient} />} />
-          <InfoCardSeparator />
-          <InfoCardRow title="Amount" value={formatMoneyPadded(balance)} />
-          <InfoCardRow title="Fee" value={formatMoneyPadded(fee)} />
-          <InfoCardSeparator />
-          {uninscribedUtxos.map((utxo, i) => (
-            <InfoCardRow
-              key={utxo.txid}
-              title={`Uninscribed UTXO #${i}`}
-              value={
-                <Link href={`https://ordinals.com/output/${utxo.txid}:${utxo.vout}`}>
-                  {`${truncateMiddle(utxo.txid, 4)}:${utxo.vout}`} ↗
-                </Link>
-              }
-            />
-          ))}
-        </Stack>
-      </InfoCard>
+      <Stack width="100%">
+        <InfoCardRow title="Your address" value={<FormAddressDisplayer address={recipient} />} />
+        <InfoCardSeparator />
+        <InfoCardRow title="Amount" value={formatMoneyPadded(balance)} />
+        <InfoCardRow title="Fee" value={formatMoneyPadded(fee)} />
+        <InfoCardSeparator />
+        {uninscribedUtxos.map((utxo, i) => (
+          <InfoCardRow
+            key={utxo.txid}
+            title={`Uninscribed UTXO #${i}`}
+            value={
+              <Link href={`https://ordinals.com/output/${utxo.txid}:${utxo.vout}`}>
+                {`${truncateMiddle(utxo.txid, 4)}:${utxo.vout}`} ↗
+              </Link>
+            }
+          />
+        ))}
+      </Stack>
     </RetrieveTaprootToNativeSegwitLayout>
   );
 }

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-summary.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-summary.tsx
@@ -7,7 +7,6 @@ import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-l
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
 import {
-  InfoCard,
   InfoCardAssetValue,
   InfoCardBtn,
   InfoCardFooter,
@@ -18,6 +17,7 @@ import { useToast } from '@app/features/toasts/use-toast';
 import { CheckmarkIcon } from '@app/ui/icons/checkmark-icon';
 import { CopyIcon } from '@app/ui/icons/copy-icon';
 import { ExternalLinkIcon } from '@app/ui/icons/external-link-icon';
+import { Card } from '@app/ui/layout/card/card';
 
 export function RpcSendTransferSummary() {
   const { state } = useLocation();
@@ -52,31 +52,29 @@ export function RpcSendTransferSummary() {
   }
 
   return (
-    <>
-      <InfoCard>
-        <InfoCardAssetValue
-          fiatSymbol={txFiatValueSymbol}
-          fiatValue={txFiatValue}
-          icon={<CheckmarkIcon width="lg" />}
-          mb="space.05"
-          symbol={symbol}
-          value={txValue}
-        />
-        <Stack pb="space.06" width="100%">
-          <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
-          <InfoCardSeparator />
-          <InfoCardRow title="Total spend" value={totalSpend} />
-          <InfoCardRow title="Sending" value={sendingValue} />
-          <InfoCardRow title="Fee" value={feeRowValue} />
-          {arrivesIn && <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />}
-        </Stack>
-        <InfoCardFooter>
-          <HStack gap="space.04" width="100%">
-            <InfoCardBtn icon={<ExternalLinkIcon />} label="View details" onClick={onClickLink} />
-            <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
-          </HStack>
-        </InfoCardFooter>
-      </InfoCard>
-    </>
+    <Card>
+      <InfoCardAssetValue
+        fiatSymbol={txFiatValueSymbol}
+        fiatValue={txFiatValue}
+        icon={<CheckmarkIcon width="lg" />}
+        mb="space.05"
+        symbol={symbol}
+        value={txValue}
+      />
+      <Stack pb="space.06" width="100%">
+        <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
+        <InfoCardSeparator />
+        <InfoCardRow title="Total spend" value={totalSpend} />
+        <InfoCardRow title="Sending" value={sendingValue} />
+        <InfoCardRow title="Fee" value={feeRowValue} />
+        {arrivesIn && <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />}
+      </Stack>
+      <InfoCardFooter>
+        <HStack gap="space.04" width="100%">
+          <InfoCardBtn icon={<ExternalLinkIcon />} label="View details" onClick={onClickLink} />
+          <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
+        </HStack>
+      </InfoCardFooter>
+    </Card>
   );
 }

--- a/src/app/pages/rpc-sign-psbt/rpc-sign-psbt-summary.tsx
+++ b/src/app/pages/rpc-sign-psbt/rpc-sign-psbt-summary.tsx
@@ -6,7 +6,6 @@ import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-link';
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
 import {
-  InfoCard,
   InfoCardAssetValue,
   InfoCardBtn,
   InfoCardFooter,
@@ -16,6 +15,7 @@ import { useToast } from '@app/features/toasts/use-toast';
 import { CheckmarkIcon } from '@app/ui/icons/checkmark-icon';
 import { CopyIcon } from '@app/ui/icons/copy-icon';
 import { ExternalLinkIcon } from '@app/ui/icons/external-link-icon';
+import { Card } from '@app/ui/layout/card/card';
 
 export function RpcSignPsbtSummary() {
   const { state } = useLocation();
@@ -40,7 +40,7 @@ export function RpcSignPsbtSummary() {
 
   return (
     <Flex alignItems="center" flexDirection="column" p="space.05" width="100%">
-      <InfoCard>
+      <Card>
         <InfoCardAssetValue
           fiatSymbol={txFiatValueSymbol}
           fiatValue={txFiatValue}
@@ -59,7 +59,7 @@ export function RpcSignPsbtSummary() {
             <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
           </HStack>
         </InfoCardFooter>
-      </InfoCard>
+      </Card>
     </Flex>
   );
 }

--- a/src/app/pages/send/locked-bitcoin-summary/locked-bitcoin-summary.tsx
+++ b/src/app/pages/send/locked-bitcoin-summary/locked-bitcoin-summary.tsx
@@ -6,16 +6,14 @@ import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-link';
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
 import { satToBtc } from '@app/common/money/unit-conversion';
-import {
-  InfoCard,
-  InfoCardAssetValue,
-  InfoCardBtn,
-  InfoCardFooter,
-} from '@app/components/info-card/info-card';
+import { InfoCardAssetValue, InfoCardBtn } from '@app/components/info-card/info-card';
 import { useToast } from '@app/features/toasts/use-toast';
+import { Footer } from '@app/ui/components/containers/footers/footer';
 import { CheckmarkIcon } from '@app/ui/icons/checkmark-icon';
 import { CopyIcon } from '@app/ui/icons/copy-icon';
 import { ExternalLinkIcon } from '@app/ui/icons/external-link-icon';
+import { Card } from '@app/ui/layout/card/card';
+import { CardContent } from '@app/ui/layout/card/card-content';
 
 export function LockBitcoinSummary() {
   const { state } = useLocation();
@@ -38,26 +36,32 @@ export function LockBitcoinSummary() {
   }
 
   return (
-    <InfoCard>
-      <InfoCardAssetValue
-        fiatSymbol={txFiatValueSymbol}
-        fiatValue={txFiatValue}
-        icon={<CheckmarkIcon width="lg" />}
-        my="space.05"
-        px="space.05"
-        symbol={symbol}
-        value={Number(satToBtc(txMoney.amount))}
-      />
-      <styled.span textStyle="body.02" p="space.05" textAlign="justify">
-        <b>Success!</b> Your bitcoin has been locked securely. All that's left is for it to be
-        confirmed on the blockchain. After confirmation, you can proceed with borrowing against it.
-      </styled.span>
-      <InfoCardFooter>
-        <HStack gap="space.04" width="100%">
-          <InfoCardBtn icon={<ExternalLinkIcon />} label="View details" onClick={onClickLink} />
-          <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
-        </HStack>
-      </InfoCardFooter>
-    </InfoCard>
+    <Card
+      footer={
+        <Footer variant="card">
+          <HStack gap="space.04" width="100%">
+            <InfoCardBtn icon={<ExternalLinkIcon />} label="View details" onClick={onClickLink} />
+            <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
+          </HStack>
+        </Footer>
+      }
+    >
+      <CardContent p="space.00">
+        <InfoCardAssetValue
+          fiatSymbol={txFiatValueSymbol}
+          fiatValue={txFiatValue}
+          icon={<CheckmarkIcon width="lg" />}
+          my="space.05"
+          px="space.05"
+          symbol={symbol}
+          value={Number(satToBtc(txMoney.amount))}
+        />
+        <styled.span textStyle="body.02" p="space.05" textAlign="justify">
+          <b>Success!</b> Your bitcoin has been locked securely. All that's left is for it to be
+          confirmed on the blockchain. After confirmation, you can proceed with borrowing against
+          it.
+        </styled.span>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-send-inscription-form.tsx
@@ -133,6 +133,7 @@ export function useSendInscriptionForm() {
           time,
           feeRowValue,
           signedTx: signedTx.extract(),
+          backgroundLocation: { pathname: RouteUrls.Home },
         },
       });
     },

--- a/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
@@ -1,21 +1,23 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { bytesToHex } from '@noble/hashes/utils';
-import { Box, Stack } from 'leather-styles/jsx';
+import { Box, Flex, Stack } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
 import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
-import { InfoCard, InfoCardRow, InfoCardSeparator } from '@app/components/info-card/info-card';
+import { InfoCardRow, InfoCardSeparator } from '@app/components/info-card/info-card';
 import { InscriptionPreview } from '@app/components/inscription-preview-card/components/inscription-preview';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by-address.hooks';
 import { useAppDispatch } from '@app/store';
 import { inscriptionSent } from '@app/store/ordinals/ordinals.slice';
 import { Button } from '@app/ui/components/button/button';
 import { Dialog } from '@app/ui/components/containers/dialog/dialog';
+import { Footer } from '@app/ui/components/containers/footers/footer';
 import { Header } from '@app/ui/components/containers/headers/header';
+import { Card } from '@app/ui/layout/card/card';
 
 import { InscriptionPreviewCard } from '../../../components/inscription-preview-card/inscription-preview-card';
 import { useBitcoinBroadcastTransaction } from '../../../query/bitcoin/transaction/use-bitcoin-broadcast-transaction';
@@ -57,6 +59,7 @@ export function SendInscriptionReview() {
             arrivesIn,
             txid,
             feeRowValue,
+            backgroundLocation: { pathname: RouteUrls.Home },
           },
         });
       },
@@ -64,6 +67,7 @@ export function SendInscriptionReview() {
         navigate(`/${RouteUrls.SendOrdinalInscription}/${RouteUrls.SendOrdinalInscriptionError}`, {
           state: {
             error: e,
+            backgroundLocation: { pathname: RouteUrls.Home },
           },
         });
       },
@@ -77,26 +81,40 @@ export function SendInscriptionReview() {
       onGoBack={() => navigate(-1)}
       onClose={() => navigate(RouteUrls.Home)}
     >
-      <Box px="space.06" mt="space.06">
-        <InscriptionPreviewCard
-          image={<InscriptionPreview inscription={inscription} />}
-          subtitle="Ordinal inscription"
-          title={inscription.title}
-        />
-      </Box>
+      <Card
+        footer={
+          <Footer variant="card">
+            <Button aria-busy={isBroadcasting} onClick={sendInscription}>
+              Confirm and send transaction
+            </Button>
+          </Footer>
+        }
+      >
+        <Box px="space.06" mt="space.06">
+          <InscriptionPreviewCard
+            image={<InscriptionPreview inscription={inscription} />}
+            subtitle="Ordinal inscription"
+            title={inscription.title}
+          />
+        </Box>
 
-      <InfoCard pt="space.06" pb="space.06" px="space.06">
-        <Stack width="100%" mb="36px">
-          <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
-          <InfoCardSeparator />
-          {arrivesIn && <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />}
-          <InfoCardRow title="Fee" value={feeRowValue} />
-        </Stack>
-
-        <Button aria-busy={isBroadcasting} width="100%" onClick={sendInscription}>
-          Confirm and send transaction
-        </Button>
-      </InfoCard>
+        <Flex
+          alignItems="center"
+          flexDirection="column"
+          justifyItems="center"
+          width="100%"
+          pt="space.06"
+          pb="space.06"
+          px="space.06"
+        >
+          <Stack width="100%" mb="36px">
+            <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
+            <InfoCardSeparator />
+            {arrivesIn && <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />}
+            <InfoCardRow title="Fee" value={feeRowValue} />
+          </Stack>
+        </Flex>
+      </Card>
     </Dialog>
   );
 }

--- a/src/app/pages/send/ordinal-inscription/sent-inscription-summary.tsx
+++ b/src/app/pages/send/ordinal-inscription/sent-inscription-summary.tsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { Box, HStack, Stack } from 'leather-styles/jsx';
+import { Box, Flex, HStack, Stack } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
 import { Blockchains } from '@shared/models/blockchain.model';
@@ -9,21 +9,18 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-link';
-import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
+import { copyToClipboard } from '@app/common/utils/copy-to-clipboard';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
-import {
-  InfoCard,
-  InfoCardBtn,
-  InfoCardRow,
-  InfoCardSeparator,
-} from '@app/components/info-card/info-card';
+import { InfoCardBtn, InfoCardRow, InfoCardSeparator } from '@app/components/info-card/info-card';
 import { InscriptionPreview } from '@app/components/inscription-preview-card/components/inscription-preview';
 import { useToast } from '@app/features/toasts/use-toast';
 import { Dialog } from '@app/ui/components/containers/dialog/dialog';
+import { Footer } from '@app/ui/components/containers/footers/footer';
 import { Header } from '@app/ui/components/containers/headers/header';
 import { CheckmarkIcon } from '@app/ui/icons/checkmark-icon';
 import { CopyIcon } from '@app/ui/icons/copy-icon';
 import { ExternalLinkIcon } from '@app/ui/icons/external-link-icon';
+import { Card } from '@app/ui/layout/card/card';
 
 import { InscriptionPreviewCard } from '../../../components/inscription-preview-card/inscription-preview-card';
 
@@ -47,7 +44,7 @@ export function SendInscriptionSummary() {
     txid,
   };
 
-  const { onCopy } = useClipboard(txid || '');
+  const id = txid || '';
   const { handleOpenBitcoinTxLink: handleOpenTxLink } = useBitcoinExplorerLink();
   const analytics = useAnalytics();
 
@@ -56,8 +53,8 @@ export function SendInscriptionSummary() {
     handleOpenTxLink(txLink);
   }
 
-  function onClickCopy() {
-    onCopy();
+  async function onClickCopy() {
+    await copyToClipboard(id);
     toast.success('ID copied!');
   }
 
@@ -67,28 +64,41 @@ export function SendInscriptionSummary() {
       isShowing
       onClose={() => navigate(RouteUrls.Home)}
     >
-      <Box mt="space.06" px="space.06">
-        <InscriptionPreviewCard
-          icon={<CheckmarkIcon mt="space.01" width="lg" />}
-          image={<InscriptionPreview inscription={inscription} />}
-          subtitle="Ordinal inscription"
-          title={inscription.title}
-        />
-      </Box>
-
-      <InfoCard pt="space.06" pb="space.06" px="space.06">
-        <Stack mb="space.06" width="100%">
-          <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
-          <InfoCardSeparator />
-          {arrivesIn && <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />}
-          <InfoCardRow title="Fee" value={feeRowValue} />
-        </Stack>
-
-        <HStack gap="space.04" width="100%">
-          <InfoCardBtn onClick={onClickLink} icon={<ExternalLinkIcon />} label="View details" />
-          <InfoCardBtn onClick={onClickCopy} icon={<CopyIcon />} label="Copy ID" />
-        </HStack>
-      </InfoCard>
+      <Card
+        footer={
+          <Footer variant="card">
+            <HStack gap="space.04" width="100%">
+              <InfoCardBtn onClick={onClickLink} icon={<ExternalLinkIcon />} label="View details" />
+              <InfoCardBtn onClick={onClickCopy} icon={<CopyIcon />} label="Copy ID" />
+            </HStack>
+          </Footer>
+        }
+      >
+        <Box mt="space.06" px="space.06">
+          <InscriptionPreviewCard
+            icon={<CheckmarkIcon mt="space.01" width="lg" />}
+            image={<InscriptionPreview inscription={inscription} />}
+            subtitle="Ordinal inscription"
+            title={inscription.title}
+          />
+        </Box>
+        <Flex
+          alignItems="center"
+          flexDirection="column"
+          justifyItems="center"
+          width="100%"
+          pt="space.06"
+          pb="space.06"
+          px="space.06"
+        >
+          <Stack mb="space.06" width="100%">
+            <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
+            <InfoCardSeparator />
+            {arrivesIn && <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />}
+            <InfoCardRow title="Fee" value={feeRowValue} />
+          </Stack>
+        </Flex>
+      </Card>
     </Dialog>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc20-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc20-send-form-confirmation.tsx
@@ -12,9 +12,7 @@ import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { sumMoney } from '@app/common/money/calculate-money';
 import { formatMoney, formatMoneyPadded } from '@app/common/money/format-money';
 import {
-  InfoCard,
   InfoCardAssetValue,
-  InfoCardFooter,
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
@@ -22,6 +20,9 @@ import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by
 import { useBrc20Transfers } from '@app/query/bitcoin/ordinals/brc20/use-brc-20';
 import { useBitcoinBroadcastTransaction } from '@app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction';
 import { Button } from '@app/ui/components/button/button';
+import { Footer } from '@app/ui/components/containers/footers/footer';
+import { Card } from '@app/ui/layout/card/card';
+import { CardContent } from '@app/ui/layout/card/card-content';
 
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 
@@ -103,34 +104,39 @@ export function Brc20SendFormConfirmation() {
   }
 
   return (
-    <InfoCard data-testid={SendCryptoAssetSelectors.ConfirmationDetails}>
-      <InfoCardAssetValue
-        data-testid={SendCryptoAssetSelectors.ConfirmationDetailsAssetValue}
-        mb="space.06"
-        mt="space.05"
-        px="space.05"
-        symbol={ticker}
-        value={Number(amount)}
-      />
-
-      <Stack pb="space.06" px="space.06" width="100%">
-        <InfoCardRow title="Sending" value={amountFormatted} />
-        <InfoCardRow title="Inscription service fee" value={serviceFeeFormatted} />
-        <InfoCardRow
-          title="Payment transaction fee"
-          value={feeRowValue}
-          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsFee}
+    <Card
+      dataTestId={SendCryptoAssetSelectors.ConfirmationDetails}
+      footer={
+        <Footer variant="card">
+          <Button aria-busy={isBroadcasting} onClick={initiateTransaction} width="100%">
+            Create transfer inscription
+          </Button>
+        </Footer>
+      }
+    >
+      <CardContent p="space.00">
+        <InfoCardAssetValue
+          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsAssetValue}
+          mb="space.06"
+          mt="space.05"
+          px="space.05"
+          symbol={ticker}
+          value={Number(amount)}
         />
-        <InfoCardSeparator />
 
-        <InfoCardRow title="Total fee" value={totalFeeFormatted} />
-      </Stack>
+        <Stack pb="space.06" px="space.06" width="100%">
+          <InfoCardRow title="Sending" value={amountFormatted} />
+          <InfoCardRow title="Inscription service fee" value={serviceFeeFormatted} />
+          <InfoCardRow
+            title="Payment transaction fee"
+            value={feeRowValue}
+            data-testid={SendCryptoAssetSelectors.ConfirmationDetailsFee}
+          />
+          <InfoCardSeparator />
 
-      <InfoCardFooter>
-        <Button aria-busy={isBroadcasting} onClick={initiateTransaction} width="100%">
-          Create transfer inscription
-        </Button>
-      </InfoCardFooter>
-    </InfoCard>
+          <InfoCardRow title="Total fee" value={totalFeeFormatted} />
+        </Stack>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -19,9 +19,7 @@ import { satToBtc } from '@app/common/money/unit-conversion';
 import { queryClient } from '@app/common/persistence';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
 import {
-  InfoCard,
   InfoCardAssetValue,
-  InfoCardFooter,
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
@@ -29,6 +27,9 @@ import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by
 import { useBitcoinBroadcastTransaction } from '@app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction';
 import { useCryptoCurrencyMarketData } from '@app/query/common/market-data/market-data.hooks';
 import { Button } from '@app/ui/components/button/button';
+import { Footer } from '@app/ui/components/containers/footers/footer';
+import { Card } from '@app/ui/layout/card/card';
+import { CardContent } from '@app/ui/layout/card/card-content';
 
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
 
@@ -123,45 +124,50 @@ export function BtcSendFormConfirmation() {
   }
 
   return (
-    <InfoCard data-testid={SendCryptoAssetSelectors.ConfirmationDetails}>
-      <InfoCardAssetValue
-        data-testid={SendCryptoAssetSelectors.ConfirmationDetailsAssetValue}
-        fiatSymbol={txFiatValueSymbol}
-        fiatValue={txFiatValue}
-        mb="space.06"
-        mt="space.05"
-        px="space.05"
-        symbol={symbol}
-        value={Number(transferAmount)}
-      />
-
-      <Stack pb="space.06" px="space.06" width="100%">
-        <InfoCardRow
-          title="To"
-          value={<FormAddressDisplayer address={recipient} />}
-          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsRecipient}
+    <Card
+      dataTestId={SendCryptoAssetSelectors.ConfirmationDetails}
+      footer={
+        <Footer variant="card">
+          <Button
+            data-testid={SharedComponentsSelectors.InfoCardButton}
+            aria-busy={isBroadcasting}
+            onClick={initiateTransaction}
+            width="100%"
+          >
+            Confirm and send transaction
+          </Button>
+        </Footer>
+      }
+    >
+      <CardContent p="space.00">
+        <InfoCardAssetValue
+          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsAssetValue}
+          fiatSymbol={txFiatValueSymbol}
+          fiatValue={txFiatValue}
+          mb="space.06"
+          mt="space.05"
+          px="space.05"
+          symbol={symbol}
+          value={Number(transferAmount)}
         />
-        <InfoCardSeparator />
-        <InfoCardRow title="Total spend" value={totalSpend} />
-        <InfoCardRow title="Sending" value={sendingValue} />
-        <InfoCardRow
-          title="Fee"
-          value={feeRowValue}
-          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsFee}
-        />
-        {arrivesIn && <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />}
-      </Stack>
 
-      <InfoCardFooter>
-        <Button
-          data-testid={SharedComponentsSelectors.InfoCardButton}
-          aria-busy={isBroadcasting}
-          onClick={initiateTransaction}
-          width="100%"
-        >
-          Confirm and send transaction
-        </Button>
-      </InfoCardFooter>
-    </InfoCard>
+        <Stack pb="space.06" px="space.06" width="100%">
+          <InfoCardRow
+            title="To"
+            value={<FormAddressDisplayer address={recipient} />}
+            data-testid={SendCryptoAssetSelectors.ConfirmationDetailsRecipient}
+          />
+          <InfoCardSeparator />
+          <InfoCardRow title="Total spend" value={totalSpend} />
+          <InfoCardRow title="Sending" value={sendingValue} />
+          <InfoCardRow
+            title="Fee"
+            value={feeRowValue}
+            data-testid={SendCryptoAssetSelectors.ConfirmationDetailsFee}
+          />
+          {arrivesIn && <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />}
+        </Stack>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/send-form-confirmation.tsx
@@ -3,14 +3,15 @@ import { Stack } from 'leather-styles/jsx';
 
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
 import {
-  InfoCard,
   InfoCardAssetValue,
-  InfoCardFooter,
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
 import { Button } from '@app/ui/components/button/button';
 import { Callout } from '@app/ui/components/callout/callout';
+import { Footer } from '@app/ui/components/containers/footers/footer';
+import { Card } from '@app/ui/layout/card/card';
+import { CardContent } from '@app/ui/layout/card/card-content';
 
 interface SendFormConfirmationProps {
   recipient: string;
@@ -45,59 +46,60 @@ export function SendFormConfirmation({
   feeWarningTooltip,
 }: SendFormConfirmationProps) {
   return (
-    <InfoCard
-      data-testid={SendCryptoAssetSelectors.ConfirmationDetails}
-      pb={{ base: '120px', md: '0' }}
+    <Card
+      footer={
+        <Footer variant="card">
+          <Button
+            aria-busy={isLoading}
+            data-testid={SendCryptoAssetSelectors.ConfirmSendTxBtn}
+            onClick={onBroadcastTransaction}
+            width="100%"
+          >
+            Confirm and send transaction
+          </Button>
+        </Footer>
+      }
     >
-      <InfoCardAssetValue
-        data-testid={SendCryptoAssetSelectors.ConfirmationDetailsAssetValue}
-        fiatSymbol={txFiatValueSymbol}
-        fiatValue={txFiatValue}
-        mb="space.05"
-        mt={['unset', 'space.05']}
-        px="space.05"
-        symbol={symbol}
-        value={Number(txValue)}
-      />
-
-      <Callout variant="info" title="Sending to an exchange?" px="space.03" mb="space.05">
-        {`Make sure you include the memo so the exchange can credit the ${symbol} to your account`}
-      </Callout>
-
-      <Stack pb="space.06" px="space.06" width="100%">
-        <InfoCardRow
-          title="To"
-          value={<FormAddressDisplayer address={recipient} />}
-          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsRecipient}
+      <CardContent dataTestId={SendCryptoAssetSelectors.ConfirmationDetails} p="space.00">
+        <InfoCardAssetValue
+          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsAssetValue}
+          fiatSymbol={txFiatValueSymbol}
+          fiatValue={txFiatValue}
+          mb="space.05"
+          mt={['unset', 'space.05']}
+          px="space.05"
+          symbol={symbol}
+          value={Number(txValue)}
         />
-        <InfoCardSeparator />
-        <InfoCardRow title="Total spend" value={totalSpend} />
-        <InfoCardRow title="Sending" value={sendingValue} />
-        <InfoCardRow
-          title="Fee"
-          value={fee}
-          titleAdditionalElement={feeWarningTooltip}
-          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsFee}
-        />
-        <InfoCardRow
-          title="Memo"
-          value={memoDisplayText}
-          data-testid={SendCryptoAssetSelectors.ConfirmationDetailsMemo}
-        />
-        <InfoCardRow title="Nonce" value={nonce} />
-        <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />
-      </Stack>
 
-      <InfoCardFooter>
-        <Button
-          aria-busy={isLoading}
-          data-testid={SendCryptoAssetSelectors.ConfirmSendTxBtn}
-          onClick={onBroadcastTransaction}
-          width="100%"
-        >
-          Confirm and send transaction
-        </Button>
-      </InfoCardFooter>
-    </InfoCard>
+        <Callout variant="info" title="Sending to an exchange?" px="space.03" mb="space.05">
+          {`Make sure you include the memo so the exchange can credit the ${symbol} to your account`}
+        </Callout>
+
+        <Stack pb="space.06" px="space.06" width="100%">
+          <InfoCardRow
+            title="To"
+            value={<FormAddressDisplayer address={recipient} />}
+            data-testid={SendCryptoAssetSelectors.ConfirmationDetailsRecipient}
+          />
+          <InfoCardSeparator />
+          <InfoCardRow title="Total spend" value={totalSpend} />
+          <InfoCardRow title="Sending" value={sendingValue} />
+          <InfoCardRow
+            title="Fee"
+            value={fee}
+            titleAdditionalElement={feeWarningTooltip}
+            data-testid={SendCryptoAssetSelectors.ConfirmationDetailsFee}
+          />
+          <InfoCardRow
+            title="Memo"
+            value={memoDisplayText}
+            data-testid={SendCryptoAssetSelectors.ConfirmationDetailsMemo}
+          />
+          <InfoCardRow title="Nonce" value={nonce} />
+          <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />
+        </Stack>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/pages/send/sent-summary/brc20-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/brc20-sent-summary.tsx
@@ -9,16 +9,17 @@ import { HandleOpenStacksTxLinkArgs } from '@app/common/hooks/use-stacks-explore
 import { formatMoney } from '@app/common/money/format-money';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import {
-  InfoCard,
   InfoCardAssetValue,
   InfoCardBtn,
-  InfoCardFooter,
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
 import { Callout } from '@app/ui/components/callout/callout';
+import { Footer } from '@app/ui/components/containers/footers/footer';
 import { Link } from '@app/ui/components/link/link';
 import { ExternalLinkIcon } from '@app/ui/icons/external-link-icon';
+import { Card } from '@app/ui/layout/card/card';
+import { CardContent } from '@app/ui/layout/card/card-content';
 
 import { TxDone } from '../send-crypto-asset-form/components/tx-done';
 
@@ -46,47 +47,52 @@ export function Brc20SentSummary() {
   }
 
   return (
-    <InfoCard>
-      <TxDone />
+    <Card
+      footer={
+        <Footer variant="card">
+          <HStack gap="space.04" width="100%">
+            <InfoCardBtn
+              icon={<ExternalLinkIcon />}
+              label="Pending BRC-20 transfers"
+              onClick={onClickLink}
+            />
+          </HStack>
+        </Footer>
+      }
+    >
+      <CardContent p="space.00">
+        <TxDone />
 
-      <InfoCardAssetValue px="space.05" symbol={ticker} value={Number(amount)} />
+        <InfoCardAssetValue px="space.05" symbol={ticker} value={Number(amount)} />
 
-      <Stack px="space.06" pb="space.06" width="100%">
-        <Callout variant="info" title="One more step is required to send tokens" mb="space.05">
-          <Stack>
-            <styled.span mb="space.02">
-              You'll need to send the transfer inscription to your recipient of choice from the home
-              screen once its status changes to "Ready to send"
-            </styled.span>
-            <Link
-              width="fit-content"
-              textStyle="body.02"
-              onClick={() => {
-                openInNewTab('https://leather.gitbook.io/guides/bitcoin/sending-brc-20-tokens');
-              }}
-            >
-              Learn more
-            </Link>
-          </Stack>
-        </Callout>
-        <InfoCardSeparator />
+        <Stack px="space.06" pb="space.06" width="100%">
+          <Callout variant="info" title="One more step is required to send tokens" mb="space.05">
+            <Stack>
+              <styled.span mb="space.02">
+                You'll need to send the transfer inscription to your recipient of choice from the
+                home screen once its status changes to "Ready to send"
+              </styled.span>
+              <Link
+                width="fit-content"
+                textStyle="body.02"
+                onClick={() => {
+                  openInNewTab('https://leather.gitbook.io/guides/bitcoin/sending-brc-20-tokens');
+                }}
+              >
+                Learn more
+              </Link>
+            </Stack>
+          </Callout>
+          <InfoCardSeparator />
 
-        <InfoCardRow title="Sending" value={amountFormatted} />
-        <InfoCardRow title="Inscription service fee" value={serviceFee} />
-        <InfoCardRow title="Payment transaction fee" value={feeRowValue} />
+          <InfoCardRow title="Sending" value={amountFormatted} />
+          <InfoCardRow title="Inscription service fee" value={serviceFee} />
+          <InfoCardRow title="Payment transaction fee" value={feeRowValue} />
 
-        <InfoCardSeparator />
-        <InfoCardRow title="Total fee" value={totalFee} />
-      </Stack>
-      <InfoCardFooter>
-        <HStack gap="space.04" width="100%">
-          <InfoCardBtn
-            icon={<ExternalLinkIcon />}
-            label="Pending BRC-20 transfers"
-            onClick={onClickLink}
-          />
-        </HStack>
-      </InfoCardFooter>
-    </InfoCard>
+          <InfoCardSeparator />
+          <InfoCardRow title="Total fee" value={totalFee} />
+        </Stack>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/pages/send/sent-summary/btc-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/btc-sent-summary.tsx
@@ -7,16 +7,17 @@ import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-l
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
 import {
-  InfoCard,
   InfoCardAssetValue,
   InfoCardBtn,
-  InfoCardFooter,
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
 import { useToast } from '@app/features/toasts/use-toast';
+import { Footer } from '@app/ui/components/containers/footers/footer';
 import { CopyIcon } from '@app/ui/icons/copy-icon';
 import { ExternalLinkIcon } from '@app/ui/icons/external-link-icon';
+import { Card } from '@app/ui/layout/card/card';
+import { CardContent } from '@app/ui/layout/card/card-content';
 
 import { TxDone } from '../send-crypto-asset-form/components/tx-done';
 
@@ -53,32 +54,36 @@ export function BtcSentSummary() {
   }
 
   return (
-    <InfoCard>
-      <TxDone />
-      <InfoCardAssetValue
-        fiatSymbol={txFiatValueSymbol}
-        fiatValue={txFiatValue}
-        px="space.05"
-        symbol={symbol}
-        value={txValue}
-      />
+    <Card
+      footer={
+        <Footer variant="card">
+          <HStack gap="space.04" width="100%">
+            <InfoCardBtn icon={<ExternalLinkIcon />} label="View details" onClick={onClickLink} />
+            <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
+          </HStack>
+        </Footer>
+      }
+    >
+      <CardContent p="space.00">
+        <TxDone />
+        <InfoCardAssetValue
+          fiatSymbol={txFiatValueSymbol}
+          fiatValue={txFiatValue}
+          px="space.05"
+          symbol={symbol}
+          value={txValue}
+        />
 
-      <Stack pb="space.06" px="space.06" width="100%">
-        <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
-        <InfoCardSeparator />
-        <InfoCardRow title="Total spend" value={totalSpend} />
+        <Stack pb="space.06" px="space.06" width="100%">
+          <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
+          <InfoCardSeparator />
+          <InfoCardRow title="Total spend" value={totalSpend} />
 
-        <InfoCardRow title="Sending" value={sendingValue} />
-        <InfoCardRow title="Fee" value={feeRowValue} />
-        {arrivesIn && <InfoCardRow title="Arrives in" value={arrivesIn} />}
-      </Stack>
-
-      <InfoCardFooter>
-        <HStack gap="space.04" width="100%">
-          <InfoCardBtn icon={<ExternalLinkIcon />} label="View details" onClick={onClickLink} />
-          <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
-        </HStack>
-      </InfoCardFooter>
-    </InfoCard>
+          <InfoCardRow title="Sending" value={sendingValue} />
+          <InfoCardRow title="Fee" value={feeRowValue} />
+          {arrivesIn && <InfoCardRow title="Arrives in" value={arrivesIn} />}
+        </Stack>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/pages/send/sent-summary/stx-sent-summary.tsx
+++ b/src/app/pages/send/sent-summary/stx-sent-summary.tsx
@@ -7,16 +7,17 @@ import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
 import { useStacksExplorerLink } from '@app/common/hooks/use-stacks-explorer-link';
 import { FormAddressDisplayer } from '@app/components/address-displayer/form-address-displayer';
 import {
-  InfoCard,
   InfoCardAssetValue,
   InfoCardBtn,
-  InfoCardFooter,
   InfoCardRow,
   InfoCardSeparator,
 } from '@app/components/info-card/info-card';
 import { useToast } from '@app/features/toasts/use-toast';
+import { Footer } from '@app/ui/components/containers/footers/footer';
 import { CopyIcon } from '@app/ui/icons/copy-icon';
 import { ExternalLinkIcon } from '@app/ui/icons/external-link-icon';
+import { Card } from '@app/ui/layout/card/card';
+import { CardContent } from '@app/ui/layout/card/card-content';
 
 import { TxDone } from '../send-crypto-asset-form/components/tx-done';
 
@@ -53,33 +54,37 @@ export function StxSentSummary() {
   }
 
   return (
-    <InfoCard pb={{ base: '120px', md: '0' }}>
-      <TxDone />
+    <Card
+      footer={
+        <Footer variant="card">
+          <HStack gap="space.04" width="100%">
+            <InfoCardBtn icon={<ExternalLinkIcon />} label="View details" onClick={onClickLink} />
+            <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
+          </HStack>
+        </Footer>
+      }
+    >
+      <CardContent p="space.00">
+        <TxDone />
 
-      <InfoCardAssetValue
-        fiatSymbol={txFiatValueSymbol}
-        fiatValue={txFiatValue}
-        px="space.05"
-        symbol={symbol}
-        value={txValue}
-      />
+        <InfoCardAssetValue
+          fiatSymbol={txFiatValueSymbol}
+          fiatValue={txFiatValue}
+          px="space.05"
+          symbol={symbol}
+          value={txValue}
+        />
 
-      <Stack pb="space.06" px="space.06" width="100%">
-        <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
-        <InfoCardSeparator />
-        <InfoCardRow title="Total spend" value={totalSpend} />
+        <Stack pb="space.06" px="space.06" width="100%">
+          <InfoCardRow title="To" value={<FormAddressDisplayer address={recipient} />} />
+          <InfoCardSeparator />
+          <InfoCardRow title="Total spend" value={totalSpend} />
 
-        <InfoCardRow title="Sending" value={sendingValue} />
-        <InfoCardRow title="Fee" value={fee} />
-        <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />
-      </Stack>
-
-      <InfoCardFooter>
-        <HStack gap="space.04" width="100%">
-          <InfoCardBtn icon={<ExternalLinkIcon />} label="View details" onClick={onClickLink} />
-          <InfoCardBtn icon={<CopyIcon />} label="Copy ID" onClick={onClickCopy} />
-        </HStack>
-      </InfoCardFooter>
-    </InfoCard>
+          <InfoCardRow title="Sending" value={sendingValue} />
+          <InfoCardRow title="Fee" value={fee} />
+          <InfoCardRow title="Estimated confirmation time" value={arrivesIn} />
+        </Stack>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/ui/layout/card/card-content.tsx
+++ b/src/app/ui/layout/card/card-content.tsx
@@ -5,7 +5,7 @@ import { token } from 'leather-styles/tokens';
 
 interface CardContentProps extends FlexProps {
   children: ReactNode;
-  dataTestId: string;
+  dataTestId?: string;
 }
 
 export function CardContent({ children, dataTestId, ...props }: CardContentProps) {

--- a/src/app/ui/layout/card/card.tsx
+++ b/src/app/ui/layout/card/card.tsx
@@ -4,13 +4,14 @@ import { Flex } from 'leather-styles/jsx';
 
 interface CardProps {
   children: ReactNode;
+  dataTestId?: string;
   header?: ReactNode;
   footer?: ReactNode;
 }
 
-export function Card({ children, header, footer }: CardProps) {
+export function Card({ children, dataTestId, header, footer }: CardProps) {
   return (
-    <Flex direction="column" border={{ base: 'unset', sm: 'default' }} rounded="lg">
+    <Flex data-testid={dataTestId} direction="column">
       {header}
       {children}
       {footer}

--- a/src/app/ui/layout/page/page.layout.tsx
+++ b/src/app/ui/layout/page/page.layout.tsx
@@ -9,7 +9,12 @@ interface PageProps {
 
 export function Page({ children }: PageProps) {
   return (
-    <Box width="pageWidth" height={{ base: '100%', md: 'fit-content' }}>
+    <Box
+      width="pageWidth"
+      height={{ base: '100%', md: 'fit-content' }}
+      border={{ base: 'unset', sm: 'default' }}
+      rounded="lg"
+    >
       {children}
     </Box>
   );


### PR DESCRIPTION
> Try out Leather build 5dffaf7 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8570519229), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5133/update-borders), [Storybook](https://fix-5133-update-borders--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5133/update-borders)<!-- Sticky Header Marker -->

This PR:
- adds borders to the `<Page` component so all pages have the required border
- refactors some other cards to deprecate `<InfoCardFooter` and standardise UI
- adds a fix for the BG location of the send ordinal flow dialog

