### PR TITLE
ci: filter only leather package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    groups:
-      leather:
-        applies-to: version-updates
-        patterns:
-          - '@leather-wallet/*'
+    allow:
+      - dependency-name: '@leather-wallet/*'


### PR DESCRIPTION
> Try out Leather build a55cbd2 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8647126731), [Test report](https://leather-wallet.github.io/playwright-reports/fix/dependabot), [Storybook](https://fix-dependabot--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/dependabot)<!-- Sticky Header Marker -->

🤞🏼 this correctly filters package updates
