### PR TITLE
fix: utxos and transactions request cancellation, closes #5058

### DIFF
--- a/src/app/query/bitcoin/runes/runes-outputs-by-address.query.ts
+++ b/src/app/query/bitcoin/runes/runes-outputs-by-address.query.ts
@@ -20,10 +20,11 @@ export function useGetRunesOutputsByAddressQuery<T extends unknown = RunesOutput
   return useQuery({
     enabled: !!address && runesEnabled,
     queryKey: ['runes-outputs-by-address', address],
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       client.bestinSlotApi.getRunesOutputsByAddress({
         address,
         network: network.chain.bitcoin.bitcoinNetwork,
+        signal,
       }),
     ...queryOptions,
     ...options,


### PR DESCRIPTION
> Try out Leather build 38a11cf — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9068571209), [Test report](https://leather-wallet.github.io/playwright-reports/fix/utxos-request), [Storybook](https://fix-utxos-request--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/utxos-request)<!-- Sticky Header Marker -->

This pr fixes request cancellation. example with switch acc dialog:
https://github.com/leather-wallet/extension/assets/46521087/67acb914-2d85-4820-8b3f-2674545d60dd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for cancelable network requests in Bitcoin-related queries by introducing an optional abort signal parameter. This enhancement improves the responsiveness and control users have over network operations within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->