### PR TITLE
chore: remove radix-ui base css styles

### DIFF
--- a/src/app/ui/components/containers/container.layout.tsx
+++ b/src/app/ui/components/containers/container.layout.tsx
@@ -1,5 +1,3 @@
-import { radixBaseCSS } from '@radix-ui/themes/styles.css';
-import { css } from 'leather-styles/css';
 import { Flex } from 'leather-styles/jsx';
 
 interface ContainerLayoutProps {
@@ -14,7 +12,6 @@ export function ContainerLayout({ children, header }: ContainerLayoutProps) {
       flexGrow={1}
       width="100%"
       height={{ base: '100vh', sm: '100%' }}
-      className={css(radixBaseCSS)}
     >
       {header}
       <Flex className="main-content" flexGrow={1} position="relative" width="100%">

--- a/src/app/ui/components/containers/dialog/dialog.tsx
+++ b/src/app/ui/components/containers/dialog/dialog.tsx
@@ -53,6 +53,7 @@ export function Dialog({
             position: 'fixed',
             inset: 0,
             animation: 'overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
+            zIndex: 999,
           })}
         >
           <RadixDialog.Content


### PR DESCRIPTION
This PR removes `radixBaseCSS` from the extension (from `@radix-ui/themes/styles.css`) https://github.com/leather-wallet/issues/issues/104

Initially before we were using radix primitives, we added the this to the extension.This is a large CSS file and we don't really need to add it at all anymore.

I tried and failed to remove this before as I noticed a lot of UI bugs but I tried again now and it seems much easier with just one slight change to add a high z-index to `Dialog`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated `ContainerLayout` component to refine styling approach.
  - Added `zIndex` property to `Dialog` component, improving its visibility and layering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->