### PR TITLE
fix: responsive width for popup

### DIFF
--- a/theme/global/global.ts
+++ b/theme/global/global.ts
@@ -1,5 +1,6 @@
-import { tokens } from '@leather-wallet/tokens';
 import { defineGlobalStyles } from '@pandacss/dev';
+
+import { tokens } from '@leather-wallet/tokens';
 
 // ts-unused-exports:disable-next-line
 export const globalCss = defineGlobalStyles({
@@ -37,7 +38,7 @@ export const globalCss = defineGlobalStyles({
     'html,body, #app, .radix-themes': {
       maxHeight: '100vh',
       minHeight: tokens.sizes.dialogHeight.value,
-      width: tokens.sizes.popupWidth.value,
+      maxWidth: tokens.sizes.popupWidth.value,
       margin: '0 auto',
 
       '::-webkit-scrollbar': {


### PR DESCRIPTION
As reported on Slack https://trustmachines.slack.com/archives/C05114YP8CV/p1718960758669539

Popup when resized slightly narrower

| Before | After |
|--------|--------|
| <img width="418" alt="image" src="https://github.com/leather-io/extension/assets/1618764/752b80f5-c981-4c77-834c-ee6a03992852"> | <img width="418" alt="image" src="https://github.com/leather-io/extension/assets/1618764/ceb1b235-2aa8-4bbe-a450-5da20c0f379f"> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved code readability and maintainability by reordering import statements.
  
- **Bug Fixes**
  - Corrected the width property setting to ensure elements display with the correct maximum width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->