### PR TITLE
chore: prevent runtime error from lottie

### DIFF
--- a/src/app/features/ledger/animations/plugging-in-cable.lottie.tsx
+++ b/src/app/features/ledger/animations/plugging-in-cable.lottie.tsx
@@ -25,8 +25,8 @@ export default function PluggingInLedgerCableAnimation(props: BoxProps) {
 
   return (
     <Box height="200px" overflow="hidden" position="relative" width="100%" {...props}>
-      <Box position="absolute" left={0} right={0}>
-        <Lottie options={options} width={380} style={invertStyle} />
+      <Box position="absolute" left={0} right={0} style={invertStyle}>
+        <Lottie options={options} width={380} />
       </Box>
     </Box>
   );


### PR DESCRIPTION
> Try out Leather build 2451914 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8850033355), [Test report](https://leather-wallet.github.io/playwright-reports/fix/ledger-lottie-error), [Storybook](https://fix-ledger-lottie-error--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/ledger-lottie-error)<!-- Sticky Header Marker -->

This PR moves the Lottie style props to stop us always getting a run time error:
![Screenshot 2024-04-26 at 15 16 43](https://github.com/leather-wallet/extension/assets/2938440/cfbf61fa-0025-4177-a621-235c0621d41e)

```
Warning: Failed prop type: Invalid prop `style` of type `object` supplied to `Lottie`, expected `string`.
    at Lottie (chrome-extension://dbbkfepagfalpohacffnpaodaklhamif/src_app_features_ledger_animations_plugging-in-cable_lottie_tsx.chunk.js:22107:34)
    at PluggingInLedgerCableAnimation (
```