### PR TITLE
refactor: remove unneeded logger errors

### DIFF
--- a/src/app/components/loaders/runes-loader.tsx
+++ b/src/app/components/loaders/runes-loader.tsx
@@ -1,5 +1,3 @@
-import { isDefined } from '@shared/utils';
-
 import type { RuneToken } from '@app/query/bitcoin/bitcoin-client';
 import { useRuneTokens } from '@app/query/bitcoin/runes/runes.hooks';
 
@@ -9,5 +7,5 @@ interface RunesLoaderProps {
 }
 export function RunesLoader({ addresses, children }: RunesLoaderProps) {
   const runes = useRuneTokens(addresses);
-  return children(runes.filter(isDefined));
+  return children(runes);
 }

--- a/src/app/query/bitcoin/runes/runes.hooks.ts
+++ b/src/app/query/bitcoin/runes/runes.hooks.ts
@@ -1,4 +1,3 @@
-import { logger } from '@shared/logger';
 import { createMoney } from '@shared/models/money.model';
 import { isDefined } from '@shared/utils';
 
@@ -41,14 +40,13 @@ export function useRuneTokens(addresses: string[]) {
     .flatMap(query => query.data)
     .filter(isDefined);
 
-  return runesBalances.map(r => {
-    const tickerInfo = runesTickerInfo.find(t => t.rune_name === r.rune_name);
-    if (!tickerInfo) {
-      logger.error('No ticker info found for Rune');
-      return;
-    }
-    return makeRuneToken(r, tickerInfo);
-  });
+  return runesBalances
+    .map(r => {
+      const tickerInfo = runesTickerInfo.find(t => t.rune_name === r.rune_name);
+      if (!tickerInfo) return;
+      return makeRuneToken(r, tickerInfo);
+    })
+    .filter(isDefined);
 }
 
 export function useRunesOutputsByAddress(address: string) {

--- a/src/app/query/common/alex-sdk/alex-sdk.hooks.ts
+++ b/src/app/query/common/alex-sdk/alex-sdk.hooks.ts
@@ -42,10 +42,7 @@ export function useAlexCurrencyPriceAsMarketData() {
       const tokenInfo = supportedCurrencies
         .filter(isDefined)
         .find(token => pullContractIdFromIdentity(token.contractAddress) === principal);
-      if (!symbol || !prices || !tokenInfo) {
-        logger.error('Could not create market data');
-        return null;
-      }
+      if (!symbol || !prices || !tokenInfo) return null;
       const currency = tokenInfo.id as Currency;
       const price = convertAmountToFractionalUnit(new BigNumber(prices[currency] ?? 0), 2);
       return createMarketData(createMarketPair(symbol, 'USD'), createMoney(price, 'USD'));


### PR DESCRIPTION
> Try out Leather build 80c9699 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8818002674), [Test report](https://leather-wallet.github.io/playwright-reports/refactor/remove-logger-errors), [Storybook](https://refactor-remove-logger-errors--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/remove-logger-errors)<!-- Sticky Header Marker -->

I don't think these are necessary to keep, so removing them. We are filtering the runes for if the token info is undefined, and we are handling if the market data is null already bc Alex doesn't support prices for all Stacks fungible tokens.