### PR TITLE
fix: audit error path-to-regexp vulnerability GHSA-9wv6-86v2-598j

### DIFF
--- a/package.json
+++ b/package.json
@@ -368,6 +368,7 @@
     "wrap-ansi": "7.0.0",
     "webpack-dev-middleware": "5.3.4",
     "eslint": "8.56.0",
+    "path-to-regexp": "0.1.10",
     "ws": "8.17.1"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   wrap-ansi: 7.0.0
   webpack-dev-middleware: 5.3.4
   eslint: 8.56.0
+  path-to-regexp: 0.1.10
   ws: 8.17.1
 
 importers:
@@ -12171,8 +12172,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@0.1.7:
-    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+  path-to-regexp@0.1.10:
+    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -26334,7 +26335,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.7
+      path-to-regexp: 0.1.10
       proxy-addr: 2.0.7
       qs: 6.11.0
       range-parser: 1.2.1
@@ -30244,7 +30245,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-to-regexp@0.1.7: {}
+  path-to-regexp@0.1.10: {}
 
   path-type@4.0.0: {}
 


### PR DESCRIPTION
> Try out Leather build 4276f5d — [Extension build](https://github.com/leather-io/extension/actions/runs/10786325000), [Test report](https://leather-io.github.io/playwright-reports/chore-path-to-regexp), [Storybook](https://chore-path-to-regexp--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-path-to-regexp)<!-- Sticky Header Marker -->

This PR fixes an issue we are having with the `audit` CI check failing for `path-to-regexp` 

https://github.com/advisories/GHSA-9wv6-86v2-598j