### PR TITLE
fix: propagate contract preview handler, closes #5059

### DIFF
--- a/src/app/features/stacks-transaction-request/contract-preview.tsx
+++ b/src/app/features/stacks-transaction-request/contract-preview.tsx
@@ -25,6 +25,7 @@ export function ContractPreviewLayout({
       gap="space.04"
       alignItems="center"
       border="default"
+      onClick={onClick}
       _hover={
         onClick
           ? {


### PR DESCRIPTION
> Try out Leather build ca28417 — [Extension build](https://github.com/leather-io/extension/actions/runs/11780426491), [Test report](https://leather-io.github.io/playwright-reports/fix-contract-preview-handler), [Storybook](https://fix-contract-preview-handler--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-contract-preview-handler)<!-- Sticky Header Marker -->

Fixes link to open smart contract function in explorer.