### PR TITLE
refactor: update wbip004 method name, closes #5866

### DIFF
--- a/src/inpage/add-leather-to-providers.ts
+++ b/src/inpage/add-leather-to-providers.ts
@@ -29,7 +29,7 @@ export function addLeatherToProviders() {
     methods: [
       'getAddresses',
       'signMessage',
-      'sentTransfer',
+      'sendTransfer',
       'signPsbt',
       'stx_signMessage',
       'stx_signTransaction',


### PR DESCRIPTION
> Try out Leather build f7aa920 — [Extension build](https://github.com/leather-io/extension/actions/runs/10959638048), [Test report](https://leather-io.github.io/playwright-reports/refactor-rename-wbip004-method), [Storybook](https://refactor-rename-wbip004-method--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor-rename-wbip004-method)<!-- Sticky Header Marker -->

This PR updates the method name "sentTransfer" to "sendTransfer" on the WBIP004 provider registration object in array `window.btc_providers`.

Ensures the registered method names match the actual RPC methods available via `LeatherProvider`.