### PR TITLE
chore: pin node < v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "name": "Leather Wallet LLC"
   },
   "type": "module",
+  "engineStrict": true,
+  "engines": {
+    "node": ">=18.0.0 <22.0.0"
+  },
   "scripts": {
     "dev": "concurrently --raw \"node webpack/dev-server.js\" \"redux-devtools --hostname=localhost --port=8000\"",
     "dev:test-app": "webpack serve --config test-app/webpack/webpack.config.dev.cjs",


### PR DESCRIPTION
> Try out Leather build f820a46 — [Extension build](https://github.com/leather-io/extension/actions/runs/11028021626), [Test report](https://leather-io.github.io/playwright-reports/chore-pin-engine), [Storybook](https://chore-pin-engine--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-pin-engine)<!-- Sticky Header Marker -->

Pins node version below unsupported version