### PR TITLE
fix: do not dismount inscription content from view

### DIFF
--- a/src/app/features/collectibles/components/collectible-item.layout.tsx
+++ b/src/app/features/collectibles/components/collectible-item.layout.tsx
@@ -32,7 +32,7 @@ export function CollectibleItemLayout({
 }: CollectibleItemLayoutProps) {
   const [isHovered, bind] = useHover();
 
-  const { ref, inView } = useInView();
+  const { ref, inView } = useInView({ triggerOnce: true });
 
   return (
     <Box


### PR DESCRIPTION
> Try out Leather build f90937e — [Extension build](https://github.com/leather-io/extension/actions/runs/11804254428), [Test report](https://leather-io.github.io/playwright-reports/fix-trigger-in-view-once), [Storybook](https://fix-trigger-in-view-once--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-trigger-in-view-once)<!-- Sticky Header Marker -->

@brandonmarshall-tm, re conversation yesterday. Once an inscriptions is rendered, we leave it rendered, even if scrolled out of the viewport.