### PR TITLE
test: close browser

### DIFF
--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -45,6 +45,7 @@ export const test = base.extend<TestFixtures>({
     });
     await use(context);
     await context.close();
+    await context.browser()?.close();
   },
   extensionId: async ({ context }, use) => {
     let [background] = context.serviceWorkers();


### PR DESCRIPTION
> Try out Leather build bc28450 — [Extension build](https://github.com/leather-io/extension/actions/runs/10145819140), [Test report](https://leather-io.github.io/playwright-reports/experimental-test-setup), [Storybook](https://experimental-test-setup--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=experimental-test-setup)<!-- Sticky Header Marker -->

I believe this change should avoid the risk of shared state between the tests. Suggest we merge and monitor and see if it improves test reliability. It will probably slow the tests a little, but really the only way to guarantee that no state is shared between tests.