### PR TITLE
chore: improve open API and add tests, ref leather-io/issues#5800

### DIFF
--- a/src/background/messaging/rpc-methods/open.ts
+++ b/src/background/messaging/rpc-methods/open.ts
@@ -1,30 +1,21 @@
-import { RpcErrorCode } from '@btckit/types';
-
 import { RouteUrls } from '@shared/route-urls';
 import { OpenRequest } from '@shared/rpc/methods/open';
-import { makeRpcErrorResponse } from '@shared/rpc/rpc-methods';
+import { makeRpcSuccessResponse } from '@shared/rpc/rpc-methods';
 
-import {
-  listenForPopupClose,
-  makeSearchParamsWithDefaults,
-  triggerRequestWindowOpen,
-} from '../messaging-utils';
+import { makeSearchParamsWithDefaults, triggerRequestWindowOpen } from '../messaging-utils';
 import { trackRpcRequestSuccess } from '../rpc-message-handler';
 
 export async function rpcOpen(message: OpenRequest, port: chrome.runtime.Port) {
   const { urlParams, tabId } = makeSearchParamsWithDefaults(port, [['requestId', message.id]]);
-  const { id } = await triggerRequestWindowOpen(RouteUrls.Home, urlParams);
+
+  await triggerRequestWindowOpen(RouteUrls.Home, urlParams);
   void trackRpcRequestSuccess({ endpoint: message.method });
 
-  listenForPopupClose({
+  chrome.tabs.sendMessage(
     tabId,
-    id,
-    response: makeRpcErrorResponse('open', {
+    makeRpcSuccessResponse('open', {
       id: message.id,
-      error: {
-        code: RpcErrorCode.USER_REJECTION,
-        message: 'User rejected request to open wallet',
-      },
-    }),
-  });
+      result: { message: 'Success' },
+    })
+  );
 }

--- a/src/shared/rpc/methods/open.ts
+++ b/src/shared/rpc/methods/open.ts
@@ -1,14 +1,7 @@
 import { DefineRpcMethod, RpcRequest, RpcResponse } from '@btckit/types';
-import * as yup from 'yup';
 
-const rpcOpenParamsSchema = yup.object().shape({
-  url: yup.string(),
-});
+export type OpenRequest = RpcRequest<'open'>;
 
-type OpenRequestParams = yup.InferType<typeof rpcOpenParamsSchema>;
-
-export type OpenRequest = RpcRequest<'open', OpenRequestParams>;
-
-type OpenResponse = RpcResponse<Response>;
+type OpenResponse = RpcResponse<{ message: string }>;
 
 export type Open = DefineRpcMethod<OpenRequest, OpenResponse>;

--- a/tests/specs/rpc-open/open.spec.ts
+++ b/tests/specs/rpc-open/open.spec.ts
@@ -1,0 +1,62 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { TEST_PASSWORD } from '@tests/mocks/constants';
+import { HomePageSelectors } from '@tests/selectors/home.selectors';
+
+import { test } from '../../fixtures/fixtures';
+
+const successResponse = {
+  jsonrpc: '2.0',
+  result: {
+    message: 'Success',
+  },
+};
+
+async function interceptRequestPopup(context: BrowserContext) {
+  return context.waitForEvent('page');
+}
+
+async function assertWalletHomeOpens(popup: Page) {
+  await popup.getByTestId(HomePageSelectors.HomePageContainer).waitFor();
+  const button = popup.getByTestId(HomePageSelectors.FundAccountBtn);
+  await test.expect(button).toBeVisible();
+}
+async function initiateOpen(page: Page) {
+  return page.evaluate(async () => (window as any).LeatherProvider?.request('open'));
+}
+
+test.describe('Rpc: Open', () => {
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+
+    await onboardingPage.signInWithTestAccount(extensionId);
+  });
+
+  test('the wallet opens successfully', async ({ page, context }) => {
+    await page.goto('localhost:3000');
+    const openPromise = await initiateOpen(page);
+
+    const popup = await interceptRequestPopup(context);
+    await assertWalletHomeOpens(popup);
+
+    const result = await openPromise;
+    if (!result) throw new Error('Expected result');
+    const { id, ...payloadWithoutId } = result;
+
+    await test.expect(payloadWithoutId).toEqual(successResponse);
+  });
+
+  test('it forces user to unlock wallet when wallet is locked', async ({
+    homePage,
+    page,
+    context,
+  }) => {
+    await homePage.lock();
+    await page.goto('localhost:3000');
+    const openPromise = initiateOpen(page);
+    const popup = await interceptRequestPopup(context);
+    await popup.getByRole('textbox').fill(TEST_PASSWORD);
+    await popup.getByRole('button', { name: 'Continue' }).click();
+    await assertWalletHomeOpens(popup);
+    await test.expect(openPromise).resolves.toMatchObject(successResponse);
+  });
+});


### PR DESCRIPTION
> Try out Leather build 0fbb526 — [Extension build](https://github.com/leather-io/extension/actions/runs/10679244350), [Test report](https://leather-io.github.io/playwright-reports/chore-5800-open-wallet-api-tests), [Storybook](https://chore-5800-open-wallet-api-tests--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-5800-open-wallet-api-tests)<!-- Sticky Header Marker -->

This PR improves the `open` API to:
- resolve promises on success
- add test coverage