### PR TITLE
fix: change runes receive address to tr

### DIFF
--- a/src/app/pages/receive/components/receive-tokens.tsx
+++ b/src/app/pages/receive/components/receive-tokens.tsx
@@ -100,11 +100,11 @@ export function ReceiveTokens({
       />
       {(network.chain.bitcoin.bitcoinNetwork === 'testnet' || runesEnabled) && (
         <ReceiveItem
-          address={btcAddressNativeSegwit}
+          address={btcAddressTaproot}
           icon={<RunesAvatarIcon />}
           // onClickQrCode={onClickQrStamp}
           onCopyAddress={async () => {
-            await copyToClipboard(btcAddressNativeSegwit);
+            await copyToClipboard(btcAddressTaproot);
             toast.success('Copied to clipboard!');
           }}
           title="Runes"

--- a/src/app/ui/components/avatar/runes-avatar-icon.tsx
+++ b/src/app/ui/components/avatar/runes-avatar-icon.tsx
@@ -1,13 +1,21 @@
+import { token } from 'leather-styles/tokens';
+
 import { Avatar, type AvatarProps } from './avatar';
 
 export function RunesAvatarIcon(props: AvatarProps) {
   return (
     <Avatar.Root size="xl" variant="square" {...props}>
       <Avatar.Svg rounded="0">
-        <rect width="32" height="32" rx="16" fill="white" />
-        <rect width="32" height="32" fill="#12100F" />
-        <rect x="4" y="4" width="24" height="24" fill="white" />
-        <rect x="10" y="10" width="12" height="12" fill="#12100F" />
+        <rect width="32" height="32" rx="16" fill={token('colors.ink.background-primary')} />
+        <rect width="32" height="32" fill={token('colors.ink.action-primary-default')} />
+        <rect x="4" y="4" width="24" height="24" fill={token('colors.ink.background-primary')} />
+        <rect
+          x="10"
+          y="10"
+          width="12"
+          height="12"
+          fill={token('colors.ink.action-primary-default')}
+        />
       </Avatar.Svg>
     </Avatar.Root>
   );


### PR DESCRIPTION
> Try out Leather build c5c8575 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8710048826), [Test report](https://leather-wallet.github.io/playwright-reports/fix/runes-receive-address), [Storybook](https://fix-runes-receive-address--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/runes-receive-address)<!-- Sticky Header Marker -->

This PR changes the address to receive Runes to taproot. It also updates the avatar icon to work in dark mode.