### PR TITLE
fix: refactor add network to use card footer, closes leather-io/issue…

### DIFF
--- a/src/app/components/error-label.tsx
+++ b/src/app/components/error-label.tsx
@@ -3,7 +3,7 @@ import { ErrorCircleIcon, Flag, type FlagProps } from '@leather.io/ui';
 export function ErrorLabel({ children, ...rest }: FlagProps) {
   return (
     <Flag
-      img={<ErrorCircleIcon variant="small" />}
+      img={<ErrorCircleIcon color="red.action-primary-default" variant="small" />}
       spacing="space.02"
       color="red.action-primary-default"
       textStyle="body.02"

--- a/src/app/features/add-network/add-network.tsx
+++ b/src/app/features/add-network/add-network.tsx
@@ -20,13 +20,26 @@ export function AddNetwork() {
       <Content>
         <Page>
           <Formik initialValues={initialFormValues} onSubmit={onSubmit}>
-            {() => (
-              <Card>
+            {({ handleSubmit }) => (
+              <Card
+                footerBorder
+                footer={
+                  <Button
+                    fullWidth
+                    aria-busy={loading}
+                    data-testid={NetworkSelectors.AddNetworkBtn}
+                    type="submit"
+                    onClick={() => handleSubmit()}
+                  >
+                    Add network
+                  </Button>
+                }
+              >
                 <Form data-testid={NetworkSelectors.NetworkPageReady}>
                   <Stack
                     gap="space.05"
                     maxWidth="pageWidth"
-                    px={['space.05', 'space.04']}
+                    px={{ base: 'space.00', sm: 'space.04', md: 'space.05' }}
                     my="space.05"
                   >
                     <styled.span textStyle="body.02">
@@ -52,13 +65,6 @@ export function AddNetwork() {
                     {error ? (
                       <ErrorLabel data-testid={NetworkSelectors.ErrorText}>{error}</ErrorLabel>
                     ) : null}
-                    <Button
-                      aria-busy={loading}
-                      data-testid={NetworkSelectors.AddNetworkBtn}
-                      type="submit"
-                    >
-                      Add network
-                    </Button>
                   </Stack>
                 </Form>
               </Card>


### PR DESCRIPTION
> Try out Leather build f928219 — [Extension build](https://github.com/leather-io/extension/actions/runs/10788080014), [Test report](https://leather-io.github.io/playwright-reports/fix-313-add-network-ui), [Storybook](https://fix-313-add-network-ui--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-313-add-network-ui)<!-- Sticky Header Marker -->

This issues addresses a bug raised in https://github.com/leather-io/issues/issues/313. I've made some adjustments here to use the CardFooter so that it matches up with the previous Add a network sheet.


https://github.com/user-attachments/assets/9bd6065d-909a-48e7-a777-07ae0b51ae4d

