### PR TITLE
chore(ledger): log transaction payload prior to sending to ledger

### DIFF
--- a/src/app/features/ledger/utils/stacks-ledger-utils.ts
+++ b/src/app/features/ledger/utils/stacks-ledger-utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import Transport from '@ledgerhq/hw-transport-webusb';
 import {
   AddressVersion,
@@ -60,8 +61,14 @@ export const prepareLedgerDeviceStacksAppConnection = prepareLedgerDeviceForAppF
 ) as (args: PrepareLedgerDeviceConnectionArgs) => Promise<StacksApp>;
 
 export function signLedgerStacksTransaction(app: StacksApp) {
-  return async (payload: Buffer, accountIndex: number) =>
-    app.sign(stxDerivationWithAccount.replace('{account}', accountIndex.toString()), payload);
+  return async (payload: Buffer, accountIndex: number) => {
+    console.log('Logging serialised stacks transaction');
+    console.log(payload.toString('hex'));
+    return app.sign(
+      stxDerivationWithAccount.replace('{account}', accountIndex.toString()),
+      payload
+    );
+  };
 }
 
 export function signLedgerStacksUtf8Message(app: StacksApp) {


### PR DESCRIPTION
> Try out Leather build cd47f56 — [Extension build](https://github.com/leather-io/extension/actions/runs/11161118067), [Test report](https://leather-io.github.io/playwright-reports/debug-ledger-txs), [Storybook](https://debug-ledger-txs--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=debug-ledger-txs)<!-- Sticky Header Marker -->

This PR logs a serialised Stacks transaction as hex before passing it to a Ledger. 