### PR TITLE
fix: colors.focus warning

### DIFF
--- a/theme/recipes/button-recipe.ts
+++ b/theme/recipes/button-recipe.ts
@@ -58,7 +58,7 @@ export const buttonRecipe = defineRecipe({
         },
         _focus: {
           _before: {
-            border: '3px solid {colors.focus}',
+            border: '3px solid {colors.blue.border}',
           },
         },
         _hover: {
@@ -81,7 +81,7 @@ export const buttonRecipe = defineRecipe({
         },
         _focus: {
           _before: {
-            border: '3px solid {colors.focus}',
+            border: '3px solid {colors.blue.border}',
           },
         },
         _hover: {
@@ -102,7 +102,7 @@ export const buttonRecipe = defineRecipe({
         },
         _focus: {
           _before: {
-            border: '3px solid {focus}',
+            border: '3px solid {colors.blue.border}',
           },
         },
         _hover: {


### PR DESCRIPTION
> Try out Leather build bfa0dfc — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8901533563), [Test report](https://leather-wallet.github.io/playwright-reports/fix/colors-focus), [Storybook](https://fix-colors-focus--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/colors-focus)<!-- Sticky Header Marker -->

Quick fix to update a missed change from mono repo.