### PR TITLE
fix(ledger): legacy auth flow

### DIFF
--- a/src/app/common/publish-subscribe.ts
+++ b/src/app/common/publish-subscribe.ts
@@ -69,6 +69,7 @@ export interface GlobalAppEvents {
   ledgerStacksMessageSigningCancelled: {
     unsignedMessage: UnsignedMessage;
   };
+  ledgerJwtMessageSigningComplete: unknown;
 }
 
 export const appEvents = createPublishSubscribe<GlobalAppEvents>();

--- a/src/app/pages/legacy-account-auth/legacy-account-auth.tsx
+++ b/src/app/pages/legacy-account-auth/legacy-account-auth.tsx
@@ -1,10 +1,15 @@
+import { Outlet, useNavigate } from 'react-router-dom';
+
+import { RouteUrls } from '@shared/route-urls';
 import { closeWindow } from '@shared/utils';
 
 import { useCancelAuthRequest } from '@app/common/authentication/use-cancel-auth-request';
 import { useFinishAuthRequest } from '@app/common/authentication/use-finish-auth-request';
 import { useAppDetails } from '@app/common/hooks/auth/use-app-details';
 import { useOnMount } from '@app/common/hooks/use-on-mount';
+import { appEvents } from '@app/common/publish-subscribe';
 import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
+import { useWalletType } from '@app/common/use-wallet-type';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { CurrentAccountDisplayer } from '@app/features/current-account/current-account-displayer';
 import { useOnOriginTabClose } from '@app/routes/hooks/use-on-tab-closed';
@@ -12,11 +17,19 @@ import { useCurrentAccountIndex } from '@app/store/accounts/account';
 
 import { ConnectAccountLayout } from '../../components/connect-account/connect-account.layout';
 
+function listenForJwtSigningComplete() {
+  return new Promise(resolve =>
+    appEvents.subscribe('ledgerJwtMessageSigningComplete', () => resolve(true))
+  );
+}
+
 export function LegacyAccountAuth() {
   const { url } = useAppDetails();
   const accountIndex = useCurrentAccountIndex();
   const finishSignIn = useFinishAuthRequest();
   const { toggleSwitchAccount } = useSwitchAccountSheet();
+  const { whenWallet } = useWalletType();
+  const navigate = useNavigate();
 
   useOnOriginTabClose(() => closeWindow());
 
@@ -25,17 +38,32 @@ export function LegacyAccountAuth() {
   const handleUnmount = async () => cancelAuthentication();
   useOnMount(() => window.addEventListener('beforeunload', handleUnmount));
 
+  async function signIntoAccount(index: number) {
+    await whenWallet({
+      async software() {
+        await finishSignIn(index);
+      },
+      async ledger() {
+        navigate(RouteUrls.ConnectLedger, { state: { index } });
+        await listenForJwtSigningComplete();
+      },
+    })();
+  }
+
   if (!url) throw new Error('No app details found');
 
   return (
-    <ConnectAccountLayout
-      requester={url.origin}
-      onUserApprovesGetAddresses={async () => finishSignIn(accountIndex)}
-      // Here we should refocus the tab that initiated the request, however
-      // because the old auth code doesn't have the tab id and should be
-      // eventually removed, we just open in a new tab
-      onClickRequestedByLink={() => openInNewTab(url.origin)}
-      switchAccount={<CurrentAccountDisplayer onSelectAccount={toggleSwitchAccount} />}
-    />
+    <>
+      <ConnectAccountLayout
+        requester={url.origin}
+        onUserApprovesGetAddresses={async () => signIntoAccount(accountIndex)}
+        // Here we should refocus the tab that initiated the request, however
+        // because the old auth code doesn't have the tab id and should be
+        // eventually removed, we just open in a new tab
+        onClickRequestedByLink={() => openInNewTab(url.origin)}
+        switchAccount={<CurrentAccountDisplayer onSelectAccount={toggleSwitchAccount} />}
+      />
+      <Outlet />
+    </>
   );
 }


### PR DESCRIPTION
> Try out Leather build 1556dfc — [Extension build](https://github.com/leather-io/extension/actions/runs/12298264231), [Test report](https://leather-io.github.io/playwright-reports/fix/ledger-legacy-auth), [Storybook](https://fix/ledger-legacy-auth--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/ledger-legacy-auth)<!-- Sticky Header Marker -->

I'd removed the Ledger signing flow from auth, forgot that we actually signed the JWT with the device.

Here, the animation doesn't really make sense, as it runs before the modal opens to do the sign operation. I wonder if this is worth fixing? It's not ideal, but seems very low impact to fix, given this is a now-depreacted API.

https://github.com/user-attachments/assets/d31f3c5f-6ac0-43ce-b750-04ef551347a1

cc/ @314159265359879 