### PR TITLE
fix(ledger): support stx_signMessage

### DIFF
--- a/src/app/common/rpc-helpers.ts
+++ b/src/app/common/rpc-helpers.ts
@@ -1,13 +1,7 @@
 import { useMemo } from 'react';
 
-import { RpcErrorCode } from '@btckit/types';
-
-import { WalletMethodMap, makeRpcErrorResponse } from '@shared/rpc/rpc-methods';
-import { closeWindow } from '@shared/utils';
-
 import { useDefaultRequestParams } from './hooks/use-default-request-search-params';
 import { initialSearchParams } from './initial-search-params';
-import { useWalletType } from './use-wallet-type';
 
 export function useRpcRequestParams() {
   const defaultParams = useDefaultRequestParams();
@@ -18,21 +12,4 @@ export function useRpcRequestParams() {
     }),
     [defaultParams]
   );
-}
-
-export function useRejectIfLedgerWallet(request: keyof WalletMethodMap) {
-  const { walletType } = useWalletType();
-  const { tabId, requestId } = useRpcRequestParams();
-  if (walletType !== 'ledger' || !tabId) return;
-  chrome.tabs.sendMessage(
-    tabId,
-    makeRpcErrorResponse(request, {
-      id: requestId,
-      error: {
-        code: RpcErrorCode.INTERNAL_ERROR,
-        message: 'Ledger wallet is not supported',
-      },
-    })
-  );
-  closeWindow();
 }

--- a/src/app/pages/rpc-sign-stacks-transaction/use-rpc-sign-stacks-transaction.ts
+++ b/src/app/pages/rpc-sign-stacks-transaction/use-rpc-sign-stacks-transaction.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 import { RpcErrorCode } from '@btckit/types';
 import { bytesToHex } from '@stacks/common';
@@ -9,18 +8,15 @@ import { makeRpcErrorResponse, makeRpcSuccessResponse } from '@shared/rpc/rpc-me
 import { closeWindow } from '@shared/utils';
 
 import { useDefaultRequestParams } from '@app/common/hooks/use-default-request-search-params';
-import { useRejectIfLedgerWallet } from '@app/common/rpc-helpers';
+import { initialSearchParams } from '@app/common/initial-search-params';
 import { getTxSenderAddress } from '@app/common/transactions/stacks/transaction.utils';
 import { useSignStacksTransaction } from '@app/store/transactions/transaction.hooks';
 
 function useRpcSignStacksTransactionParams() {
-  useRejectIfLedgerWallet('stx_signTransaction');
-
-  const [searchParams] = useSearchParams();
   const { origin, tabId } = useDefaultRequestParams();
-  const requestId = searchParams.get('requestId');
-  const txHex = searchParams.get('txHex');
-  const isMultisig = searchParams.get('isMultisig');
+  const requestId = initialSearchParams.get('requestId');
+  const txHex = initialSearchParams.get('txHex');
+  const isMultisig = initialSearchParams.get('isMultisig');
 
   if (!requestId || !txHex || !origin) throw new Error('Invalid params');
 

--- a/src/app/routes/rpc-routes.tsx
+++ b/src/app/routes/rpc-routes.tsx
@@ -6,6 +6,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { EditNonceDialog } from '@app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog';
 import { ledgerBitcoinTxSigningRoutes } from '@app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container';
 import { ledgerStacksMessageSigningRoutes } from '@app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg.routes';
+import { ledgerStacksTxSigningRoutes } from '@app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container';
 import { RpcGetAddresses } from '@app/pages/rpc-get-addresses/rpc-get-addresses';
 import { rpcSendTransferRoutes } from '@app/pages/rpc-send-transfer/rpc-send-transfer.routes';
 import { RpcSignPsbt } from '@app/pages/rpc-sign-psbt/rpc-sign-psbt';
@@ -77,6 +78,7 @@ export const rpcRequestRoutes = (
         </AccountGate>
       }
     >
+      {ledgerStacksTxSigningRoutes}
       <Route path={RouteUrls.EditNonce} element={<EditNonceDialog />} />
     </Route>
   </>

--- a/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -8,8 +8,8 @@ import {
   deriveAddressIndexZeroFromAccount,
   deriveNativeSegwitAccountFromRootKeychain,
   getNativeSegWitPaymentFromAddressIndex,
-  getNativeSegwitAccountDerivationPath,
   lookUpLedgerKeysByPath,
+  makeNativeSegwitAccountDerivationPath,
 } from '@leather.io/bitcoin';
 import { extractAddressIndexFromPath } from '@leather.io/crypto';
 import { useBitcoinClient } from '@leather.io/query';
@@ -34,7 +34,7 @@ import {
 
 const selectNativeSegwitAccountBuilder = bitcoinAccountBuilderFactory(
   deriveNativeSegwitAccountFromRootKeychain,
-  lookUpLedgerKeysByPath(getNativeSegwitAccountDerivationPath)
+  lookUpLedgerKeysByPath(makeNativeSegwitAccountDerivationPath)
 );
 
 const selectCurrentNetworkNativeSegwitAccountBuilder = createSelector(


### PR DESCRIPTION
> Try out Leather build 30288c0 — [Extension build](https://github.com/leather-io/extension/actions/runs/10404253847), [Test report](https://leather-io.github.io/playwright-reports/fix-stacks-ledger), [Storybook](https://fix-stacks-ledger--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-stacks-ledger)<!-- Sticky Header Marker -->

Closes #5756

This PR adds support for Ledger on the `stx_signMessage` RPC call. A user reported this not working, and it's quite a crucial feature, and provides better compatibility between wallets.