### PR TITLE
refactor: input calc helper methods

### DIFF
--- a/src/app/features/psbt-signer/hooks/use-parsed-inputs.tsx
+++ b/src/app/features/psbt-signer/hooks/use-parsed-inputs.tsx
@@ -41,7 +41,7 @@ export function useParsedInputs({ inputs, indexesToSign }: UseParsedInputsArgs) 
     () =>
       inputs.map((input, i) => {
         const inputAddress = isDefined(input.index)
-          ? getBitcoinInputAddress(input.index, input, bitcoinNetwork)
+          ? getBitcoinInputAddress(input, bitcoinNetwork)
           : '';
         const isCurrentAddress =
           inputAddress === bitcoinAddressNativeSegwit || inputAddress === bitcoinAddressTaproot;
@@ -60,7 +60,7 @@ export function useParsedInputs({ inputs, indexesToSign }: UseParsedInputsArgs) 
           isMutable: canChange,
           toSign: toSignAll || toSignIndex,
           txid: input.txid ? bytesToHex(input.txid) : '',
-          value: isDefined(input.index) ? getBitcoinInputValue(input.index, input) : 0,
+          value: isDefined(input.index) ? getBitcoinInputValue(input) : 0,
         };
       }),
     [

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
@@ -136,7 +136,6 @@ export function useSignLedgerBitcoinTx() {
       return [
         config,
         getInputPaymentType(
-          inputIndex,
           btcSignerPsbtClone.getInput(config.index),
           network.chain.bitcoin.bitcoinNetwork
         ),

--- a/src/shared/crypto/bitcoin/signer-config.ts
+++ b/src/shared/crypto/bitcoin/signer-config.ts
@@ -33,7 +33,7 @@ export function getAssumedZeroIndexSigningConfig({
         const input = tx.getInput(inputIndex);
 
         if (isUndefined(input.index)) throw new Error('Input must have an index for payment type');
-        const paymentType = getInputPaymentType(input.index, input, network);
+        const paymentType = getInputPaymentType(input, network);
 
         switch (paymentType) {
           case 'p2wpkh':


### PR DESCRIPTION
> Try out Leather build 28b8d41 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9062381770), [Test report](https://leather-wallet.github.io/playwright-reports/refactor/input-calc-fns), [Storybook](https://refactor-input-calc-fns--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/input-calc-fns)<!-- Sticky Header Marker -->

Removes a confusing API choice of the helpers to get an input's address or amount being spent. Reads directly from the input. 

Also turns a type literal to singular, cc discussion with @fbwoolf 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced clarity in type naming conventions for payment types in the Bitcoin utilities.
- **Bug Fixes**
	- Simplified the input parsing in the PSBT signer feature by removing an unnecessary parameter.
- **Refactor**
	- Streamlined the signing configuration in the Bitcoin utilities by adjusting the `getAssumedZeroIndexSigningConfig` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->