### PR TITLE
ci: ignore forks

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -26,6 +26,7 @@ jobs:
           workflow_conclusion: success
           name: firefox_version
           path: old
+          allow_forks: false
 
       - name: Determine if new version is live
         id: firefox
@@ -88,6 +89,7 @@ jobs:
           workflow_conclusion: success
           name: chrome_version
           path: old
+          allow_forks: false
 
       - name: Determine if new version is live
         id: chrome

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -125,6 +125,7 @@ jobs:
         with:
           workflow: create-version.yml
           name: release-notes
+          allow_forks: false
 
       - name: Zip Firefox build
         run: zip -r leather-firefox.v${{ needs.extract-version.outputs.new_version }}.zip leather-firefox-v${{ needs.extract-version.outputs.new_version }}


### PR DESCRIPTION
> Try out Leather build 369c2f4 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9251472927), [Test report](https://leather-wallet.github.io/playwright-reports/ci/down-job-args), [Storybook](https://ci-down-job-args--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci/down-job-args)<!-- Sticky Header Marker -->

Adds args to download job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configurations to enhance security by disallowing forks for specific jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->