### PR TITLE
fix : remove extra div,  ref leather-io/issues#5469

### DIFF
--- a/src/app/features/asset-list/bitcoin/brc20-token-asset-list/brc20-token-asset-list.tsx
+++ b/src/app/features/asset-list/bitcoin/brc20-token-asset-list/brc20-token-asset-list.tsx
@@ -42,6 +42,7 @@ export function Brc20TokenAssetList({ tokens, variant }: Brc20TokenAssetListProp
     });
   }
 
+  if (!tokens.length) return null;
   return (
     <Stack data-testid={CryptoAssetSelectors.CryptoAssetList}>
       {tokens.map(token => (


### PR DESCRIPTION
fixes #5469

the stack was creating an extra div  even when there were no brc20s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component performance by adding a check for an empty `tokens` array before rendering in the `Brc20TokenAssetList` component.

- **Refactor**
  - Reordered imports to optimize code structure in the `Brc20TokenAssetList` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->