### PR TITLE
fix: show transaction amount above Increase Fee, closes #5826

### DIFF
--- a/src/app/components/stacks-transaction-item/increase-fee-button.tsx
+++ b/src/app/components/stacks-transaction-item/increase-fee-button.tsx
@@ -15,8 +15,6 @@ export function IncreaseFeeButton(props: IncreaseFeeButtonProps) {
     <styled.button
       _hover={{ color: 'ink.text-subdued' }}
       bg="ink.background-primary"
-      maxWidth="110px"
-      ml="auto"
       onClick={e => {
         onIncreaseFee();
         e.stopPropagation();
@@ -25,7 +23,6 @@ export function IncreaseFeeButton(props: IncreaseFeeButtonProps) {
       pointerEvents={!isActive ? 'none' : 'all'}
       position="relative"
       px="space.02"
-      py="space.01"
       rounded="xs"
       zIndex={999}
     >

--- a/src/app/components/transaction-item/transaction-item.layout.tsx
+++ b/src/app/components/transaction-item/transaction-item.layout.tsx
@@ -15,6 +15,14 @@ interface TransactionItemLayoutProps {
   children?: ReactNode;
 }
 
+function TxValue({ txValue }: { txValue: ReactNode }) {
+  return (
+    <styled.span textStyle="label.02" px="space.02">
+      {txValue}
+    </styled.span>
+  );
+}
+
 export function TransactionItemLayout({
   openTxLink,
   rightElement,
@@ -25,7 +33,7 @@ export function TransactionItemLayout({
   txValue,
 }: TransactionItemLayoutProps) {
   return (
-    <Pressable onClick={openTxLink} p="space.03">
+    <Pressable onClick={openTxLink} my="space.02">
       <ItemLayout
         flagImg={txIcon && txIcon}
         titleLeft={txTitle}
@@ -41,9 +49,8 @@ export function TransactionItemLayout({
             {txStatus && txStatus}
           </HStack>
         }
-        titleRight={
-          rightElement ? rightElement : <styled.span textStyle="label.02">{txValue}</styled.span>
-        }
+        titleRight={<TxValue txValue={txValue} />}
+        captionRight={rightElement}
       />
     </Pressable>
   );

--- a/src/app/features/activity-list/components/pending-transaction-list/pending-transaction-list.layout.tsx
+++ b/src/app/features/activity-list/components/pending-transaction-list/pending-transaction-list.layout.tsx
@@ -11,7 +11,9 @@ export function PendingTransactionListLayout({ children }: PendingTransactionLis
       <styled.span color="ink.text-subdued" textStyle="body.02">
         Pending
       </styled.span>
-      <Stack pb="space.06">{children}</Stack>
+      <Stack pb="space.06" mt="space.04">
+        {children}
+      </Stack>
     </>
   );
 }


### PR DESCRIPTION
> Try out Leather build ea0c379 — [Extension build](https://github.com/leather-io/extension/actions/runs/10698267192), [Test report](https://leather-io.github.io/playwright-reports/fix-5826-show-amount-above-increase-fee), [Storybook](https://fix-5826-show-amount-above-increase-fee--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-5826-show-amount-above-increase-fee)<!-- Sticky Header Marker -->

This PR makes a change so we always show the transaction amount above `Increase fee` [as per](https://github.com/leather-io/extension/issues/5826#issuecomment-2324550860) 

![Screenshot 2024-09-03 at 10 10 04](https://github.com/user-attachments/assets/6e00e5b6-5a67-436b-93b0-71c325320198)
