### PR TITLE
feat: enable uninscribed utxos retrieval, closes #5067

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -100,6 +100,6 @@
     "mainnetApiUrl": "https://api2.ordinalsbot.com",
     "signetApiUrl": "https://signet.ordinalsbot.com"
   },
-  "recoverUninscribedTaprootUtxosFeatureEnabled": false,
+  "recoverUninscribedTaprootUtxosFeatureEnabled": true,
   "runesEnabled": true
 }

--- a/src/app/features/collectibles/components/collectible.layout.tsx
+++ b/src/app/features/collectibles/components/collectible.layout.tsx
@@ -23,7 +23,7 @@ export function CollectiblesLayout({
 }: CollectiblesLayoutProps) {
   return (
     <>
-      <Flex flexDirection="row" justifyContent="space-between" flex={1}>
+      <Flex flexDirection="row" justifyContent="space-between" alignItems="center" flex={1}>
         <HStack columnGap="space.02">
           <styled.span textStyle="label.01" paddingY="space.05">
             {title}

--- a/src/app/features/retrieve-taproot-to-native-segwit/components/retrieve-taproot-to-native-segwit.layout.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/components/retrieve-taproot-to-native-segwit.layout.tsx
@@ -51,7 +51,7 @@ export function RetrieveTaprootToNativeSegwitLayout(
             As we don't support tranferring from Taproot addresses yet, you can retrieve funds to
             your account's main Native SegWit balance here.
           </styled.span>
-          <styled.span mt="space.04" textStyle="body.02">
+          <styled.span my="space.04" textStyle="body.02">
             This transaction may take upwards of 30 minutes to confirm.
           </styled.span>
           {children}

--- a/src/app/query/bitcoin/balance/btc-taproot-balance.hooks.ts
+++ b/src/app/query/bitcoin/balance/btc-taproot-balance.hooks.ts
@@ -9,6 +9,8 @@ import { useTaprootAccountUtxosQuery } from '../address/utxos-by-address.query';
 import { UtxoWithDerivationPath } from '../bitcoin-client';
 import { useGetInscriptionsInfiniteQuery } from '../ordinals/inscriptions.query';
 
+const RETRIEVE_UTXO_DUST_AMOUNT = 10000;
+
 export function useCurrentTaprootAccountUninscribedUtxos() {
   const { data: utxos = [] } = useTaprootAccountUtxosQuery();
 
@@ -16,10 +18,12 @@ export function useCurrentTaprootAccountUninscribedUtxos() {
 
   return useMemo(() => {
     const inscriptions = query.data?.pages?.flatMap(page => page.inscriptions) ?? [];
-    return filterUtxosWithInscriptions(
-      inscriptions,
-      utxos.filter(utxo => utxo.status.confirmed)
-    ) as UtxoWithDerivationPath[];
+
+    const filteredUtxosList = utxos
+      .filter(utxo => utxo.status.confirmed)
+      .filter(utxo => utxo.value > RETRIEVE_UTXO_DUST_AMOUNT);
+
+    return filterUtxosWithInscriptions(inscriptions, filteredUtxosList) as UtxoWithDerivationPath[];
   }, [query.data?.pages, utxos]);
 }
 


### PR DESCRIPTION
> Try out Leather build 68795d1 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9081558919), [Test report](https://leather-wallet.github.io/playwright-reports/feat/enable-btc-retrieval), [Storybook](https://feat-enable-btc-retrieval--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/enable-btc-retrieval)<!-- Sticky Header Marker -->

This pr re-enables btc retrieval 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled recovery of uninscribed Taproot UTXOs.
  - Enabled Runes feature.

- **Improvements**
  - Improved layout alignment in the Collectibles section for better visual consistency.
  - Adjusted spacing in the Retrieve Taproot to Native Segwit section for improved readability.
  - Enhanced UTXO filtering by introducing a minimum value threshold, ensuring more relevant data is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->