### PR TITLE
fix: refactor dialog to use IconButton to fix title without affecting…

### DIFF
--- a/src/app/ui/components/containers/headers/components/header-action-button.tsx
+++ b/src/app/ui/components/containers/headers/components/header-action-button.tsx
@@ -22,7 +22,6 @@ export function HeaderActionButton({ icon, onAction, dataTestId }: HeaderActionB
       transition="transition"
       userSelect="none"
       zIndex={999}
-      position="absolute"
     />
   );
 }

--- a/src/app/ui/components/containers/headers/dialog-header.tsx
+++ b/src/app/ui/components/containers/headers/dialog-header.tsx
@@ -1,11 +1,8 @@
 import { ReactNode } from 'react';
 
-import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { Flex, styled } from 'leather-styles/jsx';
 
-import { CloseIcon } from '@leather.io/ui';
-
-import { HeaderActionButton } from './components/header-action-button';
+import { CloseIcon, IconButton } from '@leather.io/ui';
 
 interface DialogHeaderProps {
   onClose?(): void;
@@ -28,13 +25,7 @@ export function DialogHeader({ onClose, title }: DialogHeaderProps) {
           {title}
         </styled.h2>
       )}
-      {onClose && (
-        <HeaderActionButton
-          icon={<CloseIcon />}
-          dataTestId={SharedComponentsSelectors.HeaderCloseBtn}
-          onAction={onClose}
-        />
-      )}
+      {onClose && <IconButton icon={<CloseIcon />} onClick={onClose} position="absolute" />}
     </Flex>
   );
 }


### PR DESCRIPTION
This PR fixes [a bug](https://trustmachines.slack.com/archives/C05LAP952E7/p1719595558414679 ) noticed by @fbwoolf . 

It came from this fix for the dialog title https://github.com/leather-io/extension/pull/5569 

I've made a change to not share the same header action button with the dialog
