### PR TITLE
fix: set pointer events to none in toast viewport

### DIFF
--- a/src/app/ui/components/toast/toast.tsx
+++ b/src/app/ui/components/toast/toast.tsx
@@ -47,6 +47,7 @@ const toastViewportStyles = css({
   transform: 'translate(-50%, 0)',
   width: '100%',
   zIndex: 9999,
+  pointerEvents: 'none',
 });
 const Viewport: typeof RadixToast.Viewport = forwardRef((props, ref) => (
   <RadixToast.Viewport className={toastViewportStyles} ref={ref} {...props} />


### PR DESCRIPTION
> Try out Leather build 88d02db — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9207875148), [Test report](https://leather-wallet.github.io/playwright-reports/fix/toast-overlap), [Storybook](https://fix-toast-overlap--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/toast-overlap)<!-- Sticky Header Marker -->

copy of https://github.com/leather-wallet/extension/pull/5400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated toast notifications to be non-interactive, preventing accidental clicks and improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->