### PR TITLE
chore: re-enable settings menu animations

### DIFF
--- a/src/app/ui/components/dropdown-menu/dropdown-menu.tsx
+++ b/src/app/ui/components/dropdown-menu/dropdown-menu.tsx
@@ -66,8 +66,8 @@ const dropdownContentStyles = css({
   p: '0',
   willChange: 'transform, opacity',
   zIndex: 999,
-  // _closed: { animation: 'slideDownAndOut 140ms ease-in-out' },
-  // _open: { animation: 'slideUpAndFade 140ms ease-in-out' },
+  _closed: { animation: 'slideDownAndOut 140ms ease-in-out' },
+  _open: { animation: 'slideUpAndFade 140ms ease-in-out' },
 });
 const Content: typeof RadixDropdownMenu.Content = forwardRef(({ className, ...props }, ref) => (
   <RadixDropdownMenu.Content


### PR DESCRIPTION
> Try out Leather build 3413148 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9446760837), [Test report](https://leather-wallet.github.io/playwright-reports/chore-settings-menu-animation), [Storybook](https://chore-settings-menu-animation--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-settings-menu-animation)<!-- Sticky Header Marker -->

Previously I disabled these animations as they caused test failures. Checking to see if the failures were actually resolved by other issues. 