### PR TITLE
fix: asset list formatted balance, closes #5452

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.2.0",
     "@leather-wallet/models": "0.6.5",
-    "@leather-wallet/query": "0.6.6",
+    "@leather-wallet/query": "0.6.7",
     "@leather-wallet/tokens": "0.4.0",
     "@leather-wallet/utils": "0.6.5",
     "@ledgerhq/hw-transport-webusb": "6.27.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: 0.6.5
     version: 0.6.5
   '@leather-wallet/query':
-    specifier: 0.6.6
-    version: 0.6.6(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.6.7
+    version: 0.6.7(react-dom@18.2.0)(react@18.2.0)
   '@leather-wallet/tokens':
     specifier: 0.4.0
     version: 0.4.0
@@ -3604,8 +3604,8 @@ packages:
       - supports-color
     dev: true
 
-  /@leather-wallet/query@0.6.6(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-rwNLLQDRKA5LJ3UESltkbgy8IuyzrV1QDse7tL/3QwM6y7L0IcN1mMx/IDwjVGPutvsCVJPed1/j2ZMG+pDifw==}
+  /@leather-wallet/query@0.6.7(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-f/5xH3kqeAmzl+3UB0T/n6u4xKCsU5p4qWhUz/+CqVLpsFnN5ecuZeR//DJ6QSt0c7+jNL725CcB3tsa8wy2aQ==}
     peerDependencies:
       react: '*'
     dependencies:

--- a/src/app/common/format-balance.ts
+++ b/src/app/common/format-balance.ts
@@ -12,5 +12,5 @@ export function formatBalance(amount: string) {
         isAbbreviated: true,
         value: abbreviateNumber(number),
       }
-    : { value: amount, isAbbreviated: false };
+    : { isAbbreviated: false, value: amount };
 }

--- a/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -1,4 +1,4 @@
-import type { CryptoAssetBalance } from '@leather-wallet/models';
+import type { Money } from '@leather-wallet/models';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
 import { spamFilter } from '@app/common/utils/spam-filter';
@@ -12,7 +12,8 @@ import { Pressable } from '@app/ui/pressable/pressable';
 import { parseCryptoAssetBalance } from './crypto-asset-item.layout.utils';
 
 interface CryptoAssetItemLayoutProps {
-  balance: CryptoAssetBalance;
+  availableBalance: Money;
+  balanceSuffix?: string;
   captionLeft: string;
   captionRightBulletInfo?: React.ReactNode;
   contractId?: string;
@@ -24,7 +25,8 @@ interface CryptoAssetItemLayoutProps {
   titleRightBulletInfo?: React.ReactNode;
 }
 export function CryptoAssetItemLayout({
-  balance,
+  availableBalance,
+  balanceSuffix,
   captionLeft,
   captionRightBulletInfo,
   contractId,
@@ -35,18 +37,21 @@ export function CryptoAssetItemLayout({
   titleLeft,
   titleRightBulletInfo,
 }: CryptoAssetItemLayoutProps) {
-  const { availableBalance, dataTestId, formattedBalance } = parseCryptoAssetBalance(balance);
+  const { availableBalanceString, dataTestId, formattedBalance } =
+    parseCryptoAssetBalance(availableBalance);
 
   const titleRight = (
     <SkeletonLoader width="126px" isLoading={isLoading}>
       <BasicTooltip
         asChild
-        label={formattedBalance.isAbbreviated ? availableBalance.amount.toString() : undefined}
+        label={formattedBalance.isAbbreviated ? availableBalanceString : undefined}
         side="left"
       >
         <Flex alignItems="center" gap="space.02" textStyle="label.02">
           <BulletSeparator>
-            <styled.span>{formattedBalance.value}</styled.span>
+            <styled.span>
+              {formattedBalance.value} {balanceSuffix}
+            </styled.span>
             {titleRightBulletInfo}
           </BulletSeparator>
         </Flex>

--- a/src/app/components/crypto-asset-item/crypto-asset-item.layout.utils.ts
+++ b/src/app/components/crypto-asset-item/crypto-asset-item.layout.utils.ts
@@ -1,21 +1,19 @@
-import type { CryptoAssetBalance } from '@leather-wallet/models';
+import type { Money } from '@leather-wallet/models';
 import { CryptoAssetSelectors } from '@tests/selectors/crypto-asset.selectors';
 
 import { formatBalance } from '@app/common/format-balance';
 import { formatMoneyWithoutSymbol } from '@app/common/money/format-money';
 
-export function parseCryptoAssetBalance(balance: CryptoAssetBalance) {
-  const { availableBalance } = balance;
-
-  const amount = formatMoneyWithoutSymbol(availableBalance);
+export function parseCryptoAssetBalance(availableBalance: Money) {
+  const availableBalanceString = formatMoneyWithoutSymbol(availableBalance);
   const dataTestId = CryptoAssetSelectors.CryptoAssetListItem.replace(
     '{symbol}',
     availableBalance.symbol.toLowerCase()
   );
-  const formattedBalance = formatBalance(amount);
+  const formattedBalance = formatBalance(availableBalanceString);
 
   return {
-    availableBalance,
+    availableBalanceString,
     dataTestId,
     formattedBalance,
   };

--- a/src/app/features/asset-list/bitcoin/brc20-token-asset-list/brc20-token-asset-list.tsx
+++ b/src/app/features/asset-list/bitcoin/brc20-token-asset-list/brc20-token-asset-list.tsx
@@ -45,7 +45,7 @@ export function Brc20TokenAssetList({ tokens, variant }: Brc20TokenAssetListProp
     <Stack data-testid={CryptoAssetSelectors.CryptoAssetList}>
       {tokens.map(token => (
         <CryptoAssetItemLayout
-          balance={token.balance}
+          availableBalance={token.balance.availableBalance}
           captionLeft={token.info.name.toUpperCase()}
           icon={<Brc20AvatarIcon />}
           isLoading={isInitialLoading}

--- a/src/app/features/asset-list/bitcoin/btc-crypto-asset-item/btc-crypto-asset-item.tsx
+++ b/src/app/features/asset-list/bitcoin/btc-crypto-asset-item/btc-crypto-asset-item.tsx
@@ -19,7 +19,7 @@ export function BtcCryptoAssetItem({ balance, isLoading, onSelectAsset }: BtcCry
 
   return (
     <CryptoAssetItemLayout
-      balance={balance}
+      availableBalance={balance.availableBalance}
       captionLeft="BTC"
       fiatBalance={fiatAvailableBalance}
       icon={<BtcAvatarIcon />}

--- a/src/app/features/asset-list/bitcoin/runes-asset-list/runes-asset-list.tsx
+++ b/src/app/features/asset-list/bitcoin/runes-asset-list/runes-asset-list.tsx
@@ -1,4 +1,5 @@
 import type { CryptoAssetBalance, RuneCryptoAssetInfo } from '@leather-wallet/models';
+import { convertAmountToBaseUnit, createMoneyFromDecimal } from '@leather-wallet/utils';
 
 import { CryptoAssetItemLayout } from '@app/components/crypto-asset-item/crypto-asset-item.layout';
 import { RunesAvatarIcon } from '@app/ui/components/avatar/runes-avatar-icon';
@@ -14,7 +15,12 @@ interface RunesAssetListProps {
 export function RunesAssetList({ runes }: RunesAssetListProps) {
   return runes.map((rune, i) => (
     <CryptoAssetItemLayout
-      balance={rune.balance}
+      availableBalance={createMoneyFromDecimal(
+        convertAmountToBaseUnit(rune.balance.availableBalance),
+        rune.info.symbol,
+        rune.info.decimals
+      )}
+      balanceSuffix={rune.info.symbol}
       captionLeft="Runes"
       icon={<RunesAvatarIcon />}
       key={`${rune.info.symbol}${i}`}

--- a/src/app/features/asset-list/bitcoin/src20-token-asset-list/src20-token-asset-list.tsx
+++ b/src/app/features/asset-list/bitcoin/src20-token-asset-list/src20-token-asset-list.tsx
@@ -8,7 +8,7 @@ interface Src20TokenAssetListProps {
 export function Src20TokenAssetList({ tokens }: Src20TokenAssetListProps) {
   return tokens.map((token, i) => (
     <CryptoAssetItemLayout
-      balance={token.balance}
+      availableBalance={token.balance.availableBalance}
       captionLeft={token.info.name.toUpperCase()}
       key={`${token.info.id}${i}`}
       icon={<Src20AvatarIcon />}

--- a/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-item.tsx
+++ b/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-item.tsx
@@ -28,7 +28,7 @@ export function Sip10TokenAssetItem({
 
   return (
     <CryptoAssetItemLayout
-      balance={balance}
+      availableBalance={balance.availableBalance}
       fiatBalance={fiatBalance}
       captionLeft={info.symbol}
       contractId={info.contractId}

--- a/src/app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item.tsx
+++ b/src/app/features/asset-list/stacks/stx-crypo-asset-item/stx-crypto-asset-item.tsx
@@ -32,7 +32,7 @@ export function StxCryptoAssetItem({ balance, isLoading, onSelectAsset }: StxCry
 
   return (
     <CryptoAssetItemLayout
-      balance={balance}
+      availableBalance={balance.availableBalance}
       captionLeft="STX"
       captionRightBulletInfo={showLockedBalance && captionRightBulletInfo}
       fiatBalance={fiatAvailableBalance}

--- a/src/app/features/asset-list/stacks/stx20-token-asset-list/stx20-token-asset-list.tsx
+++ b/src/app/features/asset-list/stacks/stx20-token-asset-list/stx20-token-asset-list.tsx
@@ -14,7 +14,7 @@ interface Stx20TokenAssetListProps {
 export function Stx20TokenAssetList({ tokens }: Stx20TokenAssetListProps) {
   return tokens.map((token, i) => (
     <CryptoAssetItemLayout
-      balance={token.balance}
+      availableBalance={token.balance.availableBalance}
       captionLeft={token.info.name.toUpperCase()}
       icon={<Stx20AvatarIcon />}
       key={`${token.info.symbol}${i}`}

--- a/src/app/pages/choose-account/components/accounts.tsx
+++ b/src/app/pages/choose-account/components/accounts.tsx
@@ -44,6 +44,7 @@ const ChooseAccountItem = memo(
     const btcAddress = useNativeSegwitAccountIndexAddressIndexZero(account.index);
 
     const accountSlug = useMemo(() => slugify(`Account ${account?.index + 1}`), [account?.index]);
+
     return (
       <AccountListItemLayout
         accountAddresses={<AcccountAddresses index={account.index} />}

--- a/tests/page-object-models/test-app.page.ts
+++ b/tests/page-object-models/test-app.page.ts
@@ -4,7 +4,6 @@ import { TestAppSelectors } from '@tests/selectors/test-app.selectors';
 import { createTestSelector } from '@tests/utils';
 
 export class TestAppPage {
-  static readonly url = 'http://localhost:3000';
   page: Page;
   readonly signInBtnSelector = createTestSelector(OnboardingSelectors.SignUpBtn);
   readonly contractCallBtnSelector = createTestSelector(TestAppSelectors.BtnContractCall);
@@ -20,12 +19,8 @@ export class TestAppPage {
 
   static async openDemoPage(context: BrowserContext) {
     const newPage = await context.newPage();
-    await newPage.goto(TestAppPage.url);
+    await newPage.goto('localhost:3000', { waitUntil: 'networkidle' });
     return new TestAppPage(newPage);
-  }
-
-  async signIn() {
-    return this.page.click(this.signInBtnSelector, { timeout: 10000 });
   }
 
   async clickContractCallButton() {

--- a/tests/specs/profile/profile.spec.ts
+++ b/tests/specs/profile/profile.spec.ts
@@ -1,6 +1,7 @@
 import { mockGaiaProfileResponse } from '@tests/mocks/mock-profile';
 import { TestAppPage } from '@tests/page-object-models/test-app.page';
 import { UpdateProfileRequestPage } from '@tests/page-object-models/update-profile-request.page';
+import { OnboardingSelectors } from '@tests/selectors/onboarding.selectors';
 
 import { test } from '../../fixtures/fixtures';
 
@@ -9,16 +10,17 @@ test.describe.configure({ mode: 'serial' });
 test.describe('Profile updating', () => {
   let testAppPage: TestAppPage;
 
-  test.beforeEach(async ({ extensionId, globalPage, onboardingPage, context }) => {
+  test.beforeEach(async ({ context, extensionId, globalPage, onboardingPage }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);
     testAppPage = await TestAppPage.openDemoPage(context);
-    await testAppPage.signIn();
   });
 
   test('should show an error for invalid profile', async ({ context }) => {
-    const accountsPage = await context.waitForEvent('page');
-    await accountsPage.locator('text="Account 1"').click({ force: true });
+    const newPagePromise = context.waitForEvent('page');
+    await testAppPage.page.getByTestId(OnboardingSelectors.SignUpBtn).click();
+    const accountsPage = await newPagePromise;
+    await accountsPage.getByTestId('switch-account-item-0').click({ force: true });
     await testAppPage.page.bringToFront();
     await testAppPage.page.click('text=Profile', {
       timeout: 30000,
@@ -43,12 +45,13 @@ test.describe('Gaia profile request', () => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);
     testAppPage = await TestAppPage.openDemoPage(context);
-    await testAppPage.signIn();
   });
 
   test('should send a signed profile token to gaia', async ({ context }) => {
-    const accountsPage = await context.waitForEvent('page');
-    await accountsPage.locator('text="Account 2"').click({ force: true });
+    const newPagePromise = context.waitForEvent('page');
+    await testAppPage.page.getByTestId(OnboardingSelectors.SignUpBtn).click();
+    const accountsPage = await newPagePromise;
+    await accountsPage.getByTestId('switch-account-item-1').click({ force: true });
     await testAppPage.page.bringToFront();
     await testAppPage.page.click('text=Profile', {
       timeout: 30000,

--- a/tests/specs/transactions/transactions.spec.ts
+++ b/tests/specs/transactions/transactions.spec.ts
@@ -2,6 +2,7 @@ import { stxToMicroStx } from '@leather-wallet/utils';
 import { TokenTransferPayload, deserializeTransaction } from '@stacks/transactions';
 import { TestAppPage } from '@tests/page-object-models/test-app.page';
 import { TransactionRequestPage } from '@tests/page-object-models/transaction-request.page';
+import { OnboardingSelectors } from '@tests/selectors/onboarding.selectors';
 
 import { test } from '../../fixtures/fixtures';
 
@@ -11,9 +12,7 @@ test.describe('Transaction signing', () => {
   test.beforeEach(async ({ extensionId, globalPage, onboardingPage, context }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);
-
     testAppPage = await TestAppPage.openDemoPage(context);
-    await testAppPage.signIn();
   });
 
   // These tests often break if ran in parallel
@@ -23,8 +22,10 @@ test.describe('Transaction signing', () => {
     test('that it validates against insufficient funds when performing a contract call', async ({
       context,
     }) => {
-      const accountsPage = await context.waitForEvent('page');
-      await accountsPage.locator('text="Account 2"').click({ force: true });
+      const newPagePromise = context.waitForEvent('page');
+      await testAppPage.page.getByTestId(OnboardingSelectors.SignUpBtn).click();
+      const accountsPage = await newPagePromise;
+      await accountsPage.getByTestId('switch-account-item-1').click({ force: true });
       await testAppPage.page.bringToFront();
       await testAppPage.page.click('text=Debugger', {
         timeout: 30000,
@@ -42,8 +43,10 @@ test.describe('Transaction signing', () => {
 
   test.describe('App initiated STX transfer', () => {
     test('that it broadcasts correctly with given fee and amount', async ({ context }) => {
-      const accountsPage = await context.waitForEvent('page');
-      await accountsPage.locator('text="Account 1"').click({ force: true });
+      const newPagePromise = context.waitForEvent('page');
+      await testAppPage.page.getByTestId(OnboardingSelectors.SignUpBtn).click();
+      const accountsPage = await newPagePromise;
+      await accountsPage.getByTestId('switch-account-item-0').click({ force: true });
       await testAppPage.page.bringToFront();
       await testAppPage.page.click('text=Debugger', {
         timeout: 30000,


### PR DESCRIPTION
> Try out Leather build 3c91b23 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9239352881), [Test report](https://leather-wallet.github.io/playwright-reports/fix/runes-balance-formatting), [Storybook](https://fix-runes-balance-formatting--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/runes-balance-formatting)<!-- Sticky Header Marker -->

This PR should fix the formatted balance in the shared asset list item. This also includes the query pkg update that installs the Runes balance fix into the extension again. See: https://github.com/leather-wallet/mono/pull/155

![Screenshot 2024-05-25 at 9 42 06 AM](https://github.com/leather-wallet/extension/assets/6493321/d7faedcb-b4dd-4ddc-8926-971eb6d7748c)

![Screenshot 2024-05-25 at 9 42 24 AM](https://github.com/leather-wallet/extension/assets/6493321/4e7f1f9c-a46d-4929-8d83-5bd43fa8f36e)

![Screenshot 2024-05-25 at 9 43 52 AM](https://github.com/leather-wallet/extension/assets/6493321/e8a720a1-bc23-4f0e-8d63-90fdc3384b0b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added memoization for generating `accountSlug` in account selection for improved performance.

- **Updates**
  - Renamed `balance` to `availableBalance` across various components for consistency.
  - Updated balance display logic to ensure accurate and clear representation.

- **Bug Fixes**
  - Improved element locators in tests for more reliable test execution.

- **Refactor**
  - Swapped order of properties in balance formatting to enhance readability.

- **Tests**
  - Updated element locators in profile and transaction tests for better accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->