### PR TITLE
fix(analytics): segment not passing context to mixpanel

### DIFF
--- a/src/app/common/persistence.ts
+++ b/src/app/common/persistence.ts
@@ -1,5 +1,5 @@
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
-import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryClient } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
 
 import { PERSISTENCE_CACHE_TIME } from '@leather.io/constants';
@@ -19,12 +19,6 @@ const storage = {
 const chromeStorageLocalPersister = createAsyncStoragePersister({ storage });
 
 export const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    async onError(_error, query) {
-      const queryKey = query.queryKey[0] ?? '';
-      void analytics.track('query_error', { queryKey });
-    },
-  }),
   mutationCache: new MutationCache({
     async onError(_error, _variables, _context, mutation) {
       const mutationPrefix = mutation?.options.mutationKey?.[0] ?? '';

--- a/src/shared/utils/analytics.ts
+++ b/src/shared/utils/analytics.ts
@@ -30,7 +30,9 @@ export function decorateAnalyticsEventsWithContext(
       void analytics.addSourceMiddleware(({ payload, next }) => {
         Object.entries(getEventContextProperties()).forEach(([key, value]) => {
           payload.obj.context = payload.obj.context || {};
-          payload.obj.context[key] = value;
+          payload.obj.context.ip = '0.0.0.0';
+          payload.obj.properties = payload.obj.properties || {};
+          payload.obj.properties[key] = value;
         });
         next(payload);
       })


### PR DESCRIPTION
> Try out Leather build 5c6b463 — [Extension build](https://github.com/leather-io/extension/actions/runs/9974934926), [Test report](https://leather-io.github.io/playwright-reports/fix-analytics), [Storybook](https://fix-analytics--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-analytics)<!-- Sticky Header Marker -->

In some earlier changes, I refactored Analytics such that there's a single mechanism to track events.

Segment's analytics library has two concepts:

> **Properties**: Describe the event details specific to the occurrence.
> **Context**: Provides metadata about the overall environment and situation in which the event occurred.

I followed these concepts, tracking global metadata such as the app version number as general event context. However, it appears this doesn't enter Mixpanel in the way expected, meaning events appear without the properties they had before.

As this negatively impacts our dashboard, I've changed this to be reported as properties, not context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced analytics event logging by setting the `ip` to '0.0.0.0' and ensuring `properties` are initialized correctly.

- **Refactor**
	- Streamlined the initialization of `QueryClient` by removing unnecessary `queryCache` configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->