### PR TITLE
chore: update cbpay

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "1.0.2",
     "@blockstack/stacks-transactions": "0.7.0",
-    "@coinbase/cbpay-js": "1.0.2",
+    "@coinbase/cbpay-js": "2.1.0",
     "@dlc-link/dlc-tools": "1.1.1",
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(encoding@0.1.13)
       '@coinbase/cbpay-js':
-        specifier: 1.0.2
-        version: 1.0.2
+        specifier: 2.1.0
+        version: 2.1.0(regenerator-runtime@0.13.11)
       '@dlc-link/dlc-tools':
         specifier: 1.1.1
         version: 1.1.1
@@ -1679,9 +1679,14 @@ packages:
     bundledDependencies:
       - is-unicode-supported
 
-  '@coinbase/cbpay-js@1.0.2':
-    resolution: {integrity: sha512-m95VmSQm9xfA5MmOFRcVIPtZxO6GhRJKPbbxKSxGoCYf4SpAm7mz3euU1kiRr7bPMa+3wvyT36n2bHoiyuwseg==}
-    engines: {node: '>= 12'}
+  '@coinbase/cbpay-js@2.1.0':
+    resolution: {integrity: sha512-J9kuMY7qiEM9fV6k6sBJ44S2fDjdXfX7SeDCDv7fWoni5QnP7Ca3k6pHE0TSBRCkzzC0x1zK6wgieG4RyDPeNw==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      regenerator-runtime: ^0.13.9
+    peerDependenciesMeta:
+      regenerator-runtime:
+        optional: true
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -14697,7 +14702,9 @@ snapshots:
       picocolors: 1.0.1
       sisteransi: 1.0.5
 
-  '@coinbase/cbpay-js@1.0.2': {}
+  '@coinbase/cbpay-js@2.1.0(regenerator-runtime@0.13.11)':
+    optionalDependencies:
+      regenerator-runtime: 0.13.11
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
This PR:
- adds the latest version of `@coinbase/cbpay-js` 
- which in turn changes the format returned by `generateOnRampURL`

This will solve the issue raised by coinbase in  https://github.com/leather-wallet/extension/issues/5507. See [here](https://trustmachines.slack.com/archives/C05T570TNQJ/p1717170466244329)

**BEFORE**
We  were generating:
```
https://pay.coinbase.com/buy/select-asset?appId=APP_ID&destinationWallets=%7B%22bc1qn0h35pewsn9na7r2fy4rc53270990tvrgw2qhx%22%3A%5B%22BTC%22%5D%7D
```

Decoded:
```
https://pay.coinbase.com/buy/select-asset?appId=ca72edbc-0a08-468c-952d-6cde50b1dce6&destinationWallets={"bc1qn0h35pewsn9na7r2fy4rc53270990tvrgw2qhx":["BTC"]}'
```

**AFTER**
Now we are generating:
```
https://pay.coinbase.com/buy/select-asset?appId=APP_ID&destinationWallets=%5B%7B%22address%22%3A%22bc1qn0h35pewsn9na7r2fy4rc53270990tvrgw2qhx%22%2C%22assets%22%3A%5B%22BTC%22%5D%7D%5D
```

Decoded:
```
https://pay.coinbase.com/buy/select-asset?appId=ca72edbc-0a08-468c-952d-6cde50b1dce6&destinationWallets=[{"address":"bc1qn0h35pewsn9na7r2fy4rc53270990tvrgw2qhx","assets":["BTC"]}]
```
