### PR TITLE
Release: Update coinbase cpay addon

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -1,18 +1,7 @@
 {
   "$schema": "./wallet-config.schema.json",
   "messages": {
-    "global": [
-      {
-        "chainTarget": "all",
-        "dismissible": true,
-        "id": "user-survey-announcement",
-        "publishedAt": "2024-04-03T12:55:46",
-        "text": "We want to hear what you think about Leather.",
-        "learnMoreText": "Take our user survey →",
-        "learnMoreUrl": "https://blocksurvey.io/leather-wallet-user-survey-YWvSDeY2RU2mBtmuG2sbwA",
-        "purpose": "info"
-      }
-    ]
+    "global": []
   },
   "activeFiatProviders": {
     "coinbase": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "1.0.2",
     "@blockstack/stacks-transactions": "0.7.0",
-    "@coinbase/cbpay-js": "1.0.2",
+    "@coinbase/cbpay-js": "2.1.0",
     "@dlc-link/dlc-tools": "1.1.1",
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(encoding@0.1.13)
       '@coinbase/cbpay-js':
-        specifier: 1.0.2
-        version: 1.0.2
+        specifier: 2.1.0
+        version: 2.1.0(regenerator-runtime@0.13.11)
       '@dlc-link/dlc-tools':
         specifier: 1.1.1
         version: 1.1.1
@@ -1679,9 +1679,14 @@ packages:
     bundledDependencies:
       - is-unicode-supported
 
-  '@coinbase/cbpay-js@1.0.2':
-    resolution: {integrity: sha512-m95VmSQm9xfA5MmOFRcVIPtZxO6GhRJKPbbxKSxGoCYf4SpAm7mz3euU1kiRr7bPMa+3wvyT36n2bHoiyuwseg==}
-    engines: {node: '>= 12'}
+  '@coinbase/cbpay-js@2.1.0':
+    resolution: {integrity: sha512-J9kuMY7qiEM9fV6k6sBJ44S2fDjdXfX7SeDCDv7fWoni5QnP7Ca3k6pHE0TSBRCkzzC0x1zK6wgieG4RyDPeNw==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      regenerator-runtime: ^0.13.9
+    peerDependenciesMeta:
+      regenerator-runtime:
+        optional: true
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -14697,7 +14702,9 @@ snapshots:
       picocolors: 1.0.1
       sisteransi: 1.0.5
 
-  '@coinbase/cbpay-js@1.0.2': {}
+  '@coinbase/cbpay-js@2.1.0(regenerator-runtime@0.13.11)':
+    optionalDependencies:
+      regenerator-runtime: 0.13.11
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
> Try out Leather build 2c2aa5f — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9446315338), [Test report](https://leather-wallet.github.io/playwright-reports/release-coinbase-cpay), [Storybook](https://release-coinbase-cpay--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=release-coinbase-cpay)<!-- Sticky Header Marker -->

This release:
- updates the coinbase cpay library and solves https://github.com/leather-wallet/extension/issues/5507
- removes the survey banner