### PR TITLE
fix: bitcoin fees missing isloading

### DIFF
--- a/src/app/components/bitcoin-fees-list/bitcoin-fees-list.tsx
+++ b/src/app/components/bitcoin-fees-list/bitcoin-fees-list.tsx
@@ -51,8 +51,6 @@ export function BitcoinFeesList({
   );
 
   if (isLoading) return <LoadingSpinner />;
-  // TODO: This should be changed when custom fees are implemented. We can simply
-  // force custom fee setting when api requests fail and we can't calculate fees.
   if (!feesList.length) return <FeesListError />;
 
   return (

--- a/src/app/components/bitcoin-fees-list/bitcoin-fees-list.tsx
+++ b/src/app/components/bitcoin-fees-list/bitcoin-fees-list.tsx
@@ -4,6 +4,7 @@ import { Stack } from 'leather-styles/jsx';
 
 import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
 
+import { LoadingSpinner } from '../loading-spinner';
 import { FeesListError } from './components/fees-list-error';
 import { FeesListItem } from './components/fees-list-item';
 
@@ -25,6 +26,7 @@ export interface OnChooseFeeArgs {
 
 interface BitcoinFeesListProps {
   feesList: FeesListItem[];
+  isLoading: boolean;
   onChooseFee({ feeRate, feeValue, time }: OnChooseFeeArgs): Promise<void>;
   onSetSelectedFeeType(value: BtcFeeType): void;
   onValidateBitcoinSpend(value: number): boolean;
@@ -32,6 +34,7 @@ interface BitcoinFeesListProps {
 }
 export function BitcoinFeesList({
   feesList,
+  isLoading,
   onChooseFee,
   onSetSelectedFeeType,
   onValidateBitcoinSpend,
@@ -47,6 +50,7 @@ export function BitcoinFeesList({
     [onChooseFee, onSetSelectedFeeType, onValidateBitcoinSpend]
   );
 
+  if (isLoading) return <LoadingSpinner />;
   // TODO: This should be changed when custom fees are implemented. We can simply
   // force custom fee setting when api requests fail and we can't calculate fees.
   if (!feesList.length) return <FeesListError />;

--- a/src/app/components/bitcoin-fees-list/components/fees-list-error.tsx
+++ b/src/app/components/bitcoin-fees-list/components/fees-list-error.tsx
@@ -4,10 +4,9 @@ import { Box } from 'leather-styles/jsx';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { GenericError, GenericErrorListItem } from '@app/components/generic-error/generic-error';
+import { GenericError } from '@app/components/generic-error/generic-error';
 
-const body = 'Check balance and try again';
-const helpTextList = [<GenericErrorListItem key={1} text="Possibly caused by api issues" />];
+const body = 'Please set a custom fee';
 const title = 'Unable to calculate fees';
 
 export function FeesListError() {
@@ -15,12 +14,7 @@ export function FeesListError() {
 
   return (
     <Box textAlign="center" px={['unset', 'space.05']} py="space.04" width="100%">
-      <GenericError
-        body={body}
-        helpTextList={helpTextList}
-        onClose={() => navigate(RouteUrls.SendCryptoAsset)}
-        title={title}
-      />
+      <GenericError body={body} onClose={() => navigate(RouteUrls.SendCryptoAsset)} title={title} />
     </Box>
   );
 }

--- a/src/app/components/generic-error/generic-error.layout.tsx
+++ b/src/app/components/generic-error/generic-error.layout.tsx
@@ -12,7 +12,7 @@ const supportUrl =
 
 interface GenericErrorProps extends FlexProps {
   body: string;
-  helpTextList: ReactNode[];
+  helpTextList?: ReactNode[];
   onClose(): void;
   title: string;
 }
@@ -34,30 +34,32 @@ export function GenericErrorLayout(props: GenericErrorProps) {
       >
         {body}
       </styled.h2>
-      <styled.ul
-        border="default"
-        borderRadius="sm"
-        fontSize="14px"
-        lineHeight="1.6"
-        listStyleType="circle"
-        mt="space.06"
-        pb="space.05"
-        pl="40px"
-        pr="space.05"
-        pt="space.02"
-        textAlign="left"
-        width="100%"
-      >
-        {helpTextList}
-        <styled.li mt="space.04" textAlign="left">
-          <HStack alignItems="center">
-            <styled.span textStyle="label.02">Reach out to our support team</styled.span>
-            <styled.button onClick={() => openInNewTab(supportUrl)} type="button">
-              <ExternalLinkIcon />
-            </styled.button>
-          </HStack>
-        </styled.li>
-      </styled.ul>
+      {helpTextList && (
+        <styled.ul
+          border="default"
+          borderRadius="sm"
+          fontSize="14px"
+          lineHeight="1.6"
+          listStyleType="circle"
+          mt="space.06"
+          pb="space.05"
+          pl="40px"
+          pr="space.05"
+          pt="space.02"
+          textAlign="left"
+          width="100%"
+        >
+          {helpTextList}
+          <styled.li mt="space.04" textAlign="left">
+            <HStack alignItems="center">
+              <styled.span textStyle="label.02">Reach out to our support team</styled.span>
+              <styled.button onClick={() => openInNewTab(supportUrl)} type="button">
+                <ExternalLinkIcon />
+              </styled.button>
+            </HStack>
+          </styled.li>
+        </styled.ul>
+      )}
       <Link fontSize="14px" mt="space.05" onClick={onClose}>
         Close window
       </Link>

--- a/src/app/components/generic-error/generic-error.tsx
+++ b/src/app/components/generic-error/generic-error.tsx
@@ -12,7 +12,7 @@ export function GenericErrorListItem({ text }: { text: ReactNode }) {
 
 interface GenericErrorProps extends FlexProps {
   body: string;
-  helpTextList: ReactNode[];
+  helpTextList?: ReactNode[];
   onClose?(): void;
   title: string;
 }

--- a/src/app/features/bitcoin-choose-fee/bitcoin-choose-fee.tsx
+++ b/src/app/features/bitcoin-choose-fee/bitcoin-choose-fee.tsx
@@ -24,6 +24,7 @@ import { InsufficientBalanceError } from './components/insufficient-balance-erro
 
 interface BitcoinChooseFeeProps extends FlexProps {
   amount: Money;
+  defaultToCustomFee: boolean;
   feesList: React.JSX.Element;
   isLoading: boolean;
   isSendingMax: boolean;
@@ -37,6 +38,7 @@ interface BitcoinChooseFeeProps extends FlexProps {
 }
 export function BitcoinChooseFee({
   amount,
+  defaultToCustomFee,
   feesList,
   isLoading,
   isSendingMax,
@@ -71,6 +73,7 @@ export function BitcoinChooseFee({
           <ChooseFeeSubtitle isSendingMax={isSendingMax} />
         )}
         <ChooseFeeTabs
+          defaultToCustomFee={defaultToCustomFee}
           customFee={
             <BitcoinCustomFee
               amount={amount.amount.toNumber()}
@@ -97,6 +100,7 @@ export function BitcoinChooseFee({
 
 interface BitcoinChooseFeeMultipleRecipientsProps extends FlexProps {
   amount: Money;
+  defaultToCustomFee: boolean;
   feesList: React.JSX.Element;
   isLoading: boolean;
   isSendingMax: boolean;
@@ -110,6 +114,7 @@ interface BitcoinChooseFeeMultipleRecipientsProps extends FlexProps {
 }
 export function BitcoinChooseFeeMultipleRecipients({
   amount,
+  defaultToCustomFee,
   feesList,
   isLoading,
   isSendingMax,
@@ -144,6 +149,7 @@ export function BitcoinChooseFeeMultipleRecipients({
           <ChooseFeeSubtitle isSendingMax={isSendingMax} />
         )}
         <ChooseFeeTabs
+          defaultToCustomFee={defaultToCustomFee}
           customFee={
             <BitcoinCustomFeeMultipleRecipients
               amount={amount.amount.toNumber()}

--- a/src/app/features/bitcoin-choose-fee/components/choose-fee-tabs.tsx
+++ b/src/app/features/bitcoin-choose-fee/components/choose-fee-tabs.tsx
@@ -13,16 +13,17 @@ enum CustomFeeTabs {
 
 interface ChooseFeeTabsProps extends StackProps {
   customFee: React.JSX.Element;
+  defaultToCustomFee: boolean;
   feesList: React.JSX.Element;
 }
 export function ChooseFeeTabs(props: ChooseFeeTabsProps) {
-  const { feesList, customFee, ...rest } = props;
+  const { customFee, defaultToCustomFee, feesList, ...rest } = props;
   const analytics = useAnalytics();
 
   return (
     <Stack flexGrow={1} gap="space.04" mt="space.02" width="100%" {...rest}>
       <Tabs.Root
-        defaultValue={CustomFeeTabs.Recommended}
+        defaultValue={defaultToCustomFee ? CustomFeeTabs.Custom : CustomFeeTabs.Recommended}
         onValueChange={tab => void analytics.page('view', 'custom-fee-tab-' + tab)}
       >
         <Tabs.List>

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
@@ -76,6 +76,7 @@ export function RpcSendTransferChooseFee() {
         feesList={
           <BitcoinFeesList
             feesList={feesList}
+            isLoading={isLoading}
             onChooseFee={previewTransfer}
             onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
             onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
@@ -73,6 +73,7 @@ export function RpcSendTransferChooseFee() {
       <Outlet />
       <BitcoinChooseFeeMultipleRecipients
         amount={amountAsMoney}
+        defaultToCustomFee={!feesList.length}
         feesList={
           <BitcoinFeesList
             feesList={feesList}

--- a/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
@@ -60,6 +60,7 @@ export function SendInscriptionChooseFee() {
           feesList={
             <BitcoinFeesList
               feesList={feesList}
+              isLoading={isLoading}
               onChooseFee={previewTransaction}
               onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
               onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}

--- a/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
@@ -57,6 +57,7 @@ export function SendInscriptionChooseFee() {
       >
         <BitcoinChooseFee
           amount={createMoney(0, 'BTC')}
+          defaultToCustomFee={!feesList.length}
           feesList={
             <BitcoinFeesList
               feesList={feesList}

--- a/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
@@ -126,6 +126,7 @@ export function BrcChooseFee() {
     <>
       <BitcoinChooseFee
         amount={amountAsMoney}
+        defaultToCustomFee={!feesList.length}
         feesList={
           <BitcoinFeesList
             feesList={feesList}

--- a/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
@@ -129,6 +129,7 @@ export function BrcChooseFee() {
         feesList={
           <BitcoinFeesList
             feesList={feesList}
+            isLoading={isLoading}
             onChooseFee={previewTransaction}
             onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
             onValidateBitcoinSpend={onValidateBitcoinFeeSpend}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
@@ -43,7 +43,7 @@ export function BtcChooseFee() {
     <>
       <BitcoinChooseFee
         amount={amountAsMoney}
-        isLoading={isLoading}
+        defaultToCustomFee={!feesList.length}
         feesList={
           <BitcoinFeesList
             feesList={feesList}
@@ -54,6 +54,7 @@ export function BtcChooseFee() {
             selectedFeeType={selectedFeeType}
           />
         }
+        isLoading={isLoading}
         isSendingMax={isSendingMax}
         onChooseFee={previewTransaction}
         onValidateBitcoinSpend={onValidateBitcoinAmountSpend}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
@@ -47,6 +47,7 @@ export function BtcChooseFee() {
         feesList={
           <BitcoinFeesList
             feesList={feesList}
+            isLoading={isLoading}
             onChooseFee={previewTransaction}
             onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
             onValidateBitcoinSpend={onValidateBitcoinAmountSpend}


### PR DESCRIPTION
> Try out Leather build b42d6f0 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8767095000), [Test report](https://leather-wallet.github.io/playwright-reports/fix/send-transfer-fee-bug), [Storybook](https://fix-send-transfer-fee-bug--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/send-transfer-fee-bug)<!-- Sticky Header Marker -->

Fixes:
![Screenshot 2024-04-20 at 12 03 36 PM](https://github.com/leather-wallet/extension/assets/6493321/618e6176-f7af-4acf-a4b3-66eb01addad2)

Added defaulting to the custom fee tab here if the fees list is empty.