### PR TITLE
fix: add default runes symbol

### DIFF
--- a/src/app/query/bitcoin/runes/runes.hooks.ts
+++ b/src/app/query/bitcoin/runes/runes.hooks.ts
@@ -10,10 +10,13 @@ import { useGetRunesOutputsByAddressQuery } from './runes-outputs-by-address.que
 import { useGetRunesTickerInfoQuery } from './runes-ticker-info.query';
 import { useGetRunesWalletBalancesByAddressesQuery } from './runes-wallet-balances.query';
 
+const defaultRunesSymbol = '¤';
+
 function makeRuneToken(runeBalance: RuneBalance, tickerInfo: RuneTickerInfo): RuneToken {
   return {
     ...runeBalance,
     ...tickerInfo,
+    symbol: tickerInfo.symbol ?? defaultRunesSymbol,
     balance: createMoney(
       Number(runeBalance.total_balance),
       tickerInfo.rune_name,


### PR DESCRIPTION
> Try out Leather build dcec2ef — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8740597136), [Test report](https://leather-wallet.github.io/playwright-reports/fix/default-runes-symbol), [Storybook](https://fix-default-runes-symbol--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/default-runes-symbol)<!-- Sticky Header Marker -->

