### PR TITLE
fix: container when resized

### DIFF
--- a/theme/global/global.ts
+++ b/theme/global/global.ts
@@ -35,10 +35,10 @@ export const globalCss = defineGlobalStyles({
   },
   '.mode__popup': {
     'html,body, #app, .radix-themes': {
-      height: tokens.sizes.popupHeight.value,
       maxHeight: '100vh',
       minHeight: tokens.sizes.dialogHeight.value,
       width: tokens.sizes.popupWidth.value,
+      margin: '0 auto',
 
       '::-webkit-scrollbar': {
         display: 'none',


### PR DESCRIPTION
> Try out Leather build 3cb00df — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8615819948), [Test report](https://leather-wallet.github.io/playwright-reports/fix/container-resizing), [Storybook](https://fix-container-resizing--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/container-resizing)<!-- Sticky Header Marker -->

Noticed that container doesn't centre itself when the content is resize. Think it'd be nice to contain the content when this happens.

![image](https://github.com/leather-wallet/extension/assets/1618764/f86f1573-c964-4142-b9a3-f985999fdbfa)

Also @pete-watters think we can remove the height? We have the min & max height. The height is the default size of the window, but that can change if users resize themselves, reposition with window manager etc

This PR centres the content, which is a very small improvement


![image](https://github.com/leather-wallet/extension/assets/1618764/720b78b7-1842-41b0-a207-90c915592e5d)
