### PR TITLE
feat: mock mainnet btc blockstream requests

### DIFF
--- a/tests/mocks/mock-apis.ts
+++ b/tests/mocks/mock-apis.ts
@@ -2,11 +2,15 @@ import { Page } from '@playwright/test';
 import { json } from '@tests/utils';
 
 import { mockStacksFeeRequests } from './mock-stacks-fees';
+import { mockMainnetTestAccountBlockstreamRequests } from './mock-utxos';
 
 export async function setupMockApis(page: Page) {
-  await page.route(/chrome-extension/, route => route.continue());
-  await page.route(/github/, route => route.fulfill(json({})));
-  await page.route('https://api.hiro.so/', route => route.fulfill());
-  await page.route('https://api.testnet.hiro.so/', route => route.fulfill());
-  await mockStacksFeeRequests(page);
+  await Promise.all([
+    page.route(/chrome-extension/, route => route.continue()),
+    page.route(/github/, route => route.fulfill(json({}))),
+    page.route('https://api.hiro.so/', route => route.fulfill()),
+    page.route('https://api.testnet.hiro.so/', route => route.fulfill()),
+    mockMainnetTestAccountBlockstreamRequests(page),
+    mockStacksFeeRequests(page),
+  ]);
 }

--- a/tests/mocks/mock-utxos.ts
+++ b/tests/mocks/mock-utxos.ts
@@ -1,3 +1,7 @@
+import type { Page } from '@playwright/test';
+
+import { TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS } from './constants';
+
 export const mockUtxos = [
   {
     txid: '58d44000884f0ba4cdcbeb1ac082e6c802d300c16b0d3251738e8cf6a57397ce',
@@ -36,3 +40,92 @@ export const mockUtxosListWithRunes = [
     value: 546,
   },
 ];
+const mockMainnetNsTransactionsTestAccount = [
+  {
+    txid: '58d44000884f0ba4cdcbeb1ac082e6c802d300c16b0d3251738e8cf6a57397ce',
+    version: 2,
+    locktime: 0,
+    vin: [
+      {
+        txid: 'a5ab63799f0bbd2571d1b90de9ebff815f7526787e27263d2f604e22f9118d0c',
+        vout: 0,
+        prevout: {
+          scriptpubkey: '5120286626028a2d352bae8dcdfa750025d04ce7f5eb6649a4ddb9ef98eba6315f47',
+          scriptpubkey_asm:
+            'OP_PUSHNUM_1 OP_PUSHBYTES_32 286626028a2d352bae8dcdfa750025d04ce7f5eb6649a4ddb9ef98eba6315f47',
+          scriptpubkey_type: 'v1_p2tr',
+          scriptpubkey_address: 'bc1p9pnzvq52956jht5deha82qp96pxw0a0tvey6fhdea7vwhf33tarskqq3nr',
+          value: 546,
+        },
+        scriptsig: '',
+        scriptsig_asm: '',
+        witness: [
+          '839f120447cb677dbd06a2a9b69134be8d38918ee5a2e8ba3e6a3079315401a58b240edcefbbb1b16b5c036194c7c7ceb21d1f647ee352092115f1a8bb56ba53',
+        ],
+        is_coinbase: false,
+        sequence: 0,
+      },
+      {
+        txid: '5c3206e2d7655758e4db05a251571bbc902db7e5c1a1e6f99ca7d6e71bde450b',
+        vout: 6,
+        prevout: {
+          scriptpubkey: '001466124290d2fc62f8cb83c0e15836a548e43dcade',
+          scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 66124290d2fc62f8cb83c0e15836a548e43dcade',
+          scriptpubkey_type: 'v0_p2wpkh',
+          scriptpubkey_address: 'bc1qvcfy9yxjl3303jurcrs4sd49frjrmjk7x045r6',
+          value: 317348,
+        },
+        scriptsig: '',
+        scriptsig_asm: '',
+        witness: [
+          '3045022100c70352f1beed3b7e38550a679bec8fe9318654080ad7808f06c7118ca775d77302202e6b7859f7305b90d542591fdbd719f59e38a29a5204f726b66cc9227aba329701',
+          '039aa0f222ca60f0a4d03ae8047d5972856af82ff186d1b99186fc7b44f0d737c6',
+        ],
+        is_coinbase: false,
+        sequence: 0,
+      },
+    ],
+    vout: [
+      {
+        scriptpubkey: '0014a45ed156e77d9df111dfb99409beda635695b4b1',
+        scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 a45ed156e77d9df111dfb99409beda635695b4b1',
+        scriptpubkey_type: 'v0_p2wpkh',
+        scriptpubkey_address: 'bc1q530dz4h80kwlzywlhx2qn0k6vdtftd93c499yq',
+        value: 546,
+      },
+      {
+        scriptpubkey: '001466124290d2fc62f8cb83c0e15836a548e43dcade',
+        scriptpubkey_asm: 'OP_0 OP_PUSHBYTES_20 66124290d2fc62f8cb83c0e15836a548e43dcade',
+        scriptpubkey_type: 'v0_p2wpkh',
+        scriptpubkey_address: 'bc1qvcfy9yxjl3303jurcrs4sd49frjrmjk7x045r6',
+        value: 314656,
+      },
+    ],
+    size: 330,
+    weight: 792,
+    fee: 2692,
+    status: {
+      confirmed: true,
+      block_height: 810183,
+      block_hash: '000000000000000000040caf3f438bb15731f6dc0f5ce1eaa6cd2ee8213d72dd',
+      block_time: 1696185309,
+    },
+  },
+];
+
+export async function mockMainnetTestAccountBlockstreamRequests(page: Page) {
+  await Promise.all([
+    page.route('**/blockstream.info/api/address/**/utxo', route =>
+      route.fulfill({
+        json: [],
+      })
+    ),
+    page.route(
+      `**/blockstream.info/api/address/${TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS}/txs`,
+      route =>
+        route.fulfill({
+          json: mockMainnetNsTransactionsTestAccount,
+        })
+    ),
+  ]);
+}

--- a/tests/specs/onboarding/onboarding.spec.ts
+++ b/tests/specs/onboarding/onboarding.spec.ts
@@ -61,9 +61,14 @@ test.describe('Onboarding an existing user', () => {
     await test.expect(signInSeedError).not.toBeVisible();
   });
 
-  test('Activity tab', async ({ extensionId, globalPage, onboardingPage, homePage }) => {
+  test('Activity tab', async ({ extensionId, globalPage, onboardingPage, homePage, page }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signUpNewUser();
+    await page.route(`**/blockstream.info/api/address/**/txs`, route =>
+      route.fulfill({
+        json: [],
+      })
+    );
     await homePage.clickActivityTab();
     const noActivityText = homePage.page.getByText('No activity yet');
     await test.expect(noActivityText).toBeVisible();

--- a/tests/specs/send/send-btc.spec.ts
+++ b/tests/specs/send/send-btc.spec.ts
@@ -4,7 +4,7 @@ import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { getDisplayerAddress } from '@tests/utils';
 
-import { BtcFeeType } from '@leather.io/models';
+import { BESTINSLOT_API_BASE_URL_TESTNET, BtcFeeType } from '@leather.io/models';
 
 import { test } from '../../fixtures/fixtures';
 
@@ -127,7 +127,7 @@ test.describe('send btc', () => {
       });
 
       await sendPage.page.route(
-        '**/leatherapi.bestinslot.xyz/v3/inscription/in_transaction**',
+        `${BESTINSLOT_API_BASE_URL_TESTNET}/inscription/in_transaction**`,
         async route => {
           return route.fulfill({
             status: 200,
@@ -140,7 +140,7 @@ test.describe('send btc', () => {
       );
 
       await sendPage.page.route(
-        '**/leatherapi.bestinslot.xyz/v3/inscription/single_info_id**',
+        `${BESTINSLOT_API_BASE_URL_TESTNET}/inscription/single_info_id**`,
         async route => {
           return route.fulfill({
             status: 200,


### PR DESCRIPTION
> Try out Leather build 02f4f65 — [Extension build](https://github.com/leather-io/extension/actions/runs/9907964472), [Test report](https://leather-io.github.io/playwright-reports/fix-test-btc), [Storybook](https://fix-test-btc--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-test-btc)<!-- Sticky Header Marker -->

This pr mocks btc blockstream mainnet requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced onboarding test to verify 'No activity yet' text visibility under specific conditions.

- **Bug Fixes**
    - Standardized API base URLs in BTC transaction tests to use constants for improved maintainability.

- **Tests**
    - Introduced mock API requests for better simulation in test environments. 
    - Added new async functions and routes to streamline test execution and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->