### PR TITLE
test: mock network switching

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -91,12 +91,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shardTotal: [10]
 
     steps:
       - uses: actions/checkout@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
   testDir: './tests',
   timeout: 30 * 1000,
   expect: { timeout: 5000 },
-  fullyParallel: true,
+  // Extensions live cross-worker meaning `chrome.storage` is shared. Disabling
+  // `fullyParallel` means fewer tests run at the same time, but ensures a
+  // truely new context is used each time
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,

--- a/src/app/features/settings/network/network.tsx
+++ b/src/app/features/settings/network/network.tsx
@@ -26,6 +26,7 @@ export function NetworkDialog({ onClose }: NetworkDialogProps) {
   const analytics = useAnalytics();
   const networksActions = useNetworksActions();
   const currentNetwork = useCurrentNetworkState();
+
   function addNetwork() {
     void analytics.track('add_network');
     navigate(RouteUrls.AddNetwork);

--- a/tests/mocks/mock-apis.ts
+++ b/tests/mocks/mock-apis.ts
@@ -6,5 +6,7 @@ import { mockStacksFeeRequests } from '@app/query/stacks/fees/fee.query.mocks';
 export async function setupMockApis(page: Page) {
   await page.route(/chrome-extension/, route => route.continue());
   await page.route(/github/, route => route.fulfill(json({})));
+  await page.route('https://api.hiro.so/', route => route.fulfill());
+  await page.route('https://api.testnet.hiro.so/', route => route.fulfill());
   await mockStacksFeeRequests(page);
 }

--- a/tests/page-object-models/home.page.ts
+++ b/tests/page-object-models/home.page.ts
@@ -100,9 +100,7 @@ export class HomePage {
     await this.page.getByTestId(SettingsSelectors.SettingsMenuBtn).click();
     await this.page.getByTestId(SettingsSelectors.ChangeNetworkAction).click();
     await this.page.getByTestId(NetworkSelectors.NetworkListActiveNetwork).isVisible();
-    await this.page
-      .getByTestId(WalletDefaultNetworkConfigurationIds.testnet)
-      .click({ force: true });
+    await this.page.getByTestId(WalletDefaultNetworkConfigurationIds.testnet).click();
   }
 
   async clickActivityTab() {

--- a/tests/page-object-models/home.page.ts
+++ b/tests/page-object-models/home.page.ts
@@ -99,13 +99,10 @@ export class HomePage {
   async selectTestnet() {
     await this.page.getByTestId(SettingsSelectors.SettingsMenuBtn).click();
     await this.page.getByTestId(SettingsSelectors.ChangeNetworkAction).click();
+    await this.page.getByTestId(NetworkSelectors.NetworkListActiveNetwork).isVisible();
     await this.page
       .getByTestId(WalletDefaultNetworkConfigurationIds.testnet)
       .click({ force: true });
-    await this.page.getByTestId(NetworkSelectors.NetworkListActiveNetwork).isVisible();
-
-    await this.page.waitForTimeout(1000);
-    await this.page.getByTestId(WalletDefaultNetworkConfigurationIds.testnet).click();
   }
 
   async clickActivityTab() {

--- a/tests/page-object-models/onboarding.page.ts
+++ b/tests/page-object-models/onboarding.page.ts
@@ -287,7 +287,9 @@ export class OnboardingPage {
         async walletState => await chrome.storage.local.set({ 'persist:root': walletState }),
         testSoftwareAccountDefaultWalletState
       );
-      await this.page.goto(`chrome-extension://${id}/index.html`);
+      await this.page.goto(`chrome-extension://${id}/index.html`, {
+        waitUntil: 'networkidle',
+      });
     }
     await test.expect(this.page.getByText('Enter your password')).toBeVisible();
     await this.page.getByRole('textbox').fill(TEST_PASSWORD);


### PR DESCRIPTION
> Try out Leather build 1dbcafa — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9190380211), [Test report](https://leather-wallet.github.io/playwright-reports/test/mock-network-changing), [Storybook](https://test-mock-network-changing--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=test/mock-network-changing)<!-- Sticky Header Marker -->

Ref leather-wallet/issues#59



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test isolation by ensuring each test run uses a new context, enhancing reliability.

- **New Features**
  - Added route setups for new API endpoints to enhance mocking behavior.

- **Refactor**
  - Simplified the `selectTestnet()` method in the `HomePage` class to remove redundant code.
  - Updated `page.goto` method in the `OnboardingPage` class to include `waitUntil: 'networkidle'` for better navigation handling.

- **Style**
  - Added a new line before the `addNetwork` function definition for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->