### PR TITLE
ci: job to update packages

### DIFF
--- a/.github/workflows/update-leather-packages.yml
+++ b/.github/workflows/update-leather-packages.yml
@@ -1,0 +1,46 @@
+name: Update Leather.io packages
+
+on:
+  push:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [leather-deps-updated]
+
+jobs:
+  update-leather-deps:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          token: ${{ secrets.LEATHER_BOT }}
+
+      - uses: ./.github/actions/provision
+
+      - name: Update @leather.io/* packages
+        id: update-packages
+        run: echo output=$(pnpm upgrade "@leather.io/*" --latest) >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.LEATHER_BOT }}
+          branch: 'chore-update-leather-packages'
+          commit-message: 'ci: update leather.io packages'
+          title: 'ci: update npm packages'
+          committer: 'leather-bot <leather-bot@users.noreply.github.com>'
+          author: 'leather-bot <leather-bot@users.noreply.github.com>'
+          body: |
+            Updating packages
+
+            If the CI build fails it's likely that there have been breaking changes upstream in the monorepo.
+            A Leather dev should checkout the repo and fix these before merging the pull request.
+
+            <details>
+
+              <summary>Output</summary>
+
+              ${{ steps.update-packages.outputs.output }}
+
+            </details>


### PR DESCRIPTION
> Try out Leather build 5ac4c0f — [Extension build](https://github.com/leather-io/extension/actions/runs/10403931433), [Test report](https://leather-io.github.io/playwright-reports/ci-auto-update-packages), [Storybook](https://ci-auto-update-packages--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci-auto-update-packages)<!-- Sticky Header Marker -->

New job to update packages, believe we can trigger this from the monorepo too on release