### PR TITLE
fix: duplicated connect btn, closes #5255

### DIFF
--- a/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/crypto-currency-asset/crypto-currency-asset-item.layout.tsx
@@ -58,9 +58,7 @@ export function CryptoCurrencyAssetItemLayout({
 
   const captionRight = (
     <SkeletonLoader width="78px" isLoading={isLoading}>
-      {rightElement ? (
-        rightElement
-      ) : (
+      {!rightElement && (
         <Caption>
           <Flex alignItems="center" gap="space.02" color="inherit">
             <BulletSeparator>


### PR DESCRIPTION
> Try out Leather build fe0518e — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8736146704), [Test report](https://leather-wallet.github.io/playwright-reports/fix/double-connect-btn), [Storybook](https://fix-double-connect-btn--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/double-connect-btn)<!-- Sticky Header Marker -->

This pr fixes bug with double connect btn in ledger mode