### PR TITLE
fix: rename dialog as sheet, closes ref leather-io/issues#268

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@leather.io/query": "2.7.0",
     "@leather.io/stacks": "1.0.2",
     "@leather.io/tokens": "0.9.0",
-    "@leather.io/ui": "1.14.2",
+    "@leather.io/ui": "1.14.3",
     "@leather.io/utils": "0.13.2",
     "@ledgerhq/hw-transport-webusb": "6.27.19",
     "@noble/hashes": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@leather.io/ui':
-        specifier: 1.14.2
-        version: 1.14.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(typescript@5.4.5)
+        specifier: 1.14.3
+        version: 1.14.3(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(typescript@5.4.5)
       '@leather.io/utils':
         specifier: 0.13.2
         version: 0.13.2
@@ -2786,8 +2786,8 @@ packages:
   '@leather.io/tokens@0.9.0':
     resolution: {integrity: sha512-Lj0UYS6W8r7IkINssb8LodfNsefkzBzugiAM2XwCoQNgyOn4KAc3rdL5vYrXh8ErC4AT81xDb+DGkyCzejjObQ==}
 
-  '@leather.io/ui@1.14.2':
-    resolution: {integrity: sha512-siXOKq+sLy/a3O8RX9/ub7DAMpFGW3EZ+NFch/oSD3vzYIktgvGQsmYJMVblI6LAtgvKNRVKLl2GZyd03SMh9Q==}
+  '@leather.io/ui@1.14.3':
+    resolution: {integrity: sha512-/nn6rCgMcBN8E5/HTrzS5jbg8B0Bs8tkqwfzW1RQRwjP+zcFUSEBLf2RNx030M00aL4GEs2cbzkdQNej3exjoA==}
 
   '@leather.io/utils@0.13.2':
     resolution: {integrity: sha512-68rsDNS/mA9OYCPpU0yGGY3OMGWxAMqq4yZWi6mFnzqMgTvOW0MvFJOo/V4DhPxbo3sKS6mcwwbAH/YLnyBwGA==}
@@ -17551,7 +17551,7 @@ snapshots:
 
   '@leather.io/tokens@0.9.0': {}
 
-  '@leather.io/ui@1.14.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(typescript@5.4.5)':
+  '@leather.io/ui@1.14.3(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(typescript@5.4.5)':
     dependencies:
       '@expo/vector-icons': 14.0.0
       '@leather.io/tokens': 0.9.0

--- a/src/app/components/broadcast-error-dialog/broadcast-error-dialog.tsx
+++ b/src/app/components/broadcast-error-dialog/broadcast-error-dialog.tsx
@@ -4,17 +4,17 @@ import GenericError from '@assets/images/generic-error.png';
 import { Flex, styled } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
-import { Button, Dialog, DialogHeader } from '@leather.io/ui';
+import { Button, Sheet, SheetHeader } from '@leather.io/ui';
 
-export function BroadcastErrorDialog() {
+export function BroadcastErrorSheet() {
   const navigate = useNavigate();
   const location = useLocation();
   const message = get(location.state, 'message', '');
 
   return (
-    <Dialog
+    <Sheet
       isShowing
-      header={<DialogHeader />}
+      header={<SheetHeader />}
       onClose={() => navigate('..')}
       footer={
         <Button fullWidth onClick={() => navigate('..')} mt="space.05">
@@ -40,6 +40,6 @@ export function BroadcastErrorDialog() {
           {message && <>because of the error: {message.toLowerCase()}</>}
         </styled.span>
       </Flex>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/container/container.tsx
+++ b/src/app/features/container/container.tsx
@@ -11,7 +11,7 @@ import {
 } from '@app/common/app-analytics';
 import { ContainerLayout } from '@app/components/layout';
 import { LoadingSpinner } from '@app/components/loading-spinner';
-import { SwitchAccountDialog } from '@app/features/dialogs/switch-account-dialog/switch-account-dialog';
+import { SwitchAccountSheet } from '@app/features/dialogs/switch-account-dialog/switch-account-dialog';
 import { InAppMessages } from '@app/features/hiro-messages/in-app-messages';
 import { useOnChangeAccount } from '@app/routes/hooks/use-on-change-account';
 import { useOnSignOut } from '@app/routes/hooks/use-on-sign-out';
@@ -43,7 +43,7 @@ export function Container() {
   return (
     <>
       {isShowingSwitchAccount && (
-        <SwitchAccountDialog
+        <SwitchAccountSheet
           isShowing={isShowingSwitchAccount}
           onClose={() => setIsShowingSwitchAccount(false)}
         />

--- a/src/app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog.tsx
+++ b/src/app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useFormikContext } from 'formik';
 import { Stack, styled } from 'leather-styles/jsx';
 
-import { Dialog, DialogHeader, Link } from '@leather.io/ui';
+import { Link, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { StacksSendFormValues, StacksTransactionFormValues } from '@shared/models/form.model';
 
@@ -15,7 +15,7 @@ import { EditNonceForm } from './components/edit-nonce-form';
 
 const url = 'https://leather.gitbook.io/guides/transactions/nonces';
 
-export function EditNonceDialog() {
+export function EditNonceSheet() {
   const { errors, setFieldError, setFieldValue, validateField, values } = useFormikContext<
     StacksSendFormValues | StacksTransactionFormValues
   >();
@@ -47,7 +47,7 @@ export function EditNonceDialog() {
   }, [loadedNextNonce, onGoBack, setFieldError, setFieldValue, values.nonce]);
 
   return (
-    <Dialog isShowing onClose={onClose} header={<DialogHeader title="Edit nonce" />}>
+    <Sheet isShowing onClose={onClose} header={<SheetHeader title="Edit nonce" />}>
       <Stack gap="space.05" pb="space.06" px="space.05">
         <styled.span textStyle="caption.01">
           If your transaction has been pending for a long time, its nonce might not be correct.
@@ -57,6 +57,6 @@ export function EditNonceDialog() {
         </styled.span>
         <EditNonceForm onBlur={onBlur} onClose={onClose} onSubmit={onSubmit} />
       </Stack>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/dialogs/increase-fee-dialog/increase-btc-fee-dialog.tsx
+++ b/src/app/features/dialogs/increase-fee-dialog/increase-btc-fee-dialog.tsx
@@ -5,7 +5,7 @@ import { Formik } from 'formik';
 import { Flex, Stack } from 'leather-styles/jsx';
 
 import type { BitcoinTx } from '@leather.io/models';
-import { Caption, Dialog, DialogHeader, Spinner } from '@leather.io/ui';
+import { Caption, Sheet, SheetHeader, Spinner } from '@leather.io/ui';
 import { btcToSat, createMoney, formatMoney } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -20,7 +20,7 @@ import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/account
 import { IncreaseFeeActions } from './components/increase-fee-actions';
 import { useBtcIncreaseFee } from './hooks/use-btc-increase-fee';
 
-export function IncreaseBtcFeeDialog() {
+export function IncreaseBtcFeeSheet() {
   const tx = useLocationStateWithCache('btcTx') as BitcoinTx;
   const navigate = useNavigate();
   const location = useLocation();
@@ -60,10 +60,10 @@ export function IncreaseBtcFeeDialog() {
         validationSchema={validationSchema}
       >
         <>
-          <Dialog
+          <Sheet
             isShowing={location.pathname === RouteUrls.IncreaseBtcFee}
             onClose={onClose}
-            header={<DialogHeader title="Increase fee" />}
+            header={<SheetHeader title="Increase fee" />}
             footer={
               <IncreaseFeeActions
                 isDisabled={isBroadcasting}
@@ -101,7 +101,7 @@ export function IncreaseBtcFeeDialog() {
                 </Stack>
               </Suspense>
             </Stack>
-          </Dialog>
+          </Sheet>
           <Outlet />
         </>
       </Formik>

--- a/src/app/features/dialogs/increase-fee-dialog/increase-stx-fee-dialog.tsx
+++ b/src/app/features/dialogs/increase-fee-dialog/increase-stx-fee-dialog.tsx
@@ -12,7 +12,7 @@ import {
   useStacksRawTransaction,
   useStxAvailableUnlockedBalance,
 } from '@leather.io/query';
-import { Caption, Dialog, DialogHeader, Spinner } from '@leather.io/ui';
+import { Caption, Sheet, SheetHeader, Spinner } from '@leather.io/ui';
 import { microStxToStx, stxToMicroStx } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -31,7 +31,7 @@ import { useSubmittedTransactionsActions } from '@app/store/submitted-transactio
 import { IncreaseFeeActions } from './components/increase-fee-actions';
 import { IncreaseFeeField } from './components/increase-fee-field';
 
-export function IncreaseStxFeeDialog() {
+export function IncreaseStxFeeSheet() {
   const navigate = useNavigate();
   const location = useLocation();
   const { txid } = useParams();
@@ -83,10 +83,10 @@ export function IncreaseStxFeeDialog() {
       >
         {props => (
           <>
-            <Dialog
+            <Sheet
               isShowing={location.pathname === RouteUrls.IncreaseStxFee.replace(':txid', txid)}
               onClose={() => navigate(RouteUrls.Home)}
-              header={<DialogHeader title="Increase fee" />}
+              header={<SheetHeader title="Increase fee" />}
               footer={
                 <IncreaseFeeActions
                   isDisabled={stxToMicroStx(props.values.fee).isEqualTo(fee)}
@@ -124,7 +124,7 @@ export function IncreaseStxFeeDialog() {
                   </Stack>
                 </Suspense>
               </Stack>
-            </Dialog>
+            </Sheet>
             <Outlet />
           </>
         )}

--- a/src/app/features/dialogs/leather-intro-dialog/leather-intro-dialog.tsx
+++ b/src/app/features/dialogs/leather-intro-dialog/leather-intro-dialog.tsx
@@ -8,15 +8,15 @@ import { analytics } from '@shared/utils/analytics';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 
 import {
-  LeatherIntroDialog,
-  LeatherIntroDialogPart1,
-  LeatherIntroDialogPart2,
+  LeatherIntroSheet,
+  LeatherIntroSheetPart1,
+  LeatherIntroSheetPart2,
 } from './leather-intro-steps';
 
-export const leatherIntroDialogRoutes = (
-  <Route element={<LeatherIntroDialogContainer />}>
-    <Route path="we-have-a-new-name" element={<LeatherIntroDialogPart1 />} />
-    <Route path="introducing-leather" element={<LeatherIntroDialogPart2 />} />
+export const leatherIntroSheetRoutes = (
+  <Route element={<LeatherIntroSheetContainer />}>
+    <Route path="we-have-a-new-name" element={<LeatherIntroSheetPart1 />} />
+    <Route path="introducing-leather" element={<LeatherIntroSheetPart2 />} />
   </Route>
 );
 
@@ -27,15 +27,15 @@ interface IntroContextProps {
 }
 const introContext = createContext<IntroContextProps | null>(null);
 
-const { Provider: LeatherIntroDialogProvider } = introContext;
+const { Provider: LeatherIntroSheetProvider } = introContext;
 
-export function useLeatherIntroDialogContext() {
+export function useLeatherIntroSheetContext() {
   const context = useContext(introContext);
-  if (!context) throw new Error('useLeatherIntroDialogContext must be used within a Provider');
+  if (!context) throw new Error('useLeatherIntroSheetContext must be used within a Provider');
   return context;
 }
 
-function LeatherIntroDialogContainer() {
+function LeatherIntroSheetContainer() {
   const navigate = useNavigate();
   async function onRevealNewName() {
     void analytics.track('new_brand_reveal_name');
@@ -54,10 +54,10 @@ function LeatherIntroDialogContainer() {
   }
 
   return (
-    <LeatherIntroDialogProvider value={{ onRevealNewName, onAcceptTerms, onRejectAndUninstall }}>
-      <LeatherIntroDialog>
+    <LeatherIntroSheetProvider value={{ onRevealNewName, onAcceptTerms, onRejectAndUninstall }}>
+      <LeatherIntroSheet>
         <Outlet />
-      </LeatherIntroDialog>
-    </LeatherIntroDialogProvider>
+      </LeatherIntroSheet>
+    </LeatherIntroSheetProvider>
   );
 }

--- a/src/app/features/dialogs/leather-intro-dialog/leather-intro-steps.tsx
+++ b/src/app/features/dialogs/leather-intro-dialog/leather-intro-steps.tsx
@@ -11,9 +11,9 @@ import { HasChildren } from '@app/common/has-children';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 
 import { confettiConfig } from './confetti-config';
-import { useLeatherIntroDialogContext } from './leather-intro-dialog';
+import { useLeatherIntroSheetContext } from './leather-intro-dialog';
 
-export function LeatherIntroDialog({ children }: HasChildren) {
+export function LeatherIntroSheet({ children }: HasChildren) {
   return (
     <Dialog.Root defaultOpen>
       <Dialog.Content
@@ -28,8 +28,8 @@ export function LeatherIntroDialog({ children }: HasChildren) {
   );
 }
 
-export function LeatherIntroDialogPart1() {
-  const context = useLeatherIntroDialogContext();
+export function LeatherIntroSheetPart1() {
+  const context = useLeatherIntroSheetContext();
   const [showConfetti, setShowConfetti] = useState(false);
 
   return (
@@ -69,9 +69,9 @@ export function LeatherIntroDialogPart1() {
   );
 }
 
-export function LeatherIntroDialogPart2() {
+export function LeatherIntroSheetPart2() {
   const ref = useRef<HTMLVideoElement>(null);
-  const context = useLeatherIntroDialogContext();
+  const context = useLeatherIntroSheetContext();
 
   useLayoutEffect(() => {
     if (ref.current) ref.current.playbackRate = 0.65;

--- a/src/app/features/dialogs/switch-account-dialog/switch-account-dialog.tsx
+++ b/src/app/features/dialogs/switch-account-dialog/switch-account-dialog.tsx
@@ -3,7 +3,7 @@ import { Virtuoso } from 'react-virtuoso';
 
 import { Box } from 'leather-styles/jsx';
 
-import { Button, Dialog, DialogHeader } from '@leather.io/ui';
+import { Button, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { useCreateAccount } from '@app/common/hooks/account/use-create-account';
 import { useWalletType } from '@app/common/use-wallet-type';
@@ -15,12 +15,12 @@ import { VirtuosoWrapper } from '@app/ui/components/virtuoso';
 import { AccountListUnavailable } from './components/account-list-unavailable';
 import { SwitchAccountListItem } from './components/switch-account-list-item';
 
-interface SwitchAccountDialogProps {
+interface SwitchAccountSheetProps {
   isShowing: boolean;
   onClose(): void;
 }
 
-export const SwitchAccountDialog = memo(({ isShowing, onClose }: SwitchAccountDialogProps) => {
+export const SwitchAccountSheet = memo(({ isShowing, onClose }: SwitchAccountSheetProps) => {
   const currentAccountIndex = useCurrentAccountIndex();
   const createAccount = useCreateAccount();
   const { whenWallet } = useWalletType();
@@ -45,8 +45,8 @@ export const SwitchAccountDialog = memo(({ isShowing, onClose }: SwitchAccountDi
   const accountNum = stacksAddressesNum || btcAddressesNum;
 
   return (
-    <Dialog
-      header={<DialogHeader title="Select account" />}
+    <Sheet
+      header={<SheetHeader title="Select account" />}
       isShowing={isShowing}
       onClose={onClose}
       wrapChildren={false}
@@ -77,6 +77,6 @@ export const SwitchAccountDialog = memo(({ isShowing, onClose }: SwitchAccountDi
           )}
         />
       </VirtuosoWrapper>
-    </Dialog>
+    </Sheet>
   );
 });

--- a/src/app/features/feedback-button/feedback-button.tsx
+++ b/src/app/features/feedback-button/feedback-button.tsx
@@ -6,7 +6,7 @@ import { analytics, sentryFeedback } from '@shared/utils/analytics';
 
 import { useThemeSwitcher } from '@app/common/theme-provider';
 
-export async function openFeedbackDialog() {
+export async function openFeedbackSheet() {
   void analytics.track('user_clicked_feedback_button');
   const form = await sentryFeedback.createForm();
   if (!form) return null;
@@ -39,7 +39,7 @@ export function FeedbackButton() {
           : undefined
       }
       zIndex={9}
-      onClick={openFeedbackDialog}
+      onClick={openFeedbackSheet}
     >
       <Flex>
         <Box mr="space.01" mt="2px">

--- a/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
+++ b/src/app/features/ledger/flows/jwt-signing/ledger-sign-jwt-container.tsx
@@ -5,7 +5,7 @@ import { TransactionVersion, getAddressFromPublicKey } from '@stacks/transaction
 import { LedgerError } from '@zondax/ledger-stacks';
 import get from 'lodash.get';
 
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 import { delay, isError } from '@leather.io/utils';
 
 import { finalizeAuthResponse } from '@shared/actions/finalize-auth-response';
@@ -181,13 +181,13 @@ export function LedgerSignJwtContainer() {
 
   return (
     <LedgerJwtSigningProvider value={ledgerContextValue}>
-      <Dialog
+      <Sheet
         isShowing
-        header={<DialogHeader />}
+        header={<SheetHeader />}
         onClose={canCancelLedgerAction ? () => onCancelConnectLedger() : undefined}
       >
         <Outlet />
-      </Dialog>
+      </Sheet>
     </LedgerJwtSigningProvider>
   );
 }

--- a/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
+++ b/src/app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg-container.tsx
@@ -5,7 +5,7 @@ import { bytesToHex, signatureVrsToRsv } from '@stacks/common';
 import { serializeCV } from '@stacks/transactions';
 import { LedgerError } from '@zondax/ledger-stacks';
 
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 import { delay, isError } from '@leather.io/utils';
 
 import { UnsignedMessage, whenSignableMessageOfType } from '@shared/signature/signature-types';
@@ -145,13 +145,13 @@ function LedgerSignStacksMsg({ account, unsignedMessage }: LedgerSignMsgProps) {
 
   return (
     <LedgerMsgSigningProvider value={ledgerContextValue}>
-      <Dialog
+      <Sheet
         isShowing
-        header={<DialogHeader />}
+        header={<SheetHeader />}
         onClose={canCancelLedgerAction ? () => ledgerNavigate.cancelLedgerAction() : undefined}
       >
         <Outlet />
-      </Dialog>
+      </Sheet>
     </LedgerMsgSigningProvider>
   );
 }

--- a/src/app/features/ledger/generic-flows/request-keys/request-keys-flow.tsx
+++ b/src/app/features/ledger/generic-flows/request-keys/request-keys-flow.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 
@@ -19,13 +19,13 @@ export function RequestKeysFlow({ context, isActionCancellableByUser }: RequestK
 
   return (
     <LedgerRequestKeysProvider value={context}>
-      <Dialog
+      <Sheet
         isShowing
-        header={<DialogHeader />}
+        header={<SheetHeader />}
         onClose={isActionCancellableByUser ? onCancelConnectLedger : undefined}
       >
         <Outlet />
-      </Dialog>
+      </Sheet>
     </LedgerRequestKeysProvider>
   );
 }

--- a/src/app/features/ledger/generic-flows/tx-signing/tx-signing-flow.tsx
+++ b/src/app/features/ledger/generic-flows/tx-signing/tx-signing-flow.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 
@@ -14,9 +14,9 @@ export function TxSigningFlow({ context, closeAction }: TxSigningFlowProps) {
   useScrollLock(true);
   return (
     <LedgerTxSigningProvider value={context}>
-      <Dialog isShowing header={<DialogHeader />} onClose={closeAction}>
+      <Sheet isShowing header={<SheetHeader />} onClose={closeAction}>
         <Outlet />
-      </Dialog>
+      </Sheet>
     </LedgerTxSigningProvider>
   );
 }

--- a/src/app/features/ledger/generic-steps/connect-device/connect-ledger-start.tsx
+++ b/src/app/features/ledger/generic-steps/connect-device/connect-ledger-start.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { closeWindow } from '@shared/utils';
@@ -36,12 +36,12 @@ export function ConnectLedgerStart() {
   }
 
   return (
-    <Dialog isShowing header={<DialogHeader />} onClose={() => navigate('../')}>
+    <Sheet isShowing header={<SheetHeader />} onClose={() => navigate('../')}>
       <ConnectLedger
         connectBitcoin={() => connectChain('bitcoin')}
         connectStacks={() => connectChain('stacks')}
         showInstructions
       />
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/ledger/generic-steps/unsupported-browser/unsupported-browser.layout.tsx
+++ b/src/app/features/ledger/generic-steps/unsupported-browser/unsupported-browser.layout.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { styled } from 'leather-styles/jsx';
 
-import { Dialog, DialogHeader, Link } from '@leather.io/ui';
+import { Link, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { UnsupportedBrowserImg } from '@app/features/ledger/illustrations/ledger-illu-unsupported-browser';
 
@@ -13,7 +13,7 @@ export function UnsupportedBrowserLayout() {
   const navigate = useNavigate();
 
   return (
-    <Dialog header={<DialogHeader />} isShowing onClose={() => navigate(-1)}>
+    <Sheet header={<SheetHeader />} isShowing onClose={() => navigate(-1)}>
       <LedgerWrapper image={<UnsupportedBrowserImg />}>
         <LedgerTitle mb="space.03">Your browser isn't supported</LedgerTitle>
         <styled.span textStyle="label.03" color="ink.text-subdued">
@@ -28,6 +28,6 @@ export function UnsupportedBrowserLayout() {
           .
         </styled.span>
       </LedgerWrapper>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/retrieve-taproot-to-native-segwit/components/retrieve-taproot-to-native-segwit.layout.tsx
+++ b/src/app/features/retrieve-taproot-to-native-segwit/components/retrieve-taproot-to-native-segwit.layout.tsx
@@ -1,6 +1,6 @@
 import { Flex, styled } from 'leather-styles/jsx';
 
-import { BtcAvatarIcon, Button, Callout, Dialog, DialogHeader } from '@leather.io/ui';
+import { BtcAvatarIcon, Button, Callout, Sheet, SheetHeader } from '@leather.io/ui';
 
 interface RetrieveTaprootToNativeSegwitLayoutProps {
   isBroadcasting: boolean;
@@ -13,9 +13,9 @@ export function RetrieveTaprootToNativeSegwitLayout(
 ) {
   const { onClose, onApproveTransaction, isBroadcasting, children } = props;
   return (
-    <Dialog
+    <Sheet
       isShowing
-      header={<DialogHeader />}
+      header={<SheetHeader />}
       onClose={() => onClose()}
       footer={
         <Flex flexDirection="row">
@@ -48,6 +48,6 @@ export function RetrieveTaprootToNativeSegwitLayout(
           lose it!
         </Callout>
       </Flex>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/settings/network/network.tsx
+++ b/src/app/features/settings/network/network.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 
 import { WalletDefaultNetworkConfigurationIds } from '@leather.io/models';
-import { Button, Dialog, DialogHeader } from '@leather.io/ui';
+import { Button, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -14,11 +14,11 @@ import { useNetworks } from '@app/store/networks/networks.selectors';
 
 const defaultNetworkIds = Object.values(WalletDefaultNetworkConfigurationIds) as string[];
 
-interface NetworkDialogProps {
+interface NetworkSheetProps {
   onClose(): void;
 }
 
-export function NetworkDialog({ onClose }: NetworkDialogProps) {
+export function NetworkSheet({ onClose }: NetworkSheetProps) {
   const navigate = useNavigate();
   const networks = useNetworks();
   const networksActions = useNetworksActions();
@@ -40,8 +40,8 @@ export function NetworkDialog({ onClose }: NetworkDialogProps) {
   }
 
   return (
-    <Dialog
-      header={<DialogHeader title="Change network" />}
+    <Sheet
+      header={<SheetHeader title="Change network" />}
       isShowing
       onClose={onClose}
       footer={
@@ -80,6 +80,6 @@ export function NetworkDialog({ onClose }: NetworkDialogProps) {
           }}
         />
       ))}
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -32,13 +32,13 @@ import { truncateString } from '@app/common/utils';
 import { openInNewTab, openIndexPageInNewTab } from '@app/common/utils/open-in-new-tab';
 import { AppVersion } from '@app/components/app-version';
 import { Divider } from '@app/components/layout/divider';
-import { NetworkDialog } from '@app/features/settings/network/network';
+import { NetworkSheet } from '@app/features/settings/network/network';
 import { SignOut } from '@app/features/settings/sign-out/sign-out-confirm';
-import { ThemeDialog } from '@app/features/settings/theme/theme-dialog';
+import { ThemeSheet } from '@app/features/settings/theme/theme-dialog';
 import { useLedgerDeviceTargetId } from '@app/store/ledger/ledger.selectors';
 import { useCurrentNetworkId } from '@app/store/networks/networks.selectors';
 
-import { openFeedbackDialog } from '../feedback-button/feedback-button';
+import { openFeedbackSheet } from '../feedback-button/feedback-button';
 import { extractDeviceNameFromKnownTargetIds } from '../ledger/utils/generic-ledger-utils';
 import { AdvancedMenuItems } from './components/advanced-menu-items';
 import { LedgerDeviceItemRow } from './components/ledger-item-row';
@@ -205,7 +205,7 @@ export function Settings({
                   </Flex>
                 </Flag>
               </DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => openFeedbackDialog()}>
+              <DropdownMenu.Item onSelect={() => openFeedbackSheet()}>
                 <Flag img={<MegaphoneIcon />} textStyle="label.02">
                   Give feedback
                 </Flag>
@@ -224,9 +224,9 @@ export function Settings({
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
       {showSignOut && <SignOut onClose={() => setShowSignOut(!showSignOut)} />}
-      {showChangeTheme && <ThemeDialog onClose={() => setShowChangeTheme(!showChangeTheme)} />}
+      {showChangeTheme && <ThemeSheet onClose={() => setShowChangeTheme(!showChangeTheme)} />}
       {showChangeNetwork && (
-        <NetworkDialog onClose={() => setShowChangeNetwork(!showChangeNetwork)} />
+        <NetworkSheet onClose={() => setShowChangeNetwork(!showChangeNetwork)} />
       )}
     </>
   );

--- a/src/app/features/settings/sign-out/sign-out-confirm.tsx
+++ b/src/app/features/settings/sign-out/sign-out-confirm.tsx
@@ -4,7 +4,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { useKeyActions } from '@app/common/hooks/use-key-actions';
 
-import { SignOutDialog } from './sign-out';
+import { SignOutSheet } from './sign-out';
 
 interface SignOutProps {
   onClose(): void;
@@ -15,7 +15,7 @@ export function SignOut({ onClose }: SignOutProps) {
   const navigate = useNavigate();
 
   return (
-    <SignOutDialog
+    <SignOutSheet
       isShowing
       onUserDeleteWallet={() => {
         void signOut().finally(() => {

--- a/src/app/features/settings/sign-out/sign-out.tsx
+++ b/src/app/features/settings/sign-out/sign-out.tsx
@@ -2,17 +2,17 @@ import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { useFormik } from 'formik';
 import { Flex, HStack, styled } from 'leather-styles/jsx';
 
-import { Button, Callout, Dialog, DialogHeader } from '@leather.io/ui';
+import { Button, Callout, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { useWalletType } from '@app/common/use-wallet-type';
 import { ButtonRow } from '@app/components/layout';
 
-interface SignOutDialogProps {
+interface SignOutSheetProps {
   isShowing: boolean;
   onUserDeleteWallet(): void;
   onClose(): void;
 }
-export function SignOutDialog({ isShowing, onUserDeleteWallet, onClose }: SignOutDialogProps) {
+export function SignOutSheet({ isShowing, onUserDeleteWallet, onClose }: SignOutSheetProps) {
   const { whenWallet, walletType } = useWalletType();
   const form = useFormik({
     initialValues: {
@@ -34,8 +34,8 @@ export function SignOutDialog({ isShowing, onUserDeleteWallet, onClose }: SignOu
   }
 
   return (
-    <Dialog
-      header={<DialogHeader title="Sign out" />}
+    <Sheet
+      header={<SheetHeader title="Sign out" />}
       isShowing={isShowing}
       onClose={onClose}
       footer={
@@ -106,6 +106,6 @@ export function SignOutDialog({ isShowing, onUserDeleteWallet, onClose }: SignOu
           </styled.label>
         </form>
       </Flex>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/settings/theme/theme-dialog.tsx
+++ b/src/app/features/settings/theme/theme-dialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 
 import { analytics } from '@shared/utils/analytics';
 
@@ -8,11 +8,11 @@ import { UserSelectedTheme, themeLabelMap, useThemeSwitcher } from '@app/common/
 
 import { ThemeListItem } from './theme-list-item';
 
-interface ThemeDialogProps {
+interface ThemeSheetProps {
   onClose(): void;
 }
 
-export function ThemeDialog({ onClose }: ThemeDialogProps) {
+export function ThemeSheet({ onClose }: ThemeSheetProps) {
   const themes = Object.keys(themeLabelMap) as UserSelectedTheme[];
 
   const { setUserSelectedTheme } = useThemeSwitcher();
@@ -30,7 +30,7 @@ export function ThemeDialog({ onClose }: ThemeDialogProps) {
   const { userSelectedTheme } = useThemeSwitcher();
 
   return (
-    <Dialog header={<DialogHeader title="Change theme" />} isShowing onClose={onClose}>
+    <Sheet header={<SheetHeader title="Change theme" />} isShowing onClose={onClose}>
       {themes.map(theme => (
         <ThemeListItem
           key={theme}
@@ -39,6 +39,6 @@ export function ThemeDialog({ onClose }: ThemeDialogProps) {
           isActive={theme === userSelectedTheme}
         />
       ))}
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/stacks-high-fee-warning/stacks-high-fee-dialog.tsx
+++ b/src/app/features/stacks-high-fee-warning/stacks-high-fee-dialog.tsx
@@ -5,10 +5,10 @@ import { HStack, Stack } from 'leather-styles/jsx';
 import {
   Button,
   Caption,
-  Dialog,
-  DialogHeader,
   ErrorTriangleIcon,
   Link,
+  Sheet,
+  SheetHeader,
   Title,
 } from '@leather.io/ui';
 
@@ -19,23 +19,23 @@ import { ButtonRow } from '@app/components/layout';
 
 import { useStacksHighFeeWarningContext } from './stacks-high-fee-warning-container';
 
-interface HighFeeDialogProps {
+interface HighFeeSheetProps {
   learnMoreUrl: string;
 }
-export function HighFeeDialog({ learnMoreUrl }: HighFeeDialogProps) {
+export function HighFeeSheet({ learnMoreUrl }: HighFeeSheetProps) {
   const { handleSubmit, values } = useFormikContext<StacksSendFormValues>();
-  const { showHighFeeWarningDialog, setHasBypassedFeeWarning, setShowHighFeeWarningDialog } =
+  const { showHighFeeWarningSheet, setHasBypassedFeeWarning, setShowHighFeeWarningSheet } =
     useStacksHighFeeWarningContext();
 
   return (
-    <Dialog
-      data-testid={SendCryptoAssetSelectors.HighFeeWarningDialog}
-      header={<DialogHeader />}
-      isShowing={showHighFeeWarningDialog}
-      onClose={() => setShowHighFeeWarningDialog(false)}
+    <Sheet
+      data-testid={SendCryptoAssetSelectors.HighFeeWarningSheet}
+      header={<SheetHeader />}
+      isShowing={showHighFeeWarningSheet}
+      onClose={() => setShowHighFeeWarningSheet(false)}
       footer={
         <ButtonRow flexDirection="row">
-          <Button onClick={() => setShowHighFeeWarningDialog(false)} variant="outline" flexGrow={1}>
+          <Button onClick={() => setShowHighFeeWarningSheet(false)} variant="outline" flexGrow={1}>
             Edit fee
           </Button>
           <Button
@@ -43,7 +43,7 @@ export function HighFeeDialog({ learnMoreUrl }: HighFeeDialogProps) {
               setHasBypassedFeeWarning(true);
               handleSubmit();
             }}
-            data-testid={SendCryptoAssetSelectors.HighFeeWarningDialogSubmit}
+            data-testid={SendCryptoAssetSelectors.HighFeeWarningSheetSubmit}
             type="submit"
             flexGrow={1}
           >
@@ -67,6 +67,6 @@ export function HighFeeDialog({ learnMoreUrl }: HighFeeDialogProps) {
           </Link>
         </Caption>
       </Stack>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/features/stacks-high-fee-warning/stacks-high-fee-warning-container.tsx
+++ b/src/app/features/stacks-high-fee-warning/stacks-high-fee-warning-container.tsx
@@ -9,8 +9,8 @@ import { isEmpty } from '@leather.io/utils';
 import type { HasChildren } from '@app/common/has-children';
 
 interface StacksHighFeeWarningContext {
-  showHighFeeWarningDialog: boolean;
-  setShowHighFeeWarningDialog(val: boolean): void;
+  showHighFeeWarningSheet: boolean;
+  setShowHighFeeWarningSheet(val: boolean): void;
   hasBypassedFeeWarning: boolean;
   setHasBypassedFeeWarning(val: boolean): void;
   isHighFeeWithNoFormErrors(errors: FormikErrors<unknown>, fee: number | string): boolean;
@@ -27,7 +27,7 @@ export function useStacksHighFeeWarningContext() {
 const StacksHighFeeWarningProvider = stacksHighFeeWarningContext.Provider;
 
 export function StacksHighFeeWarningContainer({ children }: HasChildren) {
-  const [showHighFeeWarningDialog, setShowHighFeeWarningDialog] = useState(false);
+  const [showHighFeeWarningSheet, setShowHighFeeWarningSheet] = useState(false);
   const [hasBypassedFeeWarning, setHasBypassedFeeWarning] = useState(false);
 
   function isHighFeeWithNoFormErrors(errors: FormikErrors<unknown>, fee: number | string) {
@@ -38,8 +38,8 @@ export function StacksHighFeeWarningContainer({ children }: HasChildren) {
   return (
     <StacksHighFeeWarningProvider
       value={{
-        showHighFeeWarningDialog,
-        setShowHighFeeWarningDialog,
+        showHighFeeWarningSheet,
+        setShowHighFeeWarningSheet,
         hasBypassedFeeWarning,
         setHasBypassedFeeWarning,
         isHighFeeWithNoFormErrors,

--- a/src/app/features/stacks-transaction-request/stacks-transaction-signer.tsx
+++ b/src/app/features/stacks-transaction-request/stacks-transaction-signer.tsx
@@ -34,7 +34,7 @@ import { TransactionError } from '@app/features/stacks-transaction-request/trans
 import { useCurrentStacksAccountAddress } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useTransactionRequestState } from '@app/store/transactions/requests.hooks';
 
-import { HighFeeDialog } from '../stacks-high-fee-warning/stacks-high-fee-dialog';
+import { HighFeeSheet } from '../stacks-high-fee-warning/stacks-high-fee-dialog';
 import { FeeForm } from './fee-form';
 import { MinimalErrorMessage } from './minimal-error-message';
 import { StacksTxSubmitAction } from './submit-action';
@@ -138,7 +138,7 @@ export function StacksTransactionSigner({
             )}
             <MinimalErrorMessage />
             <StacksTxSubmitAction canSubmit={canSubmit} />
-            <HighFeeDialog learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
+            <HighFeeSheet learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
             <Outlet />
           </>
         )}

--- a/src/app/features/stacks-transaction-request/submit-action.tsx
+++ b/src/app/features/stacks-transaction-request/submit-action.tsx
@@ -27,7 +27,7 @@ export function StacksTxSubmitAction({ canSubmit }: Props) {
     const formErrors = await validateForm();
 
     if (context.isHighFeeWithNoFormErrors(formErrors, values.fee))
-      return context.setShowHighFeeWarningDialog(true);
+      return context.setShowHighFeeWarningSheet(true);
 
     handleSubmit();
   }

--- a/src/app/features/stacks-transaction-request/transaction-error/error-messages.tsx
+++ b/src/app/features/stacks-transaction-request/transaction-error/error-messages.tsx
@@ -14,7 +14,7 @@ import { analytics } from '@shared/utils/analytics';
 
 import { useScrollLock } from '@app/common/hooks/use-scroll-lock';
 import { stacksValue } from '@app/common/stacks-utils';
-import { SwitchAccountDialog } from '@app/features/dialogs/switch-account-dialog/switch-account-dialog';
+import { SwitchAccountSheet } from '@app/features/dialogs/switch-account-dialog/switch-account-dialog';
 import { ErrorMessage } from '@app/features/stacks-transaction-request/transaction-error/error-message';
 import { useCurrentStacksAccountAddress } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
@@ -34,7 +34,7 @@ function InsufficientFundsActionButtons({ eventName }: InsufficientFundsActionBu
 
   return (
     <>
-      <SwitchAccountDialog
+      <SwitchAccountSheet
         isShowing={isShowingSwitchAccount}
         onClose={() => setIsShowingSwitchAccount(false)}
       />

--- a/src/app/pages/receive/components/receive-tokens.layout.tsx
+++ b/src/app/pages/receive/components/receive-tokens.layout.tsx
@@ -5,7 +5,7 @@ import { SharedComponentsSelectors } from '@tests/selectors/shared-component.sel
 import { Box, Flex, styled } from 'leather-styles/jsx';
 import { token } from 'leather-styles/tokens';
 
-import { AddressDisplayer, Button, Dialog, DialogHeader } from '@leather.io/ui';
+import { AddressDisplayer, Button, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { useLocationState } from '@app/common/hooks/use-location-state';
 import { useBackgroundLocationRedirect } from '@app/routes/hooks/use-background-location-redirect';
@@ -25,9 +25,9 @@ export function ReceiveTokensLayout(props: ReceiveTokensLayoutProps) {
   const backgroundLocation = useLocationState<Location>('backgroundLocation');
 
   return (
-    <Dialog
+    <Sheet
       header={
-        <DialogHeader
+        <SheetHeader
           variant="large"
           title={
             <>
@@ -82,6 +82,6 @@ export function ReceiveTokensLayout(props: ReceiveTokensLayoutProps) {
           </Flex>
         </Flex>
       </Flex>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/pages/receive/receive-dialog.tsx
+++ b/src/app/pages/receive/receive-dialog.tsx
@@ -4,7 +4,7 @@ import { HomePageSelectors } from '@tests/selectors/home.selectors';
 import { Box } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
-import { Dialog, DialogHeader, Tabs } from '@leather.io/ui';
+import { Sheet, SheetHeader, Tabs } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -18,7 +18,7 @@ import { useCurrentStacksAccountAddress } from '@app/store/accounts/blockchain/s
 import { ReceiveCollectibles } from './components/receive-collectibles';
 import { ReceiveTokens } from './components/receive-tokens';
 
-type ReceiveDialog = 'full' | 'collectible';
+type ReceiveSheet = 'full' | 'collectible';
 
 export const receiveTabStyle = {
   mt: 'space.03',
@@ -27,11 +27,11 @@ export const receiveTabStyle = {
   minHeight: '260px',
 };
 
-interface ReceiveDialogProps {
+interface ReceiveSheetProps {
   type?: 'full' | 'collectible';
 }
 
-export function ReceiveDialog({ type = 'full' }: ReceiveDialogProps) {
+export function ReceiveSheet({ type = 'full' }: ReceiveSheetProps) {
   useBackgroundLocationRedirect();
 
   const backgroundLocation = useLocationState<Location>('backgroundLocation');
@@ -83,9 +83,9 @@ export function ReceiveDialog({ type = 'full' }: ReceiveDialogProps) {
   }
 
   return (
-    <Dialog
+    <Sheet
       header={
-        <DialogHeader
+        <SheetHeader
           variant="large"
           title={title}
           onClose={() => navigate(backgroundLocation ?? '..')}
@@ -133,6 +133,6 @@ export function ReceiveDialog({ type = 'full' }: ReceiveDialogProps) {
           </Tabs.Content>
         </Tabs.Root>
       )}
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/pages/send/broadcast-error/broadcast-error.tsx
+++ b/src/app/pages/send/broadcast-error/broadcast-error.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import get from 'lodash.get';
 
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -12,10 +12,10 @@ import { useOnMount } from '@app/common/hooks/use-on-mount';
 import { BroadcastErrorLayout } from './components/broadcast-error.layout';
 
 interface Props {
-  showInDialog?: boolean;
+  showInSheet?: boolean;
 }
 
-export function BroadcastError({ showInDialog = false }: Props) {
+export function BroadcastError({ showInSheet = false }: Props) {
   const { state } = useLocation();
   const navigate = useNavigate();
 
@@ -35,15 +35,15 @@ export function BroadcastError({ showInDialog = false }: Props) {
     />
   );
 
-  if (showInDialog) {
+  if (showInSheet) {
     return (
-      <Dialog
-        header={<DialogHeader title="Error" />}
+      <Sheet
+        header={<SheetHeader title="Error" />}
         isShowing
         onClose={() => navigate(RouteUrls.Home)}
       >
         {layout}
-      </Dialog>
+      </Sheet>
     );
   }
 

--- a/src/app/pages/send/ordinal-inscription/ordinal-routes.tsx
+++ b/src/app/pages/send/ordinal-inscription/ordinal-routes.tsx
@@ -21,6 +21,6 @@ export const sendOrdinalRoutes = (
     <Route path={RouteUrls.SendOrdinalInscriptionReview} element={<SendInscriptionReview />} />
 
     <Route path={RouteUrls.SendOrdinalInscriptionSent} element={<SendInscriptionSummary />} />
-    <Route path={RouteUrls.SendOrdinalInscriptionError} element={<BroadcastError showInDialog />} />
+    <Route path={RouteUrls.SendOrdinalInscriptionError} element={<BroadcastError showInSheet />} />
   </Route>
 );

--- a/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-choose-fee.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
 import type { BtcFeeType } from '@leather.io/models';
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 import { createMoney } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -60,8 +60,8 @@ export function SendInscriptionChooseFee() {
 
   return (
     <>
-      <Dialog
-        header={<DialogHeader title="Choose fee" />}
+      <Sheet
+        header={<SheetHeader title="Choose fee" />}
         isShowing
         onGoBack={() => navigate(RouteUrls.Home)}
         onClose={() => navigate(RouteUrls.Home)}
@@ -89,7 +89,7 @@ export function SendInscriptionChooseFee() {
           showError={showInsufficientBalanceError}
           maxRecommendedFeeRate={feesList[0]?.feeRate}
         />
-      </Dialog>
+      </Sheet>
       <Outlet />
     </>
   );

--- a/src/app/pages/send/ordinal-inscription/send-inscription-form.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-form.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Form, Formik } from 'formik';
 import { Box, Flex } from 'leather-styles/jsx';
 
-import { Button, Dialog, DialogHeader, OrdinalAvatarIcon } from '@leather.io/ui';
+import { Button, OrdinalAvatarIcon, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -38,8 +38,8 @@ export function SendInscriptionForm() {
       {props => {
         return (
           <Form>
-            <Dialog
-              header={<DialogHeader title="Send" />}
+            <Sheet
+              header={<SheetHeader title="Send" />}
               onGoBack={() => navigate(-1)}
               isShowing
               onClose={() => navigate(RouteUrls.Home)}
@@ -69,7 +69,7 @@ export function SendInscriptionForm() {
                   {currentError && <ErrorLabel>{currentError}</ErrorLabel>}
                 </Box>
               </SendInscriptionFormLoader>
-            </Dialog>
+            </Sheet>
           </Form>
         );
       }}

--- a/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
+++ b/src/app/pages/send/ordinal-inscription/send-inscription-review.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, Stack } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
 import { useBitcoinBroadcastTransaction } from '@leather.io/query';
-import { Button, Dialog, DialogHeader } from '@leather.io/ui';
+import { Button, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -73,8 +73,8 @@ export function SendInscriptionReview() {
   }
 
   return (
-    <Dialog
-      header={<DialogHeader title="Review" />}
+    <Sheet
+      header={<SheetHeader title="Review" />}
       isShowing
       onGoBack={() => navigate(-1)}
       onClose={() => navigate(RouteUrls.Home)}
@@ -116,6 +116,6 @@ export function SendInscriptionReview() {
           </Stack>
         </Flex>
       </Card>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/pages/send/ordinal-inscription/sent-inscription-summary.tsx
+++ b/src/app/pages/send/ordinal-inscription/sent-inscription-summary.tsx
@@ -4,7 +4,7 @@ import { Box, Flex, HStack, Stack } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
 import type { Blockchains, Inscription } from '@leather.io/models';
-import { CheckmarkIcon, CopyIcon, Dialog, DialogHeader, ExternalLinkIcon } from '@leather.io/ui';
+import { CheckmarkIcon, CopyIcon, ExternalLinkIcon, Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -53,11 +53,7 @@ export function SendInscriptionSummary() {
   }
 
   return (
-    <Dialog
-      header={<DialogHeader title="Sent" />}
-      isShowing
-      onClose={() => navigate(RouteUrls.Home)}
-    >
+    <Sheet header={<SheetHeader title="Sent" />} isShowing onClose={() => navigate(RouteUrls.Home)}>
       <Card
         footer={
           <HStack gap="space.04" width="100%">
@@ -95,6 +91,6 @@ export function SendInscriptionSummary() {
           </Stack>
         </Flex>
       </Card>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-dialog/recipient-accounts-dialog.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/components/recipient-accounts-dialog/recipient-accounts-dialog.tsx
@@ -4,7 +4,7 @@ import { Virtuoso } from 'react-virtuoso';
 
 import { Box } from 'leather-styles/jsx';
 
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 
 import { useFilteredBitcoinAccounts } from '@app/store/accounts/blockchain/bitcoin/bitcoin.ledger';
 import { useStacksAccounts } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
@@ -12,7 +12,7 @@ import { VirtuosoWrapper } from '@app/ui/components/virtuoso';
 
 import { AccountListItem } from './account-list-item';
 
-export function RecipientAccountsDialog() {
+export function RecipientAccountsSheet() {
   const stacksAccounts = useStacksAccounts();
   const navigate = useNavigate();
 
@@ -25,8 +25,8 @@ export function RecipientAccountsDialog() {
   const accountNum = stacksAddressesNum || btcAddressesNum;
 
   return (
-    <Dialog
-      header={<DialogHeader title="My accounts" />}
+    <Sheet
+      header={<SheetHeader title="My accounts" />}
       isShowing
       onClose={onGoBack}
       wrapChildren={false}
@@ -48,6 +48,6 @@ export function RecipientAccountsDialog() {
           totalCount={accountNum}
         />
       </VirtuosoWrapper>
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/pages/send/send-crypto-asset-form/family/stacks/use-stacks-common-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/family/stacks/use-stacks-common-send-form.tsx
@@ -28,7 +28,7 @@ export function useStacksCommonSendForm({
   const stxAddress = useCurrentStacksAccountAddress();
   const { data: nextNonce } = useNextNonce(stxAddress);
   const currentNetwork = useCurrentNetworkState();
-  const { isHighFeeWithNoFormErrors, setShowHighFeeWarningDialog } =
+  const { isHighFeeWithNoFormErrors, setShowHighFeeWarningSheet } =
     useStacksHighFeeWarningContext();
 
   const initialValues: StacksSendFormValues = createDefaultInitialFormValues({
@@ -51,7 +51,7 @@ export function useStacksCommonSendForm({
     const formErrors = await formikHelpers.validateForm();
 
     if (isHighFeeWithNoFormErrors(formErrors, values.fee)) {
-      setShowHighFeeWarningDialog(true);
+      setShowHighFeeWarningSheet(true);
       return false;
     }
     return true;

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
@@ -17,7 +17,7 @@ import { FeesRow } from '@app/components/fees-row/fees-row';
 import { AvailableBalance, ButtonRow, Card, Page } from '@app/components/layout';
 import { NonceSetter } from '@app/components/nonce-setter';
 import { useUpdatePersistedSendFormValues } from '@app/features/popup-send-form-restoration/use-update-persisted-send-form-values';
-import { HighFeeDialog } from '@app/features/stacks-high-fee-warning/stacks-high-fee-dialog';
+import { HighFeeSheet } from '@app/features/stacks-high-fee-warning/stacks-high-fee-dialog';
 
 import { MemoField } from '../../components/memo-field';
 import { StacksRecipientField } from '../../family/stacks/components/stacks-recipient-field';
@@ -100,7 +100,7 @@ export function StacksCommonSendForm({
                     </Link>
                   </Flex>
                 </Card>
-                <HighFeeDialog learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
+                <HighFeeSheet learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
                 <Outlet />
               </Form>
             </>

--- a/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/send-crypto-asset-form.routes.tsx
@@ -3,9 +3,9 @@ import { Route } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { BroadcastErrorDialog } from '@app/components/broadcast-error-dialog/broadcast-error-dialog';
+import { BroadcastErrorSheet } from '@app/components/broadcast-error-dialog/broadcast-error-dialog';
 import { FullPageWithHeaderLoadingSpinner } from '@app/components/loading-spinner';
-import { EditNonceDialog } from '@app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog';
+import { EditNonceSheet } from '@app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog';
 import { ledgerBitcoinTxSigningRoutes } from '@app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container';
 import { ledgerStacksTxSigningRoutes } from '@app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container';
 import { StacksHighFeeWarningContainer } from '@app/features/stacks-high-fee-warning/stacks-high-fee-warning-container';
@@ -17,7 +17,7 @@ import { ChooseCryptoAsset } from '../choose-crypto-asset/choose-crypto-asset';
 import { Brc20SentSummary } from '../sent-summary/brc20-sent-summary';
 import { BtcSentSummary } from '../sent-summary/btc-sent-summary';
 import { StxSentSummary } from '../sent-summary/stx-sent-summary';
-import { RecipientAccountsDialog } from './components/recipient-accounts-dialog/recipient-accounts-dialog';
+import { RecipientAccountsSheet } from './components/recipient-accounts-dialog/recipient-accounts-dialog';
 import { SendBitcoinAssetContainer } from './family/bitcoin/components/send-bitcoin-asset-container';
 import { BrcChooseFee } from './form/brc20/brc20-choose-fee';
 import { Brc20SendForm } from './form/brc20/brc20-send-form';
@@ -29,16 +29,16 @@ import { Sip10TokenSendForm } from './form/sip10/sip10-token-send-form';
 import { StacksSendFormConfirmation } from './form/stacks/stacks-send-form-confirmation';
 import { StxSendForm } from './form/stx/stx-send-form';
 
-const recipientAccountsDialogRoute = (
+const recipientAccountsSheetRoute = (
   <Route
     path={RouteUrls.SendCryptoAssetFormRecipientAccounts}
-    element={<RecipientAccountsDialog />}
+    element={<RecipientAccountsSheet />}
   />
 );
 
-const editNonceDialogRoute = <Route path={RouteUrls.EditNonce} element={<EditNonceDialog />} />;
-const broadcastErrorDialogRoute = (
-  <Route path={'confirm/broadcast-error'} element={<BroadcastErrorDialog />} />
+const editNonceSheetRoute = <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />;
+const broadcastErrorSheetRoute = (
+  <Route path={'confirm/broadcast-error'} element={<BroadcastErrorSheet />} />
 );
 
 export const sendCryptoAssetFormRoutes = (
@@ -60,7 +60,7 @@ export const sendCryptoAssetFormRoutes = (
         element={<BtcSendForm />}
       >
         {ledgerBitcoinTxSigningRoutes}
-        {recipientAccountsDialogRoute}
+        {recipientAccountsSheetRoute}
       </Route>
       <Route path={RouteUrls.SendBtcDisabled} element={<SendBtcDisabled />} />
       <Route path={RouteUrls.SendBtcError} element={<BroadcastError />} />
@@ -86,9 +86,9 @@ export const sendCryptoAssetFormRoutes = (
         </StacksHighFeeWarningContainer>
       }
     >
-      {broadcastErrorDialogRoute}
-      {editNonceDialogRoute}
-      {recipientAccountsDialogRoute}
+      {broadcastErrorSheetRoute}
+      {editNonceSheetRoute}
+      {recipientAccountsSheetRoute}
     </Route>
     <Route
       path={`${RouteUrls.SendCryptoAssetForm.replace(':symbol', 'stx')}/confirm`}
@@ -104,9 +104,9 @@ export const sendCryptoAssetFormRoutes = (
         </StacksHighFeeWarningContainer>
       }
     >
-      {broadcastErrorDialogRoute}
-      {editNonceDialogRoute}
-      {recipientAccountsDialogRoute}
+      {broadcastErrorSheetRoute}
+      {editNonceSheetRoute}
+      {recipientAccountsSheetRoute}
     </Route>
     <Route path="/send/:symbol/:contractId/confirm" element={<StacksSendFormConfirmation />}>
       {ledgerStacksTxSigningRoutes}

--- a/src/app/pages/swap/components/swap-asset-dialog/swap-asset-dialog-base.tsx
+++ b/src/app/pages/swap/components/swap-asset-dialog/swap-asset-dialog-base.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -6,16 +6,16 @@ import { useSwapNavigate } from '../../hooks/use-swap-navigate';
 import { useSwapContext } from '../../swap.context';
 import { SwapAssetList } from './components/swap-asset-list';
 
-export function SwapAssetDialogBase() {
+export function SwapAssetSheetBase() {
   const { swappableAssetsBase } = useSwapContext();
   const navigate = useSwapNavigate();
 
   return (
-    <Dialog
+    <Sheet
       isShowing
       onClose={() => navigate(RouteUrls.Swap)}
       header={
-        <DialogHeader
+        <SheetHeader
           title={
             <>
               Choose asset <br /> to swap
@@ -27,6 +27,6 @@ export function SwapAssetDialogBase() {
       }
     >
       <SwapAssetList assets={swappableAssetsBase} type="base" />
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/pages/swap/components/swap-asset-dialog/swap-asset-dialog-quote.tsx
+++ b/src/app/pages/swap/components/swap-asset-dialog/swap-asset-dialog-quote.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogHeader } from '@leather.io/ui';
+import { Sheet, SheetHeader } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 
@@ -6,16 +6,16 @@ import { useSwapNavigate } from '../../hooks/use-swap-navigate';
 import { useSwapContext } from '../../swap.context';
 import { SwapAssetList } from './components/swap-asset-list';
 
-export function SwapAssetDialogQuote() {
+export function SwapAssetSheetQuote() {
   const { swappableAssetsQuote } = useSwapContext();
   const navigate = useSwapNavigate();
 
   return (
-    <Dialog
+    <Sheet
       isShowing
       onClose={() => navigate(RouteUrls.Swap)}
       header={
-        <DialogHeader
+        <SheetHeader
           title={
             <>
               Choose asset <br /> to receive
@@ -27,6 +27,6 @@ export function SwapAssetDialogQuote() {
       }
     >
       <SwapAssetList assets={swappableAssetsQuote} type="quote" />
-    </Dialog>
+    </Sheet>
   );
 }

--- a/src/app/pages/swap/generate-swap-routes.tsx
+++ b/src/app/pages/swap/generate-swap-routes.tsx
@@ -5,8 +5,8 @@ import { RouteUrls } from '@shared/route-urls';
 import { ledgerStacksTxSigningRoutes } from '@app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container';
 import { AccountGate } from '@app/routes/account-gate';
 
-import { SwapAssetDialogBase } from './components/swap-asset-dialog/swap-asset-dialog-base';
-import { SwapAssetDialogQuote } from './components/swap-asset-dialog/swap-asset-dialog-quote';
+import { SwapAssetSheetBase } from './components/swap-asset-dialog/swap-asset-dialog-base';
+import { SwapAssetSheetQuote } from './components/swap-asset-dialog/swap-asset-dialog-quote';
 import { SwapError } from './components/swap-error';
 import { SwapReview } from './components/swap-review';
 import { Swap } from './swap';
@@ -15,8 +15,8 @@ export function generateSwapRoutes(container: React.ReactNode) {
   return (
     <Route element={<AccountGate>{container}</AccountGate>}>
       <Route path={RouteUrls.Swap} element={<Swap />}>
-        <Route path={RouteUrls.SwapAssetSelectBase} element={<SwapAssetDialogBase />} />
-        <Route path={RouteUrls.SwapAssetSelectQuote} element={<SwapAssetDialogQuote />} />
+        <Route path={RouteUrls.SwapAssetSelectBase} element={<SwapAssetSheetBase />} />
+        <Route path={RouteUrls.SwapAssetSelectQuote} element={<SwapAssetSheetQuote />} />
       </Route>
       <Route path={RouteUrls.SwapError} element={<SwapError />} />
       <Route path={RouteUrls.SwapReview} element={<SwapReview />}>

--- a/src/app/pages/transaction-request/transaction-request.tsx
+++ b/src/app/pages/transaction-request/transaction-request.tsx
@@ -25,7 +25,7 @@ import { nonceValidator } from '@app/common/validation/nonce-validators';
 import { NonceSetter } from '@app/components/nonce-setter';
 import { PopupHeader } from '@app/features/container/headers/popup.header';
 import { RequestingTabClosedWarningMessage } from '@app/features/errors/requesting-tab-closed-error-msg';
-import { HighFeeDialog } from '@app/features/stacks-high-fee-warning/stacks-high-fee-dialog';
+import { HighFeeSheet } from '@app/features/stacks-high-fee-warning/stacks-high-fee-dialog';
 import { ContractCallDetails } from '@app/features/stacks-transaction-request/contract-call-details/contract-call-details';
 import { ContractDeployDetails } from '@app/features/stacks-transaction-request/contract-deploy-details/contract-deploy-details';
 import { FeeForm } from '@app/features/stacks-transaction-request/fee-form';
@@ -139,7 +139,7 @@ function TransactionRequestBase() {
               <MinimalErrorMessage />
               <StacksTxSubmitAction canSubmit={canSubmit} />
 
-              <HighFeeDialog learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
+              <HighFeeSheet learnMoreUrl={HIGH_FEE_WARNING_LEARN_MORE_URL_STX} />
               <Outlet />
             </>
           )}

--- a/src/app/routes/app-routes.tsx
+++ b/src/app/routes/app-routes.tsx
@@ -16,9 +16,9 @@ import { LoadingSpinner } from '@app/components/loading-spinner';
 import { AddNetwork } from '@app/features/add-network/add-network';
 import { Container } from '@app/features/container/container';
 import { HomeHeader } from '@app/features/container/headers/home.header';
-import { IncreaseBtcFeeDialog } from '@app/features/dialogs/increase-fee-dialog/increase-btc-fee-dialog';
-import { IncreaseStxFeeDialog } from '@app/features/dialogs/increase-fee-dialog/increase-stx-fee-dialog';
-import { leatherIntroDialogRoutes } from '@app/features/dialogs/leather-intro-dialog/leather-intro-dialog';
+import { IncreaseBtcFeeSheet } from '@app/features/dialogs/increase-fee-dialog/increase-btc-fee-dialog';
+import { IncreaseStxFeeSheet } from '@app/features/dialogs/increase-fee-dialog/increase-stx-fee-dialog';
+import { leatherIntroSheetRoutes } from '@app/features/dialogs/leather-intro-dialog/leather-intro-dialog';
 import { RouterErrorBoundary } from '@app/features/errors/app-error-boundary';
 import { ledgerBitcoinTxSigningRoutes } from '@app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container';
 import { ledgerJwtSigningRoutes } from '@app/features/ledger/flows/jwt-signing/ledger-sign-jwt.routes';
@@ -104,14 +104,14 @@ function useAppRoutes() {
               path={RouteUrls.RetrieveTaprootFunds}
               element={<RetrieveTaprootToNativeSegwit />}
             />
-            <Route path={RouteUrls.IncreaseStxFee} element={<IncreaseStxFeeDialog />}>
+            <Route path={RouteUrls.IncreaseStxFee} element={<IncreaseStxFeeSheet />}>
               {ledgerStacksTxSigningRoutes}
             </Route>
             <Route
               path={`${RouteUrls.IncreaseStxFee}/${RouteUrls.TransactionBroadcastError}`}
               element={<BroadcastError />}
             />
-            <Route path={RouteUrls.IncreaseBtcFee} element={<IncreaseBtcFeeDialog />}>
+            <Route path={RouteUrls.IncreaseBtcFee} element={<IncreaseBtcFeeSheet />}>
               {ledgerBitcoinTxSigningRoutes}
             </Route>
 
@@ -123,14 +123,14 @@ function useAppRoutes() {
             path={RouteUrls.RetrieveTaprootFunds}
             element={<RetrieveTaprootToNativeSegwit />}
           />
-          <Route path={RouteUrls.IncreaseStxFee} element={<IncreaseStxFeeDialog />}>
+          <Route path={RouteUrls.IncreaseStxFee} element={<IncreaseStxFeeSheet />}>
             {ledgerStacksTxSigningRoutes}
           </Route>
           <Route
             path={`${RouteUrls.IncreaseStxFee}/${RouteUrls.TransactionBroadcastError}`}
             element={<BroadcastError />}
           />
-          <Route path={RouteUrls.IncreaseBtcFee} element={<IncreaseBtcFeeDialog />}>
+          <Route path={RouteUrls.IncreaseBtcFee} element={<IncreaseBtcFeeSheet />}>
             {ledgerBitcoinTxSigningRoutes}
           </Route>
 
@@ -170,7 +170,7 @@ function useAppRoutes() {
           {sendCryptoAssetFormRoutes}
 
           <Route path={RouteUrls.Unlock} element={<Unlock />}>
-            {leatherIntroDialogRoutes}
+            {leatherIntroSheetRoutes}
           </Route>
           <Route path={RouteUrls.UnauthorizedRequest} element={<UnauthorizedRequest />} />
           <Route

--- a/src/app/routes/receive-routes.tsx
+++ b/src/app/routes/receive-routes.tsx
@@ -3,17 +3,17 @@ import { Route } from 'react-router-dom';
 import { RouteUrls } from '@shared/route-urls';
 
 import { ReceiveBtcModal } from '@app/pages/receive/receive-btc';
-import { ReceiveDialog } from '@app/pages/receive/receive-dialog';
+import { ReceiveSheet } from '@app/pages/receive/receive-dialog';
 import { ReceiveOrdinalModal } from '@app/pages/receive/receive-ordinal';
 import { ReceiveStxModal } from '@app/pages/receive/receive-stx';
 
 export const receiveRoutes = (
   <Route>
-    <Route path={RouteUrls.Receive} element={<ReceiveDialog />} />
+    <Route path={RouteUrls.Receive} element={<ReceiveSheet />} />
     <Route path={RouteUrls.ReceiveStx} element={<ReceiveStxModal />} />
     <Route path={RouteUrls.ReceiveBtc} element={<ReceiveBtcModal />} />
     <Route path={RouteUrls.ReceiveBtcStamp} element={<ReceiveBtcModal type="btc-stamp" />} />
-    <Route path={RouteUrls.ReceiveCollectible} element={<ReceiveDialog type="collectible" />} />
+    <Route path={RouteUrls.ReceiveCollectible} element={<ReceiveSheet type="collectible" />} />
     <Route path={RouteUrls.ReceiveCollectibleOrdinal} element={<ReceiveOrdinalModal />} />
   </Route>
 );

--- a/src/app/routes/request-routes.tsx
+++ b/src/app/routes/request-routes.tsx
@@ -3,8 +3,8 @@ import { Route } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { BroadcastErrorDialog } from '@app/components/broadcast-error-dialog/broadcast-error-dialog';
-import { EditNonceDialog } from '@app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog';
+import { BroadcastErrorSheet } from '@app/components/broadcast-error-dialog/broadcast-error-dialog';
+import { EditNonceSheet } from '@app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog';
 import { ledgerStacksMessageSigningRoutes } from '@app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg.routes';
 import { ledgerStacksTxSigningRoutes } from '@app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container';
 import { StacksHighFeeWarningContainer } from '@app/features/stacks-high-fee-warning/stacks-high-fee-warning-container';
@@ -30,8 +30,8 @@ export const legacyRequestRoutes = (
       }
     >
       {ledgerStacksTxSigningRoutes}
-      <Route path={RouteUrls.EditNonce} element={<EditNonceDialog />} />
-      <Route path={RouteUrls.TransactionBroadcastError} element={<BroadcastErrorDialog />} />
+      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
+      <Route path={RouteUrls.TransactionBroadcastError} element={<BroadcastErrorSheet />} />
     </Route>
     <Route
       path={RouteUrls.SignatureRequest}

--- a/src/app/routes/rpc-routes.tsx
+++ b/src/app/routes/rpc-routes.tsx
@@ -3,7 +3,7 @@ import { Route } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { EditNonceDialog } from '@app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog';
+import { EditNonceSheet } from '@app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog';
 import { ledgerBitcoinTxSigningRoutes } from '@app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container';
 import { ledgerStacksMessageSigningRoutes } from '@app/features/ledger/flows/stacks-message-signing/ledger-stacks-sign-msg.routes';
 import { ledgerStacksTxSigningRoutes } from '@app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container';
@@ -79,7 +79,7 @@ export const rpcRequestRoutes = (
       }
     >
       {ledgerStacksTxSigningRoutes}
-      <Route path={RouteUrls.EditNonce} element={<EditNonceDialog />} />
+      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
     </Route>
   </>
 );

--- a/tests/selectors/send.selectors.ts
+++ b/tests/selectors/send.selectors.ts
@@ -25,6 +25,6 @@ export enum SendCryptoAssetSelectors {
   SendPageReady = 'send-page-ready',
 
   // stx high fee warning dialog
-  HighFeeWarningDialog = 'high-fee-warning-dialog',
-  HighFeeWarningDialogSubmit = 'high-fee-warning-dialog-submit',
+  HighFeeWarningSheet = 'high-fee-warning-sheet',
+  HighFeeWarningSheetSubmit = 'high-fee-warning-sheet-submit',
 }

--- a/tests/specs/send/send-stx.spec.ts
+++ b/tests/specs/send/send-stx.spec.ts
@@ -41,8 +41,8 @@ test.describe('send stx: tests on testnet', () => {
 
     await sendPage.previewSendTxButton.click();
 
-    await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningDialog).isVisible();
-    await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningDialogSubmit).click();
+    await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheet).isVisible();
+    await page.getByTestId(SendCryptoAssetSelectors.HighFeeWarningSheetSubmit).click();
 
     const details = await sendPage.confirmationDetails.allInnerTexts();
     test.expect(details).toBeTruthy();


### PR DESCRIPTION
> Try out Leather build 6734fd8 — [Extension build](https://github.com/leather-io/extension/actions/runs/10579484832), [Test report](https://leather-io.github.io/playwright-reports/fix-268-refactor-dialog-to-sheet), [Storybook](https://fix-268-refactor-dialog-to-sheet--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-268-refactor-dialog-to-sheet)<!-- Sticky Header Marker -->

This PR renames `Dialog` as `Sheet` as per https://github.com/leather-io/issues/issues/268

It builds upon the UI library update [here](https://github.com/leather-io/mono/pull/399)