### PR TITLE
chore: update org name

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,7 +2,7 @@ export const gaiaUrl = 'https://hub.blockstack.org';
 
 export const ZERO_INDEX = 0;
 
-export const GITHUB_ORG = 'leather-wallet';
+export const GITHUB_ORG = 'leather-io';
 export const GITHUB_REPO = 'extension';
 
 export const HIRO_EXPLORER_URL = 'https://explorer.hiro.so';


### PR DESCRIPTION
> Try out Leather build ae8b864 — [Extension build](https://github.com/leather-io/extension/actions/runs/10249550004), [Test report](https://leather-io.github.io/playwright-reports/fix-outdated-org-name), [Storybook](https://fix-outdated-org-name--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-outdated-org-name)<!-- Sticky Header Marker -->

We were using the old one