### PR TITLE
ci: auto-updated mono packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'pnpm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    group:
+      leather:
+        applies-to: version-updates
+        patterns:
+          - '@leather-wallet/*'


### PR DESCRIPTION
> Try out Leather build cad54ed — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8566694091), [Test report](https://leather-wallet.github.io/playwright-reports/ci/dependabot), [Storybook](https://ci-dependabot--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci/dependabot)<!-- Sticky Header Marker -->

Should configure dependabot to auto suggest updates to mono repo packages