### PR TITLE
fix: show loading state until total balance is fully loaded

### DIFF
--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -41,7 +41,7 @@ export function Home() {
   });
 
   const btcAddress = useCurrentAccountNativeSegwitAddressIndexZero();
-  const { totalUsdBalance, isLoading, isLoadingAdditionalData } = useTotalBalance({
+  const { totalUsdBalance, isPending, isLoadingAdditionalData } = useTotalBalance({
     btcAddress,
     stxAddress: account?.address || '',
   });
@@ -68,7 +68,7 @@ export function Home() {
           balance={totalUsdBalance}
           toggleSwitchAccount={() => toggleSwitchAccount()}
           isFetchingBnsName={isFetchingBnsName}
-          isLoadingBalance={isLoading}
+          isLoadingBalance={isPending}
           isLoadingAdditionalData={isLoadingAdditionalData}
           isBalancePrivate={isPrivateMode}
           onShowBalance={togglePrivateMode}


### PR DESCRIPTION
> Try out Leather build 56e173b — [Extension build](https://github.com/leather-io/extension/actions/runs/12081073989), [Test report](https://leather-io.github.io/playwright-reports/fix-home-balance), [Storybook](https://fix-home-balance--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix-home-balance)<!-- Sticky Header Marker -->

Adds a quick fix for home screen showing partial balance while loading.
The issue is due to one of balance queries being briefly idle, i.e. `isPending` but not `isFetching` yet:

<img width="605" alt="image" src="https://github.com/user-attachments/assets/550dddd8-24ed-4a43-ae31-403cd0662a7f">
