### PR TITLE
refactor: update to internal segment event client

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "@fungible-systems/zone-file": "2.0.0",
     "@hirosystems/token-metadata-api-client": "1.2.0",
     "@hookform/resolvers": "3.9.1",
+    "@leather.io/analytics": "2.0.0",
     "@leather.io/bitcoin": "0.16.0",
     "@leather.io/constants": "0.13.0",
     "@leather.io/crypto": "1.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@hookform/resolvers':
         specifier: 3.9.1
         version: 3.9.1(react-hook-form@7.53.1(react@18.3.1))
+      '@leather.io/analytics':
+        specifier: 2.0.0
+        version: 2.0.0
       '@leather.io/bitcoin':
         specifier: 0.16.0
         version: 0.16.0(encoding@0.1.13)
@@ -2821,7 +2824,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.28':
     resolution: {integrity: sha512-fvbVPId6s6etindzP6Nzos/CS1NurMVy4JKozjebArHr63tBid5i/UY5Pp+4wTCAM20gB2SjRdwcwoL6HFC4Iw==}
@@ -3074,6 +3077,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@leather.io/analytics@2.0.0':
+    resolution: {integrity: sha512-1ZudEmapw4p3cFw+0SzyDGFbha29DvMQ4q68IBWWrkrkVyXhsucjXpPYyss5hPp4pryqJRiI15Lip1zKK6AZKA==}
 
   '@leather.io/bitcoin@0.16.0':
     resolution: {integrity: sha512-rUAx9T7I7rQXDjEq1N1A17blwMGmopZ9DXZ9oMSmyLax/4AadPmyCxFzomdrz8awwLNk6S6/CMw+AhL3zzCgGQ==}
@@ -14760,9 +14766,6 @@ packages:
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
-  tslib@2.8.0:
-    resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -17820,7 +17823,7 @@ snapshots:
   '@dnd-kit/accessibility@3.1.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      tslib: 2.8.0
+      tslib: 2.8.1
 
   '@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -17828,26 +17831,26 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.8.0
+      tslib: 2.8.1
 
   '@dnd-kit/modifiers@7.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       react: 18.3.1
-      tslib: 2.8.0
+      tslib: 2.8.1
 
   '@dnd-kit/sortable@8.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       react: 18.3.1
-      tslib: 2.8.0
+      tslib: 2.8.1
 
   '@dnd-kit/utilities@3.2.2(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      tslib: 2.8.0
+      tslib: 2.8.1
 
   '@egjs/hammerjs@2.0.17':
     dependencies:
@@ -18192,8 +18195,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
       '@expo/code-signing-certificates': 0.0.5
-      '@expo/config': 9.0.3
-      '@expo/config-plugins': 8.0.8
+      '@expo/config': 9.0.4
+      '@expo/config-plugins': 8.0.10
       '@expo/devcert': 1.1.4
       '@expo/env': 0.3.0
       '@expo/image-utils': 0.5.1(encoding@0.1.13)
@@ -18324,7 +18327,7 @@ snapshots:
   '@expo/config@9.0.3':
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@expo/config-plugins': 8.0.8
+      '@expo/config-plugins': 8.0.10
       '@expo/config-types': 51.0.3
       '@expo/json-file': 8.3.3
       getenv: 1.0.0
@@ -18407,7 +18410,7 @@ snapshots:
       '@babel/generator': 7.26.2
       '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
-      '@expo/config': 9.0.3
+      '@expo/config': 9.0.4
       '@expo/env': 0.3.0
       '@expo/json-file': 8.3.3
       '@expo/spawn-async': 1.7.2
@@ -18470,8 +18473,8 @@ snapshots:
 
   '@expo/prebuild-config@7.0.8(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
     dependencies:
-      '@expo/config': 9.0.3
-      '@expo/config-plugins': 8.0.8
+      '@expo/config': 9.0.4
+      '@expo/config-plugins': 8.0.10
       '@expo/config-types': 51.0.3
       '@expo/image-utils': 0.5.1(encoding@0.1.13)
       '@expo/json-file': 8.3.3
@@ -18722,6 +18725,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@leather.io/analytics@2.0.0': {}
+
   '@leather.io/bitcoin@0.16.0(encoding@0.1.13)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.0.2
@@ -18857,8 +18862,8 @@ snapshots:
       '@radix-ui/react-toast': 1.1.5(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-tooltip': 1.0.7(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@react-native/assets-registry': 0.73.1
-      '@react-native/metro-config': 0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(encoding@0.1.13)
-      '@rnx-kit/metro-config': 1.3.14(@react-native/metro-config@0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(encoding@0.1.13))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-native/metro-config': 0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))
+      '@rnx-kit/metro-config': 1.3.14(@react-native/metro-config@0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0)))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@rnx-kit/metro-resolver-symlinks': 0.1.35
       '@shopify/restyle': 2.4.2(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       dompurify: 3.1.4
@@ -19369,7 +19374,7 @@ snapshots:
 
   '@radix-ui/react-arrow@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -19379,7 +19384,7 @@ snapshots:
 
   '@radix-ui/react-arrow@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -19465,7 +19470,7 @@ snapshots:
 
   '@radix-ui/react-collection@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.10)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.3.10)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -19478,7 +19483,7 @@ snapshots:
 
   '@radix-ui/react-collection@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-context': 1.0.1(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -19637,14 +19642,14 @@ snapshots:
 
   '@radix-ui/react-direction@1.0.1(@types/react@18.3.10)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.3.10
 
   '@radix-ui/react-direction@1.0.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.10
@@ -19840,7 +19845,7 @@ snapshots:
 
   '@radix-ui/react-label@2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -20127,7 +20132,7 @@ snapshots:
 
   '@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.10)(react@18.2.0)
@@ -20145,7 +20150,7 @@ snapshots:
 
   '@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.10)(react@18.3.1)
@@ -20440,14 +20445,14 @@ snapshots:
 
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.3.10)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.3.10
 
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.10
@@ -20496,7 +20501,7 @@ snapshots:
 
   '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.3.10)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.10)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
@@ -20504,7 +20509,7 @@ snapshots:
 
   '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
@@ -20519,14 +20524,14 @@ snapshots:
 
   '@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.3.10)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.3.10
 
   '@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.10
@@ -20564,7 +20569,7 @@ snapshots:
 
   '@radix-ui/react-use-rect@1.0.1(@types/react@18.3.10)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       '@radix-ui/rect': 1.0.1
       react: 18.2.0
     optionalDependencies:
@@ -20572,7 +20577,7 @@ snapshots:
 
   '@radix-ui/react-use-rect@1.0.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       '@radix-ui/rect': 1.0.1
       react: 18.3.1
     optionalDependencies:
@@ -20587,7 +20592,7 @@ snapshots:
 
   '@radix-ui/react-use-size@1.0.1(@types/react@18.3.10)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.10)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
@@ -20595,7 +20600,7 @@ snapshots:
 
   '@radix-ui/react-use-size@1.0.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
@@ -20646,7 +20651,7 @@ snapshots:
 
   '@radix-ui/rect@1.0.1':
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
 
   '@radix-ui/rect@1.1.0': {}
 
@@ -21053,7 +21058,7 @@ snapshots:
       chalk: 4.1.2
       execa: 5.1.1
       metro: 0.80.12
-      metro-config: 0.80.5(encoding@0.1.13)
+      metro-config: 0.80.12
       metro-core: 0.80.12
       node-fetch: 2.7.0(encoding@0.1.13)
       querystring: 0.2.1
@@ -21138,17 +21143,16 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(encoding@0.1.13)':
+  '@react-native/metro-config@0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))':
     dependencies:
       '@react-native/js-polyfills': 0.73.1
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))
-      metro-config: 0.80.5(encoding@0.1.13)
+      metro-config: 0.80.12
       metro-runtime: 0.80.12
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
       - bufferutil
-      - encoding
       - supports-color
       - utf-8-validate
 
@@ -21225,7 +21229,7 @@ snapshots:
 
   '@redux-devtools/chart-monitor@5.0.2(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(react@18.3.1)(redux@4.2.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@redux-devtools/core': 4.0.0(react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1)(redux@4.2.1))(react@18.3.1)(redux@4.2.1)
       '@types/react': 18.3.10
       d3-state-visualizer: 3.0.0
@@ -21281,7 +21285,7 @@ snapshots:
 
   '@redux-devtools/core@4.0.0(react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1)(redux@4.2.1))(react@18.3.1)(redux@4.2.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@redux-devtools/instrument': 2.2.0(redux@4.2.1)
       lodash: 4.17.21
       react: 18.3.1
@@ -21290,7 +21294,7 @@ snapshots:
 
   '@redux-devtools/inspector-monitor-test-tab@4.0.0(@emotion/react@11.13.3(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/inspector-monitor@6.0.1(@emotion/react@11.13.3(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(@types/react@18.3.10)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@5.3.11(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@emotion/react': 11.13.3(@types/react@18.3.10)(react@18.3.1)
       '@redux-devtools/inspector-monitor': 6.0.1(@emotion/react@11.13.3(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/ui': 1.3.2(@types/react@18.3.10)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
@@ -21312,7 +21316,7 @@ snapshots:
   '@redux-devtools/inspector-monitor-trace-tab@4.0.1(@emotion/react@11.13.3(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/inspector-monitor@6.0.1(@emotion/react@11.13.3(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)':
     dependencies:
       '@babel/code-frame': 8.0.0-alpha.12
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@emotion/react': 11.13.3(@types/react@18.3.10)(react@18.3.1)
       '@redux-devtools/inspector-monitor': 6.0.1(@emotion/react@11.13.3(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
       '@types/chrome': 0.0.263
@@ -21328,7 +21332,7 @@ snapshots:
 
   '@redux-devtools/inspector-monitor@6.0.1(@emotion/react@11.13.3(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -21363,7 +21367,7 @@ snapshots:
 
   '@redux-devtools/log-monitor@5.0.1(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(react@18.3.1)(redux@4.2.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@redux-devtools/core': 4.0.0(react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1)(redux@4.2.1))(react@18.3.1)(redux@4.2.1)
       '@types/lodash.debounce': 4.0.9
       '@types/react': 18.3.10
@@ -21391,7 +21395,7 @@ snapshots:
 
   '@redux-devtools/rtk-query-monitor@5.0.1(@emotion/react@11.13.3(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.2.7(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.10)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@5.3.11(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@emotion/react': 11.13.3(@types/react@18.3.10)(react@18.3.1)
       '@redux-devtools/core': 4.0.0(react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1)(redux@4.2.1))(react@18.3.1)(redux@4.2.1)
       '@redux-devtools/ui': 1.3.2(@types/react@18.3.10)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
@@ -21419,7 +21423,7 @@ snapshots:
 
   '@redux-devtools/slider-monitor@5.0.1(@redux-devtools/core@4.0.0(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@5.3.11(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@redux-devtools/core': 4.0.0(react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1)(redux@4.2.1))(react@18.3.1)(redux@4.2.1)
       '@redux-devtools/ui': 1.3.2(@types/react@18.3.10)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@types/react': 18.3.10
@@ -21505,7 +21509,7 @@ snapshots:
 
   '@rnx-kit/console@1.1.0': {}
 
-  '@rnx-kit/metro-config@1.3.14(@react-native/metro-config@0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(encoding@0.1.13))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@rnx-kit/metro-config@1.3.14(@react-native/metro-config@0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0)))(react-native@0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@rnx-kit/console': 1.1.0
       '@rnx-kit/tools-node': 2.1.2
@@ -21514,7 +21518,7 @@ snapshots:
       react: 18.2.0
       react-native: 0.74.1(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(@types/react@18.3.10)(encoding@0.1.13)(react@18.3.1)
     optionalDependencies:
-      '@react-native/metro-config': 0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))(encoding@0.1.13)
+      '@react-native/metro-config': 0.73.5(@babel/core@7.26.0)(@babel/preset-env@7.25.4(@babel/core@7.26.0))
 
   '@rnx-kit/metro-resolver-symlinks@0.1.35':
     dependencies:
@@ -21881,7 +21885,7 @@ snapshots:
   '@stacks/common@4.3.5':
     dependencies:
       '@types/bn.js': 5.1.6
-      '@types/node': 18.19.56
+      '@types/node': 18.19.64
       buffer: 6.0.3
 
   '@stacks/common@6.13.0':
@@ -24900,7 +24904,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
@@ -26579,7 +26583,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       csstype: 3.1.3
 
   dom-serializer@1.4.1:
@@ -29621,7 +29625,7 @@ snapshots:
 
   lower-case@2.0.2:
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.8.1
 
   lowercase-keys@2.0.0: {}
 
@@ -30829,7 +30833,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.8.0
+      tslib: 2.8.1
 
   nocache@3.0.4: {}
 
@@ -32411,7 +32415,7 @@ snapshots:
 
   react-select@5.8.0(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@emotion/cache': 11.13.1
       '@emotion/react': 11.13.3(@types/react@18.3.10)(react@18.3.1)
       '@floating-ui/dom': 1.6.10
@@ -32452,7 +32456,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -32626,7 +32630,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
 
   regexp-tree@0.1.27: {}
 
@@ -34026,8 +34030,6 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.7.0: {}
-
-  tslib@2.8.0: {}
 
   tslib@2.8.1: {}
 

--- a/src/app/common/app-analytics.ts
+++ b/src/app/common/app-analytics.ts
@@ -84,7 +84,7 @@ export function useHandleQueuedBackgroundAnalytics() {
         if (!events.length) return;
         await chrome.storage.local.remove(analyticsEventKey);
         await Promise.all(
-          events.map(({ eventName, properties }) => analytics.track(eventName, properties))
+          events.map(({ eventName, properties }) => analytics.untypedTrack(eventName, properties))
         );
       } catch (e) {
         void analytics.track('background_analytics_schema_fail');

--- a/src/app/common/hooks/use-submit-stx-transaction.ts
+++ b/src/app/common/hooks/use-submit-stx-transaction.ts
@@ -47,7 +47,9 @@ export function useSubmitTransactionCallback({ loadingKey }: UseSubmitTransactio
 
             await delay(500);
 
-            void analytics.track('broadcast_transaction', { symbol: 'stx' });
+            void analytics.track('broadcast_transaction', {
+              symbol: 'stx',
+            });
             onSuccess(safelyFormatHexTxid(response.txid));
             setIsIdle();
             await refreshAccountData(timeForApiToUpdate);

--- a/src/app/common/persistence.ts
+++ b/src/app/common/persistence.ts
@@ -36,7 +36,7 @@ export const queryClient = new QueryClient({
           hash: query.queryHash,
           error: error.toJSON(),
         };
-        void analytics.track('api_error', errorReport);
+        void analytics.untypedTrack('api_error', errorReport);
       }
 
       if (isZodError(error)) {

--- a/src/app/features/collectibles/components/stacks/stacks-crypto-assets.tsx
+++ b/src/app/features/collectibles/components/stacks/stacks-crypto-assets.tsx
@@ -25,7 +25,7 @@ export function StacksCryptoAssets({ address }: StacksCryptoAssetsProps) {
       void analytics.track('view_collectibles', {
         stacks_nfts_count: stacksNftsMetadataResp.length,
       });
-      void analytics.identify({ stacks_nfts_count: stacksNftsMetadataResp.length });
+      void analytics.client.identify({ stacks_nfts_count: stacksNftsMetadataResp.length });
     }
   }, [stacksNftsMetadataResp.length]);
 

--- a/src/app/features/ledger/hooks/use-ledger-analytics.hook.ts
+++ b/src/app/features/ledger/hooks/use-ledger-analytics.hook.ts
@@ -6,7 +6,7 @@ export function useLedgerAnalytics() {
   return useMemo(
     () => ({
       trackDeviceVersionInfo(info: object) {
-        void analytics.track('ledger_app_version_info', info);
+        void analytics.track('ledger_app_version_info', { info });
       },
       transactionSignedOnLedgerSuccessfully() {
         void analytics.track('ledger_transaction_signed_approved');

--- a/src/app/features/stacks-transaction-request/transaction-error/error-messages.tsx
+++ b/src/app/features/stacks-transaction-request/transaction-error/error-messages.tsx
@@ -27,7 +27,7 @@ function InsufficientFundsActionButtons({ eventName }: InsufficientFundsActionBu
   const [isShowingSwitchAccount, setIsShowingSwitchAccount] = useState(false);
 
   const onGetStx = () => {
-    void analytics.track(eventName);
+    void analytics.untypedTrack(eventName);
     closeWindow();
     void chrome.tabs.create({ url: 'index.html#/fund' });
   };

--- a/src/app/pages/receive/receive-btc.tsx
+++ b/src/app/pages/receive/receive-btc.tsx
@@ -32,7 +32,7 @@ export function ReceiveBtcModal({ type = 'btc' }: ReceiveBtcModalType) {
     <ReceiveTokensLayout
       address={btcAddress}
       onCopyAddressToClipboard={async () => {
-        void analytics.track('copy_btc_address_to_clipboard');
+        void analytics.track('copy_btc_address_to_clipboard', { type });
         await copyToClipboard(btcAddress);
         toast.success('Copied to clipboard!');
       }}

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-confirmation.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-confirmation.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { HStack, Stack, styled } from 'leather-styles/jsx';
 import get from 'lodash.get';
 
-import { decodeBitcoinTx } from '@leather.io/bitcoin';
 import type { CryptoCurrency } from '@leather.io/models';
 import {
   useBitcoinBroadcastTransaction,
@@ -56,7 +55,6 @@ export function RpcSendTransferConfirmation() {
   const { filteredUtxosQuery } = useCurrentNativeSegwitUtxos();
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
 
-  const psbt = decodeBitcoinTx(tx);
   const transferAmount = sumMoney(recipients.map(r => r.amount));
   const txFiatValue = i18nFormatCurrency(baseCurrencyAmountInQuote(transferAmount, btcMarketData));
   const txFiatValueSymbol = btcMarketData.price.symbol;
@@ -96,10 +94,7 @@ export function RpcSendTransferConfirmation() {
       async onSuccess(txid) {
         void analytics.track('broadcast_transaction', {
           symbol: 'btc',
-          amount: transferAmount,
-          fee,
-          inputs: psbt.inputs.length,
-          outputs: psbt.inputs.length,
+          amount: transferAmount.amount.toNumber(),
         });
         await filteredUtxosQuery.refetch();
 

--- a/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
+++ b/src/app/pages/rpc-sign-psbt/use-rpc-sign-psbt.tsx
@@ -53,7 +53,9 @@ export function useRpcSignPsbt() {
     fee,
     tx,
   }: BroadcastSignedPsbtTxArgs) {
-    void analytics.track('user_approved_sign_and_broadcast_psbt', { origin });
+    void analytics.track('user_approved_sign_and_broadcast_psbt', {
+      origin: origin || 'no_origin',
+    });
 
     const transferTotalAsMoney = sumMoney([addressNativeSegwitTotal, addressTaprootTotal]);
 

--- a/src/app/pages/send/ordinal-inscription/components/send-inscription-container.tsx
+++ b/src/app/pages/send/ordinal-inscription/components/send-inscription-container.tsx
@@ -54,12 +54,12 @@ export function SendInscriptionContainer() {
       iterationLimit: 100,
     })(routeState.inscription.address);
 
-    void analytics.track('recurse_addresses_to_find_derivation_path', {
+    void analytics.untypedTrack('recurse_addresses_to_find_derivation_path', {
       duration: result.duration,
     });
 
     if (result.status !== 'success') {
-      void analytics.track('error_did_not_find_owner_path_of_inscription', {
+      void analytics.untypedTrack('error_did_not_find_owner_path_of_inscription', {
         inscription: routeState.inscription.id,
       });
       throw new Error('Unable to find key of owner inscription address');

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -87,7 +87,7 @@ export function BtcSendFormConfirmation() {
       async onSuccess(txid) {
         void analytics.track('broadcast_transaction', {
           symbol: 'btc',
-          amount: transferAmount,
+          amount: Number(transferAmount),
           fee,
           inputs: decodedTx.inputs.length,
           outputs: decodedTx.inputs.length,

--- a/src/app/pages/transaction-request/transaction-request.tsx
+++ b/src/app/pages/transaction-request/transaction-request.tsx
@@ -75,7 +75,7 @@ function TransactionRequestBase() {
     await stacksBroadcastTransaction(unsignedTx);
 
     void analytics.track('submit_fee_for_transaction', {
-      calculation: stxFees?.calculation,
+      calculation: stxFees?.calculation || 'unknown',
       fee: values.fee,
       type: values.feeType,
     });

--- a/src/app/query/common/compliance-checker/compliance-checker.query.ts
+++ b/src/app/query/common/compliance-checker/compliance-checker.query.ts
@@ -84,7 +84,7 @@ export function useBreakOnNonCompliantEntity(address: string | string[]) {
   ]);
 
   if (complianceReports.some(report => report.data?.isOnSanctionsList)) {
-    void analytics.track('non_compliant_entity_detected');
+    void analytics.track('non_compliant_entity_detected', { address });
     throw new Error(compliantErrorBody);
   }
 }

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
@@ -184,9 +184,9 @@ export function useSignLedgerBitcoinTx() {
       // exist, and we want the user to proceed, despite the warning.
       try {
         await addNativeSegwitUtxoHexLedgerProps(psbt, nativeSegwitInputsToSign);
-        void analytics.track('successfully_added_native_segwit_tx_hex_to_ledger_tx');
+        void analytics.track('native_segwit_tx_hex_to_ledger_tx', { success: true });
       } catch (e) {
-        void analytics.track('failed_to_add_native_segwit_tx_hex_to_ledger_tx');
+        void analytics.track('native_segwit_tx_hex_to_ledger_tx', { success: false });
       }
 
       await addNativeSegwitBip32Derivation(psbt, fingerprint, nativeSegwitInputsToSign);

--- a/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks.ts
@@ -157,9 +157,13 @@ export function useUpdateLedgerSpecificNativeSegwitUtxoHexForAdddressIndexZero()
         tx.updateInput(index, {
           nonWitnessUtxo: Buffer.from(inputsTxHex[index], 'hex'),
         });
-        void analytics.track('ledger_nativesegwit_add_nonwitnessutxo');
+        void analytics.track('ledger_nativesegwit_add_nonwitnessutxo', {
+          action: 'add_nonwitness_utxo',
+        });
       } else {
-        void analytics.track('ledger_nativesegwit_skip_add_nonwitnessutxo');
+        void analytics.track('ledger_nativesegwit_add_nonwitnessutxo', {
+          action: 'skip_add_nonwitness_utxo',
+        });
       }
     });
   };

--- a/src/shared/workers/index.ts
+++ b/src/shared/workers/index.ts
@@ -7,7 +7,7 @@ export enum WorkerScript {
 export function createWorker(scriptName: WorkerScript) {
   const worker = new Worker(scriptName);
   worker.addEventListener('error', error => {
-    void analytics?.track(`worker_error_thrown_${scriptName}`, { error });
+    void analytics?.untypedTrack(`worker_error_thrown_${scriptName}`, { error });
   });
 
   return worker;


### PR DESCRIPTION
> Try out Leather build ee28197 — [Extension build](https://github.com/leather-io/extension/actions/runs/11749307970), [Test report](https://leather-io.github.io/playwright-reports/refactor-analytics-LEA-1619), [Storybook](https://refactor-analytics-LEA-1619--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor-analytics-LEA-1619)<!-- Sticky Header Marker -->

~Blocked by https://github.com/leather-io/mono/pull/602~

The Segment client is now ready to use. This updates the usage in the extension to the new client wrapper that allows us to better share event names and implementations across applications. The goal of this PR is 1:1 functionality with how the extension currently send events, but using the new client implementation which enforces event types and ensures we send a `platform` property.

As we enhance these further we'll implement new or cleaned up events in the extension. 