### PR TITLE
fix: remove hover effect in sign out button

### DIFF
--- a/src/app/features/settings/sign-out/sign-out.tsx
+++ b/src/app/features/settings/sign-out/sign-out.tsx
@@ -44,7 +44,6 @@ export function SignOutDialog({ isShowing, onUserDeleteWallet, onClose }: SignOu
           </Button>
           <Button
             color="lightModeInk.1"
-            _hover={{ background: 'black' }}
             opacity={!canSignOut ? 0.8 : undefined}
             data-testid={SettingsSelectors.BtnSignOutActuallyDeleteWallet}
             flexGrow={1}


### PR DESCRIPTION
closes https://github.com/leather-wallet/extension/issues/5406

Resolving the issue only on the <kbd>Sign out</kbd> button does not prevent the problem from recurring in other instances. Therefore, I have set a higher specificity in the button's recipe for the disabled and hover state background attribute. This ensures that disabled buttons never have a different background in the hover state, addressing concerns raised in previous PRs.

While I'm generally not a proponent of using `!important`, it is justified in this context to achieve the desired consistency across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the background color of disabled buttons takes precedence over other styles.
  - Removed hover background behavior from the Sign Out button in the settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->