### PR TITLE
fix(analytics): initial route only used in report analytics

### DIFF
--- a/src/app/common/app-analytics.ts
+++ b/src/app/common/app-analytics.ts
@@ -22,7 +22,6 @@ const defaultStaticAnalyticContext = {
   ip: '0.0.0.0',
   platform: 'web',
   product: 'extension',
-  route: location.pathname,
   version: VERSION,
   ...(flow && { flow }),
   ...(origin && { origin }),
@@ -47,6 +46,7 @@ function getDerivedStateAnalyticsContext() {
   const appState = getAnalyticsStateProps();
 
   return {
+    route: location.pathname,
     network: appState.currentNetwork.name.toLowerCase(),
     usingDefaultHiroApi: isHiroApiUrl(appState.currentNetwork.chain.stacks.url),
     walletType: appState.walletType,


### PR DESCRIPTION
> Try out Leather build 2bb8aef — [Extension build](https://github.com/leather-io/extension/actions/runs/10683921358), [Test report](https://leather-io.github.io/playwright-reports/fix-analytics-dynamic-route), [Storybook](https://fix-analytics-dynamic-route--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-analytics-dynamic-route)<!-- Sticky Header Marker -->

Location was being set only at app initialisation, not on every new request