### PR TITLE
fix: align DialogHeader title on center, ref #5419

### DIFF
--- a/src/app/ui/components/containers/headers/dialog-header.tsx
+++ b/src/app/ui/components/containers/headers/dialog-header.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
-import { Box, Flex } from 'leather-styles/jsx';
+import { Flex, styled } from 'leather-styles/jsx';
 
 import { CloseIcon } from '@app/ui/icons';
 
@@ -15,7 +15,8 @@ interface DialogHeaderProps {
 export function DialogHeader({ onClose, title }: DialogHeaderProps) {
   return (
     <Flex
-      justifyContent="center"
+      justifyContent="flex-end"
+      alignItems="center"
       m={{ base: 0, md: 'auto' }}
       p="space.04"
       bg="transparent"
@@ -23,18 +24,16 @@ export function DialogHeader({ onClose, title }: DialogHeaderProps) {
       minHeight="40px"
     >
       {title && (
-        <Flex flex="none" m="auto" alignItems="center" textStyle="heading.05">
+        <styled.h2 flex="1" textAlign="center" textStyle="heading.05">
           {title}
-        </Flex>
+        </styled.h2>
       )}
       {onClose && (
-        <Box ml="auto">
-          <HeaderActionButton
-            icon={<CloseIcon />}
-            dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
-            onAction={onClose}
-          />
-        </Box>
+        <HeaderActionButton
+          icon={<CloseIcon />}
+          dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
+          onAction={onClose}
+        />
       )}
     </Flex>
   );


### PR DESCRIPTION
> Try out Leather build 38d56e8 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9251759006), [Test report](https://leather-wallet.github.io/playwright-reports/fix/dialog-header-title-alignment), [Storybook](https://fix-dialog-header-title-alignment--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/dialog-header-title-alignment)<!-- Sticky Header Marker -->

From PR https://github.com/leather-wallet/extension/pull/5435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved alignment and styling of dialog headers for a more consistent and visually appealing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->