### PR TITLE
chore: demo redundancy of recursive account balance lookup

### DIFF
--- a/src/app/common/account-restoration/account-restore.ts
+++ b/src/app/common/account-restoration/account-restore.ts
@@ -45,6 +45,7 @@ export async function recurseAccountsForActivity({
 
     while (activity.length === 0 || activity[activity.length - 1].hasActivity) {
       const index = fibonacci.next().value;
+      console.log('fibonacci', index);
       const hasActivity = await doesAddressHaveActivityFn(index);
       activity.push({ index, hasActivity });
       yield;

--- a/src/app/store/chains/stx-chain.actions.ts
+++ b/src/app/store/chains/stx-chain.actions.ts
@@ -4,6 +4,7 @@ import { selectDefaultWalletKey } from '../in-memory-key/in-memory-key.selectors
 import { stxChainSlice } from './stx-chain.slice';
 
 export function createNewAccount(): AppThunk {
+  console.log('createNewAccount');
   return async (dispatch, getState) => {
     const secretKey = selectDefaultWalletKey(getState());
     if (!secretKey) {

--- a/src/app/store/chains/stx-chain.slice.ts
+++ b/src/app/store/chains/stx-chain.slice.ts
@@ -26,9 +26,17 @@ export const stxChainSlice = createSlice({
     },
     createNewAccount(state) {
       state.default.highestAccountIndex += 1;
+      // debugger;
+      console.log(
+        'createNewAccount',
+        state.default.highestAccountIndex,
+        (state.default.highestAccountIndex += 1)
+      );
       state.default.currentAccountIndex = state.default.highestAccountIndex;
     },
     restoreAccountIndex(state, action: PayloadAction<number>) {
+      // debugger;
+      console.log('restoreAccountIndex', action.payload);
       state.default.highestAccountIndex = action.payload;
     },
   },

--- a/src/app/store/software-keys/software-key.actions.ts
+++ b/src/app/store/software-keys/software-key.actions.ts
@@ -76,30 +76,39 @@ function setWalletEncryptionPassword(args: {
     // update the highest known account index that the wallet generates. This
     // action is performed outside this Promise's execution, as it may be slow,
     // and the user shouldn't have to wait before being directed to homepage.
-    logger.info('Initiating recursive account activity lookup');
-    try {
-      void recurseAccountsForActivity({
-        async doesAddressHaveActivityFn(index) {
-          const stxAddress = getStacksAddressByIndex(
-            secretKey,
-            AddressVersion.MainnetSingleSig
-          )(index);
-          const hasStxBalance = await doesStacksAddressHaveBalance(stxAddress);
-          const hasNames = await doesStacksAddressHaveBnsName(stxAddress);
+    // logger.info('Initiating recursive account activity lookup');
+    // try {
+    //   void recurseAccountsForActivity({
+    //     async doesAddressHaveActivityFn(index) {
+    //       const stxAddress = getStacksAddressByIndex(
+    //         secretKey,
+    //         AddressVersion.MainnetSingleSig
+    //       )(index);
+    //       const hasStxBalance = await doesStacksAddressHaveBalance(stxAddress);
+    //       const hasNames = await doesStacksAddressHaveBnsName(stxAddress);
 
-          const btcAddress = getNativeSegwitMainnetAddressFromMnemonic(secretKey)(index);
-          const hasBtcBalance = await doesBitcoinAddressHaveBalance(btcAddress.address!);
-          // TODO: add inscription check here also?
-          return hasStxBalance || hasNames || hasBtcBalance;
-        },
-      }).then(recursiveActivityIndex => {
-        if (recursiveActivityIndex <= legacyAccountActivityLookup) return;
-        logger.info('Found account activity at higher index', { recursiveActivityIndex });
-        dispatch(stxChainSlice.actions.restoreAccountIndex(recursiveActivityIndex));
-      });
-    } catch (e) {
-      // Errors during account restore are non-critical and can fail silently
-    }
+    //       const btcAddress = getNativeSegwitMainnetAddressFromMnemonic(secretKey)(index);
+    //       const hasBtcBalance = await doesBitcoinAddressHaveBalance(btcAddress.address!);
+    //       console.log('recurseAccountsForActivity', {
+    //         index,
+    //         stxAddress,
+    //         hasStxBalance,
+    //         hasNames,
+    //         btcAddress,
+    //         hasBtcBalance,
+    //       });
+    //       // TODO: add inscription check here also?
+    //       return hasStxBalance || hasNames || hasBtcBalance;
+    //     },
+    //   }).then(recursiveActivityIndex => {
+    //     // debugger;
+    //     if (recursiveActivityIndex <= legacyAccountActivityLookup) return;
+    //     logger.info('Found account activity at higher index', { recursiveActivityIndex });
+    //     dispatch(stxChainSlice.actions.restoreAccountIndex(recursiveActivityIndex));
+    //   });
+    // } catch (e) {
+    //   // Errors during account restore are non-critical and can fail silently
+    // }
 
     dispatch(
       keySlice.actions.createSoftwareWalletComplete({
@@ -109,8 +118,10 @@ function setWalletEncryptionPassword(args: {
         encryptedSecretKey,
       })
     );
-    if (legacyAccountActivityLookup !== 0)
+    if (legacyAccountActivityLookup !== 0) {
+      // debugger;
       dispatch(stxChainSlice.actions.restoreAccountIndex(legacyAccountActivityLookup));
+    }
   };
 }
 


### PR DESCRIPTION
In my investigations into account restore I found that:
- we run `recurseAccountsForActivity` however it never actually does any account creation
- all accounts are created at the start via a check for `legacyAccountActivityLookup !== 0` 

I tested this with a few different wallets:
- my own (3 accounts)
- leather dev wallet
- other account with 400 wallets

Just opening this draft to demonstrate `recurseAccountsForActivity`  is not working as we would expect. 