### PR TITLE
fix: add ledger test for bitcoin api calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@leather.io/constants": "0.8.0",
     "@leather.io/crypto": "1.0.2",
     "@leather.io/models": "0.10.0",
-    "@leather.io/query": "0.9.2",
+    "@leather.io/query": "0.9.3",
     "@leather.io/tokens": "0.6.0",
     "@leather.io/ui": "1.5.1",
     "@leather.io/utils": "0.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.10.0
         version: 0.10.0
       '@leather.io/query':
-        specifier: 0.9.2
-        version: 0.9.2(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)
+        specifier: 0.9.3
+        version: 0.9.3(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)
       '@leather.io/tokens':
         specifier: 0.6.0
         version: 0.6.0
@@ -2901,8 +2901,8 @@ packages:
   '@leather.io/prettier-config@0.5.0':
     resolution: {integrity: sha512-Pul+4MAyBKnQvqgcKJLbZl4DHnS4kCJzSuaYFW6cfHdre7BFn/iY6Er/Dvm9F8g7VMtkdYu68jEYxQ1Xc7A0KQ==}
 
-  '@leather.io/query@0.9.2':
-    resolution: {integrity: sha512-PSrLRl89rOU/LL2mXT6RI5SVytWDDQx2XDthDD6d/McwBhz2NNhRTBnKjnTTlEA1/gaHGqL+VZrOWr86HZ9Wzg==}
+  '@leather.io/query@0.9.3':
+    resolution: {integrity: sha512-hGAcA4Au/lg2yz/bD006XHNieQ/FMCzFU6r8L+o7oipjG+lzR48r8enLNE/M1SgusgKXhcp577XXGBLNO7oB9w==}
     peerDependencies:
       react: '*'
 
@@ -17583,7 +17583,7 @@ snapshots:
       - '@vue/compiler-sfc'
       - supports-color
 
-  '@leather.io/query@0.9.2(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)':
+  '@leather.io/query@0.9.3(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)':
     dependencies:
       '@fungible-systems/zone-file': 2.0.0
       '@hirosystems/token-metadata-api-client': 1.2.0(encoding@0.1.13)


### PR DESCRIPTION
Did a bunch of research and testing to understand how to write a test to see if we are making any bitcoin api calls on the homepage if only Stacks keys are present. The test here checks a bug where the requests were being made when a user clicked to change accounts. I tried quite a few things attempting to catch the timeout exception correctly if no requests are made, and I ended up coming across this that helped me: https://github.com/microsoft/playwright/issues/20372#issuecomment-1403764439

Hoping this is right. I made sure the test failed `withBitcoinKeysOnly` and `withStacksAndBitcoinKeys`, but that it passes `withStacksKeysOnly` ...so I think it is working correctly.

While working on this, I realized there was a bug with `useInfiniteQuery` which was causing the linked bug where queries were running even though we were disabling them with `!!address`, see:
https://stackoverflow.com/questions/72753877/useinfinitequerys-enabled-option-in-react-query-doesnt-work

And, fixed/installed here from mono repo: https://github.com/leather-io/mono/pull/246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `@leather.io/query` dependency to version `0.9.3`.

- **Tests**
  - Enhanced tests to improve handling of bitcoin requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->