### PR TITLE
fix: default to first account when signing in on gamma as useCurrentS…

### DIFF
--- a/src/app/features/current-account/current-account-avatar.tsx
+++ b/src/app/features/current-account/current-account-avatar.tsx
@@ -10,7 +10,7 @@ interface CurrentAccountAvatar extends CircleProps {
 export function CurrentAccountAvatar() {
   const stacksAccount = useCurrentStacksAccount();
   const { data: name = 'Account' } = useCurrentAccountDisplayName();
-  if (!stacksAccount) return null;
+  if (!stacksAccount) return <AccountAvatar index={0} name={name} publicKey="" />;
 
   return (
     <AccountAvatar index={stacksAccount.index} name={name} publicKey={stacksAccount.stxPublicKey} />

--- a/src/app/features/current-account/current-account-name.tsx
+++ b/src/app/features/current-account/current-account-name.tsx
@@ -6,7 +6,6 @@ import { Box, BoxProps, styled } from 'leather-styles/jsx';
 import { HasChildren } from '@app/common/has-children';
 import { useCurrentAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { truncateString } from '@app/common/utils';
-import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
 function AccountNameTitle({ children, ...props }: HasChildren & BoxProps) {
@@ -20,9 +19,7 @@ function AccountNameTitle({ children, ...props }: HasChildren & BoxProps) {
 }
 
 const AccountNameSuspense = memo((props: BoxProps) => {
-  const currentAccount = useCurrentStacksAccount();
   const { data: name = 'Account' } = useCurrentAccountDisplayName();
-  if (!currentAccount || typeof currentAccount.index === 'undefined') return null;
   // FIXME: The name is truncated here with JS but we could just use CSS to do this
   const nameCharLimit = 18;
   const isLong = name.length > nameCharLimit;

--- a/src/app/features/total-balance/total-balance.tsx
+++ b/src/app/features/total-balance/total-balance.tsx
@@ -33,7 +33,7 @@ function TotalBalanceSuspense({ displayAddresssBalanceOf }: TotalBalanceProps) {
   return (
     <TotalBalanceLayout>
       <HStack alignItems="center" justifyContent="right">
-        {account && displayAddresssBalanceOf === 'stx' && <StxBalance address={account.address} />}
+        {displayAddresssBalanceOf === 'stx' && <StxBalance address={account?.address || ''} />}
         {isBitcoinEnabled && displayAddresssBalanceOf === 'all' && <BtcBalance />}
       </HStack>
     </TotalBalanceLayout>


### PR DESCRIPTION
> Try out Leather build d5b9d4c — [Extension build](https://github.com/leather-io/extension/actions/runs/10217309874), [Test report](https://leather-io.github.io/playwright-reports/fix-5683-gamma-account-header), [Storybook](https://fix-5683-gamma-account-header--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-5683-gamma-account-header)<!-- Sticky Header Marker -->

This PR fixes a bug with the popup header on Gamma where:

-  if you have a new empty wallet
- you try to purchase a STX NFT 
- the approval popup header is blank 
- as it cannot access the STX current account
