### PR TITLE
return stxPublicKey from getAddresses rpc

### DIFF
--- a/src/app/pages/rpc-get-addresses/use-request-accounts.ts
+++ b/src/app/pages/rpc-get-addresses/use-request-accounts.ts
@@ -62,7 +62,8 @@ export function useGetAddresses() {
       if (stacksAccount) {
         const stacksAddressResponse = {
           symbol: 'STX',
-          address: stacksAccount?.address ?? '',
+          address: stacksAccount.address ?? '',
+          publicKey: stacksAccount.stxPublicKey ?? '',
         };
 
         keysToIncludeInResponse.push(stacksAddressResponse);


### PR DESCRIPTION
Hello,

Please correct me if I'm wrong, but in a world where Stacks app developers are using the new window provider RPC methods in lieu of `@stacks/connect`, it appears that signing Stacks transactions using Leather today requires passing a `txhex` to `LeatherProvider.request("stx_signTransaction", ...)`. In order to obtain such `txhex`, you would construct a transaction using `makeUnsignedContractCall` from `@stacks/transaction`. That function, however, requires you to have the user's Stacks public key in order to construct the unsigned transaction.

For that reason (and likely others), it would seem to make sense for `getAddresses` to return the Stacks public key associated with the current account (as it already does for Bitcoin addresses).

Note that the XVerse provider already has this behavior: https://docs.xverse.app/sats-connect/stacks-methods/stx_getaccounts

If I'm missing something about how to get a Leather user's Stacks public key without using `@stacks/connect`, or if what I describe above is otherwise incorrect or not the expected usage pattern for app developers, please let me know.

Thank you.

P.S. I assume there are RPC types that need to be updated in your monorepo as well. 