### PR TITLE
chore: fix alignment of PSBT copy, ref #5260

### DIFF
--- a/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-total-item.tsx
+++ b/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-total-item.tsx
@@ -37,7 +37,7 @@ export function PsbtAddressTotalItem({
           <styled.span textStyle="label.01">{value}</styled.span>
         )}
       </HStack>
-      <HStack alignItems="center" justifyContent="space-between" mt="space.02">
+      <HStack alignItems="center" justifyContent="space-between">
         {subtitle ? (
           <HStack gap="space.01">
             <styled.span mr="space.01" textStyle="caption.01">


### PR DESCRIPTION
> Try out Leather build e10f6fd — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8755604827), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5260/copy-icon-alignment), [Storybook](https://fix-5260-copy-icon-alignment--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5260/copy-icon-alignment)<!-- Sticky Header Marker -->

This fixes the alignment of the copy icon for PSBT signing as per [5260](https://github.com/leather-wallet/extension/issues/5260)