### PR TITLE
fix: remove blockstream from tests and add network form

### DIFF
--- a/src/app/features/add-network/add-network-form.tsx
+++ b/src/app/features/add-network/add-network-form.tsx
@@ -4,7 +4,11 @@ import { NetworkSelectors } from '@tests/selectors/network.selectors';
 import { useFormikContext } from 'formik';
 import { HStack, styled } from 'leather-styles/jsx';
 
-import type { BitcoinNetworkModes } from '@leather.io/models';
+import {
+  BITCOIN_API_BASE_URL_MAINNET,
+  BITCOIN_API_BASE_URL_TESTNET,
+  type BitcoinNetworkModes,
+} from '@leather.io/models';
 import {
   CheckmarkIcon,
   ChevronDownIcon,
@@ -60,11 +64,11 @@ export function AddNetworkForm() {
     switch (values.bitcoinNetwork) {
       case 'mainnet':
         setStacksUrl('https://api.hiro.so');
-        setBitcoinUrl('https://blockstream.info/api');
+        setBitcoinUrl(BITCOIN_API_BASE_URL_MAINNET);
         break;
       case 'testnet':
         setStacksUrl('https://api.testnet.hiro.so');
-        setBitcoinUrl('https://blockstream.info/testnet/api');
+        setBitcoinUrl(BITCOIN_API_BASE_URL_TESTNET);
         break;
       case 'signet':
         setStacksUrl('https://api.testnet.hiro.so');

--- a/src/app/features/add-network/add-network.tsx
+++ b/src/app/features/add-network/add-network.tsx
@@ -2,7 +2,7 @@ import { NetworkSelectors } from '@tests/selectors/network.selectors';
 import { Form, Formik } from 'formik';
 import { Stack, styled } from 'leather-styles/jsx';
 
-import { Button } from '@leather.io/ui';
+import { Button, Link } from '@leather.io/ui';
 
 import { ErrorLabel } from '@app/components/error-label';
 import { Card, Content, Page } from '@app/components/layout';
@@ -31,21 +31,21 @@ export function AddNetwork() {
                   >
                     <styled.span textStyle="body.02">
                       Use this form to add a new instance of the{' '}
-                      <a
+                      <Link
                         href="https://github.com/blockstack/stacks-blockchain-api"
                         target="_blank"
                         rel="noreferrer"
                       >
                         Stacks Blockchain API
-                      </a>{' '}
+                      </Link>{' '}
                       or{' '}
-                      <a
-                        href="https://github.com/Blockstream/esplora"
+                      <Link
+                        href="https://mempool.space/docs/api/rest"
                         target="_blank"
                         rel="noreferrer"
                       >
                         Bitcoin Blockchain API
-                      </a>
+                      </Link>
                       . Make sure you review and trust the host before you add it.
                     </styled.span>
                     <AddNetworkForm />

--- a/src/app/store/networks/networks.utils.ts
+++ b/src/app/store/networks/networks.utils.ts
@@ -86,7 +86,7 @@ export function transformNetworkStateToMultichainStucture(
               bitcoin: {
                 blockchain: 'bitcoin',
                 bitcoinNetwork: bitcoinNetwork ? bitcoinNetwork : 'testnet',
-                bitcoinUrl: bitcoinUrl ? bitcoinUrl : 'https://blockstream.info/testnet/api',
+                bitcoinUrl: bitcoinUrl ? bitcoinUrl : BITCOIN_API_BASE_URL_TESTNET,
               },
             },
           },

--- a/tests/specs/ledger/ledger.spec.ts
+++ b/tests/specs/ledger/ledger.spec.ts
@@ -12,7 +12,7 @@ const specs = {
 };
 
 async function interceptBitcoinRequests(homePage: HomePage) {
-  const requestPromise = homePage.page.waitForRequest(/bestinslot|blockstream|inscriptions/, {
+  const requestPromise = homePage.page.waitForRequest(/bestinslot|mempool|inscriptions/, {
     timeout: 1000,
   });
   return requestPromise;

--- a/tests/specs/network/add-network.spec.ts
+++ b/tests/specs/network/add-network.spec.ts
@@ -1,6 +1,8 @@
 import { NetworkSelectors } from '@tests/selectors/network.selectors';
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 
+import { BITCOIN_API_BASE_URL_TESTNET } from '@leather.io/models';
+
 import { test } from '../../fixtures/fixtures';
 
 test.describe('Networks tests', () => {
@@ -19,9 +21,9 @@ test.describe('Networks tests', () => {
     await page.getByTestId(NetworkSelectors.AddNetworkBitcoinAPISelector).click();
     await page.getByTestId(NetworkSelectors.BitcoinAPIOptionTestnet).click();
 
-    const bitcoinUrl = await page.getByTestId(NetworkSelectors.NetworkBitcoinAddress);
+    const bitcoinUrl = page.getByTestId(NetworkSelectors.NetworkBitcoinAddress);
 
-    test.expect(await bitcoinUrl.inputValue()).toEqual('https://blockstream.info/testnet/api');
+    test.expect(await bitcoinUrl.inputValue()).toEqual(BITCOIN_API_BASE_URL_TESTNET);
   });
 
   test('validation error when stacks api url is empty', async ({ networkPage }) => {

--- a/tests/specs/onboarding/onboarding.spec.ts
+++ b/tests/specs/onboarding/onboarding.spec.ts
@@ -6,6 +6,8 @@ import {
 import { testSoftwareAccountDefaultWalletState } from '@tests/page-object-models/onboarding.page';
 import { OnboardingSelectors } from '@tests/selectors/onboarding.selectors';
 
+import { BITCOIN_API_BASE_URL_MAINNET } from '@leather.io/models';
+
 import { test } from '../../fixtures/fixtures';
 
 test.describe('Onboarding an existing user', () => {
@@ -64,7 +66,7 @@ test.describe('Onboarding an existing user', () => {
   test('Activity tab', async ({ extensionId, globalPage, onboardingPage, homePage, page }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signUpNewUser();
-    await page.route(`**/blockstream.info/api/address/**/txs`, route =>
+    await page.route(`${BITCOIN_API_BASE_URL_MAINNET}/address/**/txs`, route =>
       route.fulfill({
         json: [],
       })


### PR DESCRIPTION
> Try out Leather build 22b569a — [Extension build](https://github.com/leather-io/extension/actions/runs/10470163645), [Test report](https://leather-io.github.io/playwright-reports/fix-blockstream-mempool), [Storybook](https://fix-blockstream-mempool--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-blockstream-mempool)<!-- Sticky Header Marker -->

This pr removes blockstream from tests and add network form