### PR TITLE
fix: fix visual bug on hover of PSBT copy, ref #4972

### DIFF
--- a/src/app/features/psbt-signer/components/psbt-inputs-and-outputs/components/psbt-input-output-item.layout.tsx
+++ b/src/app/features/psbt-signer/components/psbt-inputs-and-outputs/components/psbt-input-output-item.layout.tsx
@@ -37,7 +37,7 @@ export function PsbtInputOutputItemLayout({
             label={hasCopied ? 'Copied!' : addressHoverLabel}
             side="bottom"
           >
-            <Box display="flex" height="16px">
+            <Box display="flex">
               <styled.button _hover={{ bg: 'ink.component-background-hover' }} onClick={onCopy}>
                 {addressHoverLabel ? <CopyIcon variant="small" /> : null}
               </styled.button>

--- a/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-total-item.tsx
+++ b/src/app/features/psbt-signer/components/psbt-inputs-outputs-totals/components/psbt-address-total-item.tsx
@@ -46,7 +46,7 @@ export function PsbtAddressTotalItem({
               label={hasCopied ? 'Copied!' : hoverLabel}
               side="bottom"
             >
-              <Box display="flex" height="16px">
+              <Box display="flex">
                 <Link onClick={onCopy} variant="text">
                   {hoverLabel ? <CopyIcon /> : null}
                 </Link>


### PR DESCRIPTION
> Try out Leather build 6b4e816 — [Extension build](https://github.com/leather-io/extension/actions/runs/10216791719), [Test report](https://leather-io.github.io/playwright-reports/fix-4972-psbt-copy-glitch), [Storybook](https://fix-4972-psbt-copy-glitch--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-4972-psbt-copy-glitch)<!-- Sticky Header Marker -->

This PR fixes a visual bug with the copy option in PSBT approval modal
