### PR TITLE
chore: implement fix to limit amount of accounts rendered

### DIFF
--- a/src/app/features/dialogs/switch-account-dialog/switch-account-dialog.tsx
+++ b/src/app/features/dialogs/switch-account-dialog/switch-account-dialog.tsx
@@ -43,6 +43,7 @@ export const SwitchAccountDialog = memo(({ isShowing, onClose }: DialogProps) =>
   if (!isShowing) return null;
 
   const accountNum = stacksAddressesNum || btcAddressesNum;
+  const maxAccountsShown = accountNum > 10 ? 10 : accountNum;
 
   return (
     <Dialog
@@ -64,7 +65,7 @@ export const SwitchAccountDialog = memo(({ isShowing, onClose }: DialogProps) =>
         height={virtuosoHeight}
         style={{
           ...virtuosoStyles,
-          height: `calc(${virtuosoHeight * accountNum}px + ${getHeightOffset(true, !isLedger)}px)`,
+          height: `calc(${virtuosoHeight * maxAccountsShown}px + ${getHeightOffset(true, !isLedger)}px)`,
         }}
         initialTopMostItemIndex={whenWallet({ ledger: 0, software: currentAccountIndex })}
         totalCount={stacksAddressesNum || btcAddressesNum}

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -112,6 +112,8 @@ export const ChooseAccountsList = memo(() => {
   if (!accounts) return null;
   const accountNum = accounts.length;
 
+  const maxAccountsShown = accountNum > 10 ? 10 : accountNum;
+
   return (
     <Box mt="space.05" mb="space.06" width="100%">
       {whenWallet({ software: <AddAccountAction />, ledger: <></> })}
@@ -119,7 +121,7 @@ export const ChooseAccountsList = memo(() => {
         height={virtuosoHeight}
         style={{
           ...virtuosoStyles,
-          height: `calc(${virtuosoHeight * accountNum}px + 50px)`,
+          height: `calc(${virtuosoHeight * maxAccountsShown}px + 50px)`,
           background: token('colors.ink.background-primary'),
         }}
         data={accounts}

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-dialog/recipient-accounts-dialog.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-dialog/recipient-accounts-dialog.tsx
@@ -23,6 +23,7 @@ export function RecipientAccountsDialog() {
 
   if (stacksAddressesNum === 0 && btcAddressesNum === 0) return null;
   const accountNum = stacksAddressesNum || btcAddressesNum;
+  const maxAccountsShown = accountNum > 10 ? 10 : accountNum;
 
   return (
     <Dialog header={<Header variant="dialog" title="My accounts" />} isShowing onClose={onGoBack}>
@@ -30,7 +31,7 @@ export function RecipientAccountsDialog() {
         height={virtuosoHeight}
         style={{
           ...virtuosoStyles,
-          height: `calc(${virtuosoHeight * accountNum}px + ${getHeightOffset(true, true)}px)`,
+          height: `calc(${virtuosoHeight * maxAccountsShown}px + ${getHeightOffset(true, true)}px)`,
         }}
         itemContent={index => (
           <Box key={index} my="space.05" px="space.05">


### PR DESCRIPTION
> Try out Leather build 724e604 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8570178725), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5149/virtuoso-partial), [Storybook](https://fix-5149-virtuoso-partial--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5149/virtuoso-partial)<!-- Sticky Header Marker -->

This PR makes a small change to fix https://github.com/leather-wallet/extension/issues/5149. 

This fixes the issue and reduces the impact of the bug however it means that the UI isn't as slick as it could be and the list height doesn't dynamically update on narrower viewports. 

I am close to having a full solution in [this PR](https://github.com/leather-wallet/extension/pull/5171/files) but thought it worth improving what we have on `dev` while I am finalising that. 

Here's what I am talking about: 

https://github.com/leather-wallet/extension/assets/2938440/7a26d232-c21c-45e6-ab3c-ba2cc32d5793

