### PR TITLE
feat: filter out runes utxos, closes #5207

### DIFF
--- a/src/app/query/bitcoin/address/utxos-by-address.spec.tsx
+++ b/src/app/query/bitcoin/address/utxos-by-address.spec.tsx
@@ -1,11 +1,35 @@
 import { mockInscriptionsList } from '@tests/mocks/mock-inscriptions';
-import { mockUtxos } from '@tests/mocks/mock-utxos';
+import { mockRunesOutputsByAddressList } from '@tests/mocks/mock-runes';
+import { mockUtxos, mockUtxosListWithRunes } from '@tests/mocks/mock-utxos';
 
-import { filterUtxosWithInscriptions } from './utxos-by-address.hooks';
+import { filterUtxosWithInscriptions, filterUtxosWithRunes } from './utxos-by-address.hooks';
 
 describe(filterUtxosWithInscriptions, () => {
   test('that it filters out utxos with inscriptions so they are not spent', () => {
     const filteredUtxos = filterUtxosWithInscriptions(mockInscriptionsList, mockUtxos);
     expect(filteredUtxos).toEqual([]);
+  });
+});
+
+describe(filterUtxosWithRunes, () => {
+  test('that it filters out utxos with runes so they are not spent', () => {
+    const filteredUtxos = filterUtxosWithRunes(
+      mockRunesOutputsByAddressList,
+      mockUtxosListWithRunes
+    );
+
+    expect(filteredUtxos).toEqual([
+      {
+        txid: '66ff7d54e345170e3a76819dc90140971fdae054c9b7eea2089ba5a9720f6e44',
+        vout: 1,
+        status: {
+          confirmed: true,
+          block_height: 2585955,
+          block_hash: '00000000000000181cae54c3c19d6ed02511a2f6302a666c3d78bcf1777bb029',
+          block_time: 1712829917,
+        },
+        value: 546,
+      },
+    ]);
   });
 });

--- a/src/app/query/bitcoin/balance/btc-balance.hooks.ts
+++ b/src/app/query/bitcoin/balance/btc-balance.hooks.ts
@@ -8,8 +8,11 @@ import { isUndefined } from '@shared/utils';
 import { sumNumbers } from '@app/common/math/helpers';
 
 import { useNativeSegwitUtxosByAddress } from '../address/utxos-by-address.hooks';
+import { useRunesEnabled } from '../runes/runes.hooks';
 
 export function useGetBitcoinBalanceByAddress(address: string) {
+  const runesEnabled = useRunesEnabled();
+
   const {
     data: utxos,
     isInitialLoading,
@@ -18,6 +21,7 @@ export function useGetBitcoinBalanceByAddress(address: string) {
     address,
     filterInscriptionUtxos: true,
     filterPendingTxsUtxos: true,
+    filterRunesUtxos: runesEnabled,
   });
 
   const balance = useMemo(() => {

--- a/src/app/query/bitcoin/runes/runes-outputs-by-address.query.ts
+++ b/src/app/query/bitcoin/runes/runes-outputs-by-address.query.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+
+import type { AppUseQueryConfig } from '@app/query/query-config';
+import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
+import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
+
+import type { RunesOutputsByAddress } from '../bitcoin-client';
+import { useRunesEnabled } from './runes.hooks';
+
+export function useGetRunesOutputsByAddressQuery<T extends unknown = RunesOutputsByAddress[]>(
+  address: string,
+  options?: AppUseQueryConfig<RunesOutputsByAddress[], T>
+) {
+  const client = useBitcoinClient();
+  const runesEnabled = useRunesEnabled();
+  const network = useCurrentNetwork();
+
+  return useQuery({
+    queryKey: ['runes-outputs-by-address', address],
+    queryFn: () =>
+      client.BestinslotApi.getRunesOutputsByAddress({
+        address,
+        network: network.chain.bitcoin.bitcoinNetwork,
+      }),
+    staleTime: 1000 * 60,
+    enabled: !!address && runesEnabled,
+    ...options,
+  });
+}

--- a/src/app/query/bitcoin/runes/runes.hooks.ts
+++ b/src/app/query/bitcoin/runes/runes.hooks.ts
@@ -2,7 +2,11 @@ import { logger } from '@shared/logger';
 import { createMoney } from '@shared/models/money.model';
 import { isDefined } from '@shared/utils';
 
+import { useConfigRunesEnabled } from '@app/query/common/remote-config/remote-config.query';
+import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
+
 import type { RuneBalance, RuneTickerInfo, RuneToken } from '../bitcoin-client';
+import { useGetRunesOutputsByAddressQuery } from './runes-outputs-by-address.query';
 import { useGetRunesTickerInfoQuery } from './runes-ticker-info.query';
 import { useGetRunesWalletBalancesByAddressesQuery } from './runes-wallet-balances.query';
 
@@ -16,6 +20,13 @@ function makeRuneToken(runeBalance: RuneBalance, tickerInfo: RuneTickerInfo): Ru
       tickerInfo.decimals
     ),
   };
+}
+
+export function useRunesEnabled() {
+  const runesEnabled = useConfigRunesEnabled();
+  const network = useCurrentNetwork();
+
+  return runesEnabled || network.chain.bitcoin.bitcoinNetwork === 'testnet';
 }
 
 export function useRuneTokens(addresses: string[]) {
@@ -35,4 +46,8 @@ export function useRuneTokens(addresses: string[]) {
     }
     return makeRuneToken(r, tickerInfo);
   });
+}
+
+export function useRunesOutputsByAddress(address: string) {
+  return useGetRunesOutputsByAddressQuery(address);
 }

--- a/src/app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
+++ b/src/app/query/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
@@ -8,7 +8,7 @@ import { delay, isError } from '@shared/utils';
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
 
-import { filterOutIntentionalUtxoSpend, useCheckInscribedUtxos } from './use-check-utxos';
+import { filterOutIntentionalUtxoSpend, useCheckUnspendableUtxos } from './use-check-utxos';
 
 interface BroadcastCallbackArgs {
   tx: string;
@@ -23,7 +23,7 @@ export function useBitcoinBroadcastTransaction() {
   const client = useBitcoinClient();
   const [isBroadcasting, setIsBroadcasting] = useState(false);
   const analytics = useAnalytics();
-  const { checkIfUtxosListIncludesInscribed } = useCheckInscribedUtxos();
+  const { checkIfUtxosListIncludesInscribed } = useCheckUnspendableUtxos();
 
   const broadcastTx = useCallback(
     async ({

--- a/src/app/query/bitcoin/transaction/use-check-utxos.ts
+++ b/src/app/query/bitcoin/transaction/use-check-utxos.ts
@@ -78,7 +78,7 @@ async function checkInscribedUtxosByBestinslot({
   return hasInscribedUtxos;
 }
 
-export function useCheckInscribedUtxos(blockTxAction?: () => void) {
+export function useCheckUnspendableUtxos(blockTxAction?: () => void) {
   const client = useBitcoinClient();
   const analytics = useAnalytics();
   const [isLoading, setIsLoading] = useState(false);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -76,7 +76,7 @@ export interface NetworkConfiguration {
 }
 
 export const BESTINSLOT_API_BASE_URL_MAINNET = 'https://leatherapi.bestinslot.xyz/v3';
-export const BESTINSLOT_API_BASE_URL_TESTNET = 'https://testnet.api.bestinslot.xyz/v3';
+export const BESTINSLOT_API_BASE_URL_TESTNET = 'https://leatherapi_testnet.bestinslot.xyz/v3';
 
 export const HIRO_API_BASE_URL_MAINNET = 'https://api.hiro.so';
 export const HIRO_API_BASE_URL_TESTNET = 'https://api.testnet.hiro.so';

--- a/tests/mocks/mock-runes.ts
+++ b/tests/mocks/mock-runes.ts
@@ -1,0 +1,11 @@
+export const mockRunesOutputsByAddressList = [
+  {
+    pkscript: '00148027825ee06ad337f9716df8137a1b651163c5b0',
+    wallet_addr: 'tb1qsqncyhhqdtfn07t3dhupx7smv5gk83ds6k0gfa',
+    output: '3298edc745bdc2168e949382fd42956a7bbe43ab885a49f1212b097ac8243650:1',
+    rune_ids: ['2585883:3795'],
+    balances: [100000000],
+    rune_names: ['BESTINSLOTXYZ'],
+    spaced_rune_names: ['BESTINSLOT•XYZ'],
+  },
+];

--- a/tests/mocks/mock-utxos.ts
+++ b/tests/mocks/mock-utxos.ts
@@ -11,3 +11,28 @@ export const mockUtxos = [
     value: 546,
   },
 ];
+
+export const mockUtxosListWithRunes = [
+  {
+    txid: '66ff7d54e345170e3a76819dc90140971fdae054c9b7eea2089ba5a9720f6e44',
+    vout: 1,
+    status: {
+      confirmed: true,
+      block_height: 2585955,
+      block_hash: '00000000000000181cae54c3c19d6ed02511a2f6302a666c3d78bcf1777bb029',
+      block_time: 1712829917,
+    },
+    value: 546,
+  },
+  {
+    txid: '3298edc745bdc2168e949382fd42956a7bbe43ab885a49f1212b097ac8243650',
+    vout: 1,
+    status: {
+      confirmed: true,
+      block_height: 2586064,
+      block_hash: '0000000000000019390bbd88e463230fa4bcc0e8313081c7a4e25fe0b3024712',
+      block_time: 1712920121,
+    },
+    value: 546,
+  },
+];


### PR DESCRIPTION
> Try out Leather build 3a40511 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8739023023), [Test report](https://leather-wallet.github.io/playwright-reports/feat/filter-runes-utxos), [Storybook](https://feat-filter-runes-utxos--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/filter-runes-utxos)<!-- Sticky Header Marker -->

This pr add filtering of utxos with runes from spendable utxos list 