### PR TITLE
feat: add prepare to work with monorepo script

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "storybook-docs": "storybook dev --docs",
     "build-storybook": "storybook build",
     "chromatic": "npx chromatic --project-token=CHROMATIC_PROJECT_TOKEN",
-    "preinstall": "npx only-allow pnpm"
+    "preinstall": "npx only-allow pnpm",
+    "mono:link": "node scripts/mono-link.js && pnpm install",
+    "mono:unlink": "node scripts/mono-unlink.js && pnpm install"
   },
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "chromatic": "npx chromatic --project-token=CHROMATIC_PROJECT_TOKEN",
     "preinstall": "npx only-allow pnpm",
     "mono:link": "node scripts/mono-link.js && pnpm install",
-    "mono:unlink": "node scripts/mono-unlink.js && pnpm install"
+    "mono:unlink": "node scripts/mono-unlink.js && pnpm install",
+    "mono:link:ui": "node scripts/mono-link-ui.js && pnpm install"
   },
   "license": "MIT",
   "main": "index.js",

--- a/scripts/mono-link-ui.js
+++ b/scripts/mono-link-ui.js
@@ -1,0 +1,53 @@
+import fs from 'fs/promises';
+
+const filePath = './package.json';
+const backupFilePath = './package-original.json';
+
+async function modifyUiPackageJson() {
+  try {
+    // Check if a backup already exists
+    try {
+      await fs.access(backupFilePath);
+      console.log(`Backup file already exists: ${backupFilePath}`);
+    } catch {
+      await fs.copyFile(filePath, backupFilePath);
+      console.log(`Backup created: ${backupFilePath}`);
+    }
+
+    // Read and parse the package.json file
+    const data = await fs.readFile(filePath, 'utf-8');
+    let packageJson = JSON.parse(data);
+
+    // Modify the @leather.io/ui dependency
+    packageJson.dependencies['@leather.io/ui'] = 'file:../mono/packages/ui';
+
+    // Ensure pnpm and pnpm.overrides are initialized
+    if (!packageJson.pnpm) {
+      packageJson.pnpm = {};
+    }
+    if (!packageJson.pnpm.overrides) {
+      packageJson.pnpm.overrides = {};
+    }
+
+    // Add the specified overrides
+    const overrides = {
+      '@leather.io/rpc': 'file:../mono/packages/rpc',
+      '@leather.io/constants': 'file:../mono/packages/constants',
+      '@leather.io/models': 'file:../mono/packages/models',
+      '@leather.io/tokens': 'file:../mono/packages/tokens',
+      '@leather.io/utils': 'file:../mono/packages/utils'
+    };
+
+    packageJson.pnpm.overrides = { ...packageJson.pnpm.overrides, ...overrides };
+
+    // Write the modified package.json back to the file
+    await fs.writeFile(filePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf-8');
+    console.log(`Successfully updated ${filePath}`);
+
+  } catch (err) {
+    console.error(`Error: ${err}`);
+  }
+}
+
+// Execute the function
+modifyUiPackageJson();

--- a/scripts/mono-link.js
+++ b/scripts/mono-link.js
@@ -1,0 +1,78 @@
+import fs from 'fs/promises';
+
+// Paths to your package.json files
+const filePath = './package.json';
+const backupFilePath = './package-original.json';
+
+async function modifyPackageJson() {
+  try {
+    // Check if backup file exists
+    try {
+      await fs.access(backupFilePath);
+      console.log(`Backup file already exists: ${backupFilePath}`);
+    } catch {
+      // Backup the original package.json
+      await fs.copyFile(filePath, backupFilePath);
+      console.log(`Backup created: ${backupFilePath}`);
+    }
+
+    // Read the package.json file
+    const data = await fs.readFile(filePath, 'utf-8');
+
+    // Parse the JSON
+    let packageJson = JSON.parse(data);
+
+    // Update dependencies to use relative paths
+    const relativePaths = [
+      '@leather.io/bitcoin',
+      '@leather.io/constants',
+      '@leather.io/crypto',
+      '@leather.io/models',
+      '@leather.io/query',
+      '@leather.io/tokens',
+      '@leather.io/ui',
+      '@leather.io/utils',
+      '@leather.io/stacks',
+    ];
+    
+    const devRelativePaths = [
+      '@leather.io/panda-preset',
+      '@leather.io/rpc'
+    ];
+
+    relativePaths.forEach(dep => {
+      if (packageJson.dependencies[dep]) {
+        packageJson.dependencies[dep] = `file:../mono/packages/${dep.split('/').pop()}`;
+      }
+    });
+
+    devRelativePaths.forEach(devDep => {
+      if (packageJson.devDependencies[devDep]) {
+        packageJson.devDependencies[devDep] = `file:../mono/packages/${devDep.split('/').pop()}`;
+      }
+    });
+
+    // Update pnpm.overrides to use relative paths
+    if (!packageJson.pnpm) {
+      packageJson.pnpm = {};
+    }
+    if (!packageJson.pnpm.overrides) {
+      packageJson.pnpm.overrides = {};
+    }
+
+    relativePaths.concat(devRelativePaths).forEach(dep => {
+      if (packageJson.dependencies[dep] || packageJson.devDependencies[dep]) {
+        packageJson.pnpm.overrides[dep] = `file:../mono/packages/${dep.split('/').pop()}`;
+      }
+    });
+
+    // Write the modified JSON back to the file with an empty line at the end
+    await fs.writeFile(filePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf-8');
+    console.log(`Successfully updated ${filePath}`);
+
+  } catch (err) {
+    console.error(`Error: ${err}`);
+  }
+}
+
+modifyPackageJson();

--- a/scripts/mono-link.js
+++ b/scripts/mono-link.js
@@ -1,28 +1,21 @@
 import fs from 'fs/promises';
 
-// Paths to your package.json files
 const filePath = './package.json';
 const backupFilePath = './package-original.json';
 
 async function modifyPackageJson() {
   try {
-    // Check if backup file exists
     try {
       await fs.access(backupFilePath);
       console.log(`Backup file already exists: ${backupFilePath}`);
     } catch {
-      // Backup the original package.json
       await fs.copyFile(filePath, backupFilePath);
       console.log(`Backup created: ${backupFilePath}`);
     }
 
-    // Read the package.json file
     const data = await fs.readFile(filePath, 'utf-8');
-
-    // Parse the JSON
     let packageJson = JSON.parse(data);
 
-    // Update dependencies to use relative paths
     const relativePaths = [
       '@leather.io/bitcoin',
       '@leather.io/constants',
@@ -30,15 +23,11 @@ async function modifyPackageJson() {
       '@leather.io/models',
       '@leather.io/query',
       '@leather.io/tokens',
-      '@leather.io/ui',
       '@leather.io/utils',
       '@leather.io/stacks',
     ];
-    
-    const devRelativePaths = [
-      '@leather.io/panda-preset',
-      '@leather.io/rpc'
-    ];
+
+    const devRelativePaths = ['@leather.io/panda-preset', '@leather.io/rpc'];
 
     relativePaths.forEach(dep => {
       if (packageJson.dependencies[dep]) {
@@ -52,7 +41,6 @@ async function modifyPackageJson() {
       }
     });
 
-    // Update pnpm.overrides to use relative paths
     if (!packageJson.pnpm) {
       packageJson.pnpm = {};
     }
@@ -60,16 +48,14 @@ async function modifyPackageJson() {
       packageJson.pnpm.overrides = {};
     }
 
-    relativePaths.concat(devRelativePaths).forEach(dep => {
+    [...relativePaths, ...devRelativePaths].forEach(dep => {
       if (packageJson.dependencies[dep] || packageJson.devDependencies[dep]) {
         packageJson.pnpm.overrides[dep] = `file:../mono/packages/${dep.split('/').pop()}`;
       }
     });
 
-    // Write the modified JSON back to the file with an empty line at the end
     await fs.writeFile(filePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf-8');
     console.log(`Successfully updated ${filePath}`);
-
   } catch (err) {
     console.error(`Error: ${err}`);
   }

--- a/scripts/mono-unlink.js
+++ b/scripts/mono-unlink.js
@@ -1,0 +1,29 @@
+import fs from 'fs/promises';
+
+// Paths to your package.json files
+const filePath = './package.json';
+const backupFilePath = './package-original.json';
+
+async function revertPackageJson() {
+  try {
+    // Check if backup file exists
+    try {
+      await fs.access(backupFilePath);
+    } catch {
+      throw new Error(`Backup file not found: ${backupFilePath}`);
+    }
+
+    // Restore the original package.json
+    await fs.copyFile(backupFilePath, filePath);
+    console.log(`Successfully reverted ${filePath}`);
+
+    // Remove the backup file
+    await fs.unlink(backupFilePath);
+    console.log(`Backup file removed: ${backupFilePath}`);
+
+  } catch (err) {
+    console.error(`Error: ${err}`);
+  }
+}
+
+revertPackageJson();

--- a/scripts/mono-unlink.js
+++ b/scripts/mono-unlink.js
@@ -1,23 +1,19 @@
 import fs from 'fs/promises';
 
-// Paths to your package.json files
 const filePath = './package.json';
 const backupFilePath = './package-original.json';
 
 async function revertPackageJson() {
   try {
-    // Check if backup file exists
     try {
       await fs.access(backupFilePath);
     } catch {
       throw new Error(`Backup file not found: ${backupFilePath}`);
     }
 
-    // Restore the original package.json
     await fs.copyFile(backupFilePath, filePath);
     console.log(`Successfully reverted ${filePath}`);
 
-    // Remove the backup file
     await fs.unlink(backupFilePath);
     console.log(`Backup file removed: ${backupFilePath}`);
 


### PR DESCRIPTION
> Try out Leather build 0fcc361 — [Extension build](https://github.com/leather-io/extension/actions/runs/10560054635), [Test report](https://leather-io.github.io/playwright-reports/feat-mono-prepare-script), [Storybook](https://feat-mono-prepare-script--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-mono-prepare-script)<!-- Sticky Header Marker -->

This pr adds `mono:prepare` command and script to make extension ready to work with monorepo