### PR TITLE
fix: server side prototype pollution gadgets to RCE via ejs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8098,7 +8098,7 @@ packages:
       '@types/ejs': 3.1.5
       '@yarnpkg/esbuild-plugin-pnp': 3.0.0-rc.15(esbuild@0.20.2)
       browser-assert: 1.2.1
-      ejs: 3.1.9
+      ejs: 3.1.10
       esbuild: 0.20.2
       esbuild-plugin-alias: 0.2.1
       express: 4.19.2
@@ -9210,7 +9210,7 @@ packages:
     resolution: {integrity: sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==}
     dependencies:
       fast-glob: 3.3.2
-      minimatch: 9.0.3
+      minimatch: 9.0.4
       mkdirp: 3.0.1
       path-browserify: 1.0.1
     dev: true
@@ -13988,8 +13988,8 @@ packages:
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  /ejs@3.1.9:
-    resolution: {integrity: sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==}
+  /ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     dependencies:
@@ -15642,7 +15642,7 @@ packages:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 2.3.6
-      minimatch: 9.0.3
+      minimatch: 9.0.4
       minipass: 7.0.4
       path-scurry: 1.10.1
     dev: true
@@ -15654,7 +15654,7 @@ packages:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 2.3.6
-      minimatch: 9.0.3
+      minimatch: 9.0.4
       minipass: 7.0.4
       path-scurry: 1.10.1
     dev: true


### PR DESCRIPTION
The project `/leather-wallet/extension` was used ejs (aka Embedded JavaScript templates) package before 3.1.10 for Node.js lacks certain pollution protection.

Express framework brings a [view engine](https://expressjs.com/en/guide/using-template-engines.html) system which allows the developer to choose which templating library he wants to use. Thanks to the EJS compliance, it usage is really simple in case of an express application. The only thing that the developer has to do is creating a /views folder with HTML template and call res.render() function.

![ejs_express](https://github.com/leather-wallet/extension/assets/156341162/32189727-4734-48a4-b893-941273fe3a88)

```js
// Setup app
const express = require("express");
const app  = express();
const port = 3000;

// Select ejs templating library
app.set('view engine', 'ejs');

// Routes
app.get("/", (req, res) => {
    res.render("index");
})

// Start app
app.listen(port, () => {
    console.log(`App listening on port ${port}`)
})
```
Now that we know that it is possible to control the prototype of the config object, it allows to go further in the exploitation. In order to prepare the templating, EJS compile a [function](https://github.com/mde/ejs/blob/f818bce2a5b72866f205c9284e8257f2b155aa66/lib/ejs.js#L571) which will later be evaluated to create the HTML markup.

👨‍💻 Final PoC
Express views use a default config when calling templating function, which make it vulnerable by default!
```js
// Setup app
const express = require("express");
const app  = express();
const port = 3000;

// Select ejs templating library
app.set('view engine', 'ejs');

// Routes
app.get("/", (req, res) => {
    res.render("index");
})

app.get("/vuln", (req, res) => {
    // simulate SSPP vulnerability
    var a = req.query.a;
    var b = req.query.b;
    var c = req.query.c;

    var obj = {};
    obj[a][b] = c;

    res.send("OK!");
})

// Start app
app.listen(port, () => {
    console.log(`App listening on port ${port}`)
})
```
![poc](https://github.com/leather-wallet/extension/assets/156341162/a84d424d-24e0-45b9-8697-7bf145acd587)
![rce](https://github.com/leather-wallet/extension/assets/156341162/675e89e5-7e80-4d30-8974-e4f0eb37b4c6)


Vulnerable application
CVE-2024-33883
CWE-1321
