### PR TITLE
fix: show hash formatting, ref #5261

### DIFF
--- a/src/app/features/message-signer/hash-drawer.tsx
+++ b/src/app/features/message-signer/hash-drawer.tsx
@@ -32,6 +32,7 @@ export function HashDrawer(props: HashDrawerProps) {
         }}
         type="button"
         width="100%"
+        display="flex"
       >
         <styled.span py="space.02" textStyle="caption.01">
           {showHash ? 'Hide hash' : 'Show hash'}


### PR DESCRIPTION
> Try out Leather build ad167b1 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8753246732), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5261/show-hash-formatting), [Storybook](https://fix-5261-show-hash-formatting--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5261/show-hash-formatting)<!-- Sticky Header Marker -->

This fixes the formatting of `Show Hash` to be:
![Screenshot 2024-04-19 at 13 05 57](https://github.com/leather-wallet/extension/assets/2938440/0709315e-cc2d-4321-869f-013e1173de93)
