### PR TITLE
fix: stx balance loading condition

### DIFF
--- a/src/app/components/loaders/stx-balance-loader.tsx
+++ b/src/app/components/loaders/stx-balance-loader.tsx
@@ -2,7 +2,6 @@ import type { StxCryptoAssetBalance } from '@leather.io/models';
 import {
   isErrorTooManyRequests,
   isFetchedWithSuccess,
-  isInitializingData,
   useStxCryptoAssetBalance,
 } from '@leather.io/query';
 import { StxAvatarIcon } from '@leather.io/ui';
@@ -16,7 +15,7 @@ interface StxAssetItemBalanceLoaderProps {
 }
 export function StxAssetItemBalanceLoader({ address, children }: StxAssetItemBalanceLoaderProps) {
   const result = useStxCryptoAssetBalance(address);
-  if (isInitializingData(result)) return <CryptoAssetItemPlaceholder />;
+  if (result.isLoading) return <CryptoAssetItemPlaceholder />;
   if (isErrorTooManyRequests(result))
     return (
       <CryptoAssetItemError


### PR DESCRIPTION
> Try out Leather build 41583f5 — [Extension build](https://github.com/leather-io/extension/actions/runs/9936499949), [Test report](https://leather-io.github.io/playwright-reports/fix-stx-balance-loading), [Storybook](https://fix-stx-balance-loading--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-stx-balance-loading)<!-- Sticky Header Marker -->

This pr fixes stx asset loading, since skeleton loader now is showing even if there is cached data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved loading state management in the `StxAssetItemBalanceLoader` component for more consistent handling of data loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->