### PR TITLE
chore: stop increase fee being cutoff when long contract name

### DIFF
--- a/src/app/components/stacks-transaction-item/increase-fee-button.tsx
+++ b/src/app/components/stacks-transaction-item/increase-fee-button.tsx
@@ -1,6 +1,5 @@
 import { HStack, styled } from 'leather-styles/jsx';
 
-import { whenPageMode } from '@app/common/utils';
 import { ChevronsRightIcon } from '@app/ui/icons/chevrons-right-icon';
 
 interface IncreaseFeeButtonProps {
@@ -28,17 +27,11 @@ export function IncreaseFeeButton(props: IncreaseFeeButtonProps) {
       px="space.02"
       py="space.01"
       rounded="xs"
-      type="button"
       zIndex={999}
     >
       <HStack gap="space.01">
         <ChevronsRightIcon color="stacks" variant="small" />
-        <styled.span textStyle="label.03">
-          {whenPageMode({
-            popup: 'Fee',
-            full: 'Increase fee',
-          })}
-        </styled.span>
+        <styled.span textStyle="label.03">Increase fee</styled.span>
       </HStack>
     </styled.button>
   );

--- a/src/app/components/transaction-item/transaction-item.layout.tsx
+++ b/src/app/components/transaction-item/transaction-item.layout.tsx
@@ -33,7 +33,13 @@ export function TransactionItemLayout({
         titleLeft={txTitle}
         captionLeft={
           <HStack alignItems="center">
-            <Caption>{txCaption}</Caption>
+            <Caption
+              overflow="hidden"
+              textOverflow="ellipsis"
+              maxWidth={{ base: '160px', md: 'unset' }}
+            >
+              {txCaption}
+            </Caption>
             {txStatus && txStatus}
           </HStack>
         }


### PR DESCRIPTION
> Try out Leather build 8a11d05 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8642228018), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5173/increase-fee-cut-off), [Storybook](https://fix-5173-increase-fee-cut-off--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5173/increase-fee-cut-off)<!-- Sticky Header Marker -->

This PR adds ellipsis to the contract name caption to stop it moving the `Increase Fee` button out of view for long contract names

https://github.com/leather-wallet/extension/issues/5173
