### PR TITLE
fix: disable swap test

### DIFF
--- a/tests/specs/swap/swap.spec.ts
+++ b/tests/specs/swap/swap.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../../fixtures/fixtures';
 
-const hiroApiPostRoute = 'https://api.hiro.so/v2/transactions';
+const hiroApiPostRoute = '*/**/v2/transactions';
 
 test.describe('Swaps', () => {
   test.beforeEach(async ({ extensionId, globalPage, homePage, onboardingPage, swapPage }) => {
@@ -14,16 +14,10 @@ test.describe('Swaps', () => {
     test.expect(swapPage.page.getByText('STX')).toBeTruthy();
   });
 
-  test('that it shows swap review details and broadcasts swap', async ({ swapPage }) => {
-    const requestPromise = swapPage.page.waitForRequest(hiroApiPostRoute);
-
-    await swapPage.page.route(hiroApiPostRoute, async route => {
-      await route.abort();
-    });
-
+  test('that it shows swap review details correctly', async ({ swapPage }) => {
     await swapPage.inputSwapAmountBase();
     await swapPage.selectAssetToReceive();
-    await swapPage.swapReviewBtn.click({ delay: 1000, force: true });
+    await swapPage.swapReviewBtn.click({ delay: 2000 });
 
     const swapProtocol = await swapPage.swapDetailsProtocol.innerText();
     test.expect(swapProtocol).toEqual('ALEX');
@@ -37,7 +31,23 @@ test.describe('Swaps', () => {
     const swapAmounts = await swapPage.swapDetailsAmount.all();
     const swapAmountBase = await swapAmounts[0].innerText();
     test.expect(swapAmountBase).toEqual('1');
+  });
 
+  // This test isn't working bc there are multiple requests being made
+  // to the same endpoint. We need to know why this happening before
+  // enabling it again bc swaps keep occurring which create insufficient
+  // balance errors in our integration tests.
+  test.skip('that the swap is broadcast', async ({ swapPage }) => {
+    const requestPromise = swapPage.page.waitForRequest(hiroApiPostRoute);
+
+    await swapPage.page.route(hiroApiPostRoute, async route => {
+      await route.abort();
+    });
+
+    await swapPage.inputSwapAmountBase();
+    await swapPage.selectAssetToReceive();
+
+    await swapPage.swapReviewBtn.click({ delay: 2000 });
     await swapPage.swapSubmitBtn.click();
 
     const request = await requestPromise;


### PR DESCRIPTION
> Try out Leather build eaf3542 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8903849486), [Test report](https://leather-wallet.github.io/playwright-reports/fix/skip-swap-test), [Storybook](https://fix-skip-swap-test--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/skip-swap-test)<!-- Sticky Header Marker -->

The swaps broadcast test is submitting swaps bc there are multiple requests to the same endpoint when we try to intercept it. I have been trying look at how we can catch multiple requests, but I'm not confident yet on how to do this so I'm skipping the test for now to avoid more funds being swapped unexpectedly in our test wallet. I'm not sure what has triggered this to surface as an issue.