### PR TITLE
fix(ledger): no signer breaking homepage

### DIFF
--- a/src/app/components/account/bitcoin-account-loader.tsx
+++ b/src/app/components/account/bitcoin-account-loader.tsx
@@ -4,6 +4,8 @@ import { useConfigBitcoinEnabled } from '@app/query/common/remote-config/remote-
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { Signer } from '@app/store/accounts/blockchain/bitcoin/bitcoin-signer';
 import { useNativeSegwitSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+import { useTaprootSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
+import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 interface BitcoinAccountLoaderBaseProps {
   children(account: Signer<P2Ret>): React.ReactNode;
@@ -25,6 +27,20 @@ export function BitcoinNativeSegwitAccountLoader({ children, ...props }: BtcAcco
   const properIndex = 'current' in props ? currentAccountIndex : props.index;
 
   const signer = useNativeSegwitSigner(properIndex);
+
+  if (!signer || !isBitcoinEnabled) return null;
+  return children(signer(0));
+}
+
+export function BitcoinTaprootAccountLoader({ children, ...props }: BtcAccountLoaderProps) {
+  const isBitcoinEnabled = useConfigBitcoinEnabled();
+  const network = useCurrentNetwork();
+
+  const currentAccountIndex = useCurrentAccountIndex();
+
+  const properIndex = 'current' in props ? currentAccountIndex : props.index;
+
+  const signer = useTaprootSigner(properIndex, network.chain.bitcoin.bitcoinNetwork);
 
   if (!signer || !isBitcoinEnabled) return null;
   return children(signer(0));

--- a/src/app/features/asset-list/asset-list.tsx
+++ b/src/app/features/asset-list/asset-list.tsx
@@ -5,12 +5,15 @@ import { Stack } from 'leather-styles/jsx';
 
 import { useBtcAssetBalance } from '@app/common/hooks/balance/btc/use-btc-balance';
 import { useWalletType } from '@app/common/use-wallet-type';
+import {
+  BitcoinNativeSegwitAccountLoader,
+  BitcoinTaprootAccountLoader,
+} from '@app/components/account/bitcoin-account-loader';
 import { BitcoinContractEntryPoint } from '@app/components/bitcoin-contract-entry-point/bitcoin-contract-entry-point';
 import { CryptoCurrencyAssetItemLayout } from '@app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout';
 import { CurrentStacksAccountLoader } from '@app/components/loaders/stacks-account-loader';
 import { useHasBitcoinLedgerKeychain } from '@app/store/accounts/blockchain/bitcoin/bitcoin.ledger';
 import { useCurrentAccountNativeSegwitAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
-import { useCurrentAccountTaprootIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import { BtcAvatarIcon } from '@app/ui/components/avatar/btc-avatar-icon';
 
@@ -25,7 +28,6 @@ import { StacksFungibleTokenAssetList } from './components/stacks-fungible-token
 export function AssetsList() {
   const hasBitcoinLedgerKeys = useHasBitcoinLedgerKeychain();
   const bitcoinAddressNativeSegwit = useCurrentAccountNativeSegwitAddressIndexZero();
-  const { address: bitcoinAddressTaproot } = useCurrentAccountTaprootIndexZeroSigner();
   const network = useCurrentNetwork();
 
   const { btcAvailableAssetBalance, btcAvailableUsdBalance, isInitialLoading } = useBtcAssetBalance(
@@ -76,15 +78,18 @@ export function AssetsList() {
         )}
       </CurrentStacksAccountLoader>
 
-      {whenWallet({
-        software: (
-          <BitcoinFungibleTokenAssetList
-            btcAddressNativeSegwit={bitcoinAddressNativeSegwit}
-            btcAddressTaproot={bitcoinAddressTaproot}
-          />
-        ),
-        ledger: null,
-      })}
+      <BitcoinNativeSegwitAccountLoader current>
+        {nativeSegwitAccount => (
+          <BitcoinTaprootAccountLoader current>
+            {taprootAccount => (
+              <BitcoinFungibleTokenAssetList
+                btcAddressNativeSegwit={nativeSegwitAccount.address}
+                btcAddressTaproot={taprootAccount.address}
+              />
+            )}
+          </BitcoinTaprootAccountLoader>
+        )}
+      </BitcoinNativeSegwitAccountLoader>
 
       <PendingBrc20TransferList />
 

--- a/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/taproot-account.hooks.ts
@@ -69,7 +69,7 @@ export function useTaprootNetworkSigners() {
   );
 }
 
-function useTaprootSigner(accountIndex: number, network: BitcoinNetworkModes) {
+export function useTaprootSigner(accountIndex: number, network: BitcoinNetworkModes) {
   const account = useTaprootAccount(accountIndex);
   const extendedPublicKeyVersions = useBitcoinExtendedPublicKeyVersions();
 


### PR DESCRIPTION
> Try out Leather build 41a3e3d — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8735967593), [Test report](https://leather-wallet.github.io/playwright-reports/fix/ledger-broken-homepage), [Storybook](https://fix-ledger-broken-homepage--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/ledger-broken-homepage)<!-- Sticky Header Marker -->

Uses Loader pattern to prevent importing hook that instantly breaks the wallet when there's no data. 

Nested loaders are very ugly, and we could alternatively make a double one for both. But ugly is better than broken. We need build pages with the pattern of "Get the data you need safely via loader pattern (or another safe method), pass into your page" rather than assuming all data can be read via a hook.