### PR TITLE
chore: remove un-needed p-queue package, ref LEA-1500

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,6 @@
     "micro-packed": "0.3.2",
     "object-hash": "3.0.0",
     "os-browserify": "0.3.0",
-    "p-queue": "8.0.1",
     "pino": "8.19.0",
     "postcss-preset-env": "10.0.5",
     "prism-react-renderer": "2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,9 +281,6 @@ importers:
       os-browserify:
         specifier: 0.3.0
         version: 0.3.0
-      p-queue:
-        specifier: 8.0.1
-        version: 8.0.1
       pino:
         specifier: 8.19.0
         version: 8.19.0


### PR DESCRIPTION
> Try out Leather build e60a7cc — [Extension build](https://github.com/leather-io/extension/actions/runs/11362782687), [Test report](https://leather-io.github.io/playwright-reports/chore-LEA-1500-fetch-stacks-data), [Storybook](https://chore-LEA-1500-fetch-stacks-data--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore-LEA-1500-fetch-stacks-data)<!-- Sticky Header Marker -->

Working on LEA-1500 and I hit an issue with `p-queue` having problems with `options.signal.throwIfAborted` when calling queries in React Native. 

Digging into it and considering a downgrade in the `query` package helped me discover we don't need this in the `extension` at all