### PR TITLE
fix: show account name in signPsbt header, ref #4657 #4859

### DIFF
--- a/src/app/features/container/utils/get-popup-header.ts
+++ b/src/app/features/container/utils/get-popup-header.ts
@@ -29,6 +29,8 @@ export function showAccountInfo(pathname: RouteUrls) {
     case RouteUrls.TransactionRequest:
     case RouteUrls.ProfileUpdateRequest:
     case RouteUrls.RpcSendTransfer:
+    case RouteUrls.RpcSignPsbt:
+    case RouteUrls.RpcSignBip322Message:
       return true;
     default:
       return false;


### PR DESCRIPTION
> Try out Leather build 255d014 — [Extension build](https://github.com/leather-io/extension/actions/runs/9868905585), [Test report](https://leather-io.github.io/playwright-reports/fix-4859-display-account-in-app-nav), [Storybook](https://fix-4859-display-account-in-app-nav--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-4859-display-account-in-app-nav)<!-- Sticky Header Marker -->

This fix shows the users signed in account + account switcher on sign PSBT rather than the Leather logo so they know which account they are using for transactions

**BEFORE**
![Screenshot 2024-07-10 at 06 55 42](https://github.com/leather-io/extension/assets/2938440/e3a2fd43-9bd8-4520-88a6-5ceb8a0255b1)

![Screenshot 2024-07-10 at 06 17 50](https://github.com/leather-io/extension/assets/2938440/e23f54a2-1f62-4d31-8ba0-d241d8364aad)

**AFTER**
![Screenshot 2024-07-10 at 06 55 21](https://github.com/leather-io/extension/assets/2938440/b836a734-1550-49b3-841b-cb5708842a90)

![Screenshot 2024-07-10 at 06 17 08](https://github.com/leather-io/extension/assets/2938440/fbecdfc3-5c2a-4329-8aca-a7b052a8232b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the app to display account information when encountering specific routing paths, including 'RpcSignPsbt'.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->