### PR TITLE
fix(ui): disable pointer events on label

### DIFF
--- a/src/app/ui/components/input/input.tsx
+++ b/src/app/ui/components/input/input.tsx
@@ -22,6 +22,7 @@ const transformedLabelStyles: SystemStyleObject = {
   textStyle: 'label.03',
   transform: 'translateY(-12px)',
   fontWeight: 500,
+  pointerEvents: 'all',
 };
 
 const input = sva({
@@ -96,6 +97,9 @@ const input = sva({
       left: 'space.04',
       zIndex: 9,
       color: 'inherit',
+      // In empty state, with no placeholder, click events must be disabled to
+      // allow the label to be ignored, and the underlying input to be focused
+      pointerEvents: 'none',
       textStyle: 'body.02',
       transition: 'font-size 100ms ease-in-out, transform 100ms ease-in-out',
       // Move the input's label to the top when the input has a value


### PR DESCRIPTION
> Try out Leather build 203fb09 — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9544324249), [Test report](https://leather-wallet.github.io/playwright-reports/fix-input-events), [Storybook](https://fix-input-events--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-input-events)<!-- Sticky Header Marker -->

In 35563904d41445926f5140ea088fbfe631deea68 it appears I removed `pointer-events: none` from the input component's label, causing a click directly on the label not to focus the input.

Edit: presuming I did this because click events _are_ needed when the label is interactive, like on Address/BNS selector of STX send form.

https://github.com/leather-wallet/extension/assets/1618764/c35d77ae-bb85-4555-b04d-5994ea209dc4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the styling of the input element to disable pointer events where necessary.

- **Refactor**
  - Adjusted the rendering position of `topInputOverlay` within the `RecipientAddressTypeField` component for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->