### PR TITLE
chore: add `open` API, ref leather-io/issues#5800

### DIFF
--- a/src/background/messaging/rpc-message-handler.ts
+++ b/src/background/messaging/rpc-message-handler.ts
@@ -7,6 +7,7 @@ import { rpcSignStacksTransaction } from '@background/messaging/rpc-methods/sign
 
 import { getTabIdFromPort } from './messaging-utils';
 import { rpcGetAddresses } from './rpc-methods/get-addresses';
+import { rpcOpen } from './rpc-methods/open';
 import { rpcSendTransfer } from './rpc-methods/send-transfer';
 import { rpcSignMessage } from './rpc-methods/sign-message';
 import { rpcSignPsbt } from './rpc-methods/sign-psbt';
@@ -15,6 +16,10 @@ import { rpcSupportedMethods } from './rpc-methods/supported-methods';
 
 export async function rpcMessageHandler(message: WalletRequests, port: chrome.runtime.Port) {
   switch (message.method) {
+    case 'open': {
+      await rpcOpen(message, port);
+      break;
+    }
     case 'getAddresses': {
       await rpcGetAddresses(message, port);
       break;

--- a/src/background/messaging/rpc-methods/open.ts
+++ b/src/background/messaging/rpc-methods/open.ts
@@ -1,0 +1,30 @@
+import { RpcErrorCode } from '@btckit/types';
+
+import { RouteUrls } from '@shared/route-urls';
+import { OpenRequest } from '@shared/rpc/methods/open';
+import { makeRpcErrorResponse } from '@shared/rpc/rpc-methods';
+
+import {
+  listenForPopupClose,
+  makeSearchParamsWithDefaults,
+  triggerRequestWindowOpen,
+} from '../messaging-utils';
+import { trackRpcRequestSuccess } from '../rpc-message-handler';
+
+export async function rpcOpen(message: OpenRequest, port: chrome.runtime.Port) {
+  const { urlParams, tabId } = makeSearchParamsWithDefaults(port, [['requestId', message.id]]);
+  const { id } = await triggerRequestWindowOpen(RouteUrls.Home, urlParams);
+  void trackRpcRequestSuccess({ endpoint: message.method });
+
+  listenForPopupClose({
+    tabId,
+    id,
+    response: makeRpcErrorResponse('open', {
+      id: message.id,
+      error: {
+        code: RpcErrorCode.USER_REJECTION,
+        message: 'User rejected request to open wallet',
+      },
+    }),
+  });
+}

--- a/src/background/messaging/rpc-methods/supported-methods.ts
+++ b/src/background/messaging/rpc-methods/supported-methods.ts
@@ -13,6 +13,10 @@ export function rpcSupportedMethods(message: SupportedMethodsRequest, port: chro
         documentation: 'https://leather.gitbook.io/developers/home/welcome',
         methods: [
           {
+            name: 'open',
+            docsUrl: ['https://leather.gitbook.io/developers/bitcoin/connect-users/open-wallet'],
+          },
+          {
             name: 'getAddresses',
             docsUrl: [
               'https://leather.gitbook.io/developers/bitcoin/connect-users/get-addresses',

--- a/src/shared/rpc/methods/open.ts
+++ b/src/shared/rpc/methods/open.ts
@@ -1,0 +1,14 @@
+import { DefineRpcMethod, RpcRequest, RpcResponse } from '@btckit/types';
+import * as yup from 'yup';
+
+const rpcOpenParamsSchema = yup.object().shape({
+  url: yup.string(),
+});
+
+type OpenRequestParams = yup.InferType<typeof rpcOpenParamsSchema>;
+
+export type OpenRequest = RpcRequest<'open', OpenRequestParams>;
+
+type OpenResponse = RpcResponse<Response>;
+
+export type Open = DefineRpcMethod<OpenRequest, OpenResponse>;

--- a/src/shared/rpc/rpc-methods.ts
+++ b/src/shared/rpc/rpc-methods.ts
@@ -4,12 +4,14 @@ import type { ValueOf } from '@leather.io/models';
 
 import { SignStacksTransaction } from '@shared/rpc/methods/sign-stacks-transaction';
 
+import { Open } from './methods/open';
 import { SignPsbt } from './methods/sign-psbt';
 import { SignStacksMessage } from './methods/sign-stacks-message';
 import { SupportedMethods } from './methods/supported-methods';
 
 // Supports BtcKit methods, as well as custom Leather methods
 export type WalletMethodMap = BtcKitMethodMap &
+  Open &
   SupportedMethods &
   SignPsbt &
   SignStacksTransaction &


### PR DESCRIPTION
> Try out Leather build f841dc6 — [Extension build](https://github.com/leather-io/extension/actions/runs/10595404016), [Test report](https://leather-io.github.io/playwright-reports/chore-5800-open-wallet-api), [Storybook](https://chore-5800-open-wallet-api--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-5800-open-wallet-api)<!-- Sticky Header Marker -->

This PR adds a new RPC API to open the wallet programatically as we had an urgent request in to do it:
https://github.com/leather-io/extension/issues/5800

It adds `open` to `LeatherProvider` to allow apps to open the wallet via `LeatherProvider.request('open')`.

I am working on adding tests in **[chore/5800/open-wallet-api-tests](https://github.com/leather-io/extension/pull/5819)** but making slow progress and need to get this released today. The external party that needs this confirmed it's working [here](https://github.com/leather-io/extension/issues/5800#issuecomment-2314441703)


https://github.com/user-attachments/assets/9aaa5546-c8bb-472e-8413-d46ada717380

