### PR TITLE
fix: manage tokens toggle, closes #5974

### DIFF
--- a/src/app/components/crypto-asset-item/crypto-asset-item-toggle.tsx
+++ b/src/app/components/crypto-asset-item/crypto-asset-item-toggle.tsx
@@ -43,6 +43,10 @@ export function CryptoAssetItemToggle({
     });
   }
 
+  function onClick() {
+    switchRef.current?.click();
+  }
+
   const toggle = (
     <VStack h="100%" justifyContent="center">
       <Switch.Root
@@ -50,6 +54,7 @@ export function CryptoAssetItemToggle({
         defaultChecked={isCheckedByDefault}
         onCheckedChange={handleSelection}
         id={assetId}
+        onClick={onClick}
       >
         <Switch.Thumb />
       </Switch.Root>
@@ -58,7 +63,7 @@ export function CryptoAssetItemToggle({
 
   return (
     <Box my="space.02">
-      <Pressable onClick={() => switchRef.current?.click()} data-testid={sanitize(assetId)}>
+      <Pressable onClick={onClick} data-testid={sanitize(assetId)}>
         <ItemLayout
           img={icon}
           titleLeft={spamFilter(titleLeft)}

--- a/tests/specs/manage-tokens/manage-tokens.spec.ts
+++ b/tests/specs/manage-tokens/manage-tokens.spec.ts
@@ -7,6 +7,7 @@ test.describe('Manage tokens', () => {
   test.beforeEach(async ({ extensionId, globalPage, onboardingPage }) => {
     await globalPage.setupAndUseApiCalls(extensionId);
     await onboardingPage.signInWithTestAccount(extensionId);
+    await globalPage.page.waitForLoadState('networkidle');
   });
 
   test('that supported sip10 token is shown', async ({ homePage }) => {


### PR DESCRIPTION
> Try out Leather build 5e65e43 — [Extension build](https://github.com/leather-io/extension/actions/runs/11939775579), [Test report](https://leather-io.github.io/playwright-reports/fix-manage-tokens-toggle), [Storybook](https://fix-manage-tokens-toggle--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-manage-tokens-toggle)<!-- Sticky Header Marker -->

This pr fixes manage tokens toggle, when click on switch. Problem is that component is wrapped in `pressable`, where `user-select: none`, so we need to add onClick listener on switch to make it work