### PR TITLE
fix: failing chromatic builds

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -85,6 +85,11 @@ const config: StorybookConfig = {
   },
   webpackFinal: config => {
     config.resolve ??= {};
+    config.resolve.fallback ??= {};
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      os: require.resolve('os-browserify/browser'),
+    };
     config.resolve.plugins ??= [];
     config.resolve.plugins.push(
       new TsconfigPathsPlugin({


### PR DESCRIPTION
> Try out Leather build 5635180 — [Extension build](https://github.com/leather-io/extension/actions/runs/11782512058), [Test report](https://leather-io.github.io/playwright-reports/fix-failing-chromatic-builds), [Storybook](https://fix-failing-chromatic-builds--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-failing-chromatic-builds)<!-- Sticky Header Marker -->

This PR adds the `os` Node polyfill (`os-browserify`) to the Storybook Webpack configuration to fix our failing chromatic workflow.