### PR TITLE
fix: close ledger sheet in request keys flow

### DIFF
--- a/src/app/features/asset-list/_components/connect-ledger-asset-button.tsx
+++ b/src/app/features/asset-list/_components/connect-ledger-asset-button.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { HStack, styled } from 'leather-styles/jsx';
 
@@ -15,6 +15,7 @@ interface ConnectLedgerButtonProps {
 }
 export function ConnectLedgerButton({ chain }: ConnectLedgerButtonProps) {
   const navigate = useNavigate();
+  const location = useLocation();
 
   const onClick = () => {
     navigate(`${chain}/connect-your-ledger`, {
@@ -22,6 +23,7 @@ export function ConnectLedgerButton({ chain }: ConnectLedgerButtonProps) {
       state: {
         [immediatelyAttemptLedgerConnection]: true,
         backgroundLocation: { pathname: RouteUrls.Home },
+        fromLocation: location,
       },
     });
   };

--- a/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Route, useLocation } from 'react-router-dom';
 
+import { bytesToHex } from '@noble/hashes/utils';
 import * as btc from '@scure/btc-signer';
 import { hexToBytes } from '@stacks/common';
 import BitcoinApp from 'ledger-bitcoin';
@@ -106,6 +107,13 @@ function LedgerSignBitcoinTxContainer() {
       },
     });
 
+  function closeAction() {
+    appEvents.publish('ledgerBitcoinTxSigningCancelled', {
+      unsignedPsbt: unsignedTransaction ? bytesToHex(unsignedTransaction.toPSBT()) : '',
+    });
+    ledgerNavigate.cancelLedgerAction();
+  }
+
   const ledgerContextValue: LedgerTxSigningContext = {
     chain,
     transaction: unsignedTransaction,
@@ -118,7 +126,7 @@ function LedgerSignBitcoinTxContainer() {
   return (
     <TxSigningFlow
       context={ledgerContextValue}
-      closeAction={canCancelLedgerAction ? ledgerNavigate.cancelLedgerAction : undefined}
+      closeAction={canCancelLedgerAction ? closeAction : undefined}
     />
   );
 }

--- a/src/app/features/ledger/generic-steps/connect-device/connect-ledger-start.tsx
+++ b/src/app/features/ledger/generic-steps/connect-device/connect-ledger-start.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Sheet, SheetHeader } from '@leather.io/ui';
 
@@ -13,10 +13,15 @@ import { ConnectLedger } from './connect-ledger';
 
 export function ConnectLedgerStart() {
   const navigate = useNavigate();
+  const location = useLocation();
+
   const pageModeRoutingAction = (url: string) =>
     whenPageMode({
       full() {
-        navigate(url, { replace: true, state: { [immediatelyAttemptLedgerConnection]: true } });
+        navigate(url, {
+          replace: true,
+          state: { [immediatelyAttemptLedgerConnection]: true, fromLocation: location },
+        });
       },
       popup() {
         void openIndexPageInNewTab(url);

--- a/src/app/features/ledger/utils/generic-ledger-utils.ts
+++ b/src/app/features/ledger/utils/generic-ledger-utils.ts
@@ -128,7 +128,6 @@ function useIsLedgerActionCancellable(): boolean {
   const { pathname } = useLocation();
   return (
     pathname.includes(RouteUrls.ConnectLedger) ||
-    pathname.includes(RouteUrls.ConnectLedgerSuccess) ||
     pathname.includes(RouteUrls.ConnectLedgerError) ||
     pathname.includes(RouteUrls.AwaitingDeviceUserAction)
   );

--- a/src/app/pages/legacy-account-auth/legacy-account-auth.tsx
+++ b/src/app/pages/legacy-account-auth/legacy-account-auth.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 import { closeWindow } from '@shared/utils';
@@ -30,6 +30,7 @@ export function LegacyAccountAuth() {
   const { toggleSwitchAccount } = useSwitchAccountSheet();
   const { whenWallet } = useWalletType();
   const navigate = useNavigate();
+  const location = useLocation();
 
   useOnOriginTabClose(() => closeWindow());
 
@@ -44,7 +45,7 @@ export function LegacyAccountAuth() {
         await finishSignIn(index);
       },
       async ledger() {
-        navigate(RouteUrls.ConnectLedger, { state: { index } });
+        navigate(RouteUrls.ConnectLedger, { state: { index, fromLocation: location } });
         await listenForJwtSigningComplete();
       },
     })();

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
@@ -1,3 +1,5 @@
+import { useLocation } from 'react-router-dom';
+
 import { bytesToHex } from '@noble/hashes/utils';
 import * as btc from '@scure/btc-signer';
 import { Psbt } from 'bitcoinjs-lib';
@@ -257,6 +259,7 @@ export function useGetAssumedZeroIndexSigningConfig() {
 export function useSignBitcoinTx() {
   const { whenWallet } = useWalletType();
   const ledgerNavigate = useLedgerNavigate();
+  const location = useLocation();
   const signSoftwareTx = useSignBitcoinSoftwareTx();
   const getDefaultSigningConfig = useGetAssumedZeroIndexSigningConfig();
 
@@ -277,7 +280,11 @@ export function useSignBitcoinTx() {
         // many routes, in order to achieve a consistent API between
         // Ledger/software, we subscribe to the event that occurs when the
         // unsigned tx is signed
-        ledgerNavigate.toConnectAndSignBitcoinTransactionStep(psbt, getSigningConfig(inputsToSign));
+        ledgerNavigate.toConnectAndSignBitcoinTransactionStep(
+          psbt,
+          getSigningConfig(inputsToSign),
+          location
+        );
         return listenForBitcoinTxLedgerSigning(bytesToHex(psbt));
       },
       async software() {


### PR DESCRIPTION
> Try out Leather build efce52d — [Extension build](https://github.com/leather-io/extension/actions/runs/12949626238), [Test report](https://leather-io.github.io/playwright-reports/fix/go-back-ledger-request), [Storybook](https://fix/go-back-ledger-request--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/go-back-ledger-request)<!-- Sticky Header Marker -->

Fixed broken close ledger connect sheet
Task: https://linear.app/leather-io/issue/LEA-2078/fix-ledger-cancel-navigation