### PR TITLE
fix: disable ledger for firefox, closes #5287

### DIFF
--- a/src/app/ui/pages/welcome.layout.tsx
+++ b/src/app/ui/pages/welcome.layout.tsx
@@ -19,6 +19,7 @@ export function WelcomeLayout({
 }: WelcomeLayoutProps): React.JSX.Element {
   // On this page 'theme' is used to set specific colours and bypass automatic theming
   const { theme } = useThemeSwitcher();
+  const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
   // hardcoded specific instances of colour variables needed to bypass theme
   const inkBgSecondary = '#F5F1ED';
   const inkTextPrimary = '#12100F';
@@ -113,6 +114,7 @@ export function WelcomeLayout({
               onClick={onSelectConnectLedger}
               css={secondaryActionButton}
               fullWidth
+              disabled={isFirefox}
             >
               Use Ledger
             </Button>


### PR DESCRIPTION
This PR adds a check for `firefox` and if so disabled the `Use Ledger` button at sign in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The 'Use Ledger' button is now conditionally disabled if the user is on a Firefox browser, enhancing compatibility and preventing potential issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->