### PR TITLE
fix: rpc send transfer recipient default network

### DIFF
--- a/src/background/messaging/rpc-methods/send-transfer.ts
+++ b/src/background/messaging/rpc-methods/send-transfer.ts
@@ -5,6 +5,7 @@ import {
   type RpcSendTransferParams,
   type RpcSendTransferParamsLegacy,
   convertRpcSendTransferLegacyParamsToNew,
+  defaultRpcSendTransferNetwork,
   getRpcSendTransferParamErrors,
   validateRpcSendTransferLegacyParams,
   validateRpcSendTransferParams,
@@ -63,7 +64,7 @@ export async function rpcSendTransfer(
   const requestParams: RequestParams = [
     ...recipients,
     ...amounts,
-    ['network', params.network ?? 'mainnet'],
+    ['network', params.network ?? defaultRpcSendTransferNetwork],
     ['requestId', message.id],
   ];
 

--- a/src/shared/rpc/methods/send-transfer.ts
+++ b/src/shared/rpc/methods/send-transfer.ts
@@ -17,6 +17,8 @@ import {
   validateRpcParams,
 } from './validation.utils';
 
+export const defaultRpcSendTransferNetwork = 'mainnet';
+
 export const rpcSendTransferParamsSchemaLegacy = yup.object().shape({
   account: accountSchema,
   address: yup.string().required(),
@@ -38,7 +40,9 @@ export const rpcSendTransferParamsSchema = yup.object().shape({
           FormErrorMessages.IncorrectNetworkAddress,
           (value, context) => {
             const contextOptions = context.options as any;
-            const network = contextOptions.from[1].value.network as BitcoinNetworkModes;
+            const network =
+              (contextOptions.from[1].value.network as BitcoinNetworkModes) ||
+              defaultRpcSendTransferNetwork;
             return btcAddressNetworkValidator(network).isValidSync(value);
           }
         ),


### PR DESCRIPTION
> Try out Leather build d285924 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8783686349), [Test report](https://leather-wallet.github.io/playwright-reports/fix/recipient-address-check), [Storybook](https://fix-recipient-address-check--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/recipient-address-check)<!-- Sticky Header Marker -->

This change was not enough https://github.com/leather-wallet/extension/pull/5288 since we are validating recipient addresses as well
I don't like [the implementation of recipient network validation](https://stackoverflow.com/questions/73724613/yup-validation-at-lower-level-based-on-a-higher-value-unsure-how-to-access), though otherwise we'll need big refactor to pass network in validation fns

