### PR TITLE
 Improve dust txs when sending max amount (#4979)

### DIFF
--- a/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-input.tsx
+++ b/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee-input.tsx
@@ -4,7 +4,7 @@ import { useField } from 'formik';
 import { Stack } from 'leather-styles/jsx';
 
 import { Input } from '@leather.io/ui';
-import { createMoney, satToBtc } from '@leather.io/utils';
+import { satToBtc } from '@leather.io/utils';
 
 import type { TransferRecipient } from '@shared/models/form.model';
 
@@ -19,7 +19,6 @@ const feeInputLabel = 'sats/vB';
 
 interface Props {
   onClick?(): void;
-  amount: number;
   isSendingMax: boolean;
   recipients: TransferRecipient[];
   hasInsufficientBalanceError: boolean;
@@ -30,7 +29,6 @@ interface Props {
 
 export function BitcoinCustomFeeInput({
   onClick,
-  amount,
   isSendingMax,
   recipients,
   hasInsufficientBalanceError,
@@ -45,7 +43,6 @@ export function BitcoinCustomFeeInput({
   }>(null);
 
   const getCustomFeeValues = useBitcoinCustomFee({
-    amount: createMoney(amount, 'BTC'),
     isSendingMax,
     recipients,
   });

--- a/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee.tsx
+++ b/src/app/components/bitcoin-custom-fee/bitcoin-custom-fee.tsx
@@ -7,7 +7,6 @@ import * as yup from 'yup';
 
 import type { BtcFeeType } from '@leather.io/models';
 import { Button, Link } from '@leather.io/ui';
-import { createMoney } from '@leather.io/utils';
 
 import type { TransferRecipient } from '@shared/models/form.model';
 
@@ -31,7 +30,6 @@ interface BitcoinCustomFeeProps {
 }
 
 export function BitcoinCustomFee({
-  amount,
   customFeeInitialValue,
   hasInsufficientBalanceError,
   isSendingMax,
@@ -44,7 +42,6 @@ export function BitcoinCustomFee({
 }: BitcoinCustomFeeProps) {
   const feeInputRef = useRef<HTMLInputElement | null>(null);
   const getCustomFeeValues = useBitcoinCustomFee({
-    amount: createMoney(amount, 'BTC'),
     isSendingMax,
     recipients,
   });
@@ -97,7 +94,6 @@ export function BitcoinCustomFee({
                 </Link>
               </styled.span>
               <BitcoinCustomFeeInput
-                amount={amount}
                 isSendingMax={isSendingMax}
                 onClick={async () => {
                   feeInputRef.current?.focus();

--- a/src/app/components/bitcoin-custom-fee/hooks/use-bitcoin-custom-fee.tsx
+++ b/src/app/components/bitcoin-custom-fee/hooks/use-bitcoin-custom-fee.tsx
@@ -1,28 +1,25 @@
 import { useCallback } from 'react';
 
-import type { Money } from '@leather.io/models';
 import { useCryptoCurrencyMarketDataMeanAverage } from '@leather.io/query';
 import { baseCurrencyAmountInQuote, createMoney, i18nFormatCurrency } from '@leather.io/utils';
 
 import type { TransferRecipient } from '@shared/models/form.model';
 
 import {
+  type DetermineUtxosForSpendArgs,
   determineUtxosForSpend,
   determineUtxosForSpendAll,
 } from '@app/common/transactions/bitcoin/coinselect/local-coin-selection';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by-address.hooks';
-import { useCurrentBtcCryptoAssetBalanceNativeSegwit } from '@app/query/bitcoin/balance/btc-balance-native-segwit.hooks';
 
 export const MAX_FEE_RATE_MULTIPLIER = 50;
 
 interface UseBitcoinCustomFeeArgs {
-  amount: Money;
   isSendingMax: boolean;
   recipients: TransferRecipient[];
 }
 
-export function useBitcoinCustomFee({ amount, isSendingMax, recipients }: UseBitcoinCustomFeeArgs) {
-  const { balance } = useCurrentBtcCryptoAssetBalanceNativeSegwit();
+export function useBitcoinCustomFee({ isSendingMax, recipients }: UseBitcoinCustomFeeArgs) {
   const { data: utxos = [] } = useCurrentNativeSegwitUtxos();
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
 
@@ -30,12 +27,7 @@ export function useBitcoinCustomFee({ amount, isSendingMax, recipients }: UseBit
     (feeRate: number) => {
       if (!feeRate || !utxos.length) return { fee: 0, fiatFeeValue: '' };
 
-      const satAmount = isSendingMax
-        ? balance.availableBalance.amount.toNumber()
-        : amount.amount.toNumber();
-
-      const determineUtxosArgs = {
-        amount: satAmount,
+      const determineUtxosArgs: DetermineUtxosForSpendArgs = {
         recipients,
         utxos,
         feeRate,
@@ -51,6 +43,6 @@ export function useBitcoinCustomFee({ amount, isSendingMax, recipients }: UseBit
         )}`,
       };
     },
-    [utxos, isSendingMax, balance.availableBalance.amount, amount.amount, recipients, btcMarketData]
+    [utxos, isSendingMax, recipients, btcMarketData]
   );
 }

--- a/src/app/features/dialogs/increase-fee-dialog/increase-btc-fee-dialog.tsx
+++ b/src/app/features/dialogs/increase-fee-dialog/increase-btc-fee-dialog.tsx
@@ -93,9 +93,6 @@ export function IncreaseBtcFeeDialog() {
                   <Stack gap="space.04">
                     <Stack gap="space.01">
                       <BitcoinCustomFeeInput
-                        amount={Math.abs(
-                          btcToSat(getBitcoinTxValue(currentBitcoinAddress, btcTx)).toNumber()
-                        )}
                         isSendingMax={false}
                         recipients={recipients}
                         hasInsufficientBalanceError={false}


### PR DESCRIPTION
> _Building Leather at commit 100184a_<!-- Sticky Header Marker -->

This PR
* adds tests for coin selection when sending all economical spendable utxos
* fixes #4979 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced test cases for Bitcoin transactions to ensure spending all UTXOs without resulting in dust UTXOs.

- **Refactor**
  - Improved logic for handling change outputs in Bitcoin transactions.
  - Refined custom fee calculation logic by removing unused parameters.

- **Bug Fixes**
  - Eliminated unnecessary calculations in the Increase Bitcoin Fee Dialog component to streamline functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->