### PR TITLE
fix: change default to pulling 10 keys

### DIFF
--- a/src/app/features/ledger/flows/request-bitcoin-keys/request-bitcoin-keys.utils.ts
+++ b/src/app/features/ledger/flows/request-bitcoin-keys/request-bitcoin-keys.utils.ts
@@ -6,6 +6,7 @@ import { getTaprootAccountDerivationPath } from '@shared/crypto/bitcoin/p2tr-add
 import { getNativeSegwitAccountDerivationPath } from '@shared/crypto/bitcoin/p2wpkh-address-gen';
 import { delay } from '@shared/utils';
 
+import { defaultNumberOfKeysToPullFromLedgerDevice } from '../../generic-flows/request-keys/use-request-ledger-keys';
 import {
   WalletPolicyDetails,
   createNativeSegwitDefaultWalletPolicy,
@@ -55,10 +56,13 @@ interface PullBitcoinKeysFromLedgerDeviceArgs {
 }
 export function pullBitcoinKeysFromLedgerDevice(bitcoinApp: BitcoinApp, targetId = '') {
   return async ({ onRequestKey, network }: PullBitcoinKeysFromLedgerDeviceArgs) => {
-    const amountOfKeysToExtractFromDevice = 5;
     const fingerprint = await bitcoinApp.getMasterFingerprint();
     const keys: { id: string; path: string; policy: string; targetId: string }[] = [];
-    for (let accountIndex = 0; accountIndex < amountOfKeysToExtractFromDevice; accountIndex++) {
+    for (
+      let accountIndex = 0;
+      accountIndex < defaultNumberOfKeysToPullFromLedgerDevice;
+      accountIndex++
+    ) {
       onRequestKey?.(accountIndex);
       const { path, policy } = await getNativeSegwitExtendedPublicKey({
         bitcoinApp,
@@ -68,7 +72,11 @@ export function pullBitcoinKeysFromLedgerDevice(bitcoinApp: BitcoinApp, targetId
       });
       keys.push({ id: createWalletIdDecoratedPath(path, 'default'), path, policy, targetId });
     }
-    for (let accountIndex = 0; accountIndex < amountOfKeysToExtractFromDevice; accountIndex++) {
+    for (
+      let accountIndex = 0;
+      accountIndex < defaultNumberOfKeysToPullFromLedgerDevice;
+      accountIndex++
+    ) {
       onRequestKey?.(accountIndex + 5);
       const { path, policy } = await getTaprootExtendedPublicKey({
         bitcoinApp,

--- a/src/app/features/ledger/flows/request-stacks-keys/ledger-request-stacks-keys.tsx
+++ b/src/app/features/ledger/flows/request-stacks-keys/ledger-request-stacks-keys.tsx
@@ -9,7 +9,10 @@ import { defaultWalletKeyId } from '@shared/utils';
 import { ledgerRequestKeysRoutes } from '@app/features/ledger/generic-flows/request-keys/ledger-request-keys-route-generator';
 import { LedgerRequestKeysContext } from '@app/features/ledger/generic-flows/request-keys/ledger-request-keys.context';
 import { RequestKeysFlow } from '@app/features/ledger/generic-flows/request-keys/request-keys-flow';
-import { useRequestLedgerKeys } from '@app/features/ledger/generic-flows/request-keys/use-request-ledger-keys';
+import {
+  defaultNumberOfKeysToPullFromLedgerDevice,
+  useRequestLedgerKeys,
+} from '@app/features/ledger/generic-flows/request-keys/use-request-ledger-keys';
 import { useLedgerNavigate } from '@app/features/ledger/hooks/use-ledger-navigate';
 import {
   connectLedgerStacksApp,
@@ -42,7 +45,9 @@ function LedgerRequestStacksKeys() {
       async pullKeysFromDevice(app) {
         const resp = await pullStacksKeysFromLedgerDevice(app)({
           onRequestKey(accountIndex) {
-            ledgerNavigate.toDeviceBusyStep(`Requesting STX addresses (${accountIndex + 1}…5)`);
+            ledgerNavigate.toDeviceBusyStep(
+              `Requesting STX addresses (${accountIndex + 1}…${defaultNumberOfKeysToPullFromLedgerDevice})`
+            );
           },
         });
         if (resp.status === 'failure') {

--- a/src/app/features/ledger/flows/request-stacks-keys/request-stacks-keys.utils.ts
+++ b/src/app/features/ledger/flows/request-stacks-keys/request-stacks-keys.utils.ts
@@ -8,6 +8,7 @@ import {
 } from '@shared/crypto/stacks/stacks.utils';
 import { delay } from '@shared/utils';
 
+import { defaultNumberOfKeysToPullFromLedgerDevice } from '../../generic-flows/request-keys/use-request-ledger-keys';
 import {
   StacksAppKeysResponseItem,
   requestPublicKeyForStxAccount,
@@ -45,8 +46,8 @@ export function pullStacksKeysFromLedgerDevice(stacksApp: StacksApp) {
     onRequestKey,
   }: PullStacksKeysFromLedgerDeviceArgs): PullStacksKeysFromLedgerResponse => {
     const publicKeys = [];
-    const amountOfKeysToExtractFromDevice = 5;
-    for (let index = 0; index < amountOfKeysToExtractFromDevice; index++) {
+
+    for (let index = 0; index < defaultNumberOfKeysToPullFromLedgerDevice; index++) {
       if (onRequestKey) onRequestKey(index);
       const stxPublicKeyResp = await requestPublicKeyForStxAccount(stacksApp)(index);
       const dataPublicKeyResp = await requestPublicKeyForIdentityAccount(stacksApp)(index);

--- a/src/app/features/ledger/generic-flows/request-keys/use-request-ledger-keys.ts
+++ b/src/app/features/ledger/generic-flows/request-keys/use-request-ledger-keys.ts
@@ -16,6 +16,8 @@ import {
 } from '../../utils/generic-ledger-utils';
 import { StacksAppVersion } from '../../utils/stacks-ledger-utils';
 
+export const defaultNumberOfKeysToPullFromLedgerDevice = 10;
+
 interface UseRequestLedgerKeysArgs<App extends BitcoinApp | StacksApp> {
   chain: SupportedBlockchains;
   isAppOpen({ name }: { name: string }): boolean;


### PR DESCRIPTION
> Try out Leather build 2ea9f14 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8959315675), [Test report](https://leather-wallet.github.io/playwright-reports/fix/default-10-keys), [Storybook](https://fix-default-10-keys--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/default-10-keys)<!-- Sticky Header Marker -->

Changes default to pulling 10 STX or BTC keys.