### PR TITLE
feat: auto-scale balance font-size to avoid line-break

### DIFF
--- a/src/app/common/hooks/use-scale-text.ts
+++ b/src/app/common/hooks/use-scale-text.ts
@@ -1,0 +1,20 @@
+import { useRef } from 'react';
+
+import { useOnMount } from '@app/common/hooks/use-on-mount';
+
+export function useScaleText() {
+  const ref = useRef<HTMLHeadingElement>(null);
+
+  useOnMount(() => {
+    const el = ref.current;
+    if (el) {
+      const parentWidth = el.parentElement?.offsetWidth || 0;
+      const naturalWidth = el.scrollWidth;
+      const scale = parentWidth / naturalWidth;
+      const finalScale = Math.max(scale);
+      el.style.transform = finalScale < 1 ? `scale(${finalScale})` : 'none';
+    }
+  });
+
+  return ref;
+}

--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -5,6 +5,7 @@ import { Box, Flex, styled } from 'leather-styles/jsx';
 
 import { ChevronDownIcon, Link, SkeletonLoader } from '@leather.io/ui';
 
+import { useScaleText } from '@app/common/hooks/use-scale-text';
 import { AccountNameLayout } from '@app/components/account/account-name';
 
 interface AccountCardProps {
@@ -24,6 +25,8 @@ export function AccountCard({
   isFetchingBnsName,
   isLoadingBalance,
 }: AccountCardProps) {
+  const scaleTextRef = useScaleText();
+
   return (
     <Flex
       direction="column"
@@ -57,7 +60,18 @@ export function AccountCard({
       <Flex flexDir={{ base: 'column', md: 'row' }} justify="space-between">
         <Box mb="space.05" mt="space.04">
           <SkeletonLoader width="200px" height="38px" isLoading={isLoadingBalance}>
-            <styled.h1 textStyle="heading.02">{balance}</styled.h1>
+            <styled.h1
+              textStyle="heading.02"
+              style={{
+                whiteSpace: 'nowrap',
+                display: 'inline-block',
+                transformOrigin: 'left center',
+                maxWidth: '100%',
+              }}
+              ref={scaleTextRef}
+            >
+              {balance}
+            </styled.h1>
           </SkeletonLoader>
         </Box>
         {children}


### PR DESCRIPTION
> Try out Leather build b121984 — [Extension build](https://github.com/leather-io/extension/actions/runs/9958310899), [Test report](https://leather-io.github.io/playwright-reports/feat-scale-balance-number), [Storybook](https://feat-scale-balance-number--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-scale-balance-number)<!-- Sticky Header Marker -->

Experimental implementation addressing #5613 to scale down balance font-size for large numbers that currently cause an ugly line-break.

- There's existing text scaling code for values entered as amount within the send flow. Maybe it's smarter to reuse the same functionality/code?
- To check how this behaves and looks when going from fetching/load → final

https://github.com/leather-io/extension/assets/4112698/84d740ec-76d2-4687-8262-ab60705d4847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic text scaling based on container width in the `AccountCard` component using the new `useScaleText` hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->