### PR TITLE
fix: show correct amount for nonWitnessUtxo, ref #5113

### DIFF
--- a/src/app/features/ledger/flows/bitcoin-tx-signing/steps/approve-bitcoin-sign-ledger-tx.tsx
+++ b/src/app/features/ledger/flows/bitcoin-tx-signing/steps/approve-bitcoin-sign-ledger-tx.tsx
@@ -24,7 +24,7 @@ export function ApproveSignLedgerBitcoinTx() {
         [
           ...getPsbtTxInputs(context.transaction as unknown as btc.Transaction).map((input, i) => [
             `Input ${i + 1}`,
-            input.index && `${getBitcoinInputValue(input.index, input)} sats`,
+            `${getBitcoinInputValue(input)} sats`,
           ]),
           ...getPsbtTxOutputs(context.transaction as unknown as btc.Transaction).map(
             (output, i) => [`Output ${i + 1}`, output.amount?.toString() + ' sats']

--- a/src/app/features/ledger/flows/bitcoin-tx-signing/steps/approve-bitcoin-sign-ledger-tx.tsx
+++ b/src/app/features/ledger/flows/bitcoin-tx-signing/steps/approve-bitcoin-sign-ledger-tx.tsx
@@ -1,6 +1,10 @@
 import * as btc from '@scure/btc-signer';
 
-import { getPsbtTxInputs, getPsbtTxOutputs } from '@shared/crypto/bitcoin/bitcoin.utils';
+import {
+  getBitcoinInputValue,
+  getPsbtTxInputs,
+  getPsbtTxOutputs,
+} from '@shared/crypto/bitcoin/bitcoin.utils';
 
 import { useLedgerTxSigningContext } from '@app/features/ledger/generic-flows/tx-signing/ledger-sign-tx.context';
 import { ApproveLedgerOperationLayout } from '@app/features/ledger/generic-steps/approve-ledger-operation/approve-ledger-operation.layout';
@@ -20,7 +24,7 @@ export function ApproveSignLedgerBitcoinTx() {
         [
           ...getPsbtTxInputs(context.transaction as unknown as btc.Transaction).map((input, i) => [
             `Input ${i + 1}`,
-            input.witnessUtxo?.amount?.toString() + ' sats',
+            input.index && `${getBitcoinInputValue(input.index, input)} sats`,
           ]),
           ...getPsbtTxOutputs(context.transaction as unknown as btc.Transaction).map(
             (output, i) => [`Output ${i + 1}`, output.amount?.toString() + ' sats']

--- a/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -15,7 +15,7 @@ import {
   getNativeSegwitAccountDerivationPath,
 } from '@shared/crypto/bitcoin/p2wpkh-address-gen';
 import { BitcoinInputSigningConfig } from '@shared/crypto/bitcoin/signer-config';
-import { isDefined, reverseBytes } from '@shared/utils';
+import { reverseBytes } from '@shared/utils';
 import { analytics } from '@shared/utils/analytics';
 
 import { mnemonicToRootNode } from '@app/common/keychain/keychain';
@@ -150,8 +150,8 @@ export function useUpdateLedgerSpecificNativeSegwitUtxoHexForAdddressIndexZero()
     );
 
     inputSigningConfig.forEach(({ index }) => {
-      // don't update nonWitnessUtxo if it already exists
-      if (tx.data.inputs.every(input => !isDefined(input.nonWitnessUtxo))) {
+      // decorate input with nonWitnessUtxo unless it already exists
+      if (!tx.data.inputs[index].nonWitnessUtxo) {
         tx.updateInput(index, {
           nonWitnessUtxo: Buffer.from(inputsTxHex[index], 'hex'),
         });


### PR DESCRIPTION
> Try out Leather build 2abad35 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9074501549), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5113/ledger-nano-x-dlc), [Storybook](https://fix-5113-ledger-nano-x-dlc--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5113/ledger-nano-x-dlc)<!-- Sticky Header Marker -->

This PR ensures we display the amount correctly when trying to sign `nonWitnessUtxo`s with ledger. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Bitcoin transaction signing process for enhanced reliability and accuracy.

- **Bug Fixes**
  - Added conditional checks to prevent unnecessary updates to transaction data, ensuring data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->