### PR TITLE
fix: runes formatted balance, closes #5293

### DIFF
--- a/src/app/common/asset-utils.ts
+++ b/src/app/common/asset-utils.ts
@@ -1,5 +1,5 @@
 import type { MarketData } from '@shared/models/market.model';
-import type { Money } from '@shared/models/money.model';
+import { type Money } from '@shared/models/money.model';
 
 import { baseCurrencyAmountInQuote } from './money/calculate-money';
 import { i18nFormatCurrency } from './money/format-money';

--- a/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/brc20-token-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/brc20-token-asset-item.layout.tsx
@@ -15,10 +15,8 @@ interface Brc20TokenAssetItemLayoutProps {
   onClick?(): void;
 }
 export function Brc20TokenAssetItemLayout({ onClick, token }: Brc20TokenAssetItemLayoutProps) {
-  const balanceAsString = token.balance?.amount.toString();
-  const formattedBalance = formatBalance(
-    convertAmountToBaseUnit(token.balance ?? new BigNumber(0)).toString()
-  );
+  const balanceAsString = convertAmountToBaseUnit(token.balance ?? new BigNumber(0)).toString();
+  const formattedBalance = formatBalance(balanceAsString);
   const balanceAsFiat = convertAssetBalanceToFiat(token);
 
   return (

--- a/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/brc20-token-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/brc20-token-asset-item.layout.tsx
@@ -23,7 +23,7 @@ export function Brc20TokenAssetItemLayout({ onClick, token }: Brc20TokenAssetIte
     <Pressable onClick={onClick} my="space.02">
       <ItemLayout
         flagImg={<Brc20AvatarIcon />}
-        titleLeft={token.ticker}
+        titleLeft={token.tokenData.ticker}
         captionLeft="BRC-20"
         titleRight={
           <BasicTooltip
@@ -31,7 +31,7 @@ export function Brc20TokenAssetItemLayout({ onClick, token }: Brc20TokenAssetIte
             label={formattedBalance?.isAbbreviated ? balanceAsString : undefined}
             side="left"
           >
-            <styled.span data-testid={token.ticker} textStyle="label.02">
+            <styled.span data-testid={token.tokenData.ticker} textStyle="label.02">
               {formattedBalance.value}
             </styled.span>
           </BasicTooltip>

--- a/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/brc20-token-asset-list.tsx
+++ b/src/app/components/crypto-assets/bitcoin/brc20-token-asset-list/brc20-token-asset-list.tsx
@@ -12,10 +12,10 @@ import { useCurrentAccountNativeSegwitAddressIndexZero } from '@app/store/accoun
 import { Brc20TokenAssetItemLayout } from './brc20-token-asset-item.layout';
 
 interface Brc20TokenAssetListProps {
-  brc20Tokens: Brc20Token[];
+  tokens: Brc20Token[];
   variant?: string;
 }
-export function Brc20TokenAssetList({ brc20Tokens, variant }: Brc20TokenAssetListProps) {
+export function Brc20TokenAssetList({ tokens, variant }: Brc20TokenAssetListProps) {
   const navigate = useNavigate();
   const currentAccountBtcAddress = useCurrentAccountNativeSegwitAddressIndexZero();
   const { btcBalance: btcCryptoCurrencyAssetBalance } =
@@ -25,17 +25,17 @@ export function Brc20TokenAssetList({ brc20Tokens, variant }: Brc20TokenAssetLis
     variant === 'send' && btcCryptoCurrencyAssetBalance.balance.amount.isGreaterThan(0);
 
   function navigateToBrc20SendForm(token: Brc20Token) {
-    const { ticker, balance, holderAddress, marketData } = token;
-    navigate(RouteUrls.SendBrc20SendForm.replace(':ticker', ticker), {
-      state: { balance, ticker, holderAddress, marketData },
+    const { balance, holderAddress, marketData, tokenData } = token;
+    navigate(RouteUrls.SendBrc20SendForm.replace(':ticker', tokenData.ticker), {
+      state: { balance, ticker: tokenData.ticker, holderAddress, marketData },
     });
   }
 
   return (
     <Stack data-testid={CryptoAssetSelectors.CryptoAssetList}>
-      {brc20Tokens.map(token => (
+      {tokens.map(token => (
         <Brc20TokenAssetItemLayout
-          key={token.ticker}
+          key={token.tokenData.ticker}
           token={token}
           onClick={hasPositiveBtcBalanceForFees ? () => navigateToBrc20SendForm(token) : undefined}
         />

--- a/src/app/components/crypto-assets/bitcoin/runes-asset-list/runes-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/bitcoin/runes-asset-list/runes-asset-item.layout.tsx
@@ -12,14 +12,15 @@ interface RunesAssetItemLayoutProps {
   rune: RuneToken;
 }
 export function RunesAssetItemLayout({ rune }: RunesAssetItemLayoutProps) {
-  const balanceAsString = convertAmountToBaseUnit(rune.balance).toString();
+  const { balance, tokenData } = rune;
+  const balanceAsString = convertAmountToBaseUnit(balance).toString();
   const formattedBalance = formatBalance(balanceAsString);
 
   return (
     <Pressable my="space.02">
       <ItemLayout
         flagImg={<RunesAvatarIcon />}
-        titleLeft={rune.spaced_rune_name ?? rune.rune_name}
+        titleLeft={tokenData.spaced_rune_name ?? tokenData.rune_name}
         captionLeft="Runes"
         titleRight={
           <BasicTooltip
@@ -27,8 +28,8 @@ export function RunesAssetItemLayout({ rune }: RunesAssetItemLayoutProps) {
             label={formattedBalance.isAbbreviated ? balanceAsString : undefined}
             side="left"
           >
-            <styled.span data-testid={rune.rune_name} fontWeight={500} textStyle="label.02">
-              {formattedBalance.value} {rune.symbol}
+            <styled.span data-testid={tokenData.rune_name} fontWeight={500} textStyle="label.02">
+              {formattedBalance.value} {tokenData.symbol}
             </styled.span>
           </BasicTooltip>
         }

--- a/src/app/components/crypto-assets/bitcoin/runes-asset-list/runes-asset-item.layout.tsx
+++ b/src/app/components/crypto-assets/bitcoin/runes-asset-list/runes-asset-item.layout.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'leather-styles/jsx';
 
 import { formatBalance } from '@app/common/format-balance';
+import { convertAmountToBaseUnit } from '@app/common/money/calculate-money';
 import type { RuneToken } from '@app/query/bitcoin/bitcoin-client';
 import { RunesAvatarIcon } from '@app/ui/components/avatar/runes-avatar-icon';
 import { ItemLayout } from '@app/ui/components/item-layout/item-layout';
@@ -11,8 +12,8 @@ interface RunesAssetItemLayoutProps {
   rune: RuneToken;
 }
 export function RunesAssetItemLayout({ rune }: RunesAssetItemLayoutProps) {
-  const balance = rune.balance.amount.toString();
-  const formattedBalance = formatBalance(balance);
+  const balanceAsString = convertAmountToBaseUnit(rune.balance).toString();
+  const formattedBalance = formatBalance(balanceAsString);
 
   return (
     <Pressable my="space.02">
@@ -23,7 +24,7 @@ export function RunesAssetItemLayout({ rune }: RunesAssetItemLayoutProps) {
         titleRight={
           <BasicTooltip
             asChild
-            label={formattedBalance.isAbbreviated ? balance : undefined}
+            label={formattedBalance.isAbbreviated ? balanceAsString : undefined}
             side="left"
           >
             <styled.span data-testid={rune.rune_name} fontWeight={500} textStyle="label.02">

--- a/src/app/components/crypto-assets/bitcoin/runes-asset-list/runes-asset-list.tsx
+++ b/src/app/components/crypto-assets/bitcoin/runes-asset-list/runes-asset-list.tsx
@@ -6,5 +6,7 @@ interface RunesAssetListProps {
   runes: RuneToken[];
 }
 export function RunesAssetList({ runes }: RunesAssetListProps) {
-  return runes.map((rune, i) => <RunesAssetItemLayout key={`${rune.rune_id}${i}`} rune={rune} />);
+  return runes.map((rune, i) => (
+    <RunesAssetItemLayout key={`${rune.tokenData.rune_id}${i}`} rune={rune} />
+  ));
 }

--- a/src/app/components/crypto-assets/choose-crypto-asset/crypto-asset-list.tsx
+++ b/src/app/components/crypto-assets/choose-crypto-asset/crypto-asset-list.tsx
@@ -58,7 +58,7 @@ export function CryptoAssetList({
             <BitcoinNativeSegwitAccountLoader current>
               {() => (
                 <Brc20TokensLoader>
-                  {brc20Tokens => <Brc20TokenAssetList brc20Tokens={brc20Tokens} variant="send" />}
+                  {brc20Tokens => <Brc20TokenAssetList tokens={brc20Tokens} variant="send" />}
                 </Brc20TokensLoader>
               )}
             </BitcoinNativeSegwitAccountLoader>

--- a/src/app/features/asset-list/components/bitcoin-fungible-tokens-asset-list.tsx
+++ b/src/app/features/asset-list/components/bitcoin-fungible-tokens-asset-list.tsx
@@ -16,7 +16,7 @@ export function BitcoinFungibleTokenAssetList({
   return (
     <>
       <Brc20TokensLoader>
-        {brc20Tokens => <Brc20TokenAssetList brc20Tokens={brc20Tokens} />}
+        {brc20Tokens => <Brc20TokenAssetList tokens={brc20Tokens} />}
       </Brc20TokensLoader>
       <Src20TokensLoader address={btcAddressNativeSegwit}>
         {src20Tokens => <Src20TokenAssetList src20Tokens={src20Tokens} />}

--- a/src/app/query/bitcoin/bitcoin-client.ts
+++ b/src/app/query/bitcoin/bitcoin-client.ts
@@ -98,10 +98,11 @@ interface Brc20WalletBalancesResponse {
   data: Brc20Balance[];
 }
 
-export interface Brc20Token extends Brc20Balance, Brc20TickerInfo {
+export interface Brc20Token {
   balance: Money | null;
   holderAddress: string;
   marketData: MarketData | null;
+  tokenData: Brc20Balance & Brc20TickerInfo;
 }
 
 /* RUNES */
@@ -149,8 +150,9 @@ interface RunesTickerInfoResponse {
   data: RuneTickerInfo;
 }
 
-export interface RuneToken extends RuneBalance, RuneTickerInfo {
+export interface RuneToken {
   balance: Money;
+  tokenData: RuneBalance & RuneTickerInfo;
 }
 
 export interface RunesOutputsByAddress {

--- a/src/app/query/bitcoin/ordinals/brc20/brc20-tokens.query.ts
+++ b/src/app/query/bitcoin/ordinals/brc20/brc20-tokens.query.ts
@@ -59,14 +59,13 @@ export function useGetBrc20TokensQuery() {
           })
         );
 
-        // Initialize token with ticker data
+        // Initialize token with token data
         return brc20Tokens.data.map((token, index) => {
           return {
-            ...token,
-            ...tickerPromises[index].data,
             balance: null,
             holderAddress: address,
             marketData: null,
+            tokenData: { ...token, ...tickerPromises[index].data },
           };
         });
       });

--- a/src/app/query/bitcoin/runes/runes-outputs-by-address.query.ts
+++ b/src/app/query/bitcoin/runes/runes-outputs-by-address.query.ts
@@ -7,7 +7,7 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import type { RunesOutputsByAddress } from '../bitcoin-client';
 import { useRunesEnabled } from './runes.hooks';
 
-const queryOptions = { staleTime: 1 * 60 * 1000 };
+const queryOptions = { staleTime: 5 * 60 * 1000 };
 
 export function useGetRunesOutputsByAddressQuery<T extends unknown = RunesOutputsByAddress[]>(
   address: string,

--- a/src/app/query/bitcoin/runes/runes-outputs-by-address.query.ts
+++ b/src/app/query/bitcoin/runes/runes-outputs-by-address.query.ts
@@ -7,6 +7,8 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import type { RunesOutputsByAddress } from '../bitcoin-client';
 import { useRunesEnabled } from './runes.hooks';
 
+const queryOptions = { staleTime: 1 * 60 * 1000 };
+
 export function useGetRunesOutputsByAddressQuery<T extends unknown = RunesOutputsByAddress[]>(
   address: string,
   options?: AppUseQueryConfig<RunesOutputsByAddress[], T>
@@ -16,14 +18,14 @@ export function useGetRunesOutputsByAddressQuery<T extends unknown = RunesOutput
   const network = useCurrentNetwork();
 
   return useQuery({
+    enabled: !!address && runesEnabled,
     queryKey: ['runes-outputs-by-address', address],
     queryFn: () =>
       client.BestinslotApi.getRunesOutputsByAddress({
         address,
         network: network.chain.bitcoin.bitcoinNetwork,
       }),
-    staleTime: 1000 * 60,
-    enabled: !!address && runesEnabled,
+    ...queryOptions,
     ...options,
   });
 }

--- a/src/app/query/bitcoin/runes/runes-ticker-info.query.ts
+++ b/src/app/query/bitcoin/runes/runes-ticker-info.query.ts
@@ -6,7 +6,7 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import type { RuneTickerInfo } from '../bitcoin-client';
 
-const queryOptions = { staleTime: 1 * 60 * 1000 };
+const queryOptions = { staleTime: 5 * 60 * 1000 };
 
 export function useGetRunesTickerInfoQuery(runeNames: string[]): UseQueryResult<RuneTickerInfo>[] {
   const client = useBitcoinClient();

--- a/src/app/query/bitcoin/runes/runes-ticker-info.query.ts
+++ b/src/app/query/bitcoin/runes/runes-ticker-info.query.ts
@@ -6,6 +6,8 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import type { RuneTickerInfo } from '../bitcoin-client';
 
+const queryOptions = { staleTime: 1 * 60 * 1000 };
+
 export function useGetRunesTickerInfoQuery(runeNames: string[]): UseQueryResult<RuneTickerInfo>[] {
   const client = useBitcoinClient();
   const network = useCurrentNetwork();
@@ -18,6 +20,7 @@ export function useGetRunesTickerInfoQuery(runeNames: string[]): UseQueryResult<
         queryKey: ['runes-ticker-info', runeName],
         queryFn: () =>
           client.BestinslotApi.getRunesTickerInfo(runeName, network.chain.bitcoin.bitcoinNetwork),
+        ...queryOptions,
       };
     }),
   });

--- a/src/app/query/bitcoin/runes/runes-wallet-balances.query.ts
+++ b/src/app/query/bitcoin/runes/runes-wallet-balances.query.ts
@@ -7,7 +7,7 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import type { RuneBalance } from '../bitcoin-client';
 
-const queryOptions = { staleTime: 1 * 60 * 1000 };
+const queryOptions = { staleTime: 5 * 60 * 1000 };
 
 export function useGetRunesWalletBalancesByAddressesQuery<T extends unknown = RuneBalance[]>(
   addresses: string[],

--- a/src/app/query/bitcoin/runes/runes-wallet-balances.query.ts
+++ b/src/app/query/bitcoin/runes/runes-wallet-balances.query.ts
@@ -7,6 +7,8 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import type { RuneBalance } from '../bitcoin-client';
 
+const queryOptions = { staleTime: 1 * 60 * 1000 };
+
 export function useGetRunesWalletBalancesByAddressesQuery<T extends unknown = RuneBalance[]>(
   addresses: string[],
   options?: AppUseQueryConfig<RuneBalance[], T>
@@ -25,6 +27,7 @@ export function useGetRunesWalletBalancesByAddressesQuery<T extends unknown = Ru
             address,
             network.chain.bitcoin.bitcoinNetwork
           ),
+        ...queryOptions,
         ...options,
       };
     }),

--- a/src/app/query/bitcoin/runes/runes.hooks.ts
+++ b/src/app/query/bitcoin/runes/runes.hooks.ts
@@ -13,14 +13,16 @@ const defaultRunesSymbol = '¤';
 
 function makeRuneToken(runeBalance: RuneBalance, tickerInfo: RuneTickerInfo): RuneToken {
   return {
-    ...runeBalance,
-    ...tickerInfo,
-    symbol: tickerInfo.symbol ?? defaultRunesSymbol,
     balance: createMoney(
       Number(runeBalance.total_balance),
       tickerInfo.rune_name,
       tickerInfo.decimals
     ),
+    tokenData: {
+      ...runeBalance,
+      ...tickerInfo,
+      symbol: tickerInfo.symbol ?? defaultRunesSymbol,
+    },
   };
 }
 


### PR DESCRIPTION
> Try out Leather build 4a67a60 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8838869446), [Test report](https://leather-wallet.github.io/playwright-reports/fix/runes-formatted-balance), [Storybook](https://fix-runes-formatted-balance--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/runes-formatted-balance)<!-- Sticky Header Marker -->

This PR fixes a UI bug when we formatted the runes (and BRC-20) token balance. We needed to convert the amount to the base unit first, my bad.