### PR TITLE
chore: update runes avatar icon

### DIFF
--- a/src/app/ui/components/avatar/avatar.tsx
+++ b/src/app/ui/components/avatar/avatar.tsx
@@ -29,7 +29,7 @@ const avatarRecipe = cva({
     },
     variant: {
       circle: { rounded: '100%' },
-      square: { rounded: 'sm' },
+      square: { rounded: 'xs' },
     },
   },
   defaultVariants: {

--- a/src/app/ui/components/avatar/runes-avatar-icon.tsx
+++ b/src/app/ui/components/avatar/runes-avatar-icon.tsx
@@ -2,31 +2,12 @@ import { Avatar, type AvatarProps } from './avatar';
 
 export function RunesAvatarIcon(props: AvatarProps) {
   return (
-    <Avatar.Root {...props}>
-      <Avatar.Svg>
-        <circle cx="16" cy="16" r="16" fill="black" />
-        <circle cx="16" cy="16" r="15.5" stroke="#B1977B" strokeOpacity="0.1" />
-        <g clipPath="url(#clip0_15326_75304)">
-          <rect width="18" height="17.1" transform="translate(7 7.94995)" fill="black" />
-          <path d="M8.61722 5.97876L23.3818 26.8953" stroke="white" strokeWidth="2.25" />
-          <path d="M23.3823 5.97876L8.61768 26.8953" stroke="white" strokeWidth="2.25" />
-          <path d="M15.9998 7.82446L15.9998 25.0499" stroke="white" strokeWidth="1.75" />
-          <path
-            d="M20.0137 10.7512L22.8552 16.4273L20.0656 22.1859"
-            stroke="white"
-            strokeWidth="1.75"
-          />
-          <path
-            d="M11.999 10.7512L9.15748 16.4273L11.9471 22.1859"
-            stroke="white"
-            strokeWidth="1.75"
-          />
-        </g>
-        <defs>
-          <clipPath id="clip0_15326_75304">
-            <rect width="18" height="17.1" fill="white" transform="translate(7 7.94995)" />
-          </clipPath>
-        </defs>
+    <Avatar.Root size="xl" variant="square" {...props}>
+      <Avatar.Svg rounded="0">
+        <rect width="32" height="32" rx="16" fill="white" />
+        <rect width="32" height="32" fill="#12100F" />
+        <rect x="4" y="4" width="24" height="24" fill="white" />
+        <rect x="10" y="10" width="12" height="12" fill="#12100F" />
       </Avatar.Svg>
     </Avatar.Root>
   );


### PR DESCRIPTION
> Try out Leather build 82da0a0 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8695332094), [Test report](https://leather-wallet.github.io/playwright-reports/chore/update-runes-icon), [Storybook](https://chore-update-runes-icon--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/update-runes-icon)<!-- Sticky Header Marker -->

This PR updates the Runes avatar icon.

![Screenshot 2024-04-15 at 2 08 57 PM](https://github.com/leather-wallet/extension/assets/6493321/713739cd-e4a5-4745-86ce-5f0d6254f710)
