### PR TITLE
fix: add network form bitcoin network selector

### DIFF
--- a/src/app/features/add-network/add-network-form.tsx
+++ b/src/app/features/add-network/add-network-form.tsx
@@ -94,10 +94,10 @@ export function AddNetworkForm() {
       <Select.Root
         defaultValue={networks[0].value}
         onValueChange={value => {
-          void setFieldValue('bitcoinApi', value);
+          void setFieldValue('bitcoinNetwork', value);
         }}
       >
-        <Select.Trigger>
+        <Select.Trigger data-testid={NetworkSelectors.AddNetworkBitcoinAPISelector}>
           <Select.Value />
           <Select.Icon>
             <ChevronDownIcon variant="small" />
@@ -107,7 +107,11 @@ export function AddNetworkForm() {
           <Select.Content align="start" position="popper" sideOffset={8}>
             <Select.Viewport>
               {networks.map(item => (
-                <Select.Item key={item.label} value={item.value}>
+                <Select.Item
+                  key={item.label}
+                  value={item.value}
+                  data-testid={`bitcoin-api-option-${item.value}`}
+                >
                   <SelectItemLayout
                     contentLeft={
                       <HStack display="flex" gap="space.02" width="100%">

--- a/tests/selectors/network.selectors.ts
+++ b/tests/selectors/network.selectors.ts
@@ -5,7 +5,6 @@ export enum NetworkSelectors {
   NetworkStacksAddress = 'network-stacks-address',
   NetworkBitcoinAddress = 'network-bitcoin-address',
   NetworkKey = 'network-key',
-  AddNetworkBtn = 'add-network-btn',
   ErrorText = 'error-text',
   EmptyNameError = 'Enter a name',
   EmptyStacksAddressError = 'Enter a valid Stacks API URL',
@@ -13,4 +12,9 @@ export enum NetworkSelectors {
   EmptyKeyError = 'Enter a unique key',
   NoStacksNodeFetch = 'Unable to fetch info from stacks node',
   NoBitcoinNodeFetch = 'Unable to fetch mempool from bitcoin node',
+
+  // add network form
+  AddNetworkBtn = 'add-network-btn',
+  AddNetworkBitcoinAPISelector = 'add-network-bitcoin-api-selector',
+  BitcoinAPIOptionTestnet = 'bitcoin-api-option-testnet',
 }

--- a/tests/specs/network/add-network.spec.ts
+++ b/tests/specs/network/add-network.spec.ts
@@ -15,6 +15,15 @@ test.describe('Networks tests', () => {
     }
   );
 
+  test('that bitcoin api url changes on selecting different network', async ({ page }) => {
+    await page.getByTestId(NetworkSelectors.AddNetworkBitcoinAPISelector).click();
+    await page.getByTestId(NetworkSelectors.BitcoinAPIOptionTestnet).click();
+
+    const bitcoinUrl = await page.getByTestId(NetworkSelectors.NetworkBitcoinAddress);
+
+    test.expect(await bitcoinUrl.inputValue()).toEqual('https://blockstream.info/testnet/api');
+  });
+
   test('validation error when stacks api url is empty', async ({ networkPage }) => {
     await networkPage.inputNetworkNameField('Test network');
     await networkPage.inputNetworkStacksAddressField('');


### PR DESCRIPTION
> Try out Leather build f329f3f — [Extension build](https://github.com/leather-wallet/extension/actions/runs/9595105709), [Test report](https://leather-wallet.github.io/playwright-reports/fix-add-network-form), [Storybook](https://fix-add-network-form--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-add-network-form)<!-- Sticky Header Marker -->

fix for https://trustmachines.slack.com/archives/C05114YP8CV/p1718867969838859?thread_ts=1718822810.436869&cid=C05114YP8CV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced network configuration options with updated selectors for adding networks.
  - Updated functionality to support selecting and changing Bitcoin network configurations.
  
- **Tests**
  - Added a new test case to verify correct Bitcoin API URL updates when switching networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->