### PR TITLE
fix: collectible hover, closes #4971

### DIFF
--- a/src/app/features/collectibles/components/collectible-hover.tsx
+++ b/src/app/features/collectibles/components/collectible-hover.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 import { Box } from 'leather-styles/jsx';
 
-import { ArrowUpIcon, IconButton } from '@leather.io/ui';
+import { ExternalLinkIcon, IconButton } from '@leather.io/ui';
 
 interface CollectibleHoverProps {
   collectibleTypeIcon?: ReactNode;
@@ -38,34 +38,19 @@ export function CollectibleHover({
         {collectibleTypeIcon}
       </Box>
       {onClickCallToAction && (
-        <IconButton
-          _focus={{ outline: 'focus' }}
-          alignItems="center"
-          bg="ink.background-primary"
-          borderRadius="50%"
-          display="flex"
-          height="30px"
-          justifyContent="center"
-          icon={
-            <ArrowUpIcon
-              transform="rotate(45deg)"
-              borderRadius="50%"
-              width="30px"
-              height="30px"
-              _hover={{ bg: 'ink.component-background-hover' }}
-            />
-          }
-          onClick={e => {
-            e.stopPropagation();
-            onClickCallToAction();
-          }}
-          position="absolute"
-          right="12px"
-          top="12px"
-          type="button"
-          width="30px"
-          zIndex={999}
-        />
+        <Box bg="ink.background-primary" position="absolute" right="12px" top="12px" zIndex={999}>
+          <IconButton
+            _focus={{ outline: 'focus' }}
+            _hover={{ bg: 'ink.component-background-hover' }}
+            bg="ink.background-primary"
+            color="ink.action-primary-default"
+            icon={<ExternalLinkIcon />}
+            onClick={e => {
+              e.stopPropagation();
+              onClickCallToAction();
+            }}
+          />
+        </Box>
       )}
     </Box>
   );


### PR DESCRIPTION
This fixes the collectible hover `IconButton` disappearing issue.

![Screenshot 2024-07-04 at 8 42 36 AM](https://github.com/leather-io/extension/assets/6493321/8dde0149-8886-4a16-bf07-198d211a7127)

![Screenshot 2024-07-04 at 8 42 41 AM](https://github.com/leather-io/extension/assets/6493321/26baf9fa-412c-43d9-bc4e-a6145a151f21)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `CollectibleHover` component to use `ExternalLinkIcon` instead of `ArrowUpIcon` for better visual representation.
	- Improved the structure and styling of the `IconButton` component within the `CollectibleHover` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->