### PR TITLE
fix: always set memo for SIP10, ref #5436

### DIFF
--- a/src/app/store/transactions/token-transfer.hooks.ts
+++ b/src/app/store/transactions/token-transfer.hooks.ts
@@ -86,7 +86,6 @@ export function useGenerateFtTokenTransferUnsignedTx(info: Sip10CryptoAssetInfo)
   const { contractId } = info;
   const { contractAddress, contractAssetName, contractName } =
     getStacksContractIdStringParts(contractId);
-
   return useCallback(
     async (values?: StacksSendFormValues | StacksTransactionFormValues) => {
       try {
@@ -121,9 +120,7 @@ export function useGenerateFtTokenTransferUnsignedTx(info: Sip10CryptoAssetInfo)
           standardPrincipalCVFromAddress(recipient),
         ];
 
-        if (info.hasMemo) {
-          functionArgs.push(memo);
-        }
+        functionArgs.push(memo);
 
         const options = {
           txData: {
@@ -151,7 +148,6 @@ export function useGenerateFtTokenTransferUnsignedTx(info: Sip10CryptoAssetInfo)
     [
       account,
       info.decimals,
-      info.hasMemo,
       network,
       nextNonce?.nonce,
       contractName,


### PR DESCRIPTION
This PR makes a change to make sure we always add `memo` as a `functionArg` in `useGenerateFtTokenTransferUnsignedTx` 

