### PR TITLE
chore: add defensive code and better analytics for broadcast errors, …

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@dlc-link/dlc-tools": "1.1.1",
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.2.0",
-    "@leather-wallet/models": "0.4.4",
+    "@leather-wallet/models": "0.4.5",
     "@leather-wallet/tokens": "0.0.14",
     "@ledgerhq/hw-transport-webusb": "6.27.19",
     "@noble/hashes": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: 1.2.0
     version: 1.2.0
   '@leather-wallet/models':
-    specifier: 0.4.4
-    version: 0.4.4
+    specifier: 0.4.5
+    version: 0.4.5
   '@leather-wallet/tokens':
     specifier: 0.0.14
     version: 0.0.14
@@ -3702,8 +3702,8 @@ packages:
       bignumber.js: 9.1.2
     dev: true
 
-  /@leather-wallet/models@0.4.4:
-    resolution: {integrity: sha512-dqUTUR0EMM9WFwkeWRahlpixK+Ct2vEpDBhQdvO83tK4GhC/JlopI9hmpaSKyX9+35Ts2LpgycUiCh59kmZbMA==}
+  /@leather-wallet/models@0.4.5:
+    resolution: {integrity: sha512-H0NhxYy1C2Byrj1wswL9Zf6bWOejvgVuwgVDT6xh7zqvoPotiAtrfEe3hiBdSeUtUsTh70ha1ZMuGwf/rph67w==}
     dependencies:
       bignumber.js: 9.1.2
     dev: false

--- a/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container.tsx
+++ b/src/app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container.tsx
@@ -7,6 +7,7 @@ import get from 'lodash.get';
 
 import { RouteUrls } from '@shared/route-urls';
 import { delay, isError } from '@shared/utils';
+import { analytics } from '@shared/utils/analytics';
 
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 import { appEvents } from '@app/common/publish-subscribe';
@@ -129,7 +130,15 @@ function LedgerSignStacksTxContainer() {
           signedTx,
         });
       } catch (e) {
-        ledgerNavigate.toBroadcastErrorStep(isError(e) ? e.message : 'Unknown error');
+        const error = isError(e) ? e.message : 'Unknown error';
+        void analytics.track('ledger_transaction_publish_error', {
+          error: {
+            message: error,
+            error: e,
+          },
+        });
+
+        ledgerNavigate.toBroadcastErrorStep(error);
         return;
       }
     },

--- a/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
@@ -64,6 +64,7 @@ export function SendInscriptionReview() {
         });
       },
       onError(e) {
+        void analytics.track('ordinalbroadcast__error', { error: e });
         navigate(`/${RouteUrls.SendOrdinalInscription}/${RouteUrls.SendOrdinalInscriptionError}`, {
           state: {
             error: e,

--- a/src/app/pages/send/send-crypto-asset-form/form/brc20/brc20-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/brc20/brc20-send-form-confirmation.tsx
@@ -98,6 +98,10 @@ export function Brc20SendFormConfirmation() {
         });
       },
       onError(e) {
+        void analytics.track('broadcast_brc20_error', {
+          error: e,
+        });
+
         nav.toErrorPage(e);
       },
     });

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -138,6 +138,9 @@ export function BtcSendFormConfirmation() {
         );
       },
       onError(e) {
+        void analytics.track('broadcast_btc_error', {
+          error: e,
+        });
         nav.toErrorPage(e);
       },
     });

--- a/src/app/query/stacks/bns/bns.utils.ts
+++ b/src/app/query/stacks/bns/bns.utils.ts
@@ -140,6 +140,7 @@ export async function fetchNamesForAddress({
 export async function fetchNameOwner(client: StacksClient, name: string, isTestnet: boolean) {
   const fetchFromApi = async () => {
     const res = await client.namesApi.getNameInfo({ name });
+    if (isUndefined(res.address)) return null;
     if (!isString(res.address) || res.address.length === 0) return null;
     return res.address;
   };

--- a/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -122,6 +122,7 @@ export function useCurrentAccountNativeSegwitAddressIndexZero() {
  */
 export function useNativeSegwitAccountIndexAddressIndexZero(accountIndex: number) {
   const signer = useNativeSegwitSigner(accountIndex)?.(0);
+  // could it be this?
   return signer?.payment.address as string;
 }
 


### PR DESCRIPTION
> Try out Leather build bf36652 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9155964020), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5118/broadcast-error), [Storybook](https://fix-5118-broadcast-error--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5118/broadcast-error)<!-- Sticky Header Marker -->

This PR adds some extra analytics and defensive code to try and gather more insight into and prevent https://github.com/leather-wallet/extension/issues/5118

The analytics added are: 

- track fail of stacks tx publish on ledger via `ledger_transaction_publish_error` 
- track failure to broadcast of:
    - Ordinal via `broadcast_ordinal_error` 
    - BRC20 via `broadcast_brc20_error`
    - BTC via `broadcast_btc_error `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error tracking and analytics for transaction errors across various components.

- **Bug Fixes**
  - Improved conditional rendering for address display to handle cases where the address is undefined.

- **Chores**
  - Updated `@leather-wallet/models` dependency version from 0.4.4 to 0.4.5 for better compatibility and performance.

- **Documentation**
  - Added a comment in the `useNativeSegwitAccountIndexAddressIndexZero` function for clarity on potential scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->