### PR TITLE
Reset to mainnet on signout

### DIFF
--- a/src/app/common/hooks/use-key-actions.ts
+++ b/src/app/common/hooks/use-key-actions.ts
@@ -13,6 +13,7 @@ import { useBitcoinClient, useStacksClient } from '@app/store/common/api-clients
 import { inMemoryKeyActions } from '@app/store/in-memory-key/in-memory-key.actions';
 import { bitcoinKeysSlice } from '@app/store/ledger/bitcoin/bitcoin-key.slice';
 import { stacksKeysSlice } from '@app/store/ledger/stacks/stacks-key.slice';
+import { networksSlice } from '@app/store/networks/networks.slice';
 import { clearWalletSession } from '@app/store/session-restore';
 import { keyActions } from '@app/store/software-keys/software-key.actions';
 import { useCurrentKeyDetails } from '@app/store/software-keys/software-key.selectors';
@@ -55,6 +56,7 @@ export function useKeyActions() {
 
       async signOut() {
         await clearWalletSession();
+        dispatch(networksSlice.actions.changeNetwork('mainnet'));
         dispatch(keyActions.signOut());
         dispatch(bitcoinKeysSlice.actions.signOut());
         dispatch(stacksKeysSlice.actions.signOut());

--- a/src/app/features/settings/network/network.tsx
+++ b/src/app/features/settings/network/network.tsx
@@ -10,19 +10,22 @@ import { NetworkListItem } from '@app/features/settings/network/network-list-ite
 import { useCurrentNetworkState, useNetworksActions } from '@app/store/networks/networks.hooks';
 import { useNetworks } from '@app/store/networks/networks.selectors';
 import { Button } from '@app/ui/components/button/button';
-import { Dialog, DialogProps } from '@app/ui/components/containers/dialog/dialog';
+import { Dialog } from '@app/ui/components/containers/dialog/dialog';
 import { Footer } from '@app/ui/components/containers/footers/footer';
 import { Header } from '@app/ui/components/containers/headers/header';
 
 const defaultNetworkIds = Object.values(WalletDefaultNetworkConfigurationIds) as string[];
 
-export function NetworkDialog({ isShowing, onClose }: DialogProps) {
+interface NetworkDialogProps {
+  onClose(): void;
+}
+
+export function NetworkDialog({ onClose }: NetworkDialogProps) {
   const navigate = useNavigate();
   const networks = useNetworks();
   const analytics = useAnalytics();
   const networksActions = useNetworksActions();
   const currentNetwork = useCurrentNetworkState();
-
   function addNetwork() {
     void analytics.track('add_network');
     navigate(RouteUrls.AddNetwork);
@@ -41,7 +44,7 @@ export function NetworkDialog({ isShowing, onClose }: DialogProps) {
   return (
     <Dialog
       header={<Header variant="dialog" title="Change network" />}
-      isShowing={isShowing}
+      isShowing
       onClose={onClose}
       footer={
         <Footer>

--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -200,15 +200,11 @@ export function Settings({ triggerButton, toggleSwitchAccount }: SettingsProps) 
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
-      <SignOut isShowing={showSignOut} onClose={() => setShowSignOut(!showSignOut)} />
-      <ThemeDialog
-        isShowing={showChangeTheme}
-        onClose={() => setShowChangeTheme(!showChangeTheme)}
-      />
-      <NetworkDialog
-        isShowing={showChangeNetwork}
-        onClose={() => setShowChangeNetwork(!showChangeNetwork)}
-      />
+      {showSignOut && <SignOut onClose={() => setShowSignOut(!showSignOut)} />}
+      {showChangeTheme && <ThemeDialog onClose={() => setShowChangeTheme(!showChangeTheme)} />}
+      {showChangeNetwork && (
+        <NetworkDialog onClose={() => setShowChangeNetwork(!showChangeNetwork)} />
+      )}
     </>
   );
 }

--- a/src/app/features/settings/sign-out/sign-out-confirm.tsx
+++ b/src/app/features/settings/sign-out/sign-out-confirm.tsx
@@ -1,9 +1,7 @@
-import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 
 import { SignOutDialog } from './sign-out';
@@ -13,9 +11,6 @@ interface SignOutProps {
 }
 
 export function SignOut({ onClose }: SignOutProps) {
-  const analytics = useAnalytics();
-
-  useEffect(() => void analytics.track('sign-out'), [analytics]);
   const { signOut } = useKeyActions();
   const navigate = useNavigate();
 

--- a/src/app/features/settings/sign-out/sign-out-confirm.tsx
+++ b/src/app/features/settings/sign-out/sign-out-confirm.tsx
@@ -9,22 +9,19 @@ import { useKeyActions } from '@app/common/hooks/use-key-actions';
 import { SignOutDialog } from './sign-out';
 
 interface SignOutProps {
-  isShowing: boolean;
   onClose(): void;
 }
 
-export function SignOut({ isShowing = false, onClose }: SignOutProps) {
+export function SignOut({ onClose }: SignOutProps) {
   const analytics = useAnalytics();
 
   useEffect(() => void analytics.track('sign-out'), [analytics]);
   const { signOut } = useKeyActions();
   const navigate = useNavigate();
-  // #4370 SMELL without this early return the wallet crashes on new install with
-  // : Wallet is neither of type `ledger` nor `software`
-  if (!isShowing) return null;
+
   return (
     <SignOutDialog
-      isShowing={isShowing}
+      isShowing
       onUserDeleteWallet={() => {
         void signOut().finally(() => {
           navigate(RouteUrls.Onboarding);

--- a/src/app/features/settings/theme/theme-dialog.tsx
+++ b/src/app/features/settings/theme/theme-dialog.tsx
@@ -2,12 +2,16 @@ import { useCallback } from 'react';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { UserSelectedTheme, themeLabelMap, useThemeSwitcher } from '@app/common/theme-provider';
-import { Dialog, DialogProps } from '@app/ui/components/containers/dialog/dialog';
+import { Dialog } from '@app/ui/components/containers/dialog/dialog';
 import { Header } from '@app/ui/components/containers/headers/header';
 
 import { ThemeListItem } from './theme-list-item';
 
-export function ThemeDialog({ isShowing, onClose }: DialogProps) {
+interface ThemeDialogProps {
+  onClose(): void;
+}
+
+export function ThemeDialog({ onClose }: ThemeDialogProps) {
   const themes = Object.keys(themeLabelMap) as UserSelectedTheme[];
   const analytics = useAnalytics();
   const { setUserSelectedTheme } = useThemeSwitcher();
@@ -25,11 +29,7 @@ export function ThemeDialog({ isShowing, onClose }: DialogProps) {
   const { userSelectedTheme } = useThemeSwitcher();
 
   return (
-    <Dialog
-      header={<Header variant="dialog" title="Change theme" />}
-      isShowing={isShowing}
-      onClose={onClose}
-    >
+    <Dialog header={<Header variant="dialog" title="Change theme" />} isShowing onClose={onClose}>
       {themes.map(theme => (
         <ThemeListItem
           key={theme}


### PR DESCRIPTION
> Try out Leather build af1d8bc — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8818872416), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5239/reset-to-mainnet-on-signout), [Storybook](https://fix-5239-reset-to-mainnet-on-signout--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5239/reset-to-mainnet-on-signout)<!-- Sticky Header Marker -->

This PR adds a fix that re-sets the network to `mainnet` on sign out. 

I also added another fix to how we are adding some dialogs to the VDOM. 

I noticed that we were calling hooks in the settings menu dialogs whenever the parent is rendered and even if they aren't visible. This is a bad problem as was adding to our API requests to `network` un-necessarily. 