### PR TITLE
chore: temporarily disable swaps feature

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -101,5 +101,6 @@
     "signetApiUrl": "https://signet.ordinalsbot.com"
   },
   "recoverUninscribedTaprootUtxosFeatureEnabled": true,
-  "runesEnabled": true
+  "runesEnabled": true,
+  "swapsEnabled": false
 }

--- a/config/wallet-config.schema.json
+++ b/config/wallet-config.schema.json
@@ -145,6 +145,10 @@
     "runesEnabled": {
       "type": "boolean",
       "description": "Determines whether or not Runes are live on mainnet"
+    },
+    "swapsEnabled": {
+      "type": "boolean",
+      "description": "Determines whether or not the swaps feature is enabled"
     }
   },
   "$defs": {

--- a/src/app/pages/home/components/account-actions.tsx
+++ b/src/app/pages/home/components/account-actions.tsx
@@ -7,11 +7,15 @@ import { Flex } from 'leather-styles/jsx';
 import { whenStacksChainId } from '@shared/crypto/stacks/stacks.utils';
 import { RouteUrls } from '@shared/route-urls';
 
-import { useConfigBitcoinEnabled } from '@app/query/common/remote-config/remote-config.query';
+import {
+  useConfigBitcoinEnabled,
+  useConfigSwapEnabled,
+} from '@app/query/common/remote-config/remote-config.query';
 import { useCurrentAccountNativeSegwitIndexZeroSignerNullable } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import { IconButton } from '@app/ui/components/icon-button/icon-button';
+import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 import { CreditCardIcon, InboxIcon, SwapIcon } from '@app/ui/icons';
 
 import { SendButton } from './send-button';
@@ -24,6 +28,8 @@ export function AccountActions() {
   const currentBtcSigner = useCurrentAccountNativeSegwitIndexZeroSignerNullable();
   const btcAccount = currentBtcSigner?.address;
   const currentNetwork = useCurrentNetwork();
+  const swapsEnabled = useConfigSwapEnabled();
+  const swapsBtnDisabled = !swapsEnabled || !stacksAccount;
 
   const receivePath = isBitcoinEnabled
     ? RouteUrls.Receive
@@ -49,13 +55,15 @@ export function AccountActions() {
       )}
       {whenStacksChainId(currentNetwork.chain.stacks.chainId)({
         [ChainID.Mainnet]: (
-          <IconButton
-            data-testid={HomePageSelectors.SwapBtn}
-            disabled={!stacksAccount}
-            icon={<SwapIcon />}
-            label="Swap"
-            onClick={() => navigate(RouteUrls.Swap.replace(':base', 'STX').replace(':quote', ''))}
-          />
+          <BasicTooltip label={swapsEnabled ? '' : 'Swaps temporarily disabled'} side="left">
+            <IconButton
+              data-testid={HomePageSelectors.SwapBtn}
+              disabled={swapsBtnDisabled}
+              icon={<SwapIcon />}
+              label="Swap"
+              onClick={() => navigate(RouteUrls.Swap.replace(':base', 'STX').replace(':quote', ''))}
+            />
+          </BasicTooltip>
         ),
         [ChainID.Testnet]: null,
       })}

--- a/src/app/query/common/remote-config/remote-config.query.ts
+++ b/src/app/query/common/remote-config/remote-config.query.ts
@@ -178,3 +178,8 @@ export function useConfigRunesEnabled() {
   const config = useRemoteConfig();
   return get(config, 'runesEnabled', false);
 }
+
+export function useConfigSwapEnabled() {
+  const config = useRemoteConfig();
+  return get(config, 'swapEnabled', false);
+}

--- a/src/app/ui/components/icon-button/icon-button.tsx
+++ b/src/app/ui/components/icon-button/icon-button.tsx
@@ -7,7 +7,7 @@ interface IconButtonProps extends ButtonProps {
   icon: React.JSX.Element;
   label?: string;
 }
-export function IconButton({ icon, label, ...rest }: IconButtonProps) {
+export function IconButton({ icon, label, disabled, ...rest }: IconButtonProps) {
   return (
     <Button
       key={label}
@@ -17,6 +17,8 @@ export function IconButton({ icon, label, ...rest }: IconButtonProps) {
       variant="ghost"
       width={label ? 'iconButtonWithLabelWidth' : 'unset'}
       outline="none"
+      opacity={disabled ? '0.5' : '1'}
+      disabled={disabled}
       {...rest}
     >
       <Stack alignItems="center" gap="space.01">

--- a/tests/specs/swap/swap.spec.ts
+++ b/tests/specs/swap/swap.spec.ts
@@ -2,7 +2,8 @@ import { test } from '../../fixtures/fixtures';
 
 const hiroApiPostRoute = '*/**/v2/transactions';
 
-test.describe('Swaps', () => {
+// Skip as swaps feature is disabled
+test.skip('Swaps', () => {
   test.beforeEach(async ({ extensionId, globalPage, homePage, onboardingPage, swapPage }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);


### PR DESCRIPTION
> Try out Leather build 886bb40 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9126328916), [Test report](https://leather-wallet.github.io/playwright-reports/chore/swaps-disable), [Storybook](https://chore-swaps-disable--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/swaps-disable)<!-- Sticky Header Marker -->

This pr adds swapsEnabled parameter in config, and disables swaps button, showing tooltip on hover, video:
https://github.com/leather-wallet/extension/assets/46521087/47b85904-64f1-44b7-9e16-9a795aa448f7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added the ability to control the swaps feature in the wallet configuration with a new `swapsEnabled` setting.
  - Introduced a tooltip for the Swap button to indicate when swaps are temporarily disabled.

- **Updates**
  - Updated the `IconButton` component to support a disabled state, including visual feedback with reduced opacity.

- **Enhancements**
  - Improved user experience by dynamically enabling or disabling the Swap button based on the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->