### PR TITLE
fix: close button still showing in breakpoint

### DIFF
--- a/src/app/ui/components/containers/headers/components/big-title-header.tsx
+++ b/src/app/ui/components/containers/headers/components/big-title-header.tsx
@@ -17,11 +17,13 @@ export function BigTitleHeader({ onClose, title }: BigTitleHeaderProps) {
     <Flex justifyContent="space-between" mt={{ base: 'space.05', md: 'unset' }}>
       <styled.h3 textStyle="heading.03">{title}</styled.h3>
       {onClose && (
-        <HeaderActionButton
-          icon={<CloseIcon hideBelow="md" />}
-          dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
-          onAction={onClose}
-        />
+        <styled.div hideBelow="md">
+          <HeaderActionButton
+            icon={<CloseIcon />}
+            dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
+            onAction={onClose}
+          />
+        </styled.div>
       )}
     </Flex>
   );


### PR DESCRIPTION
closes https://github.com/leather-wallet/extension/issues/5407

Display based on viewport size breakpoint is being used in the icon instead of the button, so it is still hoverable and actionable, this PR adds a styled div around the close button with the breakpoint to display and removes the breakpoint from the icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Improved the layout of the `BigTitleHeader` component by ensuring better visibility of the action button on medium and larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->