### PR TITLE
refactor: update link to docs on open, ref #5800

### DIFF
--- a/src/background/messaging/rpc-methods/supported-methods.ts
+++ b/src/background/messaging/rpc-methods/supported-methods.ts
@@ -14,7 +14,7 @@ export function rpcSupportedMethods(message: SupportedMethodsRequest, port: chro
         methods: [
           {
             name: 'open',
-            docsUrl: ['https://leather.gitbook.io/developers/bitcoin/connect-users/open-wallet'],
+            docsUrl: ['https://leather.gitbook.io/developers/bitcoin/connect-users/open'],
           },
           {
             name: 'getAddresses',


### PR DESCRIPTION
> Try out Leather build b9afb72 — [Extension build](https://github.com/leather-io/extension/actions/runs/10595831798), [Test report](https://leather-io.github.io/playwright-reports/chore-5800-open-wallet-api-docs), [Storybook](https://chore-5800-open-wallet-api-docs--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-5800-open-wallet-api-docs)<!-- Sticky Header Marker -->

I missed one place to change from `open-wallet` - `open` - the docs links