### PR TITLE
fix: rpc send transfer params network validation, closes #5284

### DIFF
--- a/src/shared/rpc/methods/send-transfer.ts
+++ b/src/shared/rpc/methods/send-transfer.ts
@@ -26,7 +26,7 @@ export const rpcSendTransferParamsSchemaLegacy = yup.object().shape({
 
 export const rpcSendTransferParamsSchema = yup.object().shape({
   account: accountSchema,
-  network: yup.string().required().oneOf(Object.values(WalletDefaultNetworkConfigurationIds)),
+  network: yup.string().oneOf(Object.values(WalletDefaultNetworkConfigurationIds)),
   recipients: yup
     .array()
     .required()


### PR DESCRIPTION
> Try out Leather build 1b6022e — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8781933920), [Test report](https://leather-wallet.github.io/playwright-reports/fix/send-params-validation), [Storybook](https://fix-send-params-validation--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/send-params-validation)<!-- Sticky Header Marker -->

Missing network param in rpc send transfer should not break validation, as it defaults to mainnet