### PR TITLE
fix: storybook icons, closes leather-io/issues#294

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -98,6 +98,40 @@ const config: StorybookConfig = {
         chrome: [path.join(__dirname, '../tests/mocks/mock-chrome.ts'), 'chrome'],
       })
     );
+    config.module ??= {};
+    config.module.rules ??= [];
+    // This modifies the existing image rule to exclude `.svg` files
+    // so we can load it instead with @svgr/webpack
+    const imageRule = config.module.rules.find((rule: any) => {
+      if (rule && typeof rule !== 'string' && rule.test instanceof RegExp) {
+        return rule.test.test('.svg');
+      }
+    });
+    if (imageRule && typeof imageRule !== 'string') {
+      imageRule.exclude = /\.svg$/;
+    }
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: [
+        {
+          loader: '@svgr/webpack',
+          options: {
+            svgoConfig: {
+              plugins: [
+                {
+                  name: 'preset-default',
+                  params: {
+                    overrides: {
+                      removeViewBox: false,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
     return config;
   },
 };


### PR DESCRIPTION
> Try out Leather build c7c0b59 — [Extension build](https://github.com/leather-io/extension/actions/runs/10676863883), [Test report](https://leather-io.github.io/playwright-reports/fix-294-storybook-icons), [Storybook](https://fix-294-storybook-icons--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-294-storybook-icons)<!-- Sticky Header Marker -->

This PR uses the same logic as https://github.com/leather-io/mono/pull/419 to load SVG icons in the extension storybook 