### PR TITLE
chore: force resolution of fast-xml-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,6 +356,7 @@
   },
   "resolutions": {
     "braces": "3.0.3",
+    "fast-xml-parser": "4.4.1",
     "nanoid": "3.3.4",
     "socket.io-parser": "4.2.4",
     "wrap-ansi": "7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   braces: 3.0.3
+  fast-xml-parser: 4.4.1
   nanoid: 3.3.4
   socket.io-parser: 4.2.4
   wrap-ansi: 7.0.0
@@ -8618,8 +8619,8 @@ packages:
   fast-uri@3.0.1:
     resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
 
-  fast-xml-parser@4.4.0:
-    resolution: {integrity: sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==}
+  fast-xml-parser@4.4.1:
+    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -19129,7 +19130,7 @@ snapshots:
       chalk: 4.1.2
       execa: 5.1.1
       fast-glob: 3.3.2
-      fast-xml-parser: 4.4.0
+      fast-xml-parser: 4.4.1
       logkitty: 0.7.1
     transitivePeerDependencies:
       - encoding
@@ -19140,7 +19141,7 @@ snapshots:
       chalk: 4.1.2
       execa: 5.1.1
       fast-glob: 3.3.2
-      fast-xml-parser: 4.4.0
+      fast-xml-parser: 4.4.1
       ora: 5.4.1
     transitivePeerDependencies:
       - encoding
@@ -25721,7 +25722,7 @@ snapshots:
 
   fast-uri@3.0.1: {}
 
-  fast-xml-parser@4.4.0:
+  fast-xml-parser@4.4.1:
     dependencies:
       strnum: 1.0.5
 


### PR DESCRIPTION
> Try out Leather build 90b2dcf — [Extension build](https://github.com/leather-io/extension/actions/runs/10174293127), [Test report](https://leather-io.github.io/playwright-reports/chore-resolve-fast-xml), [Storybook](https://chore-resolve-fast-xml--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-resolve-fast-xml)<!-- Sticky Header Marker -->

This forces the resolution of `fast-xml-parser` to fix this audit vulnerability: https://github.com/advisories/GHSA-mpg4-rc92-vx8v 

It is a sub-dependancy of `@leather.io/ui`.  