### PR TITLE
fix: scroll in settings menu popup

### DIFF
--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -74,6 +74,8 @@ export function Settings({ triggerButton, toggleSwitchAccount }: SettingsProps) 
             sideOffset={8}
             className={css({
               width: 'settingsMenuWidth',
+              maxHeight: 'var(--radix-dropdown-menu-content-available-height)',
+              overflowY: 'scroll',
             })}
           >
             <DropdownMenu.Group>

--- a/src/app/ui/components/containers/headers/components/big-title-header.tsx
+++ b/src/app/ui/components/containers/headers/components/big-title-header.tsx
@@ -17,11 +17,13 @@ export function BigTitleHeader({ onClose, title }: BigTitleHeaderProps) {
     <Flex justifyContent="space-between" mt={{ base: 'space.05', md: 'unset' }}>
       <styled.h3 textStyle="heading.03">{title}</styled.h3>
       {onClose && (
-        <HeaderActionButton
-          icon={<CloseIcon hideBelow="md" />}
-          dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
-          onAction={onClose}
-        />
+        <styled.div hideBelow="md">
+          <HeaderActionButton
+            icon={<CloseIcon />}
+            dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
+            onAction={onClose}
+          />
+        </styled.div>
       )}
     </Flex>
   );

--- a/src/app/ui/components/containers/headers/dialog-header.tsx
+++ b/src/app/ui/components/containers/headers/dialog-header.tsx
@@ -28,7 +28,7 @@ export function DialogHeader({ onClose, title }: DialogHeaderProps) {
         </Flex>
       )}
       {onClose && (
-        <Box ml="auto">
+        <Box>
           <HeaderActionButton
             icon={<CloseIcon />}
             dataTestId={SharedComponentsSelectors.HeaderCloseBtn}


### PR DESCRIPTION
closes https://github.com/leather-wallet/extension/issues/5298

This PR fixes the case where the popup is larger in height than the viewport making some options inaccessible. Setting the `max-height` of it to the `radix-dropdown-menu-content-available-height` CSS variable and setting `overflow-y` to `scroll` fixes the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced dropdown menu in settings with maximum height and vertical scrolling for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->