### PR TITLE
fix: secret key stored cleartext in memory

### DIFF
--- a/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
+++ b/src/app/pages/onboarding/sign-in/hooks/use-sign-in.ts
@@ -58,7 +58,7 @@ export function useSignIn() {
 
       await simulateShortDelayToAvoidImmediateNavigation();
 
-      dispatch(inMemoryKeyActions.saveUsersSecretKeyToBeRestored(parsedKeyInput));
+      dispatch(inMemoryKeyActions.setDefaultKey(parsedKeyInput));
       void analytics.track('submit_valid_secret_key');
       navigate(RouteUrls.SetPassword);
       setIsIdle();

--- a/src/app/routes/account-gate.tsx
+++ b/src/app/routes/account-gate.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useDefaultWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
+import { useHasDefaultInMemoryWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
 import { useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
 import { useCurrentKeyDetails } from '@app/store/software-keys/software-key.selectors';
 
@@ -11,8 +11,8 @@ export function shouldNavigateToOnboardingStartPage(currentKeyDetails?: any) {
   return !currentKeyDetails;
 }
 
-export function shouldNavigateToUnlockWalletPage(currentInMemorySecretKey?: string) {
-  return !currentInMemorySecretKey;
+export function shouldNavigateToUnlockWalletPage(hasDefaultInMemorySecretKey: boolean) {
+  return !hasDefaultInMemorySecretKey;
 }
 
 interface AccountGateProps {
@@ -20,7 +20,7 @@ interface AccountGateProps {
 }
 export function AccountGate({ children }: AccountGateProps) {
   const currentKeyDetails = useCurrentKeyDetails();
-  const currentInMemorySecretKey = useDefaultWalletSecretKey();
+  const hasDefaultInMemorySecretKey = useHasDefaultInMemoryWalletSecretKey();
 
   const isLedger = useHasLedgerKeys();
   if (isLedger) return <>{children}</>;
@@ -28,7 +28,7 @@ export function AccountGate({ children }: AccountGateProps) {
   if (shouldNavigateToOnboardingStartPage(currentKeyDetails))
     return <Navigate to={RouteUrls.Onboarding} />;
 
-  if (shouldNavigateToUnlockWalletPage(currentInMemorySecretKey))
+  if (shouldNavigateToUnlockWalletPage(hasDefaultInMemorySecretKey))
     return <Navigate to={RouteUrls.Unlock} />;
 
   return <>{children}</>;

--- a/src/app/routes/onboarding-gate.tsx
+++ b/src/app/routes/onboarding-gate.tsx
@@ -3,12 +3,15 @@ import { Navigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useDefaultWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
+import { useHasDefaultInMemoryWalletSecretKey } from '@app/store/in-memory-key/in-memory-key.selectors';
 import { useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
 import { useCurrentKeyDetails } from '@app/store/software-keys/software-key.selectors';
 
-function hasAlreadyMadeWalletAndPlaintextKeyInMemory(encryptedKey?: string, inMemoryKey?: string) {
-  return !!encryptedKey && !!inMemoryKey;
+function hasAlreadyMadeWalletAndPlaintextKeyInMemory(
+  hasInMemorySecretKey: boolean,
+  encryptedKey?: string
+) {
+  return hasInMemorySecretKey && !!encryptedKey;
 }
 
 function keyDetailsExistsWalletAlreadyCreatedSoPreventOnboarding(keyDetails: unknown) {
@@ -20,14 +23,14 @@ interface OnboardingGateProps {
 }
 export function OnboardingGate({ children }: OnboardingGateProps) {
   const keyDetails = useCurrentKeyDetails();
-  const currentInMemoryKey = useDefaultWalletSecretKey();
+  const hasInMemorySecretKey = useHasDefaultInMemoryWalletSecretKey();
   const isLedger = useHasLedgerKeys();
 
   if (
     (keyDetails?.type === 'software' &&
       hasAlreadyMadeWalletAndPlaintextKeyInMemory(
-        keyDetails.encryptedSecretKey,
-        currentInMemoryKey
+        hasInMemorySecretKey,
+        keyDetails.encryptedSecretKey
       )) ||
     isLedger
   ) {

--- a/src/app/store/in-memory-key/in-memory-key.selectors.ts
+++ b/src/app/store/in-memory-key/in-memory-key.selectors.ts
@@ -3,22 +3,45 @@ import { useSelector } from 'react-redux';
 import { createSelector } from '@reduxjs/toolkit';
 
 import { defaultWalletKeyId } from '@shared/utils';
+import { decodeText } from '@shared/utils/text-encoding';
 
 import { mnemonicToRootNode } from '@app/common/keychain/keychain';
 
 import { RootState } from '..';
 
-const selectInMemoryKey = (state: RootState) => state.inMemoryKeys;
+const selectInMemoryKeys = (state: RootState) => state.inMemoryKeys;
 
-export const selectDefaultWalletKey = createSelector(
-  selectInMemoryKey,
+const selectDefaultInMemoryWalletKeyBytes = createSelector(
+  selectInMemoryKeys,
   state => state.keys[defaultWalletKeyId]
 );
 
-export const selectRootKeychain = createSelector(selectDefaultWalletKey, key => {
-  if (!key) return null;
-  return mnemonicToRootNode(key);
-});
+const selectHasDefaultInMemoryWalletKey = createSelector(
+  selectDefaultInMemoryWalletKeyBytes,
+  key => !!key
+);
+
+export function useHasDefaultInMemoryWalletSecretKey() {
+  return useSelector(selectHasDefaultInMemoryWalletKey);
+}
+
+// Not using a memoized "createSelector" to avoid storing the decoded key as cleartext in memory
+export const selectDefaultWalletKey = (state: RootState) => {
+  const defaultWalletBytes = selectDefaultInMemoryWalletKeyBytes(state);
+
+  if (!defaultWalletBytes) return null;
+
+  return decodeText(defaultWalletBytes);
+};
+
+export const selectRootKeychain = createSelector(
+  selectDefaultInMemoryWalletKeyBytes,
+  defaultKey => {
+    if (!defaultKey) return null;
+
+    return mnemonicToRootNode(decodeText(defaultKey));
+  }
+);
 
 export function useDefaultWalletSecretKey() {
   return useSelector(selectDefaultWalletKey);

--- a/src/app/store/in-memory-key/in-memory-key.slice.ts
+++ b/src/app/store/in-memory-key/in-memory-key.slice.ts
@@ -2,12 +2,13 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { logger } from '@shared/logger';
 import { defaultWalletKeyId } from '@shared/utils';
+import { encodeText } from '@shared/utils/text-encoding';
 
 import { keySlice } from '../software-keys/software-key.slice';
 
 interface InMemoryKeyState {
   hasRestoredKeys: boolean;
-  keys: Record<string, string | undefined>;
+  keys: Record<string, string>;
 }
 
 const initialState: InMemoryKeyState = {
@@ -25,15 +26,12 @@ export const inMemoryKeySlice = createSlice({
         logger.warn('Not generating another wallet, already exists.');
         return;
       }
-      state.keys[defaultWalletKeyId] = action.payload;
+
+      state.keys[defaultWalletKeyId] = encodeText(action.payload);
     },
 
-    saveUsersSecretKeyToBeRestored(state, action: PayloadAction<string>) {
-      state.keys[defaultWalletKeyId] = action.payload;
-    },
-
-    setKeysInMemory(state, action: PayloadAction<Record<string, string>>) {
-      return { ...state, hasRestoredKeys: true, keys: { ...state.keys, ...action.payload } };
+    setDefaultKey(state, action: PayloadAction<string>) {
+      state.keys[defaultWalletKeyId] = encodeText(action.payload);
     },
 
     lockWallet(state) {

--- a/src/app/store/session-restore.ts
+++ b/src/app/store/session-restore.ts
@@ -24,7 +24,7 @@ export async function restoreWalletSession() {
 
     if (currentKey?.type === 'software') {
       const secretKey = await decrypt(currentKey.encryptedSecretKey, key.encryptionKey);
-      store.dispatch(inMemoryKeyActions.setKeysInMemory({ default: secretKey }));
+      store.dispatch(inMemoryKeyActions.setDefaultKey(secretKey));
     }
   } catch (e) {
     logger.error('Failed to decrypt secret key');

--- a/src/app/store/software-keys/software-key.actions.ts
+++ b/src/app/store/software-keys/software-key.actions.ts
@@ -126,7 +126,7 @@ function unlockWalletAction(password: string): AppThunk {
     if (!rootKey.publicKey) throw new Error('Could not derive root key from mnemonic');
     void identifyUser(rootKey.publicKey);
 
-    dispatch(inMemoryKeySlice.actions.setKeysInMemory({ default: secretKey }));
+    dispatch(inMemoryKeySlice.actions.setDefaultKey(secretKey));
   };
 }
 

--- a/src/shared/utils/text-encoding.spec.ts
+++ b/src/shared/utils/text-encoding.spec.ts
@@ -1,0 +1,25 @@
+import { decodeText, encodeText } from './text-encoding';
+
+describe('encode and decode text', () => {
+  it('works for UTF-8 text', () => {
+    const text = 'a Ā 𐀀 文 ❤️';
+    const encoded = encodeText(text);
+    const decoded = decodeText(encoded);
+
+    expect(decoded).toEqual(text);
+  });
+
+  it('works for empty strings', () => {
+    const text = '';
+    const encoded = encodeText(text);
+    const decoded = decodeText(encoded);
+    expect(decoded).toEqual(text);
+  });
+
+  it('does not simply convert to ASCII codes', () => {
+    const text = 'a';
+    const textAsciiHex = '61';
+    const encoded = encodeText(text);
+    expect(encoded).not.toEqual(textAsciiHex);
+  });
+});

--- a/src/shared/utils/text-encoding.ts
+++ b/src/shared/utils/text-encoding.ts
@@ -1,0 +1,20 @@
+/**
+ * Encode `text` to a hex string. Accepts text with any characters (like emojis).
+ * Does not match ASCII codes for latin-script letters (ie: "a" will not be encoded to "61").
+ * @param text string to encode
+ */
+export function encodeText(text: string) {
+  return Array.from(new TextEncoder().encode(btoa(encodeURIComponent(text))))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Decode `hex` previously encoded with [encodeText]{@link encodeText} to the original text.
+ * @param hex string to decode
+ */
+export function decodeText(hex?: string) {
+  if (!hex) return '';
+  const bytes = new Uint8Array((hex.match(/.{1,2}/g) ?? []).map(byte => parseInt(byte, 16)));
+  return decodeURIComponent(atob(new TextDecoder().decode(bytes)));
+}


### PR DESCRIPTION
This PR prevents the wallet keyphrase from appearing in cleartext in memory.

### TLDR changes:
* Encode the keyphrase in memory;
* Limit the usage of the decoded keyphrase;

### Details
As reported in the Least Authority Security Audit Report in 2021, if an attacker can read/dump the user's browser memory while the extension is open and unlocked, it could steal the keyphrase and take control of the wallet.

The key is referenced in the following places:
* Redux store
* Redux memoized selectors
* `OnboardingGate`  and `AccountGate` components. The `AccountGate` is kept mounted while the wallet is unlocked.

 ![Screenshot 2024-09-23 at 09 33 57](https://github.com/user-attachments/assets/12f0c647-ef18-41cc-aa56-53e4c0968ac1)
<sub>*memory dump*</sub>

### 1º fix: Encoding the keyphrase in memory

Instead of storing the keyphrase in cleartext, it is stored as `Uint8Array`. First, the key is encoded as a Base64 string and then converted to a `Uint8Array`. This approach offers the following benefits:

* The secret keyphrase is no longer easily identifiable in memory as a sequence of 24 known English words.
* Encoding the keyphrase in Base64 first ensures that the resulting `Uint8Array` does not directly correspond to ASCII table values (e.g., `a` in the keyphrase is no longer directly mapped to `97`), making it even harder to be found in memory.

Also, don't memoize the decoded keyphrase using RTK `createSelector`.

### 2º fix: Limit the usage of the decoded keyphrase

Changed components `OnboardingGate`  and `AccountGate` to check if the keyphase exists in memory instead of getting it and storing it in a variable.
