### PR TITLE
fix: remove card from retrieve taproot ui

### DIFF
--- a/src/app/features/retrieve-taproot-to-native-segwit/components/retrieve-taproot-to-native-segwit.layout.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/components/retrieve-taproot-to-native-segwit.layout.tsx
@@ -2,7 +2,7 @@ import { Flex, styled } from 'leather-styles/jsx';
 
 import { BtcAvatarIcon, Button, Callout, Dialog, DialogHeader } from '@leather.io/ui';
 
-import { Card, Footer } from '@app/components/layout';
+import { Footer } from '@app/components/layout';
 
 interface RetrieveTaprootToNativeSegwitLayoutProps {
   isBroadcasting: boolean;
@@ -21,45 +21,35 @@ export function RetrieveTaprootToNativeSegwitLayout(
       onClose={() => onClose()}
       footer={
         <Footer>
-          <Flex flexDirection="row">
-            <Button onClick={onApproveTransaction} aria-busy={isBroadcasting} fullWidth>
-              Retrieve bitcoin
-            </Button>
-          </Flex>
+          <Button onClick={onApproveTransaction} aria-busy={isBroadcasting} fullWidth>
+            Retrieve bitcoin
+          </Button>
         </Footer>
       }
     >
-      <Card>
-        <Flex
-          alignItems="start"
-          flexDirection="column"
-          mx="space.06"
-          mt="space.05"
-          textAlign="left"
-        >
-          <BtcAvatarIcon />
-          <styled.span mt="space.04" textStyle="label.01">
-            Retrieve Bitcoin deposited to <br /> Taproot addresses
-          </styled.span>
-          <styled.span mt="space.05" textStyle="body.02">
-            Taproot addresses are used by Leather for Ordinal inscriptions, but they can also
-            contain bitcoin.
-          </styled.span>
-          <styled.span mt="space.04" textStyle="body.02">
-            As we don't support tranferring from Taproot addresses yet, you can retrieve funds to
-            your account's main Native SegWit balance here.
-          </styled.span>
-          <styled.span my="space.04" textStyle="body.02">
-            This transaction may take upwards of 30 minutes to confirm.
-          </styled.span>
-          {children}
-          <Callout variant="warning" mt="space.05" mb="space.05">
-            We recommend you check the URL for each "Uninscribed UTXO" listed above to ensure it
-            displays no inscription. If it does display one, do not proceed with retrieval or you
-            may lose it!
-          </Callout>
-        </Flex>
-      </Card>
+      <Flex alignItems="start" flexDirection="column" mx="space.06" mt="space.05" textAlign="left">
+        <BtcAvatarIcon />
+        <styled.span mt="space.04" textStyle="label.01">
+          Retrieve Bitcoin deposited to <br /> Taproot addresses
+        </styled.span>
+        <styled.span mt="space.05" textStyle="body.02">
+          Taproot addresses are used by Leather for Ordinal inscriptions, but they can also contain
+          bitcoin.
+        </styled.span>
+        <styled.span mt="space.04" textStyle="body.02">
+          As we don't support tranferring from Taproot addresses yet, you can retrieve funds to your
+          account's main Native SegWit balance here.
+        </styled.span>
+        <styled.span my="space.04" textStyle="body.02">
+          This transaction may take upwards of 30 minutes to confirm.
+        </styled.span>
+        {children}
+        <Callout variant="warning" mt="space.05" mb="space.05">
+          We recommend you check the URL for each "Uninscribed UTXO" listed above to ensure it
+          displays no inscription. If it does display one, do not proceed with retrieval or you may
+          lose it!
+        </Callout>
+      </Flex>
     </Dialog>
   );
 }


### PR DESCRIPTION
> Try out Leather build 2e5ab38 — [Extension build](https://github.com/leather-io/extension/actions/runs/10468867481), [Test report](https://leather-io.github.io/playwright-reports/fix-5248-popup-ui-retrieve-btc), [Storybook](https://fix-5248-popup-ui-retrieve-btc--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-5248-popup-ui-retrieve-btc)<!-- Sticky Header Marker -->

Issue reported by @alter-eggo [here](https://trustmachines.slack.com/archives/C05LAP952E7/p1724144032491249)

This is a `Dialog` I missed when re-working `Card` [here](https://github.com/leather-io/extension/pull/5778)

I've updated it to match how it was before:
![Screenshot 2024-08-20 at 10 26 50](https://github.com/user-attachments/assets/0b81148b-220b-41a9-8f01-39800eb33046)

The `Dialog` header is not the correct height but that will be fixed by https://github.com/leather-io/extension/issues/5734
