### PR TITLE
fix: src-20 tokens map

### DIFF
--- a/src/app/query/bitcoin/stamps/stamps-by-address.hooks.ts
+++ b/src/app/query/bitcoin/stamps/stamps-by-address.hooks.ts
@@ -1,17 +1,21 @@
+import { ensureArray, isUndefined } from '@shared/utils';
+
 import { useStampsByAddressQuery } from './stamps-by-address.query';
 
 export function useStampsByAddress(address: string) {
   return useStampsByAddressQuery(address, {
-    select(data) {
-      return data.data?.stamps;
+    select(resp) {
+      if (isUndefined(resp.data)) return [];
+      return ensureArray(resp.data.stamps);
     },
   });
 }
 
 export function useSrc20TokensByAddress(address: string) {
   return useStampsByAddressQuery(address, {
-    select(data) {
-      return data.data?.src20;
+    select(resp) {
+      if (isUndefined(resp.data)) return [];
+      return ensureArray(resp.data.src20);
     },
   });
 }


### PR DESCRIPTION
> Try out Leather build a8278c8 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/8977998492), [Test report](https://leather-wallet.github.io/playwright-reports/fix/src-20-asset-list), [Storybook](https://fix-src-20-asset-list--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/src-20-asset-list)<!-- Sticky Header Marker -->

Put up this quick fix bc the SRC-20 balance endpoint started returning an object instead of an array. Their team made a fix on their end, but we can merge this ...or do something better ...if we want to make sure it doesn't happen again for our users.

EDIT: I added the same fix for their stamps array just in case.