### PR TITLE
feat: add link in swaps disabled tooltip

### DIFF
--- a/src/app/pages/home/components/account-actions.tsx
+++ b/src/app/pages/home/components/account-actions.tsx
@@ -19,6 +19,7 @@ import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 import { CreditCardIcon, InboxIcon, SwapIcon } from '@app/ui/icons';
 
 import { SendButton } from './send-button';
+import { SwapsDisabledTooltipLabel } from './swaps-disabled-tooltip-label';
 
 export function AccountActions() {
   const navigate = useNavigate();
@@ -55,7 +56,7 @@ export function AccountActions() {
       )}
       {whenStacksChainId(currentNetwork.chain.stacks.chainId)({
         [ChainID.Mainnet]: (
-          <BasicTooltip label={swapsEnabled ? '' : 'Swaps temporarily disabled'} side="left">
+          <BasicTooltip label={swapsEnabled ? '' : <SwapsDisabledTooltipLabel />} side="left">
             <IconButton
               data-testid={HomePageSelectors.SwapBtn}
               disabled={swapsBtnDisabled}

--- a/src/app/pages/home/components/swaps-disabled-tooltip-label.tsx
+++ b/src/app/pages/home/components/swaps-disabled-tooltip-label.tsx
@@ -1,0 +1,19 @@
+import { Stack, styled } from 'leather-styles/jsx';
+
+import { Link } from '@app/ui/components/link/link';
+
+export function SwapsDisabledTooltipLabel() {
+  return (
+    <Stack gap="0">
+      <styled.span textStyle="caption.01">Swaps temporarily disabled</styled.span>
+      <Link
+        href="https://leather.io/guides/integrated-swap-disabled"
+        target="_blank"
+        color="ink.background-primary"
+        width="fit-content"
+      >
+        <styled.span textStyle="caption.01">Learn more</styled.span>
+      </Link>
+    </Stack>
+  );
+}

--- a/src/app/ui/components/tooltip/basic-tooltip.tsx
+++ b/src/app/ui/components/tooltip/basic-tooltip.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from './tooltip';
 
 interface BasicTooltipProps {
   children: ReactNode;
-  label?: string;
+  label?: string | ReactNode;
   disabled?: boolean;
   side?: RadixTooltip.TooltipContentProps['side'];
   asChild?: boolean;


### PR DESCRIPTION
> Try out Leather build abb6d77 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9129393232), [Test report](https://leather-wallet.github.io/playwright-reports/feat/add-link-tooltip), [Storybook](https://feat-add-link-tooltip--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/add-link-tooltip)<!-- Sticky Header Marker -->

This pr adds guide link in swap disabled tooltip
![Screenshot 2024-05-17 at 17 52 50](https://github.com/leather-wallet/extension/assets/46521087/5fe321e0-4d3b-4483-863a-d6868a9cfc0e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a tooltip that dynamically displays a message when swaps are disabled, with a link to learn more.
  
- **Enhancements**
  - Updated tooltip labels to support both text and React components for more flexible messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->