### PR TITLE
fix: remove hover style in sign out button, ref #5406

### DIFF
--- a/src/app/features/settings/sign-out/sign-out.tsx
+++ b/src/app/features/settings/sign-out/sign-out.tsx
@@ -44,7 +44,6 @@ export function SignOutDialog({ isShowing, onUserDeleteWallet, onClose }: SignOu
           </Button>
           <Button
             color="lightModeInk.1"
-            _hover={{ background: 'black' }}
             opacity={!canSignOut ? 0.8 : undefined}
             data-testid={SettingsSelectors.BtnSignOutActuallyDeleteWallet}
             flexGrow={1}


### PR DESCRIPTION
> Try out Leather build f3588e6 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9263647564), [Test report](https://leather-wallet.github.io/playwright-reports/fix-hover-disabled-buttons), [Storybook](https://fix-hover-disabled-buttons--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-hover-disabled-buttons)<!-- Sticky Header Marker -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Change from this PR: https://github.com/leather-wallet/extension/pull/5435

## Summary by CodeRabbit

- **Style**
  - Updated the Sign Out button to remove hover effect for a cleaner user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->