### PR TITLE
fix: estimate higher tx size for inscription sends

### DIFF
--- a/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.spec.ts
+++ b/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.spec.ts
@@ -37,7 +37,7 @@ describe(selectTaprootInscriptionTransferCoins.name, () => {
         Number(inscriptionInputAmount)
     );
 
-    expect(result.txFee).toEqual(5048);
+    expect(result.txFee).toEqual(6608);
   });
 
   test('when there are not enough utxo to cover fee', () => {

--- a/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.ts
+++ b/src/app/pages/send/ordinal-inscription/coinselect/select-inscription-coins.ts
@@ -37,10 +37,11 @@ export function selectTaprootInscriptionTransferCoins(
   const txSizer = new BtcSizeFeeEstimator();
 
   const initialTxSize = txSizer.calcTxSize({
-    input_script: 'p2tr',
+    input_script: 'p2wpkh',
     input_count: 1,
     // From the address of the recipient, we infer the output type
     p2tr_output_count: 1,
+    p2wpkh_output_count: 1,
   });
 
   const neededInputs: UtxoResponseItem[] = [];
@@ -65,9 +66,10 @@ export function selectTaprootInscriptionTransferCoins(
     if (nextUtxo) neededInputs.push(nextUtxo);
     utxos = remainingUtxos;
     txSize = txSizer.calcTxSize({
-      input_script: 'p2tr',
+      input_script: 'p2wpkh',
       input_count: neededInputs.length + 1,
       p2tr_output_count: 1,
+      p2wpkh_output_count: 1,
     });
     indexCounter.increment();
   }

--- a/src/app/pages/send/ordinal-inscription/hooks/use-generate-ordinal-tx.ts
+++ b/src/app/pages/send/ordinal-inscription/hooks/use-generate-ordinal-tx.ts
@@ -104,7 +104,7 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
       if (e instanceof InsufficientFundsError) {
         throw new InsufficientFundsError();
       }
-      logger.error('Unable to sign transaction');
+      logger.error('Unable to sign transaction', e);
       return null;
     }
   }
@@ -159,7 +159,7 @@ export function useGenerateUnsignedOrdinalTx(inscriptionInput: UtxoWithDerivatio
       if (e instanceof InsufficientFundsError) {
         throw new InsufficientFundsError();
       }
-      logger.error('Unable to sign transaction');
+      logger.error('Unable to sign transaction', e);
       return null;
     }
   }


### PR DESCRIPTION
> Try out Leather build 6f67778 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8920183656), [Test report](https://leather-wallet.github.io/playwright-reports/fix/inscription-fee-estimation), [Storybook](https://fix-inscription-fee-estimation--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/inscription-fee-estimation)<!-- Sticky Header Marker -->

@alter-eggo noticed that inscription sends were also poorly estimating, and under reporting, fee rates. I'd missed this, not realising the coinselection logic is separate.

This PR increasing the estimation by including the change output, and changing input type to `p2wkph` in the estimation logic. 

Esp for mobile, we'll need a generic coin selection module. Ideally, one that handles more use cases to avoid repetition. It'd be nice to share this logic for all bitcoin spends. [Started making notes in a Notion doc on requirements for this feature.](https://www.notion.so/trustmachines/Coin-selection-1de7a213fd9c4ded9a029bfb59af1366?pvs=4)