### PR TITLE
fix: reenable compliance checks

### DIFF
--- a/src/app/common/validation/forms/compliance-validators.ts
+++ b/src/app/common/validation/forms/compliance-validators.ts
@@ -3,10 +3,7 @@ import * as yup from 'yup';
 
 import type { NetworkModes } from '@shared/constants';
 
-import {
-  checkEntityAddressIsCompliant,
-  isComplianceCheckEnabled,
-} from '@app/query/common/compliance-checker/compliance-checker.query';
+import { checkEntityAddressIsCompliant } from '@app/query/common/compliance-checker/compliance-checker.query';
 
 export function complianceValidator(
   shouldCheckCompliance: yup.StringSchema<string, yup.AnyObject>,
@@ -18,8 +15,6 @@ export function complianceValidator(
       if (!isString(value)) return false;
 
       if (network !== 'mainnet') return true;
-
-      if (!isComplianceCheckEnabled) return true;
 
       if (!shouldCheckCompliance.isValidSync(value)) return true;
 

--- a/src/app/features/errors/app-error-boundary.tsx
+++ b/src/app/features/errors/app-error-boundary.tsx
@@ -7,12 +7,18 @@ import { Box, Flex, HStack, styled } from 'leather-styles/jsx';
 
 import { Prism } from '@app/common/clarity-prism';
 import { useClipboard } from '@app/common/hooks/use-copy-to-clipboard';
+import { compliantErrorBody } from '@app/query/common/compliance-checker/compliance-checker.query';
 import { Button } from '@app/ui/components/button/button';
 import { CodeBlock } from '@app/ui/components/codeblock';
 import { Link } from '@app/ui/components/link/link';
 import { CopyIcon } from '@app/ui/icons';
 
 import { useToast } from '../toasts/use-toast';
+
+function shouldShowContactSupportMessage(errorMsg: string) {
+  if (errorMsg.includes(compliantErrorBody)) return false;
+  return true;
+}
 
 function ErroBoundaryBody() {
   return (
@@ -84,7 +90,7 @@ export function RouterErrorBoundary() {
         {title}
       </styled.span>
 
-      <ErroBoundaryBody />
+      {shouldShowContactSupportMessage(errorText) && <ErroBoundaryBody />}
 
       {errorText && (
         <CodeBlock

--- a/tests/specs/compliance-checks/compliance-checks.spec.ts
+++ b/tests/specs/compliance-checks/compliance-checks.spec.ts
@@ -4,20 +4,24 @@ import type { BrowserContext, Page, Route } from '@playwright/test';
 import { test } from '../../fixtures/fixtures';
 
 function mockChainalysisEntityRegistrationRequest(context: BrowserContext) {
-  return async (routeHandler: (route: Route) => void) =>
+  return async (routeHandler: (route: Route) => void) => {
+    console.log('Mocking entity registration');
     context.route('https://api.chainalysis.com/api/risk/v2/entities', async route =>
       routeHandler(route)
     );
+  };
 }
 
 function mockChainalysisEntityCheckRequest(context: BrowserContext) {
-  return async (routeHandler: (route: Route) => void) =>
+  return async (routeHandler: (route: Route) => void) => {
+    console.log('Mocking entity check');
     context.route('https://api.chainalysis.com/api/risk/v2/entities/*', async route =>
       routeHandler(route)
     );
+  };
 }
 
-test.skip('Compliance checks', () => {
+test.describe('Compliance checks', () => {
   test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);
@@ -51,7 +55,7 @@ test.skip('Compliance checks', () => {
     ]);
 
     await test
-      .expect(leatherApprover.locator('text="Unable to handle request, errorCode: 1398"'))
+      .expect(leatherApprover.getByText('Unable to handle request, errorCode: 1398'))
       .toBeVisible();
   });
 


### PR DESCRIPTION
> Try out Leather build a8bfa41 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9301174784), [Test report](https://leather-wallet.github.io/playwright-reports/fix-reenable-chainalysis), [Storybook](https://fix-reenable-chainalysis--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-reenable-chainalysis)<!-- Sticky Header Marker -->

This PR reenables compliance checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a conditional message to contact support based on specific error content.

- **Bug Fixes**
  - Enabled previously skipped compliance checks test.

- **Improvements**
  - Enhanced error handling for non-compliant entities with clear error messages.
  - Improved logging for mock entity registration and check requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->