### PR TITLE
fix: show runes balance

### DIFF
--- a/src/app/query/bitcoin/runes/runes-ticker-info.query.ts
+++ b/src/app/query/bitcoin/runes/runes-ticker-info.query.ts
@@ -1,10 +1,12 @@
 import { useQueries } from '@tanstack/react-query';
 
-import { useConfigRunesEnabled } from '@app/query/common/remote-config/remote-config.query';
+import { isDefined } from '@shared/utils';
+
 import { useBitcoinClient } from '@app/store/common/api-clients.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import type { RuneBalance, RuneTickerInfo } from '../bitcoin-client';
+import { useRunesEnabled } from './runes.hooks';
 import { createRuneCryptoAssetDetails } from './runes.utils';
 
 const queryOptions = { staleTime: 5 * 60 * 1000 };
@@ -12,13 +14,12 @@ const queryOptions = { staleTime: 5 * 60 * 1000 };
 export function useGetRunesTickerInfoQuery(runesBalances: RuneBalance[]) {
   const client = useBitcoinClient();
   const network = useCurrentNetwork();
-  const runesEnabled = useConfigRunesEnabled();
+  const runesEnabled = useRunesEnabled();
 
   return useQueries({
     queries: runesBalances.map(runeBalance => {
       return {
-        enabled:
-          !runeBalance && (network.chain.bitcoin.bitcoinNetwork === 'testnet' || runesEnabled),
+        enabled: isDefined(runeBalance) && runesEnabled,
         queryKey: ['runes-ticker-info', runeBalance.rune_name],
         queryFn: () =>
           client.bestinSlotApi.getRunesTickerInfo(


### PR DESCRIPTION
> Try out Leather build be76501 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9219355375), [Test report](https://leather-wallet.github.io/playwright-reports/fix/runes-display), [Storybook](https://fix-runes-display--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/runes-display)<!-- Sticky Header Marker -->

This pr fixes problem with showing runes in asset list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the source of the `runesEnabled` variable to ensure accurate and consistent retrieval of runes ticker information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->