### PR TITLE
fix: handle undefined memo type for SIP10, ref #5436

### DIFF
--- a/src/app/features/stacks-transaction-request/hooks/use-stacks-transaction-summary.ts
+++ b/src/app/features/stacks-transaction-request/hooks/use-stacks-transaction-summary.ts
@@ -13,6 +13,7 @@ import BigNumber from 'bignumber.js';
 
 import { CryptoCurrencies } from '@shared/models/currencies.model';
 import { createMoney } from '@shared/models/money.model';
+import { isDefined } from '@shared/utils';
 
 import {
   baseCurrencyAmountInQuote,
@@ -72,13 +73,20 @@ export function useStacksTransactionSummary(token: CryptoCurrencies) {
     };
   }
 
+  function getSip10MemoDisplayText(payload: ContractCallPayload): string {
+    const noMemoText = 'No memo';
+    if (!isDefined(payload.functionArgs[3])) {
+      return noMemoText;
+    }
+    const isSome = payload.functionArgs[3].type === ClarityType.OptionalSome;
+    return isSome ? bytesToUtf8(serializeCV(payload.functionArgs[3])) : noMemoText;
+  }
+
   function formSip10TxSummary(tx: StacksTransaction, symbol: string, decimals = 6) {
     const payload = tx.payload as ContractCallPayload;
     const fee = tx.auth.spendingCondition.fee;
     const txValue = Number((payload.functionArgs[0] as IntCV).value);
-    const isSome = payload.functionArgs[3].type === ClarityType.OptionalSome;
-    const memo = bytesToUtf8(serializeCV(payload.functionArgs[3]));
-    const memoDisplayText = isSome ? memo : 'No memo';
+    const memoDisplayText = getSip10MemoDisplayText(payload);
 
     const sendingValue = formatMoney(
       convertToMoneyTypeWithDefaultOfZero(symbol, txValue, decimals)


### PR DESCRIPTION
> Try out Leather build 61c117c — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9220997844), [Test report](https://leather-wallet.github.io/playwright-reports/fix/5436/sip10-memo), [Storybook](https://fix-5436-sip10-memo--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/5436/sip10-memo)<!-- Sticky Header Marker -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Improved memo display logic for transactions, enhancing readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->