### PR TITLE
fix: adjust collectible arrow hover transparancy, closes #4971

### DIFF
--- a/src/app/features/collectibles/components/collectible-hover.tsx
+++ b/src/app/features/collectibles/components/collectible-hover.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
 
-import { Box, styled } from 'leather-styles/jsx';
+import { Box } from 'leather-styles/jsx';
 
-import { ArrowUpIcon } from '@leather.io/ui';
+import { ArrowUpIcon, IconButton } from '@leather.io/ui';
 
 interface CollectibleHoverProps {
   collectibleTypeIcon?: ReactNode;
@@ -38,15 +38,23 @@ export function CollectibleHover({
         {collectibleTypeIcon}
       </Box>
       {onClickCallToAction && (
-        <styled.button
+        <IconButton
           _focus={{ outline: 'focus' }}
-          _hover={{ bg: 'ink.component-background-hover' }}
           alignItems="center"
           bg="ink.background-primary"
           borderRadius="50%"
           display="flex"
           height="30px"
           justifyContent="center"
+          icon={
+            <ArrowUpIcon
+              transform="rotate(45deg)"
+              borderRadius="50%"
+              width="30px"
+              height="30px"
+              _hover={{ bg: 'ink.component-background-hover' }}
+            />
+          }
           onClick={e => {
             e.stopPropagation();
             onClickCallToAction();
@@ -57,9 +65,7 @@ export function CollectibleHover({
           type="button"
           width="30px"
           zIndex={999}
-        >
-          <ArrowUpIcon transform="rotate(45deg)" />
-        </styled.button>
+        />
       )}
     </Box>
   );


### PR DESCRIPTION
This PR fixes an issue with the hover effect on the arrow of collectibles: https://github.com/leather-io/extension/issues/4971 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated button styling within the `CollectibleHover` component to improve hover effects by wrapping the `ArrowUpIcon` within a styled element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->