### PR TITLE
fix(rpc): return stxPublicKey from getAddresses

### DIFF
--- a/src/app/pages/rpc-get-addresses/use-request-accounts.ts
+++ b/src/app/pages/rpc-get-addresses/use-request-accounts.ts
@@ -62,7 +62,8 @@ export function useGetAddresses() {
       if (stacksAccount) {
         const stacksAddressResponse = {
           symbol: 'STX',
-          address: stacksAccount?.address ?? '',
+          address: stacksAccount.address ?? '',
+          publicKey: stacksAccount.stxPublicKey ?? '',
         };
 
         keysToIncludeInResponse.push(stacksAddressResponse);

--- a/tests/specs/rpc-get-addresses/get-addresses.spec.ts
+++ b/tests/specs/rpc-get-addresses/get-addresses.spec.ts
@@ -40,7 +40,13 @@ function getExpectedResponseForKeys(keys: SupportedBlockchains[]) {
       derivationPath: "m/86'/0'/0'/0/0",
     },
   ];
-  const stacksKeys = [{ symbol: 'STX', address: 'SPS8CKF63P16J28AYF7PXW9E5AACH0NZNTEFWSFE' }];
+  const stacksKeys = [
+    {
+      symbol: 'STX',
+      publicKey: '0329b076bc20f7b1592b2a1a5cb91dfefe8c966e50e256458e23dd2c5d63f8f1af',
+      address: 'SPS8CKF63P16J28AYF7PXW9E5AACH0NZNTEFWSFE',
+    },
+  ];
   return {
     jsonrpc: '2.0',
     result: {


### PR DESCRIPTION
> Try out Leather build b31c59e — [Extension build](https://github.com/leather-io/extension/actions/runs/10141500664), [Test report](https://leather-io.github.io/playwright-reports/feat-get-addresses-stx-public-key), [Storybook](https://feat-get-addresses-stx-public-key--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-get-addresses-stx-public-key)<!-- Sticky Header Marker -->

Clone PR from @sjc5 

Returns STX public key with `getAddresses` response