### PR TITLE
feat: cache time infinity for txs request

### DIFF
--- a/src/app/query/bitcoin/address/transactions-by-address.query.ts
+++ b/src/app/query/bitcoin/address/transactions-by-address.query.ts
@@ -7,7 +7,7 @@ import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
 
 const staleTime = 10 * 1000;
 
-const queryOptions = { staleTime, refetchInterval: staleTime };
+const queryOptions = { staleTime, cacheTime: Infinity, refetchInterval: staleTime };
 
 export function useGetBitcoinTransactionsByAddressQuery<T extends unknown = BitcoinTx[]>(
   address: string,


### PR DESCRIPTION
> Try out Leather build c1c0263 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8843515398), [Test report](https://leather-wallet.github.io/playwright-reports/feat/tx-cache-time), [Storybook](https://feat-tx-cache-time--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/tx-cache-time)<!-- Sticky Header Marker -->

Make cacheTime infinity for txs request, so users will see activity tab loader only when fetch them for the first time