### PR TITLE
refactor: bitcoin send flow to accept multiple recipients

### DIFF
--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.spec.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.spec.ts
@@ -1,4 +1,5 @@
 import { BTC_P2WPKH_DUST_AMOUNT } from '@shared/constants';
+import { createMoney } from '@shared/models/money.model';
 
 import { sumNumbers } from '@app/common/math/helpers';
 import { createNullArrayOfLength } from '@app/common/utils';
@@ -24,9 +25,8 @@ const demoUtxos = [
 function generate10kSpendWithDummyUtxoSet(recipient: string) {
   return determineUtxosForSpend({
     utxos: demoUtxos as any,
-    amount: 10_000,
     feeRate: 20,
-    recipient,
+    recipients: [{ address: recipient, amount: createMoney(10_000, 'BTC') }],
   });
 }
 
@@ -35,8 +35,12 @@ describe(determineUtxosForSpend.name, () => {
     test('that Native Segwit, 1 input 2 outputs weighs 140 vBytes', () => {
       const estimation = determineUtxosForSpend({
         utxos: [{ value: 50_000 }] as any[],
-        amount: 40_000,
-        recipient: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+        recipients: [
+          {
+            address: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+            amount: createMoney(40_000, 'BTC'),
+          },
+        ],
         feeRate: 20,
       });
       console.log(estimation);
@@ -47,8 +51,12 @@ describe(determineUtxosForSpend.name, () => {
     test('that Native Segwit, 2 input 2 outputs weighs 200vBytes', () => {
       const estimation = determineUtxosForSpend({
         utxos: [{ value: 50_000 }, { value: 50_000 }] as any[],
-        amount: 60_000,
-        recipient: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+        recipients: [
+          {
+            address: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+            amount: createMoney(60_000, 'BTC'),
+          },
+        ],
         feeRate: 20,
       });
       console.log(estimation);
@@ -70,8 +78,12 @@ describe(determineUtxosForSpend.name, () => {
           { value: 10_000 },
           { value: 10_000 },
         ] as any[],
-        amount: 100_000,
-        recipient: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+        recipients: [
+          {
+            address: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+            amount: createMoney(100_000, 'BTC'),
+          },
+        ],
         feeRate: 20,
       });
       expect(estimation.txVBytes).toBeGreaterThan(750);
@@ -82,7 +94,6 @@ describe(determineUtxosForSpend.name, () => {
   describe('sorting algorithm', () => {
     test('that it filters out dust utxos', () => {
       const result = generate10kSpendWithDummyUtxoSet('tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m');
-      console.log(result);
       const hasDust = result.filteredUtxos.some(utxo => utxo.value <= BTC_P2WPKH_DUST_AMOUNT);
       expect(hasDust).toBeFalsy();
     });
@@ -143,8 +154,12 @@ describe(determineUtxosForSpend.name, () => {
     const amount = 29123n;
     const result = determineUtxosForSpend({
       utxos: testData as any,
-      amount: Number(amount),
-      recipient: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+      recipients: [
+        {
+          address: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+          amount: createMoney(Number(amount), 'BTC'),
+        },
+      ],
       feeRate: 3,
     });
     expect(result.outputs[0].value).toEqual(29123n);

--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
@@ -1,24 +1,13 @@
 import BigNumber from 'bignumber.js';
 import { validate } from 'bitcoin-address-validation';
 
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
+import type { TransferRecipient } from '@shared/models/form.model';
 
 import { sumNumbers } from '@app/common/math/helpers';
+import { sumMoney } from '@app/common/money/calculate-money';
 import { UtxoResponseItem } from '@app/query/bitcoin/bitcoin-client';
 
-import {
-  filterUneconomicalUtxos,
-  filterUneconomicalUtxosMultipleRecipients,
-  getBitcoinTxSizeEstimation,
-  getSizeInfoMultipleRecipients,
-} from '../utils';
-
-export interface DetermineUtxosForSpendArgs {
-  amount: number;
-  feeRate: number;
-  recipient: string;
-  utxos: UtxoResponseItem[];
-}
+import { filterUneconomicalUtxos, getSizeInfo } from '../utils';
 
 export class InsufficientFundsError extends Error {
   constructor() {
@@ -26,127 +15,28 @@ export class InsufficientFundsError extends Error {
   }
 }
 
-export function determineUtxosForSpendAll({
-  amount,
-  feeRate,
-  recipient,
-  utxos,
-}: DetermineUtxosForSpendArgs) {
-  if (!validate(recipient)) throw new Error('Cannot calculate spend of invalid address type');
-  const filteredUtxos = filterUneconomicalUtxos({ utxos, feeRate, address: recipient });
-
-  const sizeInfo = getBitcoinTxSizeEstimation({
-    inputCount: filteredUtxos.length,
-    outputCount: 1,
-    recipient,
-  });
-
-  // Fee has already been deducted from the amount with send all
-  const outputs = [{ value: BigInt(amount), address: recipient }];
-
-  const fee = Math.ceil(sizeInfo.txVBytes * feeRate);
-
-  return {
-    inputs: filteredUtxos,
-    outputs,
-    size: sizeInfo.txVBytes,
-    fee,
-  };
+export interface DetermineUtxosForSpendArgs {
+  feeRate: number;
+  recipients: TransferRecipient[];
+  utxos: UtxoResponseItem[];
 }
 
 function getUtxoTotal(utxos: UtxoResponseItem[]) {
   return sumNumbers(utxos.map(utxo => utxo.value));
 }
 
-export function determineUtxosForSpend({
-  amount,
-  feeRate,
-  recipient,
-  utxos,
-}: DetermineUtxosForSpendArgs) {
-  if (!validate(recipient)) throw new Error('Cannot calculate spend of invalid address type');
-
-  const filteredUtxos: UtxoResponseItem[] = filterUneconomicalUtxos({
-    utxos: utxos.sort((a, b) => b.value - a.value),
-    feeRate,
-    address: recipient,
-  });
-
-  if (!filteredUtxos.length) throw new InsufficientFundsError();
-
-  // Prepopulate with first UTXO, at least one is needed
-  const neededUtxos: UtxoResponseItem[] = [filteredUtxos[0]];
-
-  function estimateTransactionSize() {
-    return getBitcoinTxSizeEstimation({
-      inputCount: neededUtxos.length,
-      outputCount: 2,
-      recipient,
-    });
-  }
-
-  function hasSufficientUtxosForTx() {
-    const txEstimation = estimateTransactionSize();
-    const neededAmount = new BigNumber(txEstimation.txVBytes * feeRate).plus(amount);
-    return getUtxoTotal(neededUtxos).isGreaterThanOrEqualTo(neededAmount);
-  }
-
-  function getRemainingUnspentUtxos() {
-    return filteredUtxos.filter(utxo => !neededUtxos.includes(utxo));
-  }
-
-  while (!hasSufficientUtxosForTx()) {
-    const [nextUtxo] = getRemainingUnspentUtxos();
-    if (!nextUtxo) throw new InsufficientFundsError();
-    neededUtxos.push(nextUtxo);
-  }
-
-  const fee = Math.ceil(
-    new BigNumber(estimateTransactionSize().txVBytes).multipliedBy(feeRate).toNumber()
-  );
-
-  const outputs = [
-    // outputs[0] = the desired amount going to recipient
-    { value: BigInt(amount), address: recipient },
-    // outputs[1] = the remainder to be returned to a change address
-    { value: BigInt(getUtxoTotal(neededUtxos).toString()) - BigInt(amount) - BigInt(fee) },
-  ];
-
-  return {
-    filteredUtxos,
-    inputs: neededUtxos,
-    outputs,
-    size: estimateTransactionSize().txVBytes,
-    fee,
-    ...estimateTransactionSize(),
-  };
-}
-
-export interface DetermineUtxosForSpendArgsMultipleRecipients {
-  amount: number;
-  feeRate: number;
-  recipients: RpcSendTransferRecipient[];
-  utxos: UtxoResponseItem[];
-}
-
-interface DetermineUtxosForSpendAllArgsMultipleRecipients {
-  feeRate: number;
-  recipients: RpcSendTransferRecipient[];
-  utxos: UtxoResponseItem[];
-}
-
-export function determineUtxosForSpendAllMultipleRecipients({
+export function determineUtxosForSpendAll({
   feeRate,
   recipients,
   utxos,
-}: DetermineUtxosForSpendAllArgsMultipleRecipients) {
+}: DetermineUtxosForSpendArgs) {
   recipients.forEach(recipient => {
     if (!validate(recipient.address))
       throw new Error('Cannot calculate spend of invalid address type');
   });
-  const filteredUtxos = filterUneconomicalUtxosMultipleRecipients({ utxos, feeRate, recipients });
+  const filteredUtxos = filterUneconomicalUtxos({ utxos, feeRate, recipients });
 
-  const sizeInfo = getSizeInfoMultipleRecipients({
+  const sizeInfo = getSizeInfo({
     inputLength: filteredUtxos.length,
     isSendMax: true,
     recipients,
@@ -168,62 +58,72 @@ export function determineUtxosForSpendAllMultipleRecipients({
   };
 }
 
-export function determineUtxosForSpendMultipleRecipients({
-  amount,
-  feeRate,
-  recipients,
-  utxos,
-}: DetermineUtxosForSpendArgsMultipleRecipients) {
+export function determineUtxosForSpend({ feeRate, recipients, utxos }: DetermineUtxosForSpendArgs) {
   recipients.forEach(recipient => {
     if (!validate(recipient.address))
       throw new Error('Cannot calculate spend of invalid address type');
   });
-
-  const orderedUtxos = utxos.sort((a, b) => b.value - a.value);
-
-  const filteredUtxos = filterUneconomicalUtxosMultipleRecipients({
-    utxos: orderedUtxos,
+  const filteredUtxos = filterUneconomicalUtxos({
+    utxos: utxos.sort((a, b) => b.value - a.value),
     feeRate,
     recipients,
   });
+  if (!filteredUtxos.length) throw new InsufficientFundsError();
 
-  const neededUtxos = [];
-  let sum = 0n;
-  let sizeInfo = null;
+  const amount = sumMoney(recipients.map(recipient => recipient.amount));
 
-  for (const utxo of filteredUtxos) {
-    sizeInfo = getSizeInfoMultipleRecipients({
+  // Prepopulate with first UTXO, at least one is needed
+  const neededUtxos: UtxoResponseItem[] = [filteredUtxos[0]];
+
+  function estimateTransactionSize() {
+    return getSizeInfo({
       inputLength: neededUtxos.length,
       recipients,
     });
-    if (sum >= BigInt(amount) + BigInt(Math.ceil(sizeInfo.txVBytes * feeRate))) break;
-
-    sum += BigInt(utxo.value);
-    neededUtxos.push(utxo);
   }
 
-  if (!sizeInfo) throw new InsufficientFundsError();
+  function hasSufficientUtxosForTx() {
+    const txEstimation = estimateTransactionSize();
+    const neededAmount = new BigNumber(txEstimation.txVBytes * feeRate).plus(amount.amount);
+    return getUtxoTotal(neededUtxos).isGreaterThanOrEqualTo(neededAmount);
+  }
 
-  const fee = Math.ceil(sizeInfo.txVBytes * feeRate);
+  function getRemainingUnspentUtxos() {
+    return filteredUtxos.filter(utxo => !neededUtxos.includes(utxo));
+  }
+
+  while (!hasSufficientUtxosForTx()) {
+    const [nextUtxo] = getRemainingUnspentUtxos();
+    if (!nextUtxo) throw new InsufficientFundsError();
+    neededUtxos.push(nextUtxo);
+  }
+
+  const fee = Math.ceil(
+    new BigNumber(estimateTransactionSize().txVBytes).multipliedBy(feeRate).toNumber()
+  );
 
   const outputs: {
     value: bigint;
     address?: string;
   }[] = [
-    // outputs[0] = the desired amount going to recipient
     ...recipients.map(({ address, amount }) => ({
       value: BigInt(amount.amount.toNumber()),
       address,
     })),
-    // outputs[recipients.length] = the remainder to be returned to a change address
-    { value: sum - BigInt(amount) - BigInt(fee) },
+    {
+      value:
+        BigInt(getUtxoTotal(neededUtxos).toString()) -
+        BigInt(amount.amount.toNumber()) -
+        BigInt(fee),
+    },
   ];
 
   return {
     filteredUtxos,
     inputs: neededUtxos,
     outputs,
-    size: sizeInfo.txVBytes,
+    size: estimateTransactionSize().txVBytes,
     fee,
+    ...estimateTransactionSize(),
   };
 }

--- a/src/app/common/transactions/bitcoin/fees/bitcoin-fees.spec.ts
+++ b/src/app/common/transactions/bitcoin/fees/bitcoin-fees.spec.ts
@@ -1,6 +1,8 @@
 import BigNumber from 'bignumber.js';
 import { sha256 } from 'bitcoinjs-lib/src/crypto';
 
+import { createMoney } from '@shared/models/money.model';
+
 import { UtxoResponseItem } from '@app/query/bitcoin/bitcoin-client';
 
 import { filterUneconomicalUtxos } from '../utils';
@@ -89,13 +91,19 @@ describe(calculateMaxBitcoinSpend.name, () => {
 
 describe(filterUneconomicalUtxos.name, () => {
   const utxos = generateTransactions([600, 600, 1200, 1200, 10000, 10000, 25000, 40000, 50000000]);
+  const recipients = [
+    {
+      address: '',
+      amount: createMoney(0, 'BTC'),
+    },
+  ];
 
   test('with 1 sat/vb fee', () => {
     const fee = 1;
     const filteredUtxos = filterUneconomicalUtxos({
-      address: '',
       utxos,
       feeRate: fee,
+      recipients,
     });
 
     expect(filteredUtxos.length).toEqual(9);
@@ -104,7 +112,7 @@ describe(filterUneconomicalUtxos.name, () => {
   test('with 10 sat/vb fee', () => {
     const fee = 10;
     const filteredUtxos = filterUneconomicalUtxos({
-      address: '',
+      recipients,
       utxos,
       feeRate: fee,
     });
@@ -114,7 +122,7 @@ describe(filterUneconomicalUtxos.name, () => {
   test('with 30 sat/vb fee', () => {
     const fee = 30;
     const filteredUtxos = filterUneconomicalUtxos({
-      address: '',
+      recipients,
       utxos,
       feeRate: fee,
     });
@@ -124,7 +132,7 @@ describe(filterUneconomicalUtxos.name, () => {
   test('with 200 sat/vb fee', () => {
     const fee = 200;
     const filteredUtxos = filterUneconomicalUtxos({
-      address: '',
+      recipients,
       utxos,
       feeRate: fee,
     });
@@ -134,7 +142,7 @@ describe(filterUneconomicalUtxos.name, () => {
   test('with 400 sat/vb fee', () => {
     const fee = 400;
     const filteredUtxos = filterUneconomicalUtxos({
-      address: '',
+      recipients,
       utxos,
       feeRate: fee,
     });

--- a/src/app/common/transactions/bitcoin/fees/calculate-max-bitcoin-spend.ts
+++ b/src/app/common/transactions/bitcoin/fees/calculate-max-bitcoin-spend.ts
@@ -33,13 +33,13 @@ export function calculateMaxBitcoinSpend({
   const filteredUtxos = filterUneconomicalUtxos({
     utxos,
     feeRate: currentFeeRate,
-    address,
+    recipients: [{ address, amount: createMoney(0, 'BTC') }],
   });
 
   const { spendableAmount, fee } = getSpendableAmount({
     utxos: filteredUtxos,
     feeRate: currentFeeRate,
-    address,
+    recipients: [{ address, amount: createMoney(0, 'BTC') }],
   });
 
   return {

--- a/src/app/common/transactions/bitcoin/use-generate-bitcoin-tx.ts
+++ b/src/app/common/transactions/bitcoin/use-generate-bitcoin-tx.ts
@@ -3,31 +3,30 @@ import { useCallback } from 'react';
 import * as btc from '@scure/btc-signer';
 
 import { logger } from '@shared/logger';
+import type { TransferRecipient } from '@shared/models/form.model';
 import { Money } from '@shared/models/money.model';
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
 
 import {
   determineUtxosForSpend,
   determineUtxosForSpendAll,
-  determineUtxosForSpendAllMultipleRecipients,
-  determineUtxosForSpendMultipleRecipients,
 } from '@app/common/transactions/bitcoin/coinselect/local-coin-selection';
 import { UtxoResponseItem } from '@app/query/bitcoin/bitcoin-client';
 import { useBitcoinScureLibNetworkConfig } from '@app/store/accounts/blockchain/bitcoin/bitcoin-keychain';
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
-interface GenerateNativeSegwitSingleRecipientTxValues {
+interface GenerateNativeSegwitTxValues {
   amount: Money;
-  recipient: string;
+  recipients: TransferRecipient[];
 }
-export function useGenerateUnsignedNativeSegwitSingleRecipientTx() {
+
+export function useGenerateUnsignedNativeSegwitTx() {
   const signer = useCurrentAccountNativeSegwitIndexZeroSigner();
 
   const networkMode = useBitcoinScureLibNetworkConfig();
 
   return useCallback(
     async (
-      values: GenerateNativeSegwitSingleRecipientTxValues,
+      values: GenerateNativeSegwitTxValues,
       feeRate: number,
       utxos: UtxoResponseItem[],
       isSendingMax?: boolean
@@ -38,98 +37,15 @@ export function useGenerateUnsignedNativeSegwitSingleRecipientTx() {
       try {
         const tx = new btc.Transaction();
 
-        const amountAsNumber = values.amount.amount.toNumber();
-
         const determineUtxosArgs = {
-          amount: amountAsNumber,
-          feeRate,
-          recipient: values.recipient,
-          utxos,
-        };
-
-        const { inputs, outputs, fee } = isSendingMax
-          ? determineUtxosForSpendAll(determineUtxosArgs)
-          : determineUtxosForSpend(determineUtxosArgs);
-
-        logger.info('Coin selection', { inputs, outputs, fee });
-
-        if (!inputs.length) throw new Error('No inputs to sign');
-        if (!outputs.length) throw new Error('No outputs to sign');
-
-        if (outputs.length > 2)
-          throw new Error('Address reuse mode: wallet should have max 2 outputs');
-
-        const p2wpkh = btc.p2wpkh(signer.publicKey, networkMode);
-
-        for (const input of inputs) {
-          tx.addInput({
-            txid: input.txid,
-            index: input.vout,
-            sequence: 0,
-            witnessUtxo: {
-              // script = 0014 + pubKeyHash
-              script: p2wpkh.script,
-              amount: BigInt(input.value),
-            },
-          });
-        }
-
-        outputs.forEach(output => {
-          // When coin selection returns output with no address we assume it is
-          // a change output
-          if (!output.address) {
-            tx.addOutputAddress(signer.address, BigInt(output.value), networkMode);
-            return;
-          }
-          tx.addOutputAddress(values.recipient, BigInt(output.value), networkMode);
-        });
-
-        return { hex: tx.hex, fee, psbt: tx.toPSBT(), inputs };
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('Error signing bitcoin transaction', e);
-        return null;
-      }
-    },
-    [networkMode, signer.address, signer.publicKey]
-  );
-}
-
-interface GenerateNativeSegwitMultipleRecipientsTxValues {
-  amount: Money;
-  recipients: RpcSendTransferRecipient[];
-}
-
-export function useGenerateUnsignedNativeSegwitMultipleRecipientsTx() {
-  const signer = useCurrentAccountNativeSegwitIndexZeroSigner();
-
-  const networkMode = useBitcoinScureLibNetworkConfig();
-
-  return useCallback(
-    async (
-      values: GenerateNativeSegwitMultipleRecipientsTxValues,
-      feeRate: number,
-      utxos: UtxoResponseItem[],
-      isSendingMax?: boolean
-    ) => {
-      if (!utxos.length) return;
-      if (!feeRate) return;
-
-      try {
-        const tx = new btc.Transaction();
-
-        const amountAsNumber = values.amount.amount.toNumber();
-
-        const determineUtxosArgs = {
-          amount: amountAsNumber,
           feeRate,
           recipients: values.recipients,
           utxos,
         };
 
         const { inputs, outputs, fee } = isSendingMax
-          ? determineUtxosForSpendAllMultipleRecipients(determineUtxosArgs)
-          : determineUtxosForSpendMultipleRecipients(determineUtxosArgs);
+          ? determineUtxosForSpendAll(determineUtxosArgs)
+          : determineUtxosForSpend(determineUtxosArgs);
 
         logger.info('Coin selection', { inputs, outputs, fee });
 

--- a/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-input.tsx
+++ b/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-input.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { useField } from 'formik';
 import { Stack } from 'leather-styles/jsx';
 
+import type { TransferRecipient } from '@shared/models/form.model';
 import { createMoney } from '@shared/models/money.model';
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
 
 import { useOnMount } from '@app/common/hooks/use-on-mount';
 import { satToBtc } from '@app/common/money/unit-conversion';
@@ -13,29 +13,26 @@ import { Input } from '@app/ui/components/input/input';
 
 import { ErrorLabel } from '../error-label';
 import { BitcoinCustomFeeFiat } from './bitcoin-custom-fee-fiat';
-import {
-  useBitcoinCustomFee,
-  useBitcoinCustomFeeMultipleRecipients,
-} from './hooks/use-bitcoin-custom-fee';
+import { useBitcoinCustomFee } from './hooks/use-bitcoin-custom-fee';
+
+const feeInputLabel = 'sats/vB';
 
 interface Props {
   onClick?(): void;
   amount: number;
   isSendingMax: boolean;
-  recipient: string;
+  recipients: TransferRecipient[];
   hasInsufficientBalanceError: boolean;
   errorMessage?: string;
   setCustomFeeInitialValue?(value: string): void;
   customFeeInitialValue: string;
 }
 
-const feeInputLabel = 'sats/vB';
-
 export function BitcoinCustomFeeInput({
   onClick,
   amount,
   isSendingMax,
-  recipient,
+  recipients,
   hasInsufficientBalanceError,
   setCustomFeeInitialValue,
   customFeeInitialValue,
@@ -48,99 +45,6 @@ export function BitcoinCustomFeeInput({
   }>(null);
 
   const getCustomFeeValues = useBitcoinCustomFee({
-    amount: createMoney(amount, 'BTC'),
-    isSendingMax,
-    recipient,
-  });
-  const [unknownError, setUnknownError] = useState(false);
-  const [customInsufficientBalanceError, setCustomInsufficientBalanceError] = useState(false);
-
-  const hasError = hasInsufficientBalanceError || unknownError || customInsufficientBalanceError;
-  const errorMessage =
-    hasInsufficientBalanceError || customInsufficientBalanceError
-      ? 'Insufficient funds'
-      : 'Unknown error';
-
-  function processFeeValue(feeRate: string) {
-    try {
-      const feeValues = getCustomFeeValues(Number(feeRate));
-      setFeeValue(feeValues);
-
-      setUnknownError(false);
-      setCustomInsufficientBalanceError(false);
-    } catch (err) {
-      if (err instanceof InsufficientFundsError) {
-        return setCustomInsufficientBalanceError(true);
-      }
-
-      setUnknownError(true);
-    }
-  }
-
-  function onChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const value = e.target.value;
-    setCustomFeeInitialValue?.(e.target.value);
-    processFeeValue(value);
-  }
-
-  useOnMount(() => {
-    processFeeValue(customFeeInitialValue);
-  });
-  return (
-    <Stack gap="space.05">
-      <Stack>
-        <Input.Root hasError={hasError}>
-          <Input.Label>{feeInputLabel}</Input.Label>
-          <Input.Field
-            onClick={onClick}
-            {...field}
-            onChange={e => {
-              field.onChange(e);
-              onChange?.(e);
-            }}
-          />
-        </Input.Root>
-        {hasError && <ErrorLabel>{errorMessage}</ErrorLabel>}
-      </Stack>
-
-      {!hasError && feeValue && (
-        <BitcoinCustomFeeFiat
-          feeInBtc={satToBtc(feeValue.fee).toString()}
-          fiatFeeValue={feeValue.fiatFeeValue}
-        />
-      )}
-    </Stack>
-  );
-}
-
-interface PropsMultipleRecipients {
-  onClick?(): void;
-  amount: number;
-  isSendingMax: boolean;
-  recipients: RpcSendTransferRecipient[];
-  hasInsufficientBalanceError: boolean;
-  errorMessage?: string;
-  setCustomFeeInitialValue?(value: string): void;
-  customFeeInitialValue: string;
-}
-
-export function BitcoinCustomFeeInputMultipleRecipients({
-  onClick,
-  amount,
-  isSendingMax,
-  recipients,
-  hasInsufficientBalanceError,
-  setCustomFeeInitialValue,
-  customFeeInitialValue,
-}: PropsMultipleRecipients) {
-  const [field] = useField('feeRate');
-
-  const [feeValue, setFeeValue] = useState<null | {
-    fee: number;
-    fiatFeeValue: string;
-  }>(null);
-
-  const getCustomFeeValues = useBitcoinCustomFeeMultipleRecipients({
     amount: createMoney(amount, 'BTC'),
     isSendingMax,
     recipients,

--- a/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee.tsx
+++ b/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee.tsx
@@ -6,22 +6,16 @@ import { Stack, styled } from 'leather-styles/jsx';
 import * as yup from 'yup';
 
 import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
+import type { TransferRecipient } from '@shared/models/form.model';
 import { createMoney } from '@shared/models/money.model';
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
 
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { Button } from '@app/ui/components/button/button';
 import { Link } from '@app/ui/components/link/link';
 
 import { OnChooseFeeArgs } from '../bitcoin-fees-list/bitcoin-fees-list';
-import {
-  BitcoinCustomFeeInput,
-  BitcoinCustomFeeInputMultipleRecipients,
-} from './bitcoin-custom-fee-input';
-import {
-  useBitcoinCustomFee,
-  useBitcoinCustomFeeMultipleRecipients,
-} from './hooks/use-bitcoin-custom-fee';
+import { BitcoinCustomFeeInput } from './bitcoin-custom-fee-input';
+import { useBitcoinCustomFee } from './hooks/use-bitcoin-custom-fee';
 
 interface BitcoinCustomFeeProps {
   amount: number;
@@ -31,7 +25,7 @@ interface BitcoinCustomFeeProps {
   onChooseFee({ feeRate, feeValue, time, isCustomFee }: OnChooseFeeArgs): Promise<void>;
   onSetSelectedFeeType(value: BtcFeeType | null): void;
   onValidateBitcoinSpend(value: number): boolean;
-  recipient: string;
+  recipients: TransferRecipient[];
   setCustomFeeInitialValue: Dispatch<SetStateAction<string>>;
   maxCustomFeeRate: number;
 }
@@ -44,118 +38,12 @@ export function BitcoinCustomFee({
   onChooseFee,
   onSetSelectedFeeType,
   onValidateBitcoinSpend,
-  recipient,
+  recipients,
   setCustomFeeInitialValue,
   maxCustomFeeRate,
 }: BitcoinCustomFeeProps) {
   const feeInputRef = useRef<HTMLInputElement | null>(null);
   const getCustomFeeValues = useBitcoinCustomFee({
-    amount: createMoney(amount, 'BTC'),
-    isSendingMax,
-    recipient,
-  });
-
-  const onChooseCustomBtcFee = useCallback(
-    async ({ feeRate }: { feeRate: string }) => {
-      onSetSelectedFeeType(null);
-      const { fee: feeValue } = getCustomFeeValues(Number(feeRate));
-      const isValid = onValidateBitcoinSpend(feeValue);
-      if (!isValid) return;
-      await onChooseFee({ feeRate: Number(feeRate), feeValue, time: '', isCustomFee: true });
-    },
-    [onSetSelectedFeeType, getCustomFeeValues, onValidateBitcoinSpend, onChooseFee]
-  );
-
-  const validationSchema = yup.object({
-    feeRate: yup
-      .number()
-      .required('Fee is required')
-      .integer('Fee must be a whole number')
-      .test({
-        message: 'Fee is too high',
-        test: value => {
-          return value <= maxCustomFeeRate;
-        },
-      }),
-  });
-
-  return (
-    <Formik
-      initialValues={{ feeRate: customFeeInitialValue.toString() }}
-      onSubmit={onChooseCustomBtcFee}
-      validateOnChange={false}
-      validateOnBlur={false}
-      validateOnMount={false}
-      validationSchema={validationSchema}
-    >
-      {props => (
-        <Form>
-          <Stack gap="space.06" mt="space.02">
-            <Stack gap="space.05">
-              <styled.span color="ink.text-subdued" textStyle="body.02" maxWidth="21.5rem">
-                Higher fee rates typically lead to faster confirmation times.
-                <Link
-                  ml="space.01"
-                  onClick={() => openInNewTab('https://buybitcoinworldwide.com/fee-calculator/')}
-                  textStyle="body.02"
-                >
-                  View fee calculator
-                </Link>
-              </styled.span>
-              <BitcoinCustomFeeInput
-                amount={amount}
-                isSendingMax={isSendingMax}
-                onClick={async () => {
-                  feeInputRef.current?.focus();
-                  await props.setValues({ ...props.values });
-                }}
-                customFeeInitialValue={customFeeInitialValue}
-                setCustomFeeInitialValue={setCustomFeeInitialValue}
-                recipient={recipient}
-                hasInsufficientBalanceError={hasInsufficientBalanceError}
-              />
-            </Stack>
-            <Button
-              data-testid={SendCryptoAssetSelectors.PreviewSendTxBtn}
-              disabled={!props.values.feeRate}
-              type="submit"
-            >
-              Use custom fee
-            </Button>
-          </Stack>
-        </Form>
-      )}
-    </Formik>
-  );
-}
-
-interface BitcoinCustomFeeMultipleRecipientsProps {
-  amount: number;
-  customFeeInitialValue: string;
-  hasInsufficientBalanceError: boolean;
-  isSendingMax: boolean;
-  onChooseFee({ feeRate, feeValue, time, isCustomFee }: OnChooseFeeArgs): Promise<void>;
-  onSetSelectedFeeType(value: BtcFeeType | null): void;
-  onValidateBitcoinSpend(value: number): boolean;
-  recipients: RpcSendTransferRecipient[];
-  setCustomFeeInitialValue: Dispatch<SetStateAction<string>>;
-  maxCustomFeeRate: number;
-}
-
-export function BitcoinCustomFeeMultipleRecipients({
-  amount,
-  customFeeInitialValue,
-  hasInsufficientBalanceError,
-  isSendingMax,
-  onChooseFee,
-  onSetSelectedFeeType,
-  onValidateBitcoinSpend,
-  recipients,
-  setCustomFeeInitialValue,
-  maxCustomFeeRate,
-}: BitcoinCustomFeeMultipleRecipientsProps) {
-  const feeInputRef = useRef<HTMLInputElement | null>(null);
-  const getCustomFeeValues = useBitcoinCustomFeeMultipleRecipients({
     amount: createMoney(amount, 'BTC'),
     isSendingMax,
     recipients,
@@ -208,7 +96,7 @@ export function BitcoinCustomFeeMultipleRecipients({
                   View fee calculator
                 </Link>
               </styled.span>
-              <BitcoinCustomFeeInputMultipleRecipients
+              <BitcoinCustomFeeInput
                 amount={amount}
                 isSendingMax={isSendingMax}
                 onClick={async () => {

--- a/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list-multiple-recipients.ts
+++ b/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list-multiple-recipients.ts
@@ -1,15 +1,15 @@
 import { useMemo } from 'react';
 
 import { BtcFeeType, btcTxTimeMap } from '@shared/models/fees/bitcoin-fees.model';
+import type { TransferRecipient } from '@shared/models/form.model';
 import { Money, createMoney } from '@shared/models/money.model';
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
 
 import { baseCurrencyAmountInQuote } from '@app/common/money/calculate-money';
 import { formatMoneyPadded, i18nFormatCurrency } from '@app/common/money/format-money';
 import {
-  type DetermineUtxosForSpendArgsMultipleRecipients,
-  determineUtxosForSpendAllMultipleRecipients,
-  determineUtxosForSpendMultipleRecipients,
+  type DetermineUtxosForSpendArgs,
+  determineUtxosForSpend,
+  determineUtxosForSpendAll,
 } from '@app/common/transactions/bitcoin/coinselect/local-coin-selection';
 import { UtxoResponseItem } from '@app/query/bitcoin/bitcoin-client';
 import { useAverageBitcoinFeeRates } from '@app/query/bitcoin/fees/fee-estimates.hooks';
@@ -18,13 +18,13 @@ import { useCryptoCurrencyMarketDataMeanAverage } from '@app/query/common/market
 import { FeesListItem } from './bitcoin-fees-list';
 
 function getFeeForList(
-  determineUtxosForFeeArgs: DetermineUtxosForSpendArgsMultipleRecipients,
+  determineUtxosForFeeArgs: DetermineUtxosForSpendArgs,
   isSendingMax?: boolean
 ) {
   try {
     const { fee } = isSendingMax
-      ? determineUtxosForSpendAllMultipleRecipients(determineUtxosForFeeArgs)
-      : determineUtxosForSpendMultipleRecipients(determineUtxosForFeeArgs);
+      ? determineUtxosForSpendAll(determineUtxosForFeeArgs)
+      : determineUtxosForSpend(determineUtxosForFeeArgs);
     return fee;
   } catch (error) {
     return null;
@@ -33,14 +33,10 @@ function getFeeForList(
 
 interface UseBitcoinFeesListArgs {
   amount: Money;
-  recipients: RpcSendTransferRecipient[];
+  recipients: TransferRecipient[];
   utxos: UtxoResponseItem[];
 }
-export function useBitcoinFeesListMultipleRecipients({
-  amount,
-  recipients,
-  utxos,
-}: UseBitcoinFeesListArgs) {
+export function useBitcoinFeesList({ amount, recipients, utxos }: UseBitcoinFeesListArgs) {
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
   const { data: feeRates, isLoading } = useAverageBitcoinFeeRates();
 

--- a/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list.ts
+++ b/src/app/components/bitcoin-fees-list/use-bitcoin-fees-list.ts
@@ -56,11 +56,8 @@ export function useBitcoinFeesList({
 
     if (!feeRates || !utxos.length) return [];
 
-    const satAmount = isSendingMax ? balance.amount.toNumber() : amount.amount.toNumber();
-
     const determineUtxosDefaultArgs = {
-      amount: satAmount,
-      recipient,
+      recipients: [{ address: recipient, amount: isSendingMax ? balance : amount }],
       utxos,
     };
 
@@ -119,7 +116,7 @@ export function useBitcoinFeesList({
     }
 
     return feesArr;
-  }, [feeRates, utxos, isSendingMax, balance.amount, amount.amount, recipient, btcMarketData]);
+  }, [feeRates, utxos, isSendingMax, balance, amount, recipient, btcMarketData]);
 
   return {
     feesList,

--- a/src/app/features/bitcoin-choose-fee/bitcoin-choose-fee.tsx
+++ b/src/app/features/bitcoin-choose-fee/bitcoin-choose-fee.tsx
@@ -3,14 +3,11 @@ import { useState } from 'react';
 import { Box, FlexProps, Stack, styled } from 'leather-styles/jsx';
 
 import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
+import type { TransferRecipient } from '@shared/models/form.model';
 import { Money } from '@shared/models/money.model';
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
 
 import { formatMoney } from '@app/common/money/format-money';
-import {
-  BitcoinCustomFee,
-  BitcoinCustomFeeMultipleRecipients,
-} from '@app/components/bitcoin-custom-fee/bitcoin-custom-fee';
+import { BitcoinCustomFee } from '@app/components/bitcoin-custom-fee/bitcoin-custom-fee';
 import { MAX_FEE_RATE_MULTIPLIER } from '@app/components/bitcoin-custom-fee/hooks/use-bitcoin-custom-fee';
 import { OnChooseFeeArgs } from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
 import { useNativeSegwitBalance } from '@app/query/bitcoin/balance/btc-native-segwit-balance.hooks';
@@ -31,7 +28,7 @@ interface BitcoinChooseFeeProps extends FlexProps {
   onChooseFee({ feeRate, feeValue, time }: OnChooseFeeArgs): Promise<void>;
   onSetSelectedFeeType(value: BtcFeeType | null): void;
   onValidateBitcoinSpend(value: number): boolean;
-  recipient: string;
+  recipients: TransferRecipient[];
   recommendedFeeRate: string;
   showError: boolean;
   maxRecommendedFeeRate?: number;
@@ -45,7 +42,7 @@ export function BitcoinChooseFee({
   onChooseFee,
   onSetSelectedFeeType,
   onValidateBitcoinSpend,
-  recipient,
+  recipients,
   recommendedFeeRate,
   showError,
   maxRecommendedFeeRate = 0,
@@ -76,82 +73,6 @@ export function BitcoinChooseFee({
           defaultToCustomFee={defaultToCustomFee}
           customFee={
             <BitcoinCustomFee
-              amount={amount.amount.toNumber()}
-              customFeeInitialValue={customFeeInitialValue}
-              hasInsufficientBalanceError={showError}
-              isSendingMax={isSendingMax}
-              onChooseFee={onChooseFee}
-              onSetSelectedFeeType={onSetSelectedFeeType}
-              onValidateBitcoinSpend={onValidateBitcoinSpend}
-              recipient={recipient}
-              setCustomFeeInitialValue={setCustomFeeInitialValue}
-              maxCustomFeeRate={maxRecommendedFeeRate * MAX_FEE_RATE_MULTIPLIER}
-            />
-          }
-          feesList={feesList}
-        />
-        <Box mt="space.05" width="100%">
-          <AvailableBalance balance={formatMoney(btcBalance.balance)} />
-        </Box>
-      </Stack>
-    </BitcoinChooseFeeLayout>
-  );
-}
-
-interface BitcoinChooseFeeMultipleRecipientsProps extends FlexProps {
-  amount: Money;
-  defaultToCustomFee: boolean;
-  feesList: React.JSX.Element;
-  isLoading: boolean;
-  isSendingMax: boolean;
-  onChooseFee({ feeRate, feeValue, time }: OnChooseFeeArgs): Promise<void>;
-  onSetSelectedFeeType(value: BtcFeeType | null): void;
-  onValidateBitcoinSpend(value: number): boolean;
-  recipients: RpcSendTransferRecipient[];
-  recommendedFeeRate: string;
-  showError: boolean;
-  maxRecommendedFeeRate?: number;
-}
-export function BitcoinChooseFeeMultipleRecipients({
-  amount,
-  defaultToCustomFee,
-  feesList,
-  isLoading,
-  isSendingMax,
-  onChooseFee,
-  onSetSelectedFeeType,
-  onValidateBitcoinSpend,
-  recipients,
-  recommendedFeeRate,
-  showError,
-  maxRecommendedFeeRate = 0,
-  ...rest
-}: BitcoinChooseFeeMultipleRecipientsProps) {
-  const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
-  const { btcBalance } = useNativeSegwitBalance(nativeSegwitSigner.address);
-  const hasAmount = amount.amount.isGreaterThan(0);
-  const [customFeeInitialValue, setCustomFeeInitialValue] = useState(recommendedFeeRate);
-
-  return (
-    <BitcoinChooseFeeLayout isLoading={isLoading} {...rest}>
-      <Stack alignItems="center" width="100%">
-        {hasAmount && (
-          <styled.h3
-            textStyle="heading.03"
-            color={showError ? 'red.action-primary-default' : 'unset'}
-          >
-            {formatMoney(amount)}
-          </styled.h3>
-        )}
-        {showError ? (
-          <InsufficientBalanceError pb={hasAmount ? '0px' : '16px'} />
-        ) : (
-          <ChooseFeeSubtitle isSendingMax={isSendingMax} />
-        )}
-        <ChooseFeeTabs
-          defaultToCustomFee={defaultToCustomFee}
-          customFee={
-            <BitcoinCustomFeeMultipleRecipients
               amount={amount.amount.toNumber()}
               customFeeInitialValue={customFeeInitialValue}
               hasInsufficientBalanceError={showError}

--- a/src/app/features/dialogs/increase-fee-dialog/increase-btc-fee-dialog.tsx
+++ b/src/app/features/dialogs/increase-fee-dialog/increase-btc-fee-dialog.tsx
@@ -4,6 +4,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { Formik } from 'formik';
 import { Flex, Stack } from 'leather-styles/jsx';
 
+import { createMoney } from '@shared/models/money.model';
 import { BitcoinTx } from '@shared/models/transactions/bitcoin-transaction.model';
 import { RouteUrls } from '@shared/route-urls';
 
@@ -38,6 +39,13 @@ export function IncreaseBtcFeeDialog() {
     useBtcIncreaseFee(btcTx);
 
   const balance = formatMoney(btcAvailableAssetBalance.balance);
+
+  const recipients = [
+    {
+      address: recipient,
+      amount: createMoney(btcToSat(getBitcoinTxValue(currentBitcoinAddress, btcTx)), 'BTC'),
+    },
+  ];
 
   const onClose = () => {
     navigate(RouteUrls.Home);
@@ -90,7 +98,7 @@ export function IncreaseBtcFeeDialog() {
                           btcToSat(getBitcoinTxValue(currentBitcoinAddress, btcTx)).toNumber()
                         )}
                         isSendingMax={false}
-                        recipient={recipient}
+                        recipients={recipients}
                         hasInsufficientBalanceError={false}
                         customFeeInitialValue={initialFeeRate}
                       />

--- a/src/app/pages/rpc-send-transfer/components/send-transfer-details.tsx
+++ b/src/app/pages/rpc-send-transfer/components/send-transfer-details.tsx
@@ -1,12 +1,12 @@
 import { HStack, Stack, styled } from 'leather-styles/jsx';
 
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
+import type { TransferRecipient } from '@shared/models/form.model';
 
 import { formatMoney } from '@app/common/money/format-money';
 import { truncateMiddle } from '@app/ui/utils/truncate-middle';
 
 interface SendTransferDetailsProps {
-  recipients: RpcSendTransferRecipient[];
+  recipients: TransferRecipient[];
   currentAddress: string;
 }
 

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-choose-fee.tsx
@@ -2,18 +2,18 @@ import { Outlet, useNavigate } from 'react-router-dom';
 
 import { logger } from '@shared/logger';
 import { BtcFeeType } from '@shared/models/fees/bitcoin-fees.model';
+import type { TransferRecipient } from '@shared/models/form.model';
 import type { Money } from '@shared/models/money.model';
 import { RouteUrls } from '@shared/route-urls';
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
 
 import { useLocationStateWithCache } from '@app/common/hooks/use-location-state';
-import { useGenerateUnsignedNativeSegwitMultipleRecipientsTx } from '@app/common/transactions/bitcoin/use-generate-bitcoin-tx';
+import { useGenerateUnsignedNativeSegwitTx } from '@app/common/transactions/bitcoin/use-generate-bitcoin-tx';
 import {
   BitcoinFeesList,
   OnChooseFeeArgs,
 } from '@app/components/bitcoin-fees-list/bitcoin-fees-list';
-import { useBitcoinFeesListMultipleRecipients } from '@app/components/bitcoin-fees-list/use-bitcoin-fees-list-multiple-recipients';
-import { BitcoinChooseFeeMultipleRecipients } from '@app/features/bitcoin-choose-fee/bitcoin-choose-fee';
+import { useBitcoinFeesList } from '@app/components/bitcoin-fees-list/use-bitcoin-fees-list-multiple-recipients';
+import { BitcoinChooseFee } from '@app/features/bitcoin-choose-fee/bitcoin-choose-fee';
 import { useValidateBitcoinSpend } from '@app/features/bitcoin-choose-fee/hooks/use-validate-bitcoin-spend';
 import { UtxoResponseItem } from '@app/query/bitcoin/bitcoin-client';
 import { useSignBitcoinTx } from '@app/store/accounts/blockchain/bitcoin/bitcoin.hooks';
@@ -23,7 +23,7 @@ import { useRpcSendTransferState } from './rpc-send-transfer-container';
 
 function useRpcSendTransferFeeState() {
   const amountAsMoney = useLocationStateWithCache('amountAsMoney') as Money;
-  const recipients = useLocationStateWithCache('recipients') as RpcSendTransferRecipient[];
+  const recipients = useLocationStateWithCache('recipients') as TransferRecipient[];
   const utxos = useLocationStateWithCache('utxos') as UtxoResponseItem[];
 
   return { amountAsMoney, utxos, recipients };
@@ -35,9 +35,9 @@ export function RpcSendTransferChooseFee() {
 
   const navigate = useNavigate();
 
-  const generateTx = useGenerateUnsignedNativeSegwitMultipleRecipientsTx();
+  const generateTx = useGenerateUnsignedNativeSegwitTx();
   const signTransaction = useSignBitcoinTx();
-  const { feesList, isLoading } = useBitcoinFeesListMultipleRecipients({
+  const { feesList, isLoading } = useBitcoinFeesList({
     amount: amountAsMoney,
     recipients,
     utxos,
@@ -71,7 +71,7 @@ export function RpcSendTransferChooseFee() {
   return (
     <>
       <Outlet />
-      <BitcoinChooseFeeMultipleRecipients
+      <BitcoinChooseFee
         amount={amountAsMoney}
         defaultToCustomFee={!feesList.length}
         feesList={

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-confirmation.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-confirmation.tsx
@@ -6,9 +6,9 @@ import get from 'lodash.get';
 import { decodeBitcoinTx } from '@shared/crypto/bitcoin/bitcoin.utils';
 import { logger } from '@shared/logger';
 import { CryptoCurrencies } from '@shared/models/currencies.model';
+import type { TransferRecipient } from '@shared/models/form.model';
 import { createMoney } from '@shared/models/money.model';
 import { RouteUrls } from '@shared/route-urls';
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
 import { makeRpcSuccessResponse } from '@shared/rpc/rpc-methods';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
@@ -36,7 +36,7 @@ function useRpcSendTransferConfirmationState() {
   const location = useLocation();
   return {
     fee: get(location.state, 'fee') as string,
-    recipients: get(location.state, 'recipients') as RpcSendTransferRecipient[],
+    recipients: get(location.state, 'recipients') as TransferRecipient[],
     time: get(location.state, 'time') as string,
     tx: get(location.state, 'tx') as string,
     feeRowValue: get(location.state, 'feeRowValue') as string,

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-summary.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-summary.tsx
@@ -2,7 +2,7 @@ import { useLocation } from 'react-router-dom';
 
 import { HStack, Stack } from 'leather-styles/jsx';
 
-import type { RpcSendTransferRecipient } from '@shared/rpc/methods/send-transfer';
+import type { TransferRecipient } from '@shared/models/form.model';
 
 import { useAnalytics } from '@app/common/hooks/analytics/use-analytics';
 import { useBitcoinExplorerLink } from '@app/common/hooks/use-bitcoin-explorer-link';
@@ -66,7 +66,7 @@ export function RpcSendTransferSummary() {
         />
         <Stack pb="space.06" width="100%">
           <Stack>
-            {recipients.map((recipient: RpcSendTransferRecipient, index: number) => (
+            {recipients.map((recipient: TransferRecipient, index: number) => (
               <InfoCardRow
                 key={index}
                 title="To"

--- a/src/app/pages/send/ordinal-inscription/hooks/use-generate-ordinal-tx.ts
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-generate-ordinal-tx.ts
@@ -5,6 +5,7 @@ import { extractAddressIndexFromPath } from '@shared/crypto/bitcoin/bitcoin.util
 import { BitcoinInputSigningConfig } from '@shared/crypto/bitcoin/signer-config';
 import { logger } from '@shared/logger';
 import { OrdinalSendFormValues } from '@shared/models/form.model';
+import { createMoney } from '@shared/models/money.model';
 
 import {
   InsufficientFundsError,
@@ -116,9 +117,8 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
     if (!nativeSegwitSigner || !nativeSegwitUtxos || !values.feeRate) return;
 
     const determineUtxosArgs = {
-      amount: 0,
       feeRate,
-      recipient,
+      recipients: [{ address: recipient, amount: createMoney(0, 'BTC') }],
       utxos: nativeSegwitUtxos,
     };
 

--- a/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
@@ -30,6 +30,13 @@ export function SendInscriptionChooseFee() {
   const { reviewTransaction } = useSendInscriptionForm();
   const { showInsufficientBalanceError, onValidateBitcoinFeeSpend } = useValidateBitcoinSpend();
 
+  const recipients = [
+    {
+      address: recipient,
+      amount: createMoney(0, 'BTC'),
+    },
+  ];
+
   async function previewTransaction({ feeRate, feeValue, time, isCustomFee }: OnChooseFeeArgs) {
     try {
       setIsLoadingReview(true);
@@ -73,7 +80,7 @@ export function SendInscriptionChooseFee() {
           onChooseFee={previewTransaction}
           onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
           onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
-          recipient={recipient}
+          recipients={recipients}
           recommendedFeeRate={recommendedFeeRate}
           showError={showInsufficientBalanceError}
           maxRecommendedFeeRate={feesList[0]?.feeRate}

--- a/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-recipient-field.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/bitcoin/components/bitcoin-recipient-field.tsx
@@ -2,6 +2,6 @@ import { fetchBtcNameOwner } from '@app/query/stacks/bns/bns.utils';
 
 import { RecipientField } from '../../../components/recipient-fields/recipient-field';
 
-export function BitcoinRecipientField() {
+export function TransferRecipientField() {
   return <RecipientField bnsLookupFn={fetchBtcNameOwner} />;
 }

--- a/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc-20/brc-20-choose-fee.tsx
@@ -10,7 +10,7 @@ import { createMoney } from '@shared/models/money.model';
 import { RouteUrls } from '@shared/route-urls';
 
 import { formFeeRowValue } from '@app/common/send/utils';
-import { useGenerateUnsignedNativeSegwitSingleRecipientTx } from '@app/common/transactions/bitcoin/use-generate-bitcoin-tx';
+import { useGenerateUnsignedNativeSegwitTx } from '@app/common/transactions/bitcoin/use-generate-bitcoin-tx';
 import {
   BitcoinFeesList,
   OnChooseFeeArgs,
@@ -41,7 +41,7 @@ export function BrcChooseFee() {
   const toast = useToast();
   const navigate = useNavigate();
   const { amount, recipient, ticker, utxos, holderAddress } = useBrc20ChooseFeeState();
-  const generateTx = useGenerateUnsignedNativeSegwitSingleRecipientTx();
+  const generateTx = useGenerateUnsignedNativeSegwitTx();
   const signTx = useSignBitcoinTx();
   const { selectedFeeType, setSelectedFeeType } = useSendBitcoinAssetContextState();
   const { initiateTransfer } = useBrc20Transfers(holderAddress);
@@ -51,6 +51,12 @@ export function BrcChooseFee() {
     recipient,
     utxos,
   });
+  const recipients = [
+    {
+      address: recipient,
+      amount: amountAsMoney,
+    },
+  ];
   const recommendedFeeRate = feesList[1]?.feeRate.toString() || '';
 
   const { showInsufficientBalanceError, onValidateBitcoinFeeSpend } =
@@ -74,7 +80,12 @@ export function BrcChooseFee() {
       const resp = await generateTx(
         {
           amount: serviceFeeAsMoney,
-          recipient: serviceFeeRecipient,
+          recipients: [
+            {
+              address: serviceFeeRecipient,
+              amount: serviceFeeAsMoney,
+            },
+          ],
         },
         feeRate,
         utxos
@@ -143,7 +154,7 @@ export function BrcChooseFee() {
         onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
         onValidateBitcoinSpend={onValidateBitcoinFeeSpend}
         recommendedFeeRate={recommendedFeeRate}
-        recipient={recipient}
+        recipients={recipients}
         showError={showInsufficientBalanceError}
         maxRecommendedFeeRate={feesList[0]?.feeRate}
       />

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-choose-fee.tsx
@@ -31,6 +31,14 @@ export function BtcChooseFee() {
     recipient: txValues.recipient,
     utxos,
   });
+
+  const recipients = [
+    {
+      address: txValues.recipient,
+      amount: amountAsMoney,
+    },
+  ];
+
   const recommendedFeeRate = feesList[1]?.feeRate.toString() || '';
 
   const { showInsufficientBalanceError, onValidateBitcoinAmountSpend } = useValidateBitcoinSpend(
@@ -58,7 +66,7 @@ export function BtcChooseFee() {
         onChooseFee={previewTransaction}
         onValidateBitcoinSpend={onValidateBitcoinAmountSpend}
         onSetSelectedFeeType={(value: BtcFeeType | null) => setSelectedFeeType(value)}
-        recipient={txValues.recipient}
+        recipients={recipients}
         recommendedFeeRate={recommendedFeeRate}
         showError={showInsufficientBalanceError}
         maxRecommendedFeeRate={feesList[0]?.feeRate}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form.tsx
@@ -24,7 +24,7 @@ import { CardContent } from '@app/ui/layout/card/card-content';
 import { AmountField } from '../../components/amount-field';
 import { SelectedAssetField } from '../../components/selected-asset-field';
 import { SendFiatValue } from '../../components/send-fiat-value';
-import { BitcoinRecipientField } from '../../family/bitcoin/components/bitcoin-recipient-field';
+import { TransferRecipientField } from '../../family/bitcoin/components/bitcoin-recipient-field';
 import { BitcoinSendMaxButton } from '../../family/bitcoin/components/bitcoin-send-max-button';
 import { useSendFormRouteState } from '../../hooks/use-send-form-route-state';
 import { createDefaultInitialFormValues, defaultSendFormFormikProps } from '../../send-form.utils';
@@ -108,7 +108,7 @@ export function BtcSendForm() {
                     name={btcBalance.asset.name}
                     symbol={symbol}
                   />
-                  <BitcoinRecipientField />
+                  <TransferRecipientField />
                   {currentNetwork.chain.bitcoin.bitcoinNetwork === 'testnet' && (
                     <Callout variant="warning" title="Funds have no value" mt="space.04">
                       This is a Bitcoin testnet transaction.

--- a/src/shared/models/form.model.ts
+++ b/src/shared/models/form.model.ts
@@ -1,4 +1,5 @@
 import { SupportedInscription } from './inscription.model';
+import type { Money } from './money.model';
 
 export interface BitcoinSendFormValues {
   amount: number | string;
@@ -36,4 +37,9 @@ export interface StacksTransactionFormValues {
   feeCurrency: string;
   feeType: string;
   nonce?: number | string;
+}
+
+export interface TransferRecipient {
+  address: string;
+  amount: Money;
 }

--- a/src/shared/rpc/methods/send-transfer.ts
+++ b/src/shared/rpc/methods/send-transfer.ts
@@ -8,7 +8,6 @@ import {
   btcAddressNetworkValidator,
   btcAddressValidator,
 } from '@shared/forms/bitcoin-address-validators';
-import type { Money } from '@shared/models/money.model';
 
 import {
   accountSchema,
@@ -60,19 +59,14 @@ export interface RpcSendTransferParamsLegacy extends SendTransferRequestParams {
   network: string;
 }
 
-export interface RpcSendTransferRecipient {
-  address: string;
-  amount: Money;
-}
-
-interface RpcSendTransferRecipientParam {
+interface TransferRecipientParam {
   address: string;
   amount: string;
 }
 
 export interface RpcSendTransferParams {
   account?: number;
-  recipients: RpcSendTransferRecipientParam[];
+  recipients: TransferRecipientParam[];
   network: string;
 }
 

--- a/test-app/src/components/bitcoin.tsx
+++ b/test-app/src/components/bitcoin.tsx
@@ -439,6 +439,60 @@ export const Bitcoin = () => {
           (window as any).LeatherProvider?.request('sendTransfer', {
             recipients: [
               {
+                address: 'bc1qps90ws94pvk548y9jg03gn5lwjqnyud4lg6y56',
+                amount: '800',
+              },
+              {
+                address: 'bc1qps90ws94pvk548y9jg03gn5lwjqnyud4lg6y56',
+                amount: '10000',
+              },
+            ],
+            network: 'mainnet',
+          })
+            .then((resp: any) => {
+              console.log({ sucesss: resp });
+            })
+            .catch((error: Error) => {
+              console.log({ error });
+            });
+        }}
+      >
+        Send native segwit transfer to multiple addresses
+      </styled.button>
+      <styled.button
+        mt={3}
+        onClick={() => {
+          console.log('requesting');
+          (window as any).LeatherProvider?.request('sendTransfer', {
+            recipients: [
+              {
+                address: 'bc1p8nyc4sl8agqfjs2rq4yer6wnhd89naw05s0ha8hpmg8j36ht6yvswqyaxm',
+                amount: '800',
+              },
+              {
+                address: 'bc1p8nyc4sl8agqfjs2rq4yer6wnhd89naw05s0ha8hpmg8j36ht6yvswqyaxm',
+                amount: '10000',
+              },
+            ],
+            network: 'mainnet',
+          })
+            .then((resp: any) => {
+              console.log({ sucesss: resp });
+            })
+            .catch((error: Error) => {
+              console.log({ error });
+            });
+        }}
+      >
+        Send taproot transfer to multiple addresses
+      </styled.button>
+      <styled.button
+        mt={3}
+        onClick={() => {
+          console.log('requesting');
+          (window as any).LeatherProvider?.request('sendTransfer', {
+            recipients: [
+              {
                 address: TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
                 amount: '10000',
               },

--- a/tests/specs/rpc-get-addresses/get-addresses.spec.ts
+++ b/tests/specs/rpc-get-addresses/get-addresses.spec.ts
@@ -58,7 +58,7 @@ async function interceptRequestPopup(context: BrowserContext) {
 }
 
 async function initiateGetAddresses(page: Page) {
-  return page.evaluate(async () => window.LeatherProvider?.request('getAddresses'));
+  return page.evaluate(async () => (window as any).LeatherProvider?.request('getAddresses'));
 }
 
 async function clickConnectLeatherButton(popup: Page) {


### PR DESCRIPTION
> Try out Leather build a89dbca — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8925771572), [Test report](https://leather-wallet.github.io/playwright-reports/refactor/multiple-recipients), [Storybook](https://refactor-multiple-recipients--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/multiple-recipients)<!-- Sticky Header Marker -->

This pr refactors bitcoin send flows to accept multiple recipients, like it is in rpc send transfer flow