### PR TITLE
fix: shimmer styles import

### DIFF
--- a/src/app/components/account-total-balance.tsx
+++ b/src/app/components/account-total-balance.tsx
@@ -1,6 +1,5 @@
 import { memo } from 'react';
 
-import { css } from 'leather-styles/css';
 import { styled } from 'leather-styles/jsx';
 
 import { useTotalBalance } from '@app/common/hooks/balance/use-total-balance';
@@ -24,7 +23,7 @@ export const AccountTotalBalance = memo(({ btcAddress, stxAddress }: AccountTota
   return (
     <SkeletonLoader height="20px" isLoading={isInitialLoading}>
       <styled.span
-        className={css(shimmerStyles)}
+        className={shimmerStyles}
         textStyle="label.02"
         data-state={isLoading ? 'loading' : undefined}
       >

--- a/src/app/components/account/account-name.tsx
+++ b/src/app/components/account/account-name.tsx
@@ -1,6 +1,5 @@
 import { memo } from 'react';
 
-import { css } from 'leather-styles/css';
 import { styled } from 'leather-styles/jsx';
 
 import { shimmerStyles } from '@app/ui/shared/shimmer-styles';
@@ -12,7 +11,7 @@ interface AccountNameLayoutProps {
 
 export const AccountNameLayout = memo(({ children, isLoading }: AccountNameLayoutProps) => (
   <styled.span
-    className={css(shimmerStyles)}
+    className={shimmerStyles}
     textStyle="label.02"
     aria-busy={isLoading}
     data-state={isLoading ? 'loading' : undefined}

--- a/src/app/ui/components/skeleton-loader/skeleton-loader.tsx
+++ b/src/app/ui/components/skeleton-loader/skeleton-loader.tsx
@@ -1,4 +1,3 @@
-import { css } from 'leather-styles/css';
 import { Box } from 'leather-styles/jsx';
 
 import { shimmerStyles } from '@app/ui/shared/shimmer-styles';
@@ -24,7 +23,7 @@ export function SkeletonLoader({
         bgColor="ink.non-interactive"
         data-state="loading"
         borderRadius="sm"
-        className={css(shimmerStyles)}
+        className={shimmerStyles}
       />
     );
   }

--- a/src/app/ui/shared/shimmer-styles.ts
+++ b/src/app/ui/shared/shimmer-styles.ts
@@ -1,6 +1,6 @@
-import type { SystemStyleObject } from 'leather-styles/types';
+import { css } from 'leather-styles/css';
 
-export const shimmerStyles: SystemStyleObject = {
+export const shimmerStyles = css({
   '&[data-state=loading]': {
     display: 'inline-block',
     WebkitMask: 'linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300% 100%',
@@ -8,4 +8,4 @@ export const shimmerStyles: SystemStyleObject = {
     animation: 'shimmer 1.5s infinite',
     color: 'ink.text-subdued',
   },
-};
+});


### PR DESCRIPTION
> Try out Leather build 5c5fb19 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8631306761), [Test report](https://leather-wallet.github.io/playwright-reports/fix/shimmer-style), [Storybook](https://fix-shimmer-style--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/shimmer-style)<!-- Sticky Header Marker -->

Not sure why, but sometimes shimmer styles were not applied, seems some style import problem, wrapping to `css()` fixed it