### PR TITLE
fix: warn users against using support tool for help

### DIFF
--- a/src/shared/utils/analytics.ts
+++ b/src/shared/utils/analytics.ts
@@ -77,7 +77,8 @@ export function initSentry() {
         showBranding: false,
         messageLabel: 'Feedback',
         submitButtonLabel: 'Send feedback',
-        messagePlaceholder: 'How can we improve Leather?',
+        messagePlaceholder:
+          'This is not a support tool. To get help, follow the link in the main menu on the homepage.',
         successMessageText: 'Thanks for helping make Leather better',
         themeDark: {
           background: token('colors.ink.background-primary'),


### PR DESCRIPTION
> Try out Leather build 07d1b9b — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9270149969), [Test report](https://leather-wallet.github.io/playwright-reports/feat-change-feedback-text), [Storybook](https://feat-change-feedback-text--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-change-feedback-text)<!-- Sticky Header Marker -->

The commit helps support by warning users not to use the support tool for help.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated guidance message in the error reporting tool to direct users to the support link in the main menu on the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->