### PR TITLE
fix: sign out unknown wallet type error

### DIFF
--- a/src/app/features/settings/sign-out/sign-out.tsx
+++ b/src/app/features/settings/sign-out/sign-out.tsx
@@ -11,6 +11,7 @@ import { DialogHeader } from '@app/ui/components/containers/headers/dialog-heade
 
 interface SignOutDialogProps extends DialogProps {
   onUserDeleteWallet(): void;
+  onClose(): void;
 }
 export function SignOutDialog({ isShowing, onUserDeleteWallet, onClose }: SignOutDialogProps) {
   const { whenWallet, walletType } = useWalletType();
@@ -20,11 +21,18 @@ export function SignOutDialog({ isShowing, onUserDeleteWallet, onClose }: SignOu
       confirmPasswordDisable: whenWallet({ ledger: true, software: false }),
     },
     onSubmit() {
-      onUserDeleteWallet();
+      handleSignOut();
     },
   });
 
   const canSignOut = form.values.confirmBackup && form.values.confirmPasswordDisable;
+
+  function handleSignOut() {
+    if (canSignOut) {
+      onClose();
+      onUserDeleteWallet();
+    }
+  }
 
   return (
     <Dialog
@@ -48,7 +56,7 @@ export function SignOutDialog({ isShowing, onUserDeleteWallet, onClose }: SignOu
             data-testid={SettingsSelectors.BtnSignOutActuallyDeleteWallet}
             flexGrow={1}
             disabled={!canSignOut}
-            onClick={() => canSignOut && onUserDeleteWallet()}
+            onClick={handleSignOut}
             type="submit"
           >
             Sign out


### PR DESCRIPTION
> Try out Leather build 0a5ad8c — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9513932116), [Test report](https://leather-wallet.github.io/playwright-reports/fix-sign-out), [Storybook](https://fix-sign-out--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-sign-out)<!-- Sticky Header Marker -->

This pr fixes unhandled `unknown wallet type` error on sign out
due to https://github.com/leather-wallet/extension/pull/5530#issuecomment-2165353232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the sign-out dialog to include an `onClose` function for better user experience.
  
- **Bug Fixes**
  - Updated the sign-out process to handle user actions more effectively.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->