### PR TITLE
fix: brc20 sends software only

### DIFF
--- a/src/app/features/asset-list/asset-list.tsx
+++ b/src/app/features/asset-list/asset-list.tsx
@@ -108,9 +108,14 @@ export function AssetList({ onClick, variant = 'read-only' }: AssetListProps) {
           <BitcoinTaprootAccountLoader current>
             {taprootAccount => (
               <>
-                <Brc20TokensLoader>
-                  {tokens => <Brc20TokenAssetList assets={tokens} variant={variant} />}
-                </Brc20TokensLoader>
+                {whenWallet({
+                  software: (
+                    <Brc20TokensLoader>
+                      {tokens => <Brc20TokenAssetList assets={tokens} variant={variant} />}
+                    </Brc20TokensLoader>
+                  ),
+                  ledger: null,
+                })}
                 {isReadOnly && (
                   <>
                     <Src20TokensLoader address={nativeSegwitAccount.address}>


### PR DESCRIPTION
> Try out Leather build 5447e1c — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9130221712), [Test report](https://leather-wallet.github.io/playwright-reports/fix/brc20-sends), [Storybook](https://fix-brc20-sends--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/brc20-sends)<!-- Sticky Header Marker -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved rendering logic within the `AssetList` component to conditionally display `Brc20TokenAssetList` based on wallet type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->