### PR TITLE
feat: decrease num of addresses to fetch

### DIFF
--- a/src/app/query/bitcoin/address/utxos-by-address.query.ts
+++ b/src/app/query/bitcoin/address/utxos-by-address.query.ts
@@ -35,7 +35,7 @@ export function useGetUtxosByAddressQuery<T extends unknown = UtxoResponseItem[]
   });
 }
 
-const stopSearchAfterNumberAddressesWithoutUtxos = 20;
+const stopSearchAfterNumberAddressesWithoutUtxos = 5;
 
 /**
  * Returns all utxos for the user's current taproot account. The search for

--- a/src/app/query/bitcoin/blockstream-rate-limiter.ts
+++ b/src/app/query/bitcoin/blockstream-rate-limiter.ts
@@ -4,7 +4,7 @@ import { BITCOIN_API_BASE_URL_TESTNET } from '@shared/constants';
 
 const blockstreamMainnetApiLimiter = new PQueue({
   interval: 5000,
-  intervalCap: 20,
+  intervalCap: 30,
 });
 
 const blockstreamTestnetApiLimiter = new PQueue({

--- a/src/app/query/bitcoin/ordinals/inscriptions.query.ts
+++ b/src/app/query/bitcoin/ordinals/inscriptions.query.ts
@@ -15,7 +15,7 @@ import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/account
 import { useCurrentTaprootAccount } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
-const stopSearchAfterNumberAddressesWithoutOrdinals = 20;
+const stopSearchAfterNumberAddressesWithoutOrdinals = 5;
 const addressesSimultaneousFetchLimit = 5;
 
 // Hiro API max limit = 60


### PR DESCRIPTION
> Try out Leather build 437687c — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8797196245), [Test report](https://leather-wallet.github.io/playwright-reports/feat/decrease-num-of-addresses), [Storybook](https://feat-decrease-num-of-addresses--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/decrease-num-of-addresses)<!-- Sticky Header Marker -->

Decreased num of checking empty taproot addresses, also increased num of requests to blockstream (checked and haven't got 429s)