### PR TITLE
feat: sponsored sbtc txns

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -97,6 +97,11 @@
     "enabled": true,
     "emilyApiUrl": "https://sbtc-emily.com",
     "showPromoLinkOnNetworks": ["mainnet", "testnet", "sbtcTestnet"],
+    "sponsorshipsEnabled": true,
+    "sponsorshipApiUrl": {
+      "mainnet": "https://sponsor.leather.io",
+      "testnet": "http://testnet-13-60-14-218.nip.io"
+    },
     "contracts": {
       "mainnet": {
         "address": "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token"

--- a/config/wallet-config.schema.json
+++ b/config/wallet-config.schema.json
@@ -158,9 +158,26 @@
           "type": "boolean",
           "description": "Determines whether or not SBTC is enabled"
         },
+        "sponsorshipsEnabled": {
+          "type": "boolean",
+          "description": "Determines whether or not sponsored sBTC transactions are enabled"
+        },
         "emilyApiUrl": {
           "type": "string",
           "description": "URL for the Emily API"
+        },
+        "sponsorshipApiUrl": {
+          "type": "object",
+          "properties": {
+            "mainnet": {
+              "type": "string",
+              "description": "Mainnet URL for the Leather Sponsor API"
+            },
+            "testnet": {
+              "type": "string",
+              "description": "Testnet URL for the Leather Sponsor API"
+            }
+          }
         },
         "showPromoLinkOnNetworks": {
           "type": "array",

--- a/src/app/features/stacks-transaction-request/fee-form.tsx
+++ b/src/app/features/stacks-transaction-request/fee-form.tsx
@@ -7,28 +7,34 @@ import { StacksTransactionFormValues } from '@shared/models/form.model';
 import { isTxSponsored } from '@app/common/transactions/stacks/transaction.utils';
 import { FeesRow } from '@app/components/fees-row/fees-row';
 import { LoadingRectangle } from '@app/components/loading-rectangle';
+import type { SbtcSponsorshipEligibility } from '@app/query/sbtc/sponsored-transactions.query';
 import { useUnsignedPrepareTransactionDetails } from '@app/store/transactions/transaction.hooks';
 
 interface FeeFormProps {
   fees?: Fees;
   disableFeeSelection?: boolean;
   defaultFeeValue?: number;
+  sbtcSponsorshipEligibility?: SbtcSponsorshipEligibility;
 }
 
-export function FeeForm({ fees, disableFeeSelection, defaultFeeValue }: FeeFormProps) {
+export function FeeForm({
+  fees,
+  disableFeeSelection,
+  defaultFeeValue,
+  sbtcSponsorshipEligibility,
+}: FeeFormProps) {
   const { values } = useFormikContext<StacksTransactionFormValues>();
   const transaction = useUnsignedPrepareTransactionDetails(values);
-
   const isSponsored = transaction ? isTxSponsored(transaction) : false;
 
   return (
     <>
-      {fees?.estimates.length ? (
+      {!!sbtcSponsorshipEligibility && fees?.estimates.length ? (
         <FeesRow
           disableFeeSelection={disableFeeSelection}
           defaultFeeValue={defaultFeeValue}
           fees={fees}
-          isSponsored={isSponsored}
+          isSponsored={sbtcSponsorshipEligibility?.isEligible || isSponsored}
         />
       ) : (
         <LoadingRectangle height="32px" width="100%" />

--- a/src/app/pages/swap/bitflow-swap.utils.ts
+++ b/src/app/pages/swap/bitflow-swap.utils.ts
@@ -3,7 +3,7 @@ import type { RouteQuote } from 'bitflow-sdk';
 
 import { BtcFeeType, FeeTypes } from '@leather.io/models';
 import { type SwapAsset, defaultSwapFee } from '@leather.io/query';
-import { capitalize, isDefined, microStxToStx } from '@leather.io/utils';
+import { capitalize, isDefined } from '@leather.io/utils';
 
 import type { SwapFormValues } from '@shared/models/form.model';
 
@@ -31,7 +31,7 @@ export function getStacksSwapSubmissionData({
   values,
 }: getStacksSwapSubmissionDataArgs): SwapSubmissionData {
   return {
-    fee: microStxToStx(defaultSwapFee.amount).toNumber(),
+    fee: defaultSwapFee.amount.toString(),
     feeCurrency: 'STX',
     feeType: FeeTypes[FeeTypes.Middle],
     liquidityFee: estimateLiquidityFee(routeQuote.route.dex_path),

--- a/src/app/pages/swap/components/swap-details/swap-details.tsx
+++ b/src/app/pages/swap/components/swap-details/swap-details.tsx
@@ -4,6 +4,8 @@ import { HStack, styled } from 'leather-styles/jsx';
 
 import { ChevronRightIcon } from '@leather.io/ui';
 import {
+  convertAmountToBaseUnit,
+  createMoney,
   createMoneyFromDecimal,
   formatMoneyPadded,
   isDefined,
@@ -97,7 +99,9 @@ export function SwapDetails() {
         value={
           swapSubmissionData.sponsored
             ? 'Sponsored'
-            : `${swapSubmissionData.fee.toString()} ${swapSubmissionData.feeCurrency}`
+            : `${convertAmountToBaseUnit(
+                createMoney(new BigNumber(swapSubmissionData.fee), swapSubmissionData.feeCurrency)
+              ).toString()} ${swapSubmissionData.feeCurrency}`
         }
       />
       {Number(swapSubmissionData?.nonce) >= 0 ? (

--- a/src/app/pages/swap/hooks/use-bitflow-swap.tsx
+++ b/src/app/pages/swap/hooks/use-bitflow-swap.tsx
@@ -15,7 +15,7 @@ import { SwapSubmissionData } from '../swap.context';
 import { useBitflowSwappableAssets } from './use-bitflow-swappable-assets';
 import { useBtcSwapAsset } from './use-btc-bridge-asset';
 
-const bitflowSBtcTokenId = 'token-sbtcmain';
+const bitflowSBtcTokenId = 'token-sbtc';
 
 function getBitflowSwappableAssetsWithSbtcAtTop(assets: SwapAsset[]) {
   const bitflowSbtcAsset = assets.find(asset => asset.tokenId === bitflowSBtcTokenId);

--- a/src/app/pages/swap/hooks/use-sponsor-tx-fees.tsx
+++ b/src/app/pages/swap/hooks/use-sponsor-tx-fees.tsx
@@ -1,0 +1,65 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import type { StacksTransaction } from '@stacks/transactions';
+
+import { FeeTypes } from '@leather.io/models';
+import { defaultFeesMaxValuesAsMoney } from '@leather.io/query';
+
+import { logger } from '@shared/logger';
+import type { SwapFormValues } from '@shared/models/form.model';
+import { RouteUrls } from '@shared/route-urls';
+
+import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
+import { useToast } from '@app/features/toasts/use-toast';
+import { useConfigSbtc } from '@app/query/common/remote-config/remote-config.query';
+import {
+  type TransactionBase,
+  submitSponsoredSbtcTransaction,
+  verifySponsoredSbtcTransaction,
+} from '@app/query/sbtc/sponsored-transactions.query';
+import { useSignStacksTransaction } from '@app/store/transactions/transaction.hooks';
+
+export function useSponsorTransactionFees() {
+  const { sponsorshipApiUrl } = useConfigSbtc();
+  const { setIsIdle } = useLoading(LoadingKeys.SUBMIT_SWAP_TRANSACTION);
+  const signTx = useSignStacksTransaction();
+  const navigate = useNavigate();
+  const toast = useToast();
+
+  const checkEligibilityForSponsor = async (values: SwapFormValues, baseTx: TransactionBase) => {
+    return await verifySponsoredSbtcTransaction({
+      apiUrl: sponsorshipApiUrl,
+      baseTx,
+      nonce: Number(values.nonce),
+      fee: defaultFeesMaxValuesAsMoney[FeeTypes.Middle].amount.toNumber(),
+    });
+  };
+
+  const submitSponsoredTx = useCallback(
+    async (unsignedSponsoredTx: StacksTransaction) => {
+      try {
+        const signedSponsoredTx = await signTx(unsignedSponsoredTx);
+        if (!signedSponsoredTx) return logger.error('Unable to sign sponsored transaction!');
+
+        const result = await submitSponsoredSbtcTransaction(sponsorshipApiUrl, signedSponsoredTx);
+        if (!result.txid) {
+          navigate(RouteUrls.SwapError, { state: { message: result.error } });
+          return;
+        }
+
+        toast.success('Transaction submitted!');
+        setIsIdle();
+        navigate(RouteUrls.Activity);
+      } catch (error) {
+        return logger.error('Failed to submit sponsor transaction', error);
+      }
+    },
+    [navigate, setIsIdle, signTx, toast, sponsorshipApiUrl]
+  );
+
+  return {
+    checkEligibilityForSponsor,
+    submitSponsoredTx,
+  };
+}

--- a/src/app/query/common/remote-config/remote-config.query.ts
+++ b/src/app/query/common/remote-config/remote-config.query.ts
@@ -8,16 +8,16 @@ import { useHasCurrentBitcoinAccount } from '@app/store/accounts/blockchain/bitc
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 export {
-  HiroMessage,
-  AvailableRegions,
   ActiveFiatProvider,
-  useRemoteLeatherMessages,
+  AvailableRegions,
+  HiroMessage,
   useActiveFiatProviders,
-  useHasFiatProviders,
-  useRecoverUninscribedTaprootUtxosFeatureEnabled,
   useConfigNftMetadataEnabled,
   useConfigRunesEnabled,
   useConfigSwapsEnabled,
+  useHasFiatProviders,
+  useRecoverUninscribedTaprootUtxosFeatureEnabled,
+  useRemoteLeatherMessages,
 } from '@leather.io/query';
 
 export function useConfigBitcoinEnabled() {
@@ -45,7 +45,12 @@ interface SbtcConfig {
   enabled: boolean;
   contracts: Record<'mainnet' | 'testnet', { address: string }>;
   emilyApiUrl: string;
+  sponsorshipApiUrl: {
+    mainnet: string;
+    testnet: string;
+  };
   swapsEnabled: boolean;
+  sponsorshipsEnabled: boolean;
 }
 
 export function useConfigSbtc() {
@@ -57,11 +62,16 @@ export function useConfigSbtc() {
     const displayPromoCardOnNetworks = (sbtc as any)?.showPromoLinkOnNetworks ?? [];
     const contractIdMainnet = sbtc?.contracts.mainnet.address ?? '';
     const contractIdTestnet = sbtc?.contracts.testnet.address ?? '';
+    const apiUrlMainnet = sbtc?.sponsorshipApiUrl.mainnet ?? '';
+    const apiUrlTestnet = sbtc?.sponsorshipApiUrl.testnet ?? '';
 
     return {
+      configLoading: !sbtc,
       isSbtcEnabled: sbtc?.enabled ?? false,
+      isSbtcSponsorshipsEnabled: (sbtc?.enabled && sbtc?.sponsorshipsEnabled) ?? false,
       emilyApiUrl: sbtc?.emilyApiUrl ?? '',
       contractId: network.chain.bitcoin.mode === 'mainnet' ? contractIdMainnet : contractIdTestnet,
+      sponsorshipApiUrl: network.chain.bitcoin.mode === 'mainnet' ? apiUrlMainnet : apiUrlTestnet,
       isSbtcContract(contract: string) {
         return (
           contract === getPrincipalFromContractId(contractIdMainnet) ||

--- a/src/app/query/sbtc/sponsored-transactions.hooks.ts
+++ b/src/app/query/sbtc/sponsored-transactions.hooks.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+import { FeeTypes, type Fees } from '@leather.io/models';
+import type { NextNonce } from '@leather.io/query';
+
+import { logger } from '@shared/logger';
+
+import { useCurrentStacksAccountAddress } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+
+import { useConfigSbtc } from '../common/remote-config/remote-config.query';
+import {
+  type SbtcSponsorshipEligibility,
+  type SbtcSponsorshipVerificationResult,
+  type TransactionBase,
+  verifySponsoredSbtcTransaction,
+} from './sponsored-transactions.query';
+
+export function useCheckSbtcSponsorshipEligible(
+  baseTx?: TransactionBase,
+  nextNonce?: NextNonce,
+  stxFees?: Fees
+): SbtcSponsorshipVerificationResult {
+  const sbtcConfig = useConfigSbtc();
+  const stxAddress = useCurrentStacksAccountAddress();
+  const [isLoading, setIsLoading] = useState(true);
+  const [result, setResult] = useState<SbtcSponsorshipEligibility | undefined>();
+  const [lastAddressChecked, setLastAddressChecked] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!sbtcConfig.configLoading && !sbtcConfig.isSbtcSponsorshipsEnabled) {
+      if (isLoading) setIsLoading(false);
+      return;
+    }
+    if (!(sbtcConfig && baseTx && nextNonce && stxFees)) {
+      return;
+    }
+    if (result && stxAddress === lastAddressChecked) {
+      return;
+    }
+    // use the standard recommended fee from estimates
+    const standardFeeEstimate = stxFees.estimates[FeeTypes.Middle].fee.amount.toNumber();
+    verifySponsoredSbtcTransaction({
+      apiUrl: sbtcConfig.sponsorshipApiUrl,
+      baseTx,
+      nonce: nextNonce.nonce,
+      fee: standardFeeEstimate,
+    })
+      .then(result => {
+        setResult(result);
+        setLastAddressChecked(stxAddress);
+      })
+      .catch(e => {
+        logger.error('Verification failure: ', e);
+        setResult({ isEligible: false });
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [baseTx, stxFees, result, stxAddress, lastAddressChecked, nextNonce, isLoading, sbtcConfig]);
+
+  return {
+    isVerifying: isLoading,
+    result,
+  };
+}

--- a/src/app/query/sbtc/sponsored-transactions.query.ts
+++ b/src/app/query/sbtc/sponsored-transactions.query.ts
@@ -1,0 +1,91 @@
+import { bytesToHex } from '@stacks/common';
+import { StacksTransaction } from '@stacks/transactions';
+import axios from 'axios';
+
+import { logger } from '@shared/logger';
+
+import { queryClient } from '@app/common/persistence';
+import { generateUnsignedTransaction } from '@app/common/transactions/stacks/generate-unsigned-txs';
+
+export interface TransactionBase {
+  options?: any;
+  transaction: StacksTransaction | undefined;
+}
+
+export interface SbtcSponsorshipVerificationResult {
+  isVerifying: boolean;
+  result: SbtcSponsorshipEligibility | undefined;
+}
+
+export interface SbtcSponsorshipEligibility {
+  isEligible: boolean;
+  unsignedSponsoredTx?: StacksTransaction;
+}
+
+interface SbtcSponsorshipSubmissionResult {
+  txid?: string;
+  error?: string;
+}
+
+export async function submitSponsoredSbtcTransaction(
+  apiUrl: string,
+  sponsoredTx: StacksTransaction
+): Promise<SbtcSponsorshipSubmissionResult> {
+  try {
+    const { data } = await axios.post(`${apiUrl}/submit`, {
+      tx: bytesToHex(sponsoredTx.serialize()),
+    });
+    return {
+      txid: data.txid,
+    };
+  } catch (error: any) {
+    const errMsg = `sBTC Sponsorship Failure (${error?.response?.data?.error || 'Unknown'})`;
+    return {
+      error: errMsg,
+    };
+  }
+}
+
+interface VerifySponsoredSbtcTransactionArgs {
+  apiUrl: string;
+  baseTx: TransactionBase;
+  nonce?: number;
+  fee?: number;
+}
+export async function verifySponsoredSbtcTransaction({
+  apiUrl,
+  baseTx,
+  nonce,
+  fee,
+}: VerifySponsoredSbtcTransactionArgs): Promise<SbtcSponsorshipEligibility> {
+  try {
+    // add sponsorship option
+    const { options } = baseTx as any;
+    options.txData.sponsored = true;
+    const sponsoredTx = await generateUnsignedTransaction({
+      ...options,
+      fee,
+      nonce,
+    });
+    const serializedTx = bytesToHex(sponsoredTx.serialize());
+
+    const result = await queryClient.fetchQuery({
+      queryKey: ['verify-sponsored-sbtc-transaction', serializedTx],
+      queryFn: async () => {
+        const { data } = await axios.post(
+          `${apiUrl}/verify`,
+          {
+            tx: serializedTx,
+          },
+          { timeout: 5000 }
+        );
+        return data;
+      },
+    });
+
+    return { isEligible: result, unsignedSponsoredTx: sponsoredTx };
+  } catch (error) {
+    logger.error('Transaction verification failed:', error);
+    return { isEligible: false };
+  }
+}

--- a/src/app/store/transactions/contract-call.hooks.ts
+++ b/src/app/store/transactions/contract-call.hooks.ts
@@ -30,7 +30,8 @@ export function useGenerateStacksContractCallUnsignedTx() {
         fee: values.fee ?? 0,
         txData: { ...payload, network },
       };
-      return generateUnsignedTransaction(options);
+      const transaction = await generateUnsignedTransaction(options);
+      return { transaction, options };
     },
     [account, network, nextNonce?.nonce]
   );


### PR DESCRIPTION
> Try out Leather build dc94e36 — [Extension build](https://github.com/leather-io/extension/actions/runs/12390222412), [Test report](https://leather-io.github.io/playwright-reports/feat/sbtc-sponsored-txns), [Storybook](https://feat/sbtc-sponsored-txns--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/sbtc-sponsored-txns)<!-- Sticky Header Marker -->

@fbwoolf @kyranjamie @markmhendrickson Ready for review. Covers sponsorships for both contract calls and swaps. Need to change API URL config once in place. Will update shortly once updated testing APIs are online.

@fbwoolf I removed the swap sponsorship condition checks from here (other than feature flag enabled) to rely solely on the API verification rules (gives us a bit more flexibility in updating sponsorship rules).