### PR TITLE
test: add fee mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "lint:prettier": "prettier --check \"{src,tests}/**/*.{ts,tsx}\" \"*.{js,json}\"",
     "lint:prettier:fix": "prettier --write \"{src,tests}/**/*.{ts,tsx}\" *.js",
-    "lint:unused-exports": "ts-unused-exports tsconfig.json --ignoreFiles=icons --ignoreFiles=leather-styles --ignoreFiles=tests --excludePathsFromReport=.*stories",
+    "lint:unused-exports": "ts-unused-exports tsconfig.json --ignoreFiles=icons --ignoreFiles=leather-styles --ignoreFiles=mocks --ignoreFiles=tests --excludePathsFromReport=.*stories",
     "lint:remote-wallet-config": "npx ajv-cli validate -s config/wallet-config.schema.json -d config/wallet-config.json",
     "lint:deps": "dependency-cruise  --config .dependency-cruiser.js \"src/**/*.{ts,tsx}\"",
     "prod:ext": "pnpm build",

--- a/src/app/query/stacks/fees/fee.query.mocks.ts
+++ b/src/app/query/stacks/fees/fee.query.mocks.ts
@@ -1,0 +1,33 @@
+import type { Page } from '@playwright/test';
+
+export async function mockStacksFeeRequests(page: Page) {
+  await page.route('*/**/v2/fees/transaction', route =>
+    route.fulfill({
+      json: {
+        estimated_cost: {
+          write_length: 0,
+          write_count: 0,
+          read_length: 0,
+          read_count: 0,
+          runtime: 0,
+        },
+        estimated_cost_scalar: 6,
+        estimations: [
+          {
+            fee_rate: 35.99908181950457,
+            fee: 215,
+          },
+          {
+            fee_rate: 382.0532104229179,
+            fee: 2292,
+          },
+          {
+            fee_rate: 65987.51710815083,
+            fee: 395925,
+          },
+        ],
+        cost_scalar_change_by_byte: 0.00476837158203125,
+      },
+    })
+  );
+}

--- a/tests/mocks/mock-apis.ts
+++ b/tests/mocks/mock-apis.ts
@@ -1,7 +1,10 @@
 import { Page } from '@playwright/test';
 import { json } from '@tests/utils';
 
-export const setupMockApis = async (page: Page) => {
+import { mockStacksFeeRequests } from '@app/query/stacks/fees/fee.query.mocks';
+
+export async function setupMockApis(page: Page) {
   await page.route(/chrome-extension/, route => route.continue());
   await page.route(/github/, route => route.fulfill(json({})));
-};
+  await mockStacksFeeRequests(page);
+}

--- a/tests/page-object-models/global.page.ts
+++ b/tests/page-object-models/global.page.ts
@@ -17,14 +17,6 @@ export class GlobalPage {
     await setupMockApis(this.page);
     await this.page.waitForTimeout(600);
     await this.gotoNakedRoot(extensionId);
-    // I've no idea why this delay is needed. Was required when switching to MV3. Without it,
-    // this error is thrown. Let's try removing with later versions of Playwright.
-    //
-    // Error: page.goto: Navigation failed because page was closed!
-    // =========================== logs ===========================
-    // navigating to "chrome-extension://bcokkkbghbnpbjpkoifjakaofdjfgeaj/index.html", waiting until "load"
-    // ============================================================
-    // await this.page.goto(`chrome-extension://${extensionId}/index.html`);
   }
 
   async setupAndUseMockedApiCalls(extensionId: string) {

--- a/tests/specs/send/send-stx.spec.ts
+++ b/tests/specs/send/send-stx.spec.ts
@@ -17,6 +17,7 @@ const amount = '0.000001';
 test.describe('send stx: tests on testnet', () => {
   test.beforeEach(async ({ extensionId, globalPage, homePage, onboardingPage, sendPage }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
+
     await onboardingPage.signInWithTestAccount(extensionId);
     await homePage.selectTestnet();
     await homePage.sendButton.click();


### PR DESCRIPTION
> Try out Leather build 35ebfa5 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9188188598), [Test report](https://leather-wallet.github.io/playwright-reports/test/mock-stx-fees), [Storybook](https://test-mock-stx-fees--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=test/mock-stx-fees)<!-- Sticky Header Marker -->

Mocking Stacks fee requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Added mock responses for fee-related requests using Playwright to enhance internal testing.
  - Streamlined setup of mock APIs for testing purposes.

- **Chores**
  - Removed outdated commented-out code related to MV3 migration delays.

- **Style**
  - Enhanced code readability by adding a blank line in the `send-stx` test file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->