### PR TITLE
fix: prevent form submit on tooltip click, ref #5258

### DIFF
--- a/src/app/ui/components/containers/footers/available-balance.tsx
+++ b/src/app/ui/components/containers/footers/available-balance.tsx
@@ -18,7 +18,7 @@ export function AvailableBalance({
         <styled.span color="ink.text-subdued" textStyle="caption.01">
           Available balance
         </styled.span>
-        <BasicTooltip label={balanceTooltipLabel} side="top">
+        <BasicTooltip asChild label={balanceTooltipLabel} side="top">
           <Box>
             <InfoCircleIcon color="ink.text-subdued" variant="small" />
           </Box>

--- a/src/app/ui/components/tooltip/basic-tooltip.tsx
+++ b/src/app/ui/components/tooltip/basic-tooltip.tsx
@@ -11,6 +11,7 @@ interface BasicTooltipProps {
   side?: RadixTooltip.TooltipContentProps['side'];
   asChild?: boolean;
 }
+
 export function BasicTooltip({ children, label, disabled, side, asChild }: BasicTooltipProps) {
   const isDisabled = !label || disabled;
   return (


### PR DESCRIPTION
> Try out Leather build 2013e29 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8756256332), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5258/stop-send-submit-on-tooltip-click), [Storybook](https://fix-5258-stop-send-submit-on-tooltip-click--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5258/stop-send-submit-on-tooltip-click)<!-- Sticky Header Marker -->

This PR stops the send form submit from triggering when clicking on the tooltip icon.  