### PR TITLE
fix: tool to clear submitted tx state

### DIFF
--- a/src/app/debug.ts
+++ b/src/app/debug.ts
@@ -11,6 +11,7 @@ import { queryClient } from './common/persistence';
 import { store } from './store';
 import { stxChainSlice } from './store/chains/stx-chain.slice';
 import { settingsSlice } from './store/settings/settings.slice';
+import { submittedTransactionsActions } from './store/submitted-transactions/submitted-transactions.actions';
 
 declare global {
   interface Window {
@@ -45,6 +46,9 @@ const debug = {
   },
   resetMessages() {
     store.dispatch(settingsSlice.actions.resetMessages());
+  },
+  clearSubmittedTransactions() {
+    store.dispatch(submittedTransactionsActions.clearSubmittedTransactions());
   },
   clearReactQueryCache() {
     queryClient.clear();

--- a/src/app/store/submitted-transactions/submitted-transactions.slice.ts
+++ b/src/app/store/submitted-transactions/submitted-transactions.slice.ts
@@ -24,5 +24,8 @@ export const submittedTransactionsSlice = createSlice({
     transactionReplacedByFee(state, action: PayloadAction<string>) {
       submittedTransactionsAdapter.removeOne(state, action.payload);
     },
+    clearSubmittedTransactions(state) {
+      submittedTransactionsAdapter.removeAll(state);
+    },
   },
 });


### PR DESCRIPTION
> Try out Leather build 2b8a5eb — [Extension build](https://github.com/leather-io/extension/actions/runs/10415705006), [Test report](https://leather-io.github.io/playwright-reports/fix-debug-tool-pendingtxs), [Storybook](https://fix-debug-tool-pendingtxs--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-debug-tool-pendingtxs)<!-- Sticky Header Marker -->

@314159265359879 @renashah when this is merged, you'll be able to clear these manually running `debug.clearSubmittedTransactions()` in dev tools. 

Going into dev tools isn't something users should ever have to do, but at least offers an escape hatch when txs do become stuck. With Nakamoto, the concept of "submitted transactions" will perhaps not be necessary.