### PR TITLE
fix: multisig transfer send amount, closes #5941

### DIFF
--- a/src/background/messaging/rpc-methods/sign-stacks-transaction.ts
+++ b/src/background/messaging/rpc-methods/sign-stacks-transaction.ts
@@ -15,10 +15,8 @@ import {
   serializeCV,
   serializePostCondition,
 } from '@stacks/transactions';
-import BigNumber from 'bignumber.js';
 import { createUnsecuredToken } from 'jsontokens';
 
-import { STX_DECIMALS } from '@leather.io/constants';
 import { isDefined, isUndefined } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -68,10 +66,7 @@ const transactionPayloadToTransactionRequest = (
     case PayloadType.TokenTransfer:
       transactionRequest.txType = TransactionTypes.STXTransfer;
       transactionRequest.recipient = cvToValue(stacksTransaction.payload.recipient, true);
-      transactionRequest.amount = new BigNumber(Number(stacksTransaction.payload.amount))
-        .shiftedBy(-STX_DECIMALS)
-        .toNumber()
-        .toLocaleString('en-US', { maximumFractionDigits: STX_DECIMALS });
+      transactionRequest.amount = stacksTransaction.payload.amount.toString();
       transactionRequest.memo = cleanMemoString(stacksTransaction.payload.memo.content);
       break;
     case PayloadType.ContractCall:


### PR DESCRIPTION
> Try out Leather build c429698 — [Extension build](https://github.com/leather-io/extension/actions/runs/11781887364), [Test report](https://leather-io.github.io/playwright-reports/fix-transfer-multisig-send-amount), [Storybook](https://fix-transfer-multisig-send-amount--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-transfer-multisig-send-amount)<!-- Sticky Header Marker -->

this pr fixes multisig send transfer amount bug (just in ui)