### PR TITLE
fix: fix bug with sending ordinals from ledger, #ref 5253

### DIFF
--- a/src/app/features/ledger/hooks/use-ledger-navigate.ts
+++ b/src/app/features/ledger/hooks/use-ledger-navigate.ts
@@ -42,7 +42,11 @@ export function useLedgerNavigate() {
         return navigate(RouteUrls.ConnectLedger, {
           replace: true,
           relative: 'route',
-          state: { tx: bytesToHex(psbt), inputsToSign },
+          state: {
+            tx: bytesToHex(psbt),
+            inputsToSign,
+            backgroundLocation: { pathname: RouteUrls.Home },
+          },
         });
       },
 
@@ -59,48 +63,94 @@ export function useLedgerNavigate() {
       },
 
       toConnectionSuccessStep(chain: SupportedBlockchains) {
-        return navigate(RouteUrls.ConnectLedgerSuccess, { replace: true, state: { chain } });
+        return navigate(RouteUrls.ConnectLedgerSuccess, {
+          replace: true,
+          state: {
+            chain,
+            backgroundLocation: { pathname: RouteUrls.Home },
+          },
+        });
       },
 
       toErrorStep(chain: SupportedBlockchains, errorMessage?: string) {
         return navigate(RouteUrls.ConnectLedgerError, {
           replace: true,
-          state: { latestLedgerError: errorMessage, chain },
+          state: {
+            latestLedgerError: errorMessage,
+            chain,
+            backgroundLocation: { pathname: RouteUrls.Home },
+          },
         });
       },
 
       toAwaitingDeviceOperation({ hasApprovedOperation }: { hasApprovedOperation: boolean }) {
         return navigate(RouteUrls.AwaitingDeviceUserAction, {
           replace: true,
-          state: { hasApprovedOperation },
+          state: {
+            hasApprovedOperation,
+            backgroundLocation: { pathname: RouteUrls.Home },
+          },
         });
       },
 
       toPublicKeyMismatchStep() {
-        return navigate(RouteUrls.LedgerPublicKeyMismatch, { replace: true });
+        return navigate(RouteUrls.LedgerPublicKeyMismatch, {
+          replace: true,
+          state: {
+            backgroundLocation: { pathname: RouteUrls.Home },
+          },
+        });
       },
 
       toDevicePayloadInvalid() {
-        return navigate(RouteUrls.LedgerDevicePayloadInvalid, { replace: true });
+        return navigate(RouteUrls.LedgerDevicePayloadInvalid, {
+          replace: true,
+          state: {
+            backgroundLocation: { pathname: RouteUrls.Home },
+          },
+        });
       },
 
       toOperationRejectedStep(description?: string) {
         return navigate(RouteUrls.LedgerOperationRejected, {
           replace: true,
-          state: { description },
+          state: {
+            backgroundLocation: { pathname: RouteUrls.Home },
+            description,
+          },
         });
       },
 
       toDeviceDisconnectStep() {
-        return navigate(RouteUrls.LedgerDisconnected, { replace: true });
+        return navigate(RouteUrls.LedgerDisconnected, {
+          replace: true,
+          state: {
+            backgroundLocation: { pathname: RouteUrls.Home },
+          },
+        });
       },
 
       toBroadcastErrorStep(error: string) {
-        return navigate(RouteUrls.LedgerBroadcastError, { replace: true, state: { error } });
+        return navigate(RouteUrls.LedgerBroadcastError, {
+          replace: true,
+          state: {
+            backgroundLocation: { pathname: RouteUrls.Home },
+            error,
+          },
+        });
       },
 
       cancelLedgerAction() {
-        return navigate('..', { relative: 'path', replace: true, state: { ...location.state } });
+        // for send ordinal '..' brings you back to the `choose-fee` step but you lose context of the ordinal
+        const backLocation = location.pathname.match(RouteUrls.SendOrdinalInscription)
+          ? RouteUrls.Home
+          : '..';
+
+        return navigate(backLocation, {
+          relative: 'path',
+          replace: true,
+          state: { ...location.state },
+        });
       },
 
       cancelLedgerActionAndReturnHome() {
@@ -108,6 +158,6 @@ export function useLedgerNavigate() {
       },
     }),
 
-    [location.state, navigate]
+    [location, navigate]
   );
 }


### PR DESCRIPTION
> Try out Leather build b878f29 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8743060239), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5253/ledger-broken-send-ordinal), [Storybook](https://fix-5253-ledger-broken-send-ordinal--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5253/ledger-broken-send-ordinal)<!-- Sticky Header Marker -->

This PR fixes a bug with the `Send Ordinal` flow when logged in with Ledger. It was introduced in https://github.com/leather-wallet/extension/commit/6262267ff11fdeaa3f0d995fb5f286debcbbfd17 

The issue is that the ledger dialogs were not appearing underneath the `send-ordinal` flow, only on ledger, due to them not having a dialog background location set. 

We had a similar problem with the `Choose fee` dialog here before: https://github.com/leather-wallet/extension/pull/4632/files. 

The underlying issue comes from the change made to make sure we [overlay modals on the correct background](https://github.com/leather-wallet/extension/pull/4325/).

Linking this PR for the record also: https://github.com/leather-wallet/extension/pull/4316/