### PR TITLE
fix: swap test

### DIFF
--- a/tests/page-object-models/swap.page.ts
+++ b/tests/page-object-models/swap.page.ts
@@ -32,8 +32,7 @@ export class SwapPage {
     const swapAssetSelectors = await this.page.locator(this.selectAssetBtn).all();
     await swapAssetSelectors[1].click();
     await this.page.locator(this.chooseAssetList).waitFor();
-    const swapAssets = await this.page.locator(this.chooseAssetListItem).all();
-    await swapAssets[0].click();
+    await this.page.locator('text="ALEX Token"').click();
     await this.page.locator(this.swapReviewBtn).click();
   }
 


### PR DESCRIPTION
> Try out Leather build 6428be0 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8527503011), [Test report](https://leather-wallet.github.io/playwright-reports/fix/swap-test), [Storybook](https://fix-swap-test--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/swap-test)<!-- Sticky Header Marker -->

This PR should fix a test with swaps breaking bc the sdk is returning a new token that is listed before the `Alex Token` used in the test.