### PR TITLE
chore: readd fragments to help escape single quote

### DIFF
--- a/src/app/pages/onboarding/back-up-secret-key/back-up-secret-key.tsx
+++ b/src/app/pages/onboarding/back-up-secret-key/back-up-secret-key.tsx
@@ -28,7 +28,12 @@ export const BackUpSecretKeyPage = memo(() => {
       <Content>
         <TwoColumnLayout
           title="Back up your Secret Key"
-          content="You'll need it to access your wallet on a new device, or this one if you lose your password — so back it up somewhere safe!"
+          content={
+            <>
+              You'll need it to access your wallet on a new device, or this one if you lose your
+              password — so back it up somewhere safe!
+            </>
+          }
           action={
             <Stack gap="space.05" mt="space.04">
               <HStack alignItems="center">

--- a/src/app/pages/onboarding/set-password/set-password.tsx
+++ b/src/app/pages/onboarding/set-password/set-password.tsx
@@ -131,7 +131,12 @@ function SetPasswordPage() {
                     password
                   </>
                 }
-                content="Your password protects your Secret Key on this device only. To access your wallet on another device, you'll need just your Secret Key."
+                content={
+                  <>
+                    Your password protects your Secret Key on this device only. To access your
+                    wallet on another device, you'll need just your Secret Key.
+                  </>
+                }
               >
                 <>
                   <PasswordField strengthResult={strengthResult} isDisabled={loading} />


### PR DESCRIPTION
> Try out Leather build 433dba8 — [Extension build](https://github.com/leather-io/extension/actions/runs/10212854489), [Test report](https://leather-io.github.io/playwright-reports/chore-fix-panda-build-error), [Storybook](https://chore-fix-panda-build-error--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-fix-panda-build-error)<!-- Sticky Header Marker -->

I hastily removed what seemed un-necessary fragments yesterday but that actually creates a panda build error:
```
🐼 error [sheet:process] > 1 | .leather-content_You\'ll_need_it_to_access_your_wallet_on_a_new_device\,_or_this_one_if_you_lose_your_password_—_so_back_it_up_somewhere_safe\! {content: You'll need it to access your wallet on a new device, or this one if you lose your password — so back it up somewhere safe !important;
    |                                                                                                                                                              ^
  2 | }
  3 | 
🐼 error [sheet:process] > 1 | .leather-content_Your_password_protects_your_Secret_Key_on_this_device_only\._To_access_your_wallet_on_another_device\,_you\'ll_need_just_your_Secret_Key\. {content: Your password protects your Secret Key on this device only. To access your wallet on another device, you'll need just your Secret Key.;
```

I tried a few things to escape the `'` but it seems easier and cleaner to just keep them as fragments 