### PR TITLE
fix: update popup headers to show account info

### DIFF
--- a/src/app/features/container/utils/get-popup-header.ts
+++ b/src/app/features/container/utils/get-popup-header.ts
@@ -1,6 +1,3 @@
-/**
- * POPUP header logic notes here -> https://github.com/leather-io/extension/issues/4371#issuecomment-1919114939
- */
 import { RouteUrls } from '@shared/route-urls';
 
 export function isRpcRoute(pathname: RouteUrls) {
@@ -24,11 +21,14 @@ export function isRpcRoute(pathname: RouteUrls) {
 
 export function showAccountInfo(pathname: RouteUrls) {
   switch (pathname) {
+    case RouteUrls.PsbtRequest:
     case RouteUrls.TransactionRequest:
     case RouteUrls.ProfileUpdateRequest:
     case RouteUrls.RpcSendTransfer:
     case RouteUrls.RpcSignPsbt:
     case RouteUrls.RpcSignBip322Message:
+    case RouteUrls.SignatureRequest:
+    case RouteUrls.RpcStacksSignature:
       return true;
     default:
       return false;
@@ -39,20 +39,25 @@ export function showBalanceInfo(pathname: RouteUrls) {
   switch (pathname) {
     case RouteUrls.ProfileUpdateRequest:
     case RouteUrls.RpcSendTransfer:
-      return true;
+    case RouteUrls.PsbtRequest:
+    case RouteUrls.RpcSignBip322Message:
+    case RouteUrls.RpcStacksSignature:
     case RouteUrls.TransactionRequest:
+      return true;
     default:
       return false;
   }
 }
 
 export function getDisplayAddresssBalanceOf(pathname: RouteUrls) {
-  //  TODO it's unclear when to show ALL or STX balance here
   switch (pathname) {
-    case RouteUrls.TransactionRequest:
     case RouteUrls.ProfileUpdateRequest:
     case RouteUrls.RpcSendTransfer:
+    case RouteUrls.PsbtRequest:
+    case RouteUrls.RpcSignBip322Message:
       return 'all';
+    case RouteUrls.RpcStacksSignature:
+    case RouteUrls.TransactionRequest:
     default:
       return 'stx';
   }


### PR DESCRIPTION
> _Building Leather at commit 5326a39_<!-- Sticky Header Marker -->

This PR follows an audit of our popups and makes some changes to the data we show in headers. I have discussed it with @markmhendrickson in https://github.com/leather-io/issues/issues/157#issuecomment-2244495675

Updated from Logo to Account, Network + Balance info:
- `RouteUrls.PsbtRequest` : `/psbt`
- `RouteUrls.SignatureRequest` : `/signature`
- `RouteUrls.RpcStacksSignature` : `/sign-stacks-message`

Updated to include balance info:
- `RouteUrls.RpcSignBip322Message` : `/sign-bip322-message` - BTC via `all` 
- `RouteUrls.RpcStacksSignature` : `/sign-stacks-message` - STX via `stx`
- `RouteUrls.TransactionRequest` : `/transaction` - STX via `stx`


![Screenshot 2024-07-24 at 07 13 58](https://github.com/user-attachments/assets/1a6e2ba3-fc30-446c-9705-8b737ff530f9)
![Screenshot 2024-07-24 at 07 13 19](https://github.com/user-attachments/assets/e770ccec-1850-45fa-80a9-d9877a5487ee)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced account and balance information display by supporting additional route types, allowing for improved recognition and handling of various routes.
- **Bug Fixes**
	- Adjusted logic in multiple functions to ensure correct return values under newly recognized route conditions, enhancing accuracy in information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->