### PR TITLE
fix: scroll in settings menu popup

### DIFF
--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -74,6 +74,8 @@ export function Settings({ triggerButton, toggleSwitchAccount }: SettingsProps) 
             sideOffset={8}
             className={css({
               width: 'settingsMenuWidth',
+              maxHeight: 'var(--radix-dropdown-menu-content-available-height)',
+              overflowY: 'scroll',
             })}
           >
             <DropdownMenu.Group>

--- a/src/app/ui/components/containers/headers/components/big-title-header.tsx
+++ b/src/app/ui/components/containers/headers/components/big-title-header.tsx
@@ -17,11 +17,13 @@ export function BigTitleHeader({ onClose, title }: BigTitleHeaderProps) {
     <Flex justifyContent="space-between" mt={{ base: 'space.05', md: 'unset' }}>
       <styled.h3 textStyle="heading.03">{title}</styled.h3>
       {onClose && (
-        <HeaderActionButton
-          icon={<CloseIcon hideBelow="md" />}
-          dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
-          onAction={onClose}
-        />
+        <styled.div hideBelow="md">
+          <HeaderActionButton
+            icon={<CloseIcon />}
+            dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
+            onAction={onClose}
+          />
+        </styled.div>
       )}
     </Flex>
   );


### PR DESCRIPTION
> Try out Leather build 06ea9e1 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9202878572), [Test report](https://leather-wallet.github.io/playwright-reports/fix/scroll-settings-menu-popup), [Storybook](https://fix-scroll-settings-menu-popup--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/scroll-settings-menu-popup)<!-- Sticky Header Marker -->

This PR adds 3 fixes:
- https://github.com/leather-wallet/extension/pull/5411 
    - I allows the settings menu to scroll if needed. Previously it wasn't scrolling in small view if there was a survey banner.
- https://github.com/leather-wallet/extension/pull/5409 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Settings menu with scrollable content to improve user navigation and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->