### PR TITLE
Improve dust txs when sending max amount

### DIFF
--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.spec.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.spec.ts
@@ -3,7 +3,8 @@ import { createNullArrayOfLength, sumNumbers } from '@leather-wallet/utils';
 import { BTC_P2WPKH_DUST_AMOUNT } from '@shared/constants';
 import { createMoney } from '@shared/models/money.model';
 
-import { determineUtxosForSpend } from './local-coin-selection';
+import { filterUneconomicalUtxos, getSizeInfo } from '../utils';
+import { determineUtxosForSpend, determineUtxosForSpendAll } from './local-coin-selection';
 
 const demoUtxos = [
   { value: 8200 },
@@ -169,5 +170,66 @@ describe(determineUtxosForSpend.name, () => {
         .minus(amount.toString())
         .toString()
     );
+  });
+
+  test('that spending all economical spendable utxos does not result in dust utxos', () => {
+    const feeRate = 3;
+    const recipients = [
+      {
+        address: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+        amount: createMoney(Number(1), 'BTC'),
+      },
+    ];
+    const filteredUtxos = filterUneconomicalUtxos({
+      utxos: demoUtxos.sort((a, b) => b.value - a.value) as any,
+      feeRate,
+      recipients,
+    });
+    const amount = filteredUtxos.reduce((total, utxo) => total + utxo.value, 0) - 2251;
+    recipients[0].amount = createMoney(Number(amount), 'BTC');
+
+    const result = determineUtxosForSpend({
+      utxos: filteredUtxos as any,
+      recipients: [
+        {
+          address: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+          amount: createMoney(Number(amount), 'BTC'),
+        },
+      ],
+      feeRate,
+    });
+    expect(result.inputs.length).toEqual(10);
+    expect(result.outputs.length).toEqual(2);
+    expect(result.outputs[1].value).toEqual(0n);
+    expect(result.fee).toEqual(2251);
+  });
+
+  test('that spending all utxos with sendMax does not result in dust utxos', () => {
+    const utxos = [{ value: 1000 }, { value: 2000 }, { value: 3000 }];
+    const recipients = [
+      {
+        address: 'tb1qt28eagxcl9gvhq2rpj5slg7dwgxae2dn2hk93m',
+        amount: createMoney(Number(1), 'BTC'),
+      },
+    ];
+    const sizeInfo = getSizeInfo({
+      inputLength: utxos.length,
+      isSendMax: true,
+      recipients,
+    });
+    const feeRate = 3;
+    const fee = Math.floor(sizeInfo.txVBytes * feeRate);
+    const amount = utxos.reduce((total, utxo) => total + utxo.value, 0) - fee;
+    recipients[0].amount = createMoney(Number(amount), 'BTC');
+
+    const result = determineUtxosForSpendAll({
+      utxos: utxos as any,
+      recipients,
+      feeRate,
+    });
+    expect(result.inputs.length).toEqual(utxos.length);
+    expect(result.outputs.length).toEqual(1);
+    expect(result.fee).toEqual(735);
+    expect(fee).toEqual(735);
   });
 });

--- a/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
+++ b/src/app/common/transactions/bitcoin/coinselect/local-coin-selection.ts
@@ -102,6 +102,9 @@ export function determineUtxosForSpend({ feeRate, recipients, utxos }: Determine
     new BigNumber(estimateTransactionSize().txVBytes).multipliedBy(feeRate).toNumber()
   );
 
+  const changeAmount =
+    BigInt(getUtxoTotal(neededUtxos).toString()) - BigInt(amount.amount.toNumber()) - BigInt(fee);
+
   const outputs: {
     value: bigint;
     address?: string;
@@ -111,10 +114,7 @@ export function determineUtxosForSpend({ feeRate, recipients, utxos }: Determine
       address,
     })),
     {
-      value:
-        BigInt(getUtxoTotal(neededUtxos).toString()) -
-        BigInt(amount.amount.toNumber()) -
-        BigInt(fee),
+      value: changeAmount,
     },
   ];
 

--- a/src/app/components/bitcoin-custom-fee/hooks/use-bitcoin-custom-fee.tsx
+++ b/src/app/components/bitcoin-custom-fee/hooks/use-bitcoin-custom-fee.tsx
@@ -8,6 +8,7 @@ import { Money, createMoney } from '@shared/models/money.model';
 import { baseCurrencyAmountInQuote } from '@app/common/money/calculate-money';
 import { i18nFormatCurrency } from '@app/common/money/format-money';
 import {
+  type DetermineUtxosForSpendArgs,
   determineUtxosForSpend,
   determineUtxosForSpendAll,
 } from '@app/common/transactions/bitcoin/coinselect/local-coin-selection';
@@ -31,12 +32,7 @@ export function useBitcoinCustomFee({ amount, isSendingMax, recipients }: UseBit
     (feeRate: number) => {
       if (!feeRate || !utxos.length) return { fee: 0, fiatFeeValue: '' };
 
-      const satAmount = isSendingMax
-        ? balance.availableBalance.amount.toNumber()
-        : amount.amount.toNumber();
-
-      const determineUtxosArgs = {
-        amount: satAmount,
+      const determineUtxosArgs: DetermineUtxosForSpendArgs = {
         recipients,
         utxos,
         feeRate,


### PR DESCRIPTION
> Try out Leather build 5b702e8 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9316160974), [Test report](https://leather-wallet.github.io/playwright-reports/fix-4749), [Storybook](https://fix-4749--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-4749)<!-- Sticky Header Marker -->

This PR
* adds tests for coin selection when sending all economical spendable utxos
* fixes #4979 