### PR TITLE
fix: increase zIndex of tooltip to prevent it being obscured

### DIFF
--- a/src/app/ui/components/tooltip/tooltip.tsx
+++ b/src/app/ui/components/tooltip/tooltip.tsx
@@ -48,6 +48,7 @@ const defaultContentStyles = css({
   textAlign: 'center',
   wordWrap: 'break-word',
   color: 'ink.background-primary',
+  zIndex: 4,
 
   "&[data-state='delayed-open'][data-side='top']": {
     animationName: 'slideDownAndFade',


### PR DESCRIPTION
> Try out Leather build 54b27ba — [Extension build](https://github.com/leather-io/extension/actions/runs/9868843156), [Test report](https://leather-io.github.io/playwright-reports/fix-5622-tooltip-hover-zindex), [Storybook](https://fix-5622-tooltip-hover-zindex--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-5622-tooltip-hover-zindex)<!-- Sticky Header Marker -->

This fixes a UI issue with the tooltip being obscured by text and buttons on the send flow:
![Screenshot 2024-07-10 at 06 44 15](https://github.com/leather-io/extension/assets/2938440/20693ca5-6837-40c5-b651-2a585f7509f9)
