### PR TITLE
fix: apply spamFilter more generically to all crypto captions and titles

### DIFF
--- a/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -73,7 +73,7 @@ export function CryptoAssetItemLayout({
     <ItemLayout
       flagImg={icon}
       titleLeft={spamFilter(titleLeft)}
-      captionLeft={captionLeft}
+      captionLeft={spamFilter(captionLeft)}
       titleRight={titleRight}
       captionRight={captionRight}
     />

--- a/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-item.tsx
+++ b/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-item.tsx
@@ -1,5 +1,4 @@
 import type { CryptoAssetBalance, MarketData, Sip10CryptoAssetInfo } from '@leather.io/models';
-import { spamFilter } from '@leather.io/utils';
 
 import { convertAssetBalanceToFiat } from '@app/common/asset-utils';
 import { getSafeImageCanonicalUri } from '@app/common/stacks-utils';
@@ -20,23 +19,23 @@ export function Sip10TokenAssetItem({
   marketData,
   onSelectAsset,
 }: Sip10TokenAssetItemProps) {
-  const name = spamFilter(info.name);
   const fiatBalance = convertAssetBalanceToFiat({
     balance: balance.availableBalance,
     marketData,
   });
+  const { contractId, imageCanonicalUri, name, symbol } = info;
 
   return (
     <CryptoAssetItemLayout
       availableBalance={balance.availableBalance}
       fiatBalance={fiatBalance}
-      captionLeft={info.symbol}
-      contractId={info.contractId}
+      captionLeft={symbol}
+      contractId={contractId}
       icon={
         <StacksAssetAvatar
           color="white"
-          gradientString={info.contractId}
-          imageCanonicalUri={getSafeImageCanonicalUri(info.imageCanonicalUri, name)}
+          gradientString={contractId}
+          imageCanonicalUri={getSafeImageCanonicalUri(imageCanonicalUri, name)}
         >
           {name[0]}
         </StacksAssetAvatar>


### PR DESCRIPTION
This PR makes a small change to how we apply the `spamFilter`. We weren't applying it properly to `SIP-10` `symbol`s. 

I've changed it so that we instead apply the filtering in `CryptoAssetItemLayout` to make sure we don't miss any names / symbols. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced spam filtering for asset captions in the Crypto Asset Item Layout.
  
- **Refactor**
  - Improved code structure in SIP10 Token Asset Item by removing redundant spam filter usage and optimizing property assignment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->