### PR TITLE
chore: update query cache with known data

### DIFF
--- a/src/app/store/software-keys/software-key.actions.ts
+++ b/src/app/store/software-keys/software-key.actions.ts
@@ -1,6 +1,11 @@
 import { AddressVersion } from '@stacks/transactions';
 
-import { type BitcoinClient, type StacksClient, fetchNamesForAddress } from '@leather.io/query';
+import {
+  type BitcoinClient,
+  QueryPrefixes,
+  type StacksClient,
+  fetchNamesForAddress,
+} from '@leather.io/query';
 
 import { decryptMnemonic, encryptMnemonic } from '@shared/crypto/mnemonic-encryption';
 import { logger } from '@shared/logger';
@@ -10,6 +15,7 @@ import { identifyUser } from '@shared/utils/analytics';
 import { recurseAccountsForActivity } from '@app/common/account-restoration/account-restore';
 import { checkForLegacyGaiaConfigWithKnownGeneratedAccountIndex } from '@app/common/account-restoration/legacy-gaia-config-lookup';
 import { mnemonicToRootNode } from '@app/common/keychain/keychain';
+import { queryClient } from '@app/common/persistence';
 import { AppThunk } from '@app/store';
 import { initalizeWalletSession } from '@app/store/session-restore';
 
@@ -54,6 +60,7 @@ function setWalletEncryptionPassword(args: {
         isTestnet: false,
         signal: new AbortSignal(),
       });
+      queryClient.setQueryData([QueryPrefixes.BnsNamesByAddress, address], resp);
       return resp.names.length > 0;
     }
 


### PR DESCRIPTION
> Try out Leather build 8352d00 — [Extension build](https://github.com/leather-io/extension/actions/runs/9940412588), [Test report](https://leather-io.github.io/playwright-reports/update-query-cache), [Storybook](https://update-query-cache--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=update-query-cache)<!-- Sticky Header Marker -->

@alter-eggo We do some requests to find account activity on account load. It's a waste not to add this to the query cache. Might be relevant to your work re throttling & general request usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `setWalletEncryptionPassword` function with new data handling capabilities to improve functionality and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->