### PR TITLE
fix: rpc send transfer data, closes #5243

### DIFF
--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
@@ -135,7 +135,10 @@ export function determineUtxosForSpendAllMultipleRecipients({
   });
 
   // Fee has already been deducted from the amount with send all
-  const outputs = recipients.map(({ address, amount }) => ({ value: BigInt(amount), address }));
+  const outputs = recipients.map(({ address, amount }) => ({
+    value: BigInt(amount.amount.toNumber()),
+    address,
+  }));
 
   const fee = Math.ceil(sizeInfo.txVBytes * feeRate);
 
@@ -190,7 +193,10 @@ export function determineUtxosForSpendMultipleRecipients({
     address?: string;
   }[] = [
     // outputs[0] = the desired amount going to recipient
-    ...recipients.map(({ address, amount }) => ({ value: BigInt(amount), address })),
+    ...recipients.map(({ address, amount }) => ({
+      value: BigInt(amount.amount.toNumber()),
+      address,
+    })),
     // outputs[recipients.length] = the remainder to be returned to a change address
     { value: sum - BigInt(amount) - BigInt(fee) },
   ];

--- a/src/app/pages/rpc-send-transfer/components/send-transfer-confirmation-details.tsx
+++ b/src/app/pages/rpc-send-transfer/components/send-transfer-confirmation-details.tsx
@@ -1,18 +1,18 @@
 import { HStack, Stack, styled } from 'leather-styles/jsx';
 
+import type { Money } from '@shared/models/money.model';
+
+import { formatMoney } from '@app/common/money/format-money';
+
 interface SendTransferConfirmationDetailsProps {
   currentAddress: string;
   recipient: string;
-  time: string;
-  total: string;
-  feeRowValue: string;
+  amount: Money;
 }
 export function SendTransferConfirmationDetails({
   currentAddress,
   recipient,
-  time,
-  total,
-  feeRowValue,
+  amount,
 }: SendTransferConfirmationDetailsProps) {
   return (
     <Stack border="active" borderRadius="sm" p="space.05" gap="space.04" width="100%">
@@ -25,19 +25,9 @@ export function SendTransferConfirmationDetails({
         <styled.span>{recipient}</styled.span>
       </HStack>
       <HStack alignItems="center" gap="space.04" justifyContent="space-between">
-        <styled.span color="ink.text-subdued">Fee</styled.span>
-        <styled.span>{feeRowValue}</styled.span>
+        <styled.span color="ink.text-subdued">Amount</styled.span>
+        <styled.span>{formatMoney(amount)}</styled.span>
       </HStack>
-      <HStack alignItems="center" gap="space.04" justifyContent="space-between">
-        <styled.span color="ink.text-subdued">Total</styled.span>
-        <styled.span>{total}</styled.span>
-      </HStack>
-      {time && (
-        <HStack alignItems="center" gap="space.04" justifyContent="space-between">
-          <styled.span color="ink.text-subdued">Estimated Time</styled.span>
-          <styled.span>{time}</styled.span>
-        </HStack>
-      )}
     </Stack>
   );
 }

--- a/src/app/pages/rpc-send-transfer/components/send-transfer-details.tsx
+++ b/src/app/pages/rpc-send-transfer/components/send-transfer-details.tsx
@@ -2,6 +2,7 @@ import { HStack, Stack, styled } from 'leather-styles/jsx';
 
 import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
 
+import { formatMoney } from '@app/common/money/format-money';
 import { truncateMiddle } from '@app/ui/utils/truncate-middle';
 
 interface SendTransferDetailsProps {
@@ -31,7 +32,7 @@ export function SendTransferDetails({ recipients, currentAddress }: SendTransfer
           </HStack>
           <HStack alignItems="center" gap="space.04" justifyContent="space-between">
             <styled.span textStyle="caption.01">Amount</styled.span>
-            <styled.span textStyle="label.01">{amount}</styled.span>
+            <styled.span textStyle="label.01">{formatMoney(amount)}</styled.span>
           </HStack>
         </Stack>
       ))}

--- a/src/app/pages/rpc-send-transfer/use-rpc-send-transfer.ts
+++ b/src/app/pages/rpc-send-transfer/use-rpc-send-transfer.ts
@@ -39,7 +39,7 @@ export function useRpcSendTransfer() {
 
   const recipients = recipientsAddresses.map((address, index) => ({
     address,
-    amount: amounts[index],
+    amount: createMoney(Number(amounts[index]), 'BTC'),
   }));
 
   return {

--- a/src/shared/rpc/methods/send-transfer.ts
+++ b/src/shared/rpc/methods/send-transfer.ts
@@ -8,6 +8,7 @@ import {
   btcAddressNetworkValidator,
   btcAddressValidator,
 } from '@shared/forms/bitcoin-address-validators';
+import type { Money } from '@shared/models/money.model';
 
 import {
   accountSchema,
@@ -57,12 +58,17 @@ export interface RpcSendTransferParamsLegacy extends SendTransferRequestParams {
 
 export interface RpcSendTransferRecipient {
   address: string;
+  amount: Money;
+}
+
+interface RpcSendTransferRecipientParam {
+  address: string;
   amount: string;
 }
 
 export interface RpcSendTransferParams {
   account?: number;
-  recipients: RpcSendTransferRecipient[];
+  recipients: RpcSendTransferRecipientParam[];
   network: string;
 }
 

--- a/test-app/src/components/bitcoin.tsx
+++ b/test-app/src/components/bitcoin.tsx
@@ -413,11 +413,11 @@ export const Bitcoin = () => {
             recipients: [
               {
                 address: TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
-                amount: '10000',
+                amount: '800',
               },
               {
                 address: TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
-                amount: '0.010000',
+                amount: '10000',
               },
             ],
             network: 'testnet',


### PR DESCRIPTION
> Try out Leather build fb054a0 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8725620643), [Test report](https://leather-wallet.github.io/playwright-reports/fix/rpc-send-amounts), [Storybook](https://fix-rpc-send-amounts--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/rpc-send-amounts)<!-- Sticky Header Marker -->

This pr fixes data that we show to users in rpc send transfer flow
![Screenshot 2024-04-17 at 15 55 57](https://github.com/leather-wallet/extension/assets/46521087/e34c0ea3-acb5-4ba0-b4d3-2f8390a9ee40)
![Screenshot 2024-04-17 at 15 56 02](https://github.com/leather-wallet/extension/assets/46521087/0d0cd678-6002-48ab-95fb-6ebe1ca9f853)
![Screenshot 2024-04-17 at 15 56 08](https://github.com/leather-wallet/extension/assets/46521087/e3feea09-1b25-4892-9d4d-b837cc7000ea)


