### PR TITLE
feat: mock nfts and txs hiro requests

### DIFF
--- a/tests/mocks/mock-apis.ts
+++ b/tests/mocks/mock-apis.ts
@@ -1,7 +1,10 @@
 import { Page } from '@playwright/test';
 import { json } from '@tests/utils';
 
+import { mockMainnetTestAccountStacksBnsNameRequest } from './mock-stacks-bns';
 import { mockStacksFeeRequests } from './mock-stacks-fees';
+import { mockMainnetTestAccountStacksNFTsRequest } from './mock-stacks-nfts';
+import { mockMainnetTestAccountStacksTxsRequests } from './mock-stacks-txs';
 import { mockMainnetTestAccountBitcoinRequests } from './mock-utxos';
 
 export async function setupMockApis(page: Page) {
@@ -12,5 +15,8 @@ export async function setupMockApis(page: Page) {
     page.route('https://api.testnet.hiro.so/', route => route.fulfill()),
     mockMainnetTestAccountBitcoinRequests(page),
     mockStacksFeeRequests(page),
+    mockMainnetTestAccountStacksBnsNameRequest(page),
+    mockMainnetTestAccountStacksTxsRequests(page),
+    mockMainnetTestAccountStacksNFTsRequest(page),
   ]);
 }

--- a/tests/mocks/mock-stacks-bns.ts
+++ b/tests/mocks/mock-stacks-bns.ts
@@ -1,0 +1,13 @@
+import type { Page } from '@playwright/test';
+
+import { TEST_ACCOUNT_1_STX_ADDRESS } from './constants';
+
+export async function mockMainnetTestAccountStacksBnsNameRequest(page: Page) {
+  await page.route(`**/api.hiro.so/v1/addresses/stacks/${TEST_ACCOUNT_1_STX_ADDRESS}`, route =>
+    route.fulfill({
+      json: {
+        names: [],
+      },
+    })
+  );
+}

--- a/tests/mocks/mock-stacks-nfts.ts
+++ b/tests/mocks/mock-stacks-nfts.ts
@@ -1,0 +1,18 @@
+import type { Page } from '@playwright/test';
+
+import { TEST_ACCOUNT_1_STX_ADDRESS } from './constants';
+
+export async function mockMainnetTestAccountStacksNFTsRequest(page: Page) {
+  await page.route(
+    `**/api.hiro.so/extended/v1/tokens/nft/holdings?principal=${TEST_ACCOUNT_1_STX_ADDRESS}&limit=50`,
+    route =>
+      route.fulfill({
+        json: {
+          limit: 50,
+          offset: 0,
+          total: 0,
+          results: [],
+        },
+      })
+  );
+}

--- a/tests/mocks/mock-stacks-txs.ts
+++ b/tests/mocks/mock-stacks-txs.ts
@@ -1,0 +1,33 @@
+import type { Page } from '@playwright/test';
+
+import { TEST_ACCOUNT_1_STX_ADDRESS } from './constants';
+
+export async function mockMainnetTestAccountStacksTxsRequests(page: Page) {
+  await Promise.all([
+    page.route(
+      `**/api.hiro.so/extended/v1/address/${TEST_ACCOUNT_1_STX_ADDRESS}/transactions_with_transfers?limit=50`,
+      route =>
+        route.fulfill({
+          json: {
+            limit: 50,
+            offset: 0,
+            total: 0,
+            results: [],
+          },
+        })
+    ),
+
+    page.route(
+      `**/api.hiro.so/extended/v1/tx/mempool?address=${TEST_ACCOUNT_1_STX_ADDRESS}&limit=50`,
+      route =>
+        route.fulfill({
+          json: {
+            limit: 50,
+            offset: 0,
+            total: 0,
+            results: [],
+          },
+        })
+    ),
+  ]);
+}


### PR DESCRIPTION
> Try out Leather build e52e0d9 — [Extension build](https://github.com/leather-io/extension/actions/runs/10512923672), [Test report](https://leather-io.github.io/playwright-reports/feat-mock-hiro), [Storybook](https://feat-mock-hiro--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat-mock-hiro)<!-- Sticky Header Marker -->

This pr adds mocking of hiro txs, bns names and nfts requests in tests