### PR TITLE
fix: notifications area preventing pointer interactions

### DIFF
--- a/src/app/ui/components/toast/toast.tsx
+++ b/src/app/ui/components/toast/toast.tsx
@@ -47,6 +47,7 @@ const toastViewportStyles = css({
   transform: 'translate(-50%, 0)',
   width: '100%',
   zIndex: 9999,
+  pointerEvents: 'none',
 });
 const Viewport: typeof RadixToast.Viewport = forwardRef((props, ref) => (
   <RadixToast.Viewport className={toastViewportStyles} ref={ref} {...props} />


### PR DESCRIPTION
closes https://github.com/leather-wallet/extension/issues/5371

Settings `pointer-events` to `none` disables any pointer interaction, by setting this on the toast viewport, it fixes the issue that the user is not able to interact with the pointer in elements that are below the notification area

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the toast component's interaction behavior by making it non-interactive with `pointerEvents: 'none'`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->