### PR TITLE
refactor: bitcoin queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@leather.io/constants": "0.8.2",
     "@leather.io/crypto": "1.0.4",
     "@leather.io/models": "0.10.2",
-    "@leather.io/query": "1.0.2",
+    "@leather.io/query": "2.0.0",
     "@leather.io/tokens": "0.6.2",
     "@leather.io/ui": "1.6.4",
     "@leather.io/utils": "0.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 0.10.2
         version: 0.10.2
       '@leather.io/query':
-        specifier: 1.0.2
-        version: 1.0.2(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)
+        specifier: 2.0.0
+        version: 2.0.0(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)
       '@leather.io/tokens':
         specifier: 0.6.2
         version: 0.6.2
@@ -2618,8 +2618,8 @@ packages:
   '@leather.io/prettier-config@0.5.0':
     resolution: {integrity: sha512-Pul+4MAyBKnQvqgcKJLbZl4DHnS4kCJzSuaYFW6cfHdre7BFn/iY6Er/Dvm9F8g7VMtkdYu68jEYxQ1Xc7A0KQ==}
 
-  '@leather.io/query@1.0.2':
-    resolution: {integrity: sha512-cyIfEMwU0a2Hh/edAlYYks9IiEd9RJ//qYprGrymvKPc56vQLxYVdSjAFFT/PB1NXzsM+ZBJK3ElNsbHkWegwQ==}
+  '@leather.io/query@2.0.0':
+    resolution: {integrity: sha512-J46LTfcwVW7al9+rhozgOH08HncZ4bd4I3c8Z+DM6sB2uUmch4/KM/8siuWCYUcC+NYZlAXeVy6+acZUmM9i7Q==}
     peerDependencies:
       react: '*'
 
@@ -16709,8 +16709,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.24.8
       '@expo/code-signing-certificates': 0.0.5
-      '@expo/config': 9.0.2
-      '@expo/config-plugins': 8.0.4
+      '@expo/config': 9.0.3
+      '@expo/config-plugins': 8.0.8
       '@expo/devcert': 1.1.2
       '@expo/env': 0.3.0
       '@expo/image-utils': 0.5.1(encoding@0.1.13)
@@ -16840,7 +16840,7 @@ snapshots:
   '@expo/config@9.0.2':
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@expo/config-plugins': 8.0.4
+      '@expo/config-plugins': 8.0.8
       '@expo/config-types': 51.0.2
       '@expo/json-file': 8.3.3
       getenv: 1.0.0
@@ -16924,7 +16924,7 @@ snapshots:
       '@babel/generator': 7.24.10
       '@babel/parser': 7.24.8
       '@babel/types': 7.24.9
-      '@expo/config': 9.0.2
+      '@expo/config': 9.0.3
       '@expo/env': 0.3.0
       '@expo/json-file': 8.3.3
       '@expo/spawn-async': 1.7.2
@@ -16987,8 +16987,8 @@ snapshots:
 
   '@expo/prebuild-config@7.0.4(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
     dependencies:
-      '@expo/config': 9.0.2
-      '@expo/config-plugins': 8.0.4
+      '@expo/config': 9.0.3
+      '@expo/config-plugins': 8.0.8
       '@expo/config-types': 51.0.2
       '@expo/image-utils': 0.5.1(encoding@0.1.13)
       '@expo/json-file': 8.3.3
@@ -17262,7 +17262,7 @@ snapshots:
       - '@vue/compiler-sfc'
       - supports-color
 
-  '@leather.io/query@1.0.2(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)':
+  '@leather.io/query@2.0.0(@stacks/network@6.13.0(encoding@0.1.13))(encoding@0.1.13)(react@18.3.1)':
     dependencies:
       '@fungible-systems/zone-file': 2.0.0
       '@hirosystems/token-metadata-api-client': 1.2.0(encoding@0.1.13)
@@ -19432,7 +19432,7 @@ snapshots:
       chalk: 4.1.2
       execa: 5.1.1
       metro: 0.80.9(encoding@0.1.13)
-      metro-config: 0.80.5(encoding@0.1.13)
+      metro-config: 0.80.9(encoding@0.1.13)
       metro-core: 0.80.9
       node-fetch: 2.7.0(encoding@0.1.13)
       querystring: 0.2.1
@@ -19521,7 +19521,7 @@ snapshots:
     dependencies:
       '@react-native/js-polyfills': 0.73.1
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))
-      metro-config: 0.80.5(encoding@0.1.13)
+      metro-config: 0.80.9(encoding@0.1.13)
       metro-runtime: 0.80.9
     transitivePeerDependencies:
       - '@babel/core'
@@ -20241,7 +20241,7 @@ snapshots:
   '@stacks/common@4.3.5':
     dependencies:
       '@types/bn.js': 5.1.5
-      '@types/node': 18.19.40
+      '@types/node': 18.19.41
       buffer: 6.0.3
 
   '@stacks/common@6.13.0':

--- a/src/app/components/inscription-preview-card/components/inscription-text.tsx
+++ b/src/app/components/inscription-preview-card/components/inscription-text.tsx
@@ -1,7 +1,7 @@
 import { sanitize } from 'dompurify';
 import { Box } from 'leather-styles/jsx';
 
-import { useInscriptionTextContentQuery } from '@leather.io/query';
+import { useGetInscriptionTextContentQuery } from '@leather.io/query';
 
 import { parseJson } from '@app/components/json';
 import { LoadingSpinner } from '@app/components/loading-spinner';
@@ -10,7 +10,7 @@ interface InscriptionTextProps {
   contentSrc: string;
 }
 export function InscriptionText(props: InscriptionTextProps) {
-  const query = useInscriptionTextContentQuery(props.contentSrc);
+  const query = useGetInscriptionTextContentQuery(props.contentSrc);
 
   if (query.isLoading) return <LoadingSpinner size="16px" />;
 

--- a/src/app/features/activity-list/activity-list.tsx
+++ b/src/app/features/activity-list/activity-list.tsx
@@ -6,7 +6,7 @@ import uniqby from 'lodash.uniqby';
 import {
   useBitcoinPendingTransactions,
   useGetAccountTransactionsWithTransfersQuery,
-  useGetBitcoinTransactionsByAddressesQuery,
+  useGetBitcoinTransactionsByAddressListQuery,
   useStacksPendingTransactions,
 } from '@leather.io/query';
 
@@ -52,7 +52,7 @@ export function ActivityList() {
   const [
     { isLoading: isLoadingNsBitcoinTransactions, data: nsBitcoinTransactions = [] },
     { isLoading: isLoadingTrBitcoinTransactions, data: trBitcoinTransactions = [] },
-  ] = useGetBitcoinTransactionsByAddressesQuery([nsBitcoinAddress, trBitcoinAddress]);
+  ] = useGetBitcoinTransactionsByAddressListQuery([nsBitcoinAddress, trBitcoinAddress]);
 
   const [{ data: nsPendingTxs = [] }, { data: trPendingTxs = [] }] = useBitcoinPendingTransactions([
     nsBitcoinAddress,

--- a/src/app/features/collectibles/components/bitcoin/inscription-text.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription-text.tsx
@@ -1,4 +1,4 @@
-import { useInscriptionTextContentQuery } from '@leather.io/query';
+import { useGetInscriptionTextContentQuery } from '@leather.io/query';
 import { OrdinalAvatarIcon } from '@leather.io/ui';
 
 import { parseJson } from '@app/components/json';
@@ -17,7 +17,7 @@ export function InscriptionText({
   onClickCallToAction,
   onClickSend,
 }: InscriptionTextProps) {
-  const query = useInscriptionTextContentQuery(contentSrc);
+  const query = useGetInscriptionTextContentQuery(contentSrc);
 
   if (query.isLoading || query.isError) return null;
 

--- a/src/app/features/collectibles/hooks/use-is-fetching-collectibles.ts
+++ b/src/app/features/collectibles/hooks/use-is-fetching-collectibles.ts
@@ -9,10 +9,10 @@ function areAnyQueriesFetching(...args: number[]) {
 
 export function useIsFetchingCollectiblesRelatedQuery() {
   // Ordinal inscriptions
-  const n1 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.TaprootAddressUtxos] });
-  const n2 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.InscriptionsByAddress] });
-  const n3 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.InscriptionMetadata] });
-  const n4 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.OrdinalTextContent] });
+  const n1 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.GetTaprootUtxosByAddress] });
+  const n2 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.GetInscriptionsByAddress] });
+  const n3 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.GetInscription] });
+  const n4 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.GetInscriptionTextContent] });
   const n5 = useIsFetching({ queryKey: [BitcoinQueryPrefixes.GetInscriptions] });
 
   // BNS

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -137,7 +137,7 @@ export const Debugger = () => {
       bufferCV(Buffer.from('hello, world')),
       stringAsciiCV('hey-ascii'),
       stringUtf8CV('hey-utf8'),
-      standardPrincipalCV('ST1X6M947Z7E58CNE0H8YJVJTVKS9VW0PHEG3NHN3'),
+      standardPrincipalCV('STS8CKF63P16J28AYF7PXW9E5AACH0NZNRV74CM7'),
       trueCV(),
     ];
     const postConditions = [
@@ -150,7 +150,7 @@ export const Debugger = () => {
     console.log('creating allow mode contract call');
     await doContractCall({
       network,
-      contractAddress: 'ST1X6M947Z7E58CNE0H8YJVJTVKS9VW0PHEG3NHN3',
+      contractAddress: 'STS8CKF63P16J28AYF7PXW9E5AACH0NZNRV74CM7',
       contractName: 'faker',
       functionName: 'rawr',
       functionArgs: args,

--- a/tests/mocks/mock-inscriptions.ts
+++ b/tests/mocks/mock-inscriptions.ts
@@ -1,4 +1,4 @@
-import { type InscriptionResponseHiro, createInscriptionHiro } from '@leather.io/query';
+import { type InscriptionResponseHiro, createHiroInscription } from '@leather.io/query';
 
 export const mockInscriptionResponse1: InscriptionResponseHiro = {
   address: 'bc1pwrmewwprc8k8l2k63x4advg0nx0jk50xzqnee996lm87mcuza7kq6drg2k',
@@ -27,7 +27,7 @@ export const mockInscriptionResponse1: InscriptionResponseHiro = {
   value: '10000',
 };
 
-export const mockInscription1 = createInscriptionHiro(mockInscriptionResponse1);
+export const mockInscription1 = createHiroInscription(mockInscriptionResponse1);
 
 export const mockInscriptionResponse2: InscriptionResponseHiro = {
   address: 'bc1pwrmewwprc8k8l2k63x4advg0nx0jk50xzqnee996lm87mcuza7kq6drg2k',
@@ -56,7 +56,7 @@ export const mockInscriptionResponse2: InscriptionResponseHiro = {
   value: '10000',
 };
 
-export const mockInscription2 = createInscriptionHiro(mockInscriptionResponse2);
+export const mockInscription2 = createHiroInscription(mockInscriptionResponse2);
 
 export const mockInscriptionResponsesList = [
   {
@@ -86,4 +86,4 @@ export const mockInscriptionResponsesList = [
     value: '546',
   },
 ];
-export const mockInscriptionsList = mockInscriptionResponsesList.map(createInscriptionHiro);
+export const mockInscriptionsList = mockInscriptionResponsesList.map(createHiroInscription);

--- a/tests/specs/transactions/transactions.spec.ts
+++ b/tests/specs/transactions/transactions.spec.ts
@@ -35,6 +35,7 @@ test.describe('Transaction signing', () => {
 
       await testAppPage.clickContractCallButton();
       const transactionRequestPage = new TransactionRequestPage(await context.waitForEvent('page'));
+      await transactionRequestPage.waitForTransactionRequestPage();
       const error =
         await transactionRequestPage.waitForTransactionRequestError('Insufficient balance');
 


### PR DESCRIPTION
> Try out Leather build 1894053 — [Extension build](https://github.com/leather-io/extension/actions/runs/10023085929), [Test report](https://leather-io.github.io/playwright-reports/refactor-bitcoin-queries), [Storybook](https://refactor-bitcoin-queries--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor-bitcoin-queries)<!-- Sticky Header Marker -->

Implements bitcoin query refactor work from the mono repo.

Merging this PR will close the two open issues linked here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated package dependencies to enhance functionality and maintain compatibility.

- **Refactor**
	- Renamed several functions for clarity, including:
		- `useInscriptionTextContentQuery` to `useGetInscriptionTextContentQuery`
		- `useGetBitcoinTransactionsByAddressesQuery` to `useGetBitcoinTransactionsByAddressListQuery`
		- `createInscriptionHiro` to `createHiroInscription`
	- Updated query keys for improved semantic clarity in fetching collectibles-related data.
	- Updated the `Debugger` component to reference a different smart contract address.

- **Bug Fixes**
	- Enhanced error handling in transaction request methods with a timeout for better robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->