### PR TITLE
fix: minimum bitcoin spend, closes #5739

### DIFF
--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -19,7 +19,7 @@ import { FormErrorMessages } from '../../../../shared/error-messages';
 import { formatInsufficientBalanceError, formatPrecisionError } from '../../error-formatters';
 import { currencyAmountValidator, stxAmountPrecisionValidator } from './currency-validators';
 
-const minSpendAmountInSats = 6000;
+const minSpendAmountInSats = 546;
 
 function amountValidator() {
   return yup


### PR DESCRIPTION
> Try out Leather build 0a25012 — [Extension build](https://github.com/leather-io/extension/actions/runs/10403945992), [Test report](https://leather-io.github.io/playwright-reports/fix-change-lower-tx-threshold), [Storybook](https://fix-change-lower-tx-threshold--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-change-lower-tx-threshold)<!-- Sticky Header Marker -->

Lowers min. bitcoin spend to 546 per advice here https://bitcoin.stackexchange.com/questions/86068/how-was-the-dust-limit-of-546-satoshis-was-chosen-why-not-550-satoshis

Closes #5739