### PR TITLE
fix: stamp error reporting

### DIFF
--- a/src/app/features/collectibles/components/bitcoin/stamps.tsx
+++ b/src/app/features/collectibles/components/bitcoin/stamps.tsx
@@ -23,11 +23,5 @@ export function Stamps() {
 
   if (!stamps.length) return null;
 
-  return (
-    <>
-      {stamps.map(s => (
-        <Stamp bitcoinStamp={s} key={s.tx_hash} />
-      ))}
-    </>
-  );
+  return stamps.map(s => <Stamp bitcoinStamp={s} key={s.tx_hash} />);
 }

--- a/src/app/query/bitcoin/stamps/stamps-by-address.query.ts
+++ b/src/app/query/bitcoin/stamps/stamps-by-address.query.ts
@@ -29,7 +29,7 @@ const stampSchema = z.object({
   creator_name: z.string().optional().nullable(),
   stamp_gen: z.string().optional(),
   stamp_hash: z.string().optional(),
-  is_btc_stamp: z.number().optional(),
+  is_btc_stamp: z.number().nullable().optional(),
   is_reissue: z.number().optional(),
   file_hash: z.string().optional(),
 });
@@ -80,7 +80,7 @@ async function fetchStampsByAddress(address: string): Promise<StampsByAddressQue
   try {
     return stampsByAdressSchema.parse(resp.data);
   } catch (e) {
-    if (e instanceof ZodError) void analytics.track('schema_fail', e);
+    if (e instanceof ZodError) void analytics.track('schema_fail', { ...e });
     throw e;
   }
 }


### PR DESCRIPTION
> Try out Leather build 807f55f — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9161935644), [Test report](https://leather-wallet.github.io/playwright-reports/fix/stamp-validation-error-tracking), [Storybook](https://fix-stamp-validation-error-tracking--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/stamp-validation-error-tracking)<!-- Sticky Header Marker -->

I think, because it's an instance of an error, it isn't reporting properly, and that spreading the error props, initialising a new obj, fixes it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Simplified the rendering logic in the Stamps component for better code readability.

- **Bug Fixes**
  - Improved error tracking in the fetchStampsByAddress function to include detailed error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->