### PR TITLE
fix: confine clickable area of account switcher to account name and c…

### DIFF
--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -38,6 +38,7 @@ export function AccountCard({
         data-testid={SettingsSelectors.SwitchAccountTrigger}
         onClick={toggleSwitchAccount}
         variant="text"
+        maxWidth="fit-content"
       >
         <Flex>
           <AccountNameLayout


### PR DESCRIPTION
> Try out Leather build 7592398 — [Extension build](https://github.com/leather-io/extension/actions/runs/9868719212), [Test report](https://leather-io.github.io/playwright-reports/fix-5621-account-switcher-area), [Storybook](https://fix-5621-account-switcher-area--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-5621-account-switcher-area)<!-- Sticky Header Marker -->

This PR confines the clickable area of account switcher to account name and chevron as otherwise you can open it clicking anywhere along the account card: 
![346590129-4d01ddf3-68ed-49e4-9503-3d64219c6328](https://github.com/leather-io/extension/assets/2938440/274c50f7-6b94-4ea7-b7dd-022da8e36486)
