### PR TITLE
fix: sip10 token send form fees bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@dlc-link/dlc-tools": "1.1.1",
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.2.0",
-    "@leather-wallet/models": "0.6.1",
+    "@leather-wallet/models": "0.6.3",
     "@leather-wallet/tokens": "0.0.15",
     "@ledgerhq/hw-transport-webusb": "6.27.19",
     "@noble/hashes": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: 1.2.0
     version: 1.2.0
   '@leather-wallet/models':
-    specifier: 0.6.1
-    version: 0.6.1
+    specifier: 0.6.3
+    version: 0.6.3
   '@leather-wallet/tokens':
     specifier: 0.0.15
     version: 0.0.15
@@ -3702,8 +3702,8 @@ packages:
       bignumber.js: 9.1.2
     dev: true
 
-  /@leather-wallet/models@0.6.1:
-    resolution: {integrity: sha512-PVbsCypJaVY7W6pOqDfFlZuvx8pZhpBo+8mMo2wddDNSnSGoIhxQtZVTzZPHTb4d++UWPuxrDx0WVcu7G2Y9gA==}
+  /@leather-wallet/models@0.6.3:
+    resolution: {integrity: sha512-Q8GIE4sH6yg57LtF28Ya/bDAueQdf++M0yAMMJKSJSW4Ue62HNcX2s60RdxAE/mlKQHZKK8JL9y2jwXKVNlJXA==}
     dependencies:
       bignumber.js: 9.1.2
     dev: false

--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -6,6 +6,7 @@ import { isNumber } from '@shared/utils';
 import { analytics } from '@shared/utils/analytics';
 
 import { countDecimals } from '@app/common/math/helpers';
+import { convertAmountToBaseUnit } from '@app/common/money/calculate-money';
 import {
   btcToSat,
   microStxToStx,
@@ -109,6 +110,7 @@ export function stxAvailableBalanceValidator(availableBalance: Money) {
 
 export function stacksFungibleTokenAmountValidator(balance: Money) {
   const { amount, decimals } = balance;
+
   return amountValidator()
     .test((value, context) => {
       if (!isNumber(value)) return false;
@@ -125,7 +127,7 @@ export function stacksFungibleTokenAmountValidator(balance: Money) {
       message: formatInsufficientBalanceError(balance, sum => microStxToStx(sum.amount).toString()),
       test(value) {
         if (!isNumber(value) || !amount) return false;
-        return new BigNumber(value).isLessThanOrEqualTo(amount);
+        return new BigNumber(value).isLessThanOrEqualTo(convertAmountToBaseUnit(amount, decimals));
       },
     });
 }

--- a/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-item.tsx
+++ b/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-item.tsx
@@ -20,7 +20,7 @@ export function Sip10TokenAssetItem({
   marketData,
   onSelectAsset,
 }: Sip10TokenAssetItemProps) {
-  const name = spamFilter(info.name);
+  const name = spamFilter(info.tokenName);
   const fiatBalance = convertAssetBalanceToFiat({
     balance: balance.availableBalance,
     marketData,

--- a/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-list-unsupported.tsx
+++ b/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-list-unsupported.tsx
@@ -38,7 +38,7 @@ export function Sip10TokenAssetListUnsupported({
             {tokens.map(token => (
               <Sip10TokenAssetItem
                 balance={token.balance}
-                key={token.info.name}
+                key={token.info.tokenName}
                 info={token.info}
                 isLoading={isLoading}
                 marketData={priceAsMarketData(

--- a/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-list.tsx
+++ b/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-list.tsx
@@ -24,7 +24,7 @@ export function Sip10TokenAssetList({
       {tokens.map(token => (
         <Sip10TokenAssetItem
           balance={token.balance}
-          key={token.info.name}
+          key={token.info.tokenName}
           info={token.info}
           isLoading={isLoading}
           marketData={priceAsMarketData(

--- a/src/app/pages/send/send-crypto-asset-form/form/sip10/sip10-token-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/sip10/sip10-token-send-form.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import type { CryptoAssetBalance, MarketData, Sip10CryptoAssetInfo } from '@leather-wallet/models';
 
@@ -22,12 +22,14 @@ function Sip10TokenSendFormLoader({ children }: Sip10TokenSendFormLoaderProps) {
   const token = useSip10Token(contractId ?? '');
   const priceAsMarketData = useAlexCurrencyPriceAsMarketData();
   const toast = useToast();
+  const navigate = useNavigate();
 
   if (!contractId) return;
 
   if (!token) {
     toast.error('Token not found');
-    return <Navigate to={RouteUrls.SendCryptoAsset} />;
+    navigate(RouteUrls.SendCryptoAsset);
+    return;
   }
 
   return children({

--- a/src/app/pages/send/send-crypto-asset-form/form/sip10/use-sip10-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/sip10/use-sip10-send-form.tsx
@@ -45,7 +45,7 @@ export function useSip10SendForm({ balance, info }: UseSip10SendFormArgs) {
   function createFtAvatar() {
     return {
       avatar: info.contractId,
-      imageCanonicalUri: getSafeImageCanonicalUri(info.imageCanonicalUri, info.name),
+      imageCanonicalUri: getSafeImageCanonicalUri(info.imageCanonicalUri, info.tokenName),
     };
   }
 
@@ -76,7 +76,7 @@ export function useSip10SendForm({ balance, info }: UseSip10SendFormArgs) {
 
       sendFormNavigate.toConfirmAndSignStacksSip10Transaction({
         decimals: info.decimals,
-        name: info.name,
+        name: info.tokenName,
         tx,
       });
     },

--- a/src/app/query/stacks/fees/fees.query.ts
+++ b/src/app/query/stacks/fees/fees.query.ts
@@ -23,6 +23,7 @@ function fetchTransactionFeeEstimation(currentNetwork: any, limiter: PQueue) {
           }
         ),
       {
+        priority: 2,
         throwOnTimeout: true,
       }
     );

--- a/src/app/query/stacks/sip10/sip10-tokens.utils.ts
+++ b/src/app/query/stacks/sip10/sip10-tokens.utils.ts
@@ -16,18 +16,20 @@ export function createSip10CryptoAssetInfo(
   key: string,
   ftAsset: FtMetadataResponse
 ): Sip10CryptoAssetInfo {
-  const { assetName, contractName } = getAssetStringParts(key);
-  const name = ftAsset.name ? ftAsset.name : assetName;
+  const { assetName, contractName, address } = getAssetStringParts(key);
+  const tokenName = ftAsset.name ? ftAsset.name : assetName;
 
   return {
     canTransfer: isTransferableSip10Token(ftAsset),
+    contractAddress: address,
+    contractAssetName: assetName,
     contractId,
     contractName,
     decimals: ftAsset.decimals ?? 0,
     hasMemo: isTransferableSip10Token(ftAsset),
     imageCanonicalUri: ftAsset.image_canonical_uri ?? '',
-    name,
-    symbol: ftAsset.symbol ?? getTicker(name),
+    tokenName,
+    symbol: ftAsset.symbol ?? getTicker(tokenName),
   };
 }
 

--- a/src/app/store/transactions/token-transfer.hooks.ts
+++ b/src/app/store/transactions/token-transfer.hooks.ts
@@ -17,6 +17,7 @@ import {
   uintCV,
 } from '@stacks/transactions';
 
+import { logger } from '@shared/logger';
 import type { StacksSendFormValues, StacksTransactionFormValues } from '@shared/models/form.model';
 
 import { stxToMicroStx } from '@app/common/money/unit-conversion';
@@ -28,7 +29,6 @@ import {
 import { useNextNonce } from '@app/query/stacks/nonce/account-nonces.hooks';
 import { useCurrentStacksNetworkState } from '@app/store/networks/networks.hooks';
 import { makePostCondition } from '@app/store/transactions/transaction.hooks';
-import { getAssetStringParts } from '@app/ui/utils/get-asset-string-parts';
 
 import { useCurrentStacksAccount } from '../accounts/blockchain/stacks/stacks-account.hooks';
 
@@ -83,70 +83,79 @@ export function useGenerateFtTokenTransferUnsignedTx(info: Sip10CryptoAssetInfo)
   const { data: nextNonce } = useNextNonce();
   const account = useCurrentStacksAccount();
   const network = useCurrentStacksNetworkState();
+  const { contractName, contractAddress, contractAssetName } = info;
 
   return useCallback(
     async (values?: StacksSendFormValues | StacksTransactionFormValues) => {
-      if (!account) return;
+      try {
+        if (!account) return;
 
-      const functionName = 'transfer';
-      const recipient =
-        values && 'recipient' in values
-          ? createAddress(values.recipient || '')
-          : createEmptyAddress();
-      const amount = values && 'amount' in values ? values.amount : 0;
-      const memo =
-        values && 'memo' in values && values.memo !== ''
-          ? someCV(bufferCVFromString(values.memo || ''))
-          : noneCV();
+        const functionName = 'transfer';
+        const recipient =
+          values && 'recipient' in values
+            ? createAddress(values.recipient || '')
+            : createEmptyAddress();
+        const amount = values && 'amount' in values ? values.amount : 0;
+        const memo =
+          values && 'memo' in values && values.memo !== ''
+            ? someCV(bufferCVFromString(values.memo || ''))
+            : noneCV();
 
-      const amountAsFractionalUnit = ftUnshiftDecimals(amount, info.decimals || 0);
-      const {
-        address: contractAddress,
-        contractName,
-        assetName,
-      } = getAssetStringParts(info.contractId);
-
-      const postConditionOptions = {
-        amount: amountAsFractionalUnit,
-        contractAddress,
-        contractAssetName: assetName,
-        contractName,
-        stxAddress: account.address,
-      };
-
-      const postConditions = [makePostCondition(postConditionOptions)];
-
-      // (transfer (uint principal principal) (response bool uint))
-      const functionArgs: ClarityValue[] = [
-        uintCV(amountAsFractionalUnit),
-        standardPrincipalCVFromAddress(createAddress(account.address)),
-        standardPrincipalCVFromAddress(recipient),
-      ];
-
-      if (info.hasMemo) {
-        functionArgs.push(memo);
-      }
-
-      const options = {
-        txData: {
-          txType: TransactionTypes.ContractCall,
+        const amountAsFractionalUnit = ftUnshiftDecimals(amount, info.decimals || 0);
+        const postConditionOptions = {
+          amount: amountAsFractionalUnit,
           contractAddress,
+          contractAssetName,
           contractName,
-          functionName,
-          functionArgs: functionArgs.map(serializeCV).map(arg => bytesToHex(arg)),
-          postConditions,
-          postConditionMode: PostConditionMode.Deny,
-          network,
-          publicKey: account.stxPublicKey,
-        },
-        fee: stxToMicroStx(values?.fee || 0).toNumber(),
-        publicKey: account.stxPublicKey,
-        nonce: Number(values?.nonce) ?? nextNonce?.nonce,
-      } as const;
+          stxAddress: account.address,
+        };
 
-      return generateUnsignedTransaction(options);
+        const postConditions = [makePostCondition(postConditionOptions)];
+
+        // (transfer (uint principal principal) (response bool uint))
+        const functionArgs: ClarityValue[] = [
+          uintCV(amountAsFractionalUnit),
+          standardPrincipalCVFromAddress(createAddress(account.address)),
+          standardPrincipalCVFromAddress(recipient),
+        ];
+
+        if (info.hasMemo) {
+          functionArgs.push(memo);
+        }
+
+        const options = {
+          txData: {
+            txType: TransactionTypes.ContractCall,
+            contractAddress,
+            contractName,
+            functionName,
+            functionArgs: functionArgs.map(serializeCV).map(arg => bytesToHex(arg)),
+            postConditions,
+            postConditionMode: PostConditionMode.Deny,
+            network,
+            publicKey: account.stxPublicKey,
+          },
+          fee: stxToMicroStx(values?.fee || 0).toNumber(),
+          publicKey: account.stxPublicKey,
+          nonce: Number(values?.nonce) ?? nextNonce?.nonce,
+        } as const;
+
+        return generateUnsignedTransaction(options);
+      } catch (error) {
+        logger.error('Failed to generate unsigned transaction', error);
+        return;
+      }
     },
-    [account, info.contractId, info.decimals, info.hasMemo, network, nextNonce?.nonce]
+    [
+      account,
+      info.decimals,
+      info.hasMemo,
+      network,
+      nextNonce?.nonce,
+      contractName,
+      contractAssetName,
+      contractAddress,
+    ]
   );
 }
 


### PR DESCRIPTION
> Try out Leather build 2ed7544 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9191178591), [Test report](https://leather-wallet.github.io/playwright-reports/fix/sip10-send-form), [Storybook](https://fix-sip10-send-form--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/sip10-send-form)<!-- Sticky Header Marker -->

This pr fixes sip10 send form fees bug, discussed:
https://trustmachines.slack.com/archives/C0520G8J33M/p1716339282877119
https://trustmachines.slack.com/archives/C05LAP952E7/p1716363736626209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new function to retrieve asset contract addresses from contract IDs or fully qualified asset names.

- **Improvements**
  - Updated navigation logic for sending SIP10 tokens to enhance performance and maintainability.
  - Standardized address retrieval in asset string parts for consistency.

- **Refactor**
  - Replaced `Navigate` component with `useNavigate` hook for more efficient navigation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->