### PR TITLE
Feat/add ignore inscriptions UI

### DIFF
--- a/src/app/common/hooks/use-hover-with-children.ts
+++ b/src/app/common/hooks/use-hover-with-children.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+
+interface HoverBind {
+  onMouseEnter(event: React.MouseEvent<HTMLElement, MouseEvent>): void;
+  onMouseLeave(event: React.MouseEvent<HTMLElement, MouseEvent>): void;
+}
+
+export function useHoverWithChildren(): [boolean, HoverBind] {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleMouseEnter = useCallback(() => {
+    setIsHovered(true);
+  }, []);
+
+  const handleMouseLeave = useCallback((event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    const relatedTarget = event.relatedTarget as HTMLElement;
+
+    // If the related target is a child of the current element, don't trigger mouseleave
+    if (event.currentTarget.contains(relatedTarget)) {
+      return;
+    }
+
+    setIsHovered(false);
+  }, []);
+
+  const bind: HoverBind = {
+    onMouseEnter: handleMouseEnter,
+    onMouseLeave: handleMouseLeave,
+  };
+
+  return [isHovered, bind];
+}

--- a/src/app/components/account-total-balance.tsx
+++ b/src/app/components/account-total-balance.tsx
@@ -4,7 +4,7 @@ import { styled } from 'leather-styles/jsx';
 
 import { SkeletonLoader, shimmerStyles } from '@leather.io/ui';
 
-import { useTotalBalance } from '@app/common/hooks/balance/use-total-balance';
+import { useBalances } from '@app/common/hooks/balance/use-balances';
 import { PrivateText } from '@app/components/privacy/private-text';
 
 interface AccountTotalBalanceProps {
@@ -13,7 +13,7 @@ interface AccountTotalBalanceProps {
 }
 
 export const AccountTotalBalance = memo(({ btcAddress, stxAddress }: AccountTotalBalanceProps) => {
-  const { totalUsdBalance, isFetching, isLoading, isLoadingAdditionalData } = useTotalBalance({
+  const { totalUsdBalance, isFetching, isLoading, isLoadingAdditionalData } = useBalances({
     btcAddress,
     stxAddress,
   });

--- a/src/app/debug.ts
+++ b/src/app/debug.ts
@@ -57,6 +57,12 @@ const debug = {
     chrome.storage.local.clear();
     chrome.storage.session.clear();
   },
+  bypassInscriptionChecks() {
+    store.dispatch(settingsSlice.actions.dangerouslyChosenToBypassAllInscriptionChecks());
+  },
+  resetInscriptionState() {
+    store.dispatch(settingsSlice.actions.resetInscriptionState());
+  },
 };
 
 export function setDebugOnGlobal() {

--- a/src/app/features/collectibles/components/bitcoin/high-sat-value-utxo.tsx
+++ b/src/app/features/collectibles/components/bitcoin/high-sat-value-utxo.tsx
@@ -1,0 +1,23 @@
+import { Box, Circle } from 'leather-styles/jsx';
+
+import type { Inscription } from '@leather.io/models';
+
+import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
+
+const featureBuilt = false;
+
+interface HighSatValueUtxoProps {
+  inscription: Inscription;
+}
+
+export function HighSatValueUtxoWarning({ inscription }: HighSatValueUtxoProps) {
+  if (Number(inscription.value) < 5_000) return null;
+  if (!featureBuilt) return null;
+  return (
+    <Box position="absolute" top="space.01" right="space.01">
+      <BasicTooltip label="This inscription has loads of BTC on it, remove protections? Click">
+        <Circle bg="red" size="sm" />
+      </BasicTooltip>
+    </Box>
+  );
+}

--- a/src/app/features/collectibles/components/bitcoin/inscription-text.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription-text.tsx
@@ -10,7 +10,7 @@ import { CollectibleText } from '../_collectible-types/collectible-text';
 interface InscriptionTextProps {
   contentSrc: string;
   inscriptionNumber: number;
-  onClickCallToAction(): void;
+  onClickCallToAction?(): void;
   onClickSend(): void;
 }
 export function InscriptionText({

--- a/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -1,17 +1,33 @@
+import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { Box } from 'leather-styles/jsx';
+
 import { type Inscription } from '@leather.io/models';
-import { OrdinalAvatarIcon } from '@leather.io/ui';
+import {
+  DropdownMenu,
+  EllipsisVIcon,
+  ExternalLinkIcon,
+  Flag,
+  IconButton,
+  LockIcon,
+  OrdinalAvatarIcon,
+  TrashIcon,
+  UnlockIcon,
+} from '@leather.io/ui';
 
 import { ORD_IO_URL } from '@shared/constants';
 import { RouteUrls } from '@shared/route-urls';
 
+import { useHoverWithChildren } from '@app/common/hooks/use-hover-with-children';
 import { openInNewTab } from '@app/common/utils/open-in-new-tab';
+import { useDiscardedInscriptions } from '@app/store/settings/settings.selectors';
 
 import { CollectibleAudio } from '../_collectible-types/collectible-audio';
 import { CollectibleIframe } from '../_collectible-types/collectible-iframe';
 import { CollectibleImage } from '../_collectible-types/collectible-image';
 import { CollectibleOther } from '../_collectible-types/collectible-other';
+import { HighSatValueUtxoWarning } from './high-sat-value-utxo';
 import { InscriptionText } from './inscription-text';
 
 interface InscriptionProps {
@@ -25,74 +41,136 @@ function openInscriptionUrl(num: number) {
 export function Inscription({ inscription }: InscriptionProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const [isHovered, bind] = useHoverWithChildren();
+  const { hasInscriptionBeenDiscarded, discardInscription, recoverInscription } =
+    useDiscardedInscriptions();
 
-  function openSendInscriptionModal() {
+  const openSendInscriptionModal = useCallback(() => {
     navigate(RouteUrls.SendOrdinalInscription, {
       state: { inscription, backgroundLocation: location },
     });
-  }
+  }, [navigate, inscription, location]);
 
-  switch (inscription.mimeType) {
-    case 'audio':
-      return (
-        <CollectibleAudio
-          icon={<OrdinalAvatarIcon size="lg" />}
-          key={inscription.title}
-          onClickCallToAction={() => openInscriptionUrl(inscription.number)}
-          onClickSend={() => openSendInscriptionModal()}
-          subtitle="Ordinal inscription"
-          title={`# ${inscription.number}`}
-        />
-      );
-    case 'html':
-    case 'svg':
-    case 'video':
-    case 'gltf':
-      return (
-        <CollectibleIframe
-          icon={<OrdinalAvatarIcon size="lg" />}
-          key={inscription.title}
-          onClickCallToAction={() => openInscriptionUrl(inscription.number)}
-          onClickSend={() => openSendInscriptionModal()}
-          src={inscription.src}
-          subtitle="Ordinal inscription"
-          title={`# ${inscription.number}`}
-        />
-      );
-    case 'image':
-      return (
-        <CollectibleImage
-          icon={<OrdinalAvatarIcon size="lg" />}
-          key={inscription.title}
-          onClickCallToAction={() => openInscriptionUrl(inscription.number)}
-          onClickSend={() => openSendInscriptionModal()}
-          src={inscription.src}
-          subtitle="Ordinal inscription"
-          title={`# ${inscription.number}`}
-        />
-      );
-    case 'text':
-      return (
-        <InscriptionText
-          contentSrc={inscription.src}
-          inscriptionNumber={inscription.number}
-          onClickCallToAction={() => openInscriptionUrl(inscription.number)}
-          onClickSend={() => openSendInscriptionModal()}
-        />
-      );
-    case 'other':
-      return (
-        <CollectibleOther
-          key={inscription.title}
-          onClickCallToAction={() => openInscriptionUrl(inscription.number)}
-          onClickSend={() => openSendInscriptionModal()}
-          subtitle="Ordinal inscription"
-          title={`# ${inscription.number}`}
+  const content = useMemo(() => {
+    const sharedProps = { onClickSend: () => openSendInscriptionModal() };
+    switch (inscription.mimeType) {
+      case 'audio':
+        return (
+          <CollectibleAudio
+            icon={<OrdinalAvatarIcon size="lg" />}
+            key={inscription.title}
+            subtitle="Ordinal inscription"
+            title={`# ${inscription.number}`}
+            {...sharedProps}
+          />
+        );
+      case 'html':
+      case 'svg':
+      case 'video':
+      case 'gltf':
+        return (
+          <CollectibleIframe
+            icon={<OrdinalAvatarIcon size="lg" />}
+            key={inscription.title}
+            src={inscription.src}
+            subtitle="Ordinal inscription"
+            title={`# ${inscription.number}`}
+            {...sharedProps}
+          />
+        );
+      case 'image':
+        return (
+          <CollectibleImage
+            icon={<OrdinalAvatarIcon size="lg" />}
+            key={inscription.title}
+            src={inscription.src}
+            subtitle="Ordinal inscription"
+            title={`# ${inscription.number}`}
+            {...sharedProps}
+          />
+        );
+      case 'text':
+        return (
+          <InscriptionText
+            contentSrc={inscription.src}
+            inscriptionNumber={inscription.number}
+            {...sharedProps}
+          />
+        );
+      case 'other':
+        return (
+          <CollectibleOther
+            key={inscription.title}
+            subtitle="Ordinal inscription"
+            title={`# ${inscription.number}`}
+            {...sharedProps}
+          >
+            <OrdinalAvatarIcon size="lg" />
+          </CollectibleOther>
+        );
+      default:
+        return null;
+    }
+  }, [
+    inscription.mimeType,
+    inscription.number,
+    inscription.src,
+    inscription.title,
+    openSendInscriptionModal,
+  ]);
+
+  return (
+    <Box position="relative" {...bind}>
+      <Box opacity={hasInscriptionBeenDiscarded(inscription) ? 0.5 : 1}>{content}</Box>
+      {isHovered && (
+        <Box bg="ink.background-primary" right="space.03" top="space.03" zIndex="90">
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger>
+              <IconButton
+                _focus={{ outline: 'focus' }}
+                _hover={{ bg: 'ink.component-background-hover' }}
+                bg="ink.background-primary"
+                transform="rotate(90deg)"
+                color="ink.action-primary-default"
+                icon={<EllipsisVIcon variant="small" />}
+              />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content side="bottom" style={{ marginRight: '96px' }}>
+              <DropdownMenu.Item onClick={() => openInscriptionUrl(inscription.number)}>
+                <Flag img={<ExternalLinkIcon variant="small" />}>Open original</Flag>
+              </DropdownMenu.Item>
+              {hasInscriptionBeenDiscarded(inscription) ? (
+                <DropdownMenu.Item onClick={() => recoverInscription(inscription)}>
+                  <Flag img={<LockIcon variant="small" />}>Protect</Flag>
+                </DropdownMenu.Item>
+              ) : (
+                <DropdownMenu.Item onClick={() => discardInscription(inscription)}>
+                  <Flag img={<UnlockIcon variant="small" />}>Unprotect</Flag>
+                </DropdownMenu.Item>
+              )}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </Box>
+      )}
+
+      <HighSatValueUtxoWarning inscription={inscription} />
+
+      {hasInscriptionBeenDiscarded(inscription) && (
+        <Box
+          p="space.02"
+          borderRadius="xs"
+          border="1px solid"
+          borderColor="ink.border-transparent"
+          background="ink.background-secondary"
+          position="absolute"
+          bottom="134px"
+          left="18px"
         >
-          <OrdinalAvatarIcon size="lg" />
-        </CollectibleOther>
-      );
-    default:
-      return null;
-  }
+          <Flag opacity={0.5} spacing="space.01" img={<TrashIcon variant="small" />}>
+            Unprotected
+          </Flag>
+        </Box>
+      )}
+    </Box>
+  );
 }

--- a/src/app/features/collectibles/components/bitcoin/ordinals.tsx
+++ b/src/app/features/collectibles/components/bitcoin/ordinals.tsx
@@ -18,8 +18,8 @@ export function Ordinals() {
       void analytics.track('view_collectibles', {
         ordinals_count: inscriptionsLength,
       });
-      void analytics.identify({ ordinals_count: inscriptionsLength });
     }
+    void analytics.identify({ ordinals_count: inscriptionsLength });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [results.inscriptions?.length]);
 

--- a/src/app/features/collectibles/components/collectible-item.layout.tsx
+++ b/src/app/features/collectibles/components/collectible-item.layout.tsx
@@ -4,7 +4,8 @@ import { useInView } from 'react-intersection-observer';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { Box, Stack, styled } from 'leather-styles/jsx';
 import { token } from 'leather-styles/tokens';
-import { useHover } from 'use-events';
+
+import { useHoverWithChildren } from '@app/common/hooks/use-hover-with-children';
 
 import { CollectibleHover } from './collectible-hover';
 
@@ -30,7 +31,7 @@ export function CollectibleItemLayout({
   title,
   ...rest
 }: CollectibleItemLayoutProps) {
-  const [isHovered, bind] = useHover();
+  const [isHovered, bind] = useHoverWithChildren();
 
   const { ref, inView } = useInView({ triggerOnce: true });
 

--- a/src/app/features/discarded-inscriptions/use-inscribed-spendable-utxos.ts
+++ b/src/app/features/discarded-inscriptions/use-inscribed-spendable-utxos.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+
+import { useNativeSegwitUtxosByAddress } from '@leather.io/query';
+
+import { useCurrentNativeSegwitInscriptions } from '@app/query/bitcoin/ordinals/inscriptions/inscriptions.query';
+import { useCurrentAccountNativeSegwitIndexZeroSignerNullable } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+import { useDiscardedInscriptions } from '@app/store/settings/settings.selectors';
+
+export function useInscribedSpendableUtxos() {
+  const { hasInscriptionBeenDiscarded } = useDiscardedInscriptions();
+
+  const { data: nativeSegwitInscriptions } = useCurrentNativeSegwitInscriptions();
+
+  const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSignerNullable();
+  const address = nativeSegwitSigner?.address;
+
+  // Utxos but don't filter the inscribed ones
+  const { data: nativeSegwitUtxos } = useNativeSegwitUtxosByAddress({
+    address: address ?? '',
+    filterInscriptionUtxos: false,
+    filterPendingTxsUtxos: true,
+    filterRunesUtxos: true,
+  });
+
+  return useMemo(() => {
+    if (!nativeSegwitUtxos || !nativeSegwitInscriptions) return [];
+
+    // Preformatting utxos so that inscriptions are declared as an object
+    // property aids the following filter logic
+    const utxosFormatted = nativeSegwitUtxos.map(utxo => ({
+      ...utxo,
+      inscriptions: nativeSegwitInscriptions.filter(
+        inscription => inscription.txid === utxo.txid && Number(inscription.output) === utxo.vout
+      ),
+    }));
+
+    const utxosThatCanBeSpentBecauseAllUtxosInsideWereDiscarded = utxosFormatted
+      // If there are no inscriptions they're not being filtered and we don't care about them
+      .filter(utxo => utxo.inscriptions.length > 0)
+      // For a given utxo with inscriptions, check that all inscriptions in it
+      // have been discarded. This check ensures we don't spend a utxo if only
+      // one of potentially many have been discarded
+      .filter(utxo =>
+        utxo.inscriptions.every(inscription => hasInscriptionBeenDiscarded(inscription))
+      );
+
+    return utxosThatCanBeSpentBecauseAllUtxosInsideWereDiscarded;
+  }, [nativeSegwitUtxos, nativeSegwitInscriptions, hasInscriptionBeenDiscarded]);
+}

--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -7,7 +7,7 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
 import { useOnboardingState } from '@app/common/hooks/auth/use-onboarding-state';
-import { useTotalBalance } from '@app/common/hooks/balance/use-total-balance';
+import { useBalances } from '@app/common/hooks/balance/use-balances';
 import { useOnMount } from '@app/common/hooks/use-on-mount';
 import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { whenPageMode } from '@app/common/utils';
@@ -45,7 +45,7 @@ export function Home() {
   });
 
   const btcAddress = useCurrentAccountNativeSegwitAddressIndexZero();
-  const { totalUsdBalance, isPending, isLoadingAdditionalData } = useTotalBalance({
+  const { totalUsdBalance, availableUsdBalance, isPending, isLoadingAdditionalData } = useBalances({
     btcAddress,
     stxAddress: account?.address || '',
   });
@@ -69,7 +69,8 @@ export function Home() {
       <Box px={{ base: 'space.05', md: 0 }} pb={{ base: 'space.05', md: 0 }}>
         <AccountCard
           name={name}
-          balance={totalUsdBalance}
+          availableBalance={availableUsdBalance}
+          totalBalance={totalUsdBalance}
           toggleSwitchAccount={() => toggleSwitchAccount()}
           isFetchingBnsName={isFetchingBnsName}
           isLoadingBalance={isPending}

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -36,6 +36,7 @@ import {
 } from '@app/components/info-card/info-card';
 import { Card, Content, Page } from '@app/components/layout';
 import { PageHeader } from '@app/features/container/headers/page.header';
+import { useInscribedSpendableUtxos } from '@app/features/discarded-inscriptions/use-inscribed-spendable-utxos';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by-address.hooks';
 
 import { useSendFormNavigate } from '../../hooks/use-send-form-navigate';
@@ -81,8 +82,11 @@ export function BtcSendFormConfirmation() {
   const sendingValue = formatMoneyPadded(createMoneyFromDecimal(Number(transferAmount), symbol));
   const summaryFee = formatMoneyPadded(createMoney(Number(fee), symbol));
 
+  const utxosOfSpendableInscriptions = useInscribedSpendableUtxos();
+
   async function initiateTransaction() {
     await broadcastTx({
+      skipSpendableCheckUtxoIds: utxosOfSpendableInscriptions.map(utxo => utxo.txid),
       tx: transaction.hex,
       async onSuccess(txid) {
         void analytics.track('broadcast_transaction', {

--- a/src/app/query/bitcoin/address/utxos-by-address.hooks.ts
+++ b/src/app/query/bitcoin/address/utxos-by-address.hooks.ts
@@ -1,5 +1,6 @@
 import { useNativeSegwitUtxosByAddress } from '@leather.io/query';
 
+import { useInscribedSpendableUtxos } from '@app/features/discarded-inscriptions/use-inscribed-spendable-utxos';
 import { useCurrentAccountNativeSegwitIndexZeroSignerNullable } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
 const defaultArgs = {
@@ -12,16 +13,13 @@ const defaultArgs = {
  * Warning: ⚠️ To avoid spending inscriptions, when using UTXOs
  * we set `filterInscriptionUtxos` and `filterPendingTxsUtxos` to true
  */
-export function useCurrentNativeSegwitUtxos(args = defaultArgs) {
-  const { filterInscriptionUtxos, filterPendingTxsUtxos, filterRunesUtxos } = args;
-
+export function useCurrentNativeSegwitUtxos() {
   const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSignerNullable();
   const address = nativeSegwitSigner?.address ?? '';
+  const spendableUtxos = useInscribedSpendableUtxos();
 
-  return useNativeSegwitUtxosByAddress({
-    address,
-    filterInscriptionUtxos,
-    filterPendingTxsUtxos,
-    filterRunesUtxos,
-  });
+  const query = useNativeSegwitUtxosByAddress({ address, ...defaultArgs });
+
+  const queryResponseData = query.data ?? [];
+  return { ...query, data: [...queryResponseData, ...spendableUtxos] };
 }

--- a/src/app/query/bitcoin/balance/btc-balance-native-segwit.hooks.ts
+++ b/src/app/query/bitcoin/balance/btc-balance-native-segwit.hooks.ts
@@ -2,46 +2,61 @@ import { useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import type { BtcCryptoAssetBalance, Money } from '@leather.io/models';
 import { useNativeSegwitUtxosByAddress, useRunesEnabled } from '@leather.io/query';
 import { createMoney, isUndefined, sumNumbers } from '@leather.io/utils';
 
+import { useInscribedSpendableUtxos } from '@app/features/discarded-inscriptions/use-inscribed-spendable-utxos';
 import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 
-function createBtcCryptoAssetBalance(balance: Money): BtcCryptoAssetBalance {
-  return {
-    availableBalance: balance,
-    protectedBalance: createMoney(0, 'BTC'),
-    uneconomicalBalance: createMoney(0, 'BTC'),
-    pendingBalance: createMoney(0, 'BTC'),
-    totalBalance: balance,
-    inboundBalance: createMoney(0, 'BTC'),
-    outboundBalance: createMoney(0, 'BTC'),
-  };
-}
+import { useFilterNativeSegwitInscriptions } from '../ordinals/inscriptions/inscriptions.query';
+
+const defaultZeroValues = {
+  protectedBalance: createMoney(0, 'BTC'),
+  uneconomicalBalance: createMoney(0, 'BTC'),
+  inboundBalance: createMoney(0, 'BTC'),
+  outboundBalance: createMoney(0, 'BTC'),
+  pendingBalance: createMoney(0, 'BTC'),
+};
 
 export function useBtcCryptoAssetBalanceNativeSegwit(address: string) {
   const runesEnabled = useRunesEnabled();
 
-  const query = useNativeSegwitUtxosByAddress({
+  const spendableInscriptionUtxos = useInscribedSpendableUtxos();
+
+  const { filterOutInscriptions: filterOutNativeSegwitInscriptions } =
+    useFilterNativeSegwitInscriptions();
+
+  const totalUtxosQuery = useNativeSegwitUtxosByAddress({
     address,
-    filterInscriptionUtxos: true,
+    filterInscriptionUtxos: false,
     filterPendingTxsUtxos: true,
     filterRunesUtxos: runesEnabled,
   });
 
   const balance = useMemo(() => {
-    if (isUndefined(query.data))
-      return createBtcCryptoAssetBalance(createMoney(new BigNumber(0), 'BTC'));
-    return createBtcCryptoAssetBalance(
-      createMoney(sumNumbers(query.data.map(utxo => utxo.value)), 'BTC')
-    );
-  }, [query.data]);
+    if (isUndefined(totalUtxosQuery.data) || isUndefined(totalUtxosQuery.data))
+      return {
+        ...defaultZeroValues,
+        totalBalance: createMoney(new BigNumber(0), 'BTC'),
+        availableBalance: createMoney(new BigNumber(0), 'BTC'),
+      };
+    return {
+      ...defaultZeroValues,
+      totalBalance: createMoney(sumNumbers(totalUtxosQuery.data.map(utxo => utxo.value)), 'BTC'),
+      availableBalance: createMoney(
+        // Here we add back in the utxos that are spending beacuse they've been discarded
+        sumNumbers(
+          [
+            ...filterOutNativeSegwitInscriptions(totalUtxosQuery.data),
+            ...spendableInscriptionUtxos,
+          ].map(utxo => utxo.value)
+        ),
+        'BTC'
+      ),
+    };
+  }, [totalUtxosQuery.data, filterOutNativeSegwitInscriptions, spendableInscriptionUtxos]);
 
-  return {
-    ...query,
-    balance,
-  };
+  return { ...totalUtxosQuery, balance };
 }
 
 export function useCurrentBtcCryptoAssetBalanceNativeSegwit() {

--- a/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
+++ b/src/app/store/accounts/blockchain/bitcoin/bitcoin.hooks.ts
@@ -287,12 +287,19 @@ export function useSignBitcoinTx() {
   };
 }
 
-export function useCurrentBitcoinAccountXpubs() {
-  const taprootAccount = useCurrentTaprootAccount();
+export function useCurrentBitcoinAccountNativeSegwitXpub() {
   const nativeSegwitAccount = useCurrentNativeSegwitAccount();
+  return `wpkh(${nativeSegwitAccount?.keychain.publicExtendedKey})`;
+}
 
-  return [
-    `wpkh(${nativeSegwitAccount?.keychain.publicExtendedKey})`,
-    `tr(${taprootAccount?.keychain.publicExtendedKey})`,
-  ];
+function useCurrentBitcoinAccountTaprootXpub() {
+  const taprootAccount = useCurrentTaprootAccount();
+  return `tr(${taprootAccount?.keychain.publicExtendedKey})`;
+}
+
+export function useCurrentBitcoinAccountXpubs() {
+  const taprootXpub = useCurrentBitcoinAccountTaprootXpub();
+  const nativeSegwitXpub = useCurrentBitcoinAccountNativeSegwitXpub();
+
+  return [taprootXpub, nativeSegwitXpub];
 }

--- a/src/app/store/settings/settings.selectors.ts
+++ b/src/app/store/settings/settings.selectors.ts
@@ -1,8 +1,13 @@
-import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { createSelector } from '@reduxjs/toolkit';
 
+import type { Inscription } from '@leather.io/models';
+
 import { RootState } from '@app/store';
+
+import { settingsSlice } from './settings.slice';
 
 const selectSettings = (state: RootState) => state.settings;
 
@@ -25,4 +30,32 @@ const selectIsPrivateMode = createSelector(selectSettings, state => state.isPriv
 
 export function useIsPrivateMode() {
   return useSelector(selectIsPrivateMode);
+}
+
+const selectDiscardedInscriptions = createSelector(
+  selectSettings,
+  state => state.discardedInscriptions
+);
+
+type InscriptionIdentifier = Pick<Inscription, 'txid' | 'output' | 'offset'>;
+
+export function useDiscardedInscriptions() {
+  const discardedInscriptions = useSelector(selectDiscardedInscriptions);
+  const dispatch = useDispatch();
+
+  return useMemo(
+    () => ({
+      discardedInscriptions,
+      hasInscriptionBeenDiscarded({ txid, output: vout, offset }: InscriptionIdentifier) {
+        return discardedInscriptions.includes([txid, vout, offset].join(':'));
+      },
+      discardInscription({ txid, output: vout, offset }: InscriptionIdentifier) {
+        dispatch(settingsSlice.actions.discardInscription([txid, vout, offset].join(':')));
+      },
+      recoverInscription({ txid, output: vout, offset }: InscriptionIdentifier) {
+        dispatch(settingsSlice.actions.recoverInscription([txid, vout, offset].join(':')));
+      },
+    }),
+    [discardedInscriptions, dispatch]
+  );
 }

--- a/src/app/store/settings/settings.slice.ts
+++ b/src/app/store/settings/settings.slice.ts
@@ -6,11 +6,14 @@ interface InitialState {
   userSelectedTheme: UserSelectedTheme;
   dismissedMessages: string[];
   isPrivateMode?: boolean;
+  bypassInscriptionChecks?: boolean;
+  discardedInscriptions: string[];
 }
 
 const initialState: InitialState = {
   userSelectedTheme: 'system',
   dismissedMessages: [],
+  discardedInscriptions: [],
 };
 
 export const settingsSlice = createSlice({
@@ -29,6 +32,21 @@ export const settingsSlice = createSlice({
     },
     togglePrivateMode(state) {
       state.isPrivateMode = !state.isPrivateMode;
+    },
+    dangerouslyChosenToBypassAllInscriptionChecks(state) {
+      state.bypassInscriptionChecks = true;
+    },
+    discardInscription(state, action: PayloadAction<string>) {
+      if (!Array.isArray(state.discardedInscriptions)) state.discardedInscriptions = [];
+      state.discardedInscriptions.push(action.payload);
+    },
+    recoverInscription(state, action: PayloadAction<string>) {
+      state.discardedInscriptions = state.discardedInscriptions.filter(
+        inscriptionId => inscriptionId !== action.payload
+      );
+    },
+    resetInscriptionState(state) {
+      state.discardedInscriptions = [];
     },
   },
 });

--- a/src/app/ui/components/account/account.card.stories.tsx
+++ b/src/app/ui/components/account/account.card.stories.tsx
@@ -33,7 +33,8 @@ export function AccountCard() {
   return (
     <Component
       name="leather.btc"
-      balance="$1,000"
+      availableBalance="$1,000"
+      totalBalance="$1,000"
       toggleSwitchAccount={() => null}
       isLoadingBalance={false}
       isFetchingBnsName={false}
@@ -52,7 +53,8 @@ export function AccountCardLoading() {
   return (
     <Component
       name="leather.btc"
-      balance="$1,000"
+      availableBalance="$1,000"
+      totalBalance="$1,000"
       toggleSwitchAccount={() => null}
       isLoadingBalance
       isFetchingBnsName={false}
@@ -71,7 +73,8 @@ export function AccountCardBnsNameLoading() {
   return (
     <Component
       name="leather.btc"
-      balance="$1,000"
+      availableBalance="$1,000"
+      totalBalance="$1,000"
       toggleSwitchAccount={() => null}
       isLoadingBalance={false}
       isFetchingBnsName
@@ -91,7 +94,8 @@ export function AccountCardPrivateBalance() {
   return (
     <Component
       name="leather.btc"
-      balance="$1,000"
+      availableBalance="$1,000"
+      totalBalance="$1,000"
       toggleSwitchAccount={() => null}
       isLoadingBalance={false}
       isFetchingBnsName={false}

--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -4,27 +4,38 @@ import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { Box, Flex, styled } from 'leather-styles/jsx';
 
-import { ChevronDownIcon, Link, SkeletonLoader, shimmerStyles } from '@leather.io/ui';
+import {
+  ChevronDownIcon,
+  Flag,
+  InfoCircleIcon,
+  Link,
+  SkeletonLoader,
+  shimmerStyles,
+} from '@leather.io/ui';
 
 import { useScaleText } from '@app/common/hooks/use-scale-text';
 import { AccountNameLayout } from '@app/components/account/account-name';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
 
+import { BasicTooltip } from '../tooltip/basic-tooltip';
+
 interface AccountCardProps {
   name: string;
-  balance: string;
+  availableBalance: string;
+  totalBalance: string;
   children: ReactNode;
-  toggleSwitchAccount(): void;
   isFetchingBnsName: boolean;
   isLoadingBalance: boolean;
   isLoadingAdditionalData?: boolean;
   isBalancePrivate?: boolean;
+  toggleSwitchAccount(): void;
   onShowBalance?(): void;
 }
 
 export function AccountCard({
   name,
-  balance,
+  availableBalance,
+  totalBalance,
   toggleSwitchAccount,
   onShowBalance,
   children,
@@ -89,9 +100,28 @@ export function AccountCard({
                 display="inline-block"
                 overflow="hidden"
               >
-                {balance}
+                {totalBalance}
               </PrivateTextLayout>
             </styled.h1>
+            <styled.h2 textStyle="label.02" color="ink.text-subdued" mt="space.01">
+              Available balance:
+              <styled.span ml="space.01">
+                <BasicTooltip
+                  side="right"
+                  label="Some funds may be unavailable to protect your collectible assets. Disable protection to access your remaining balance."
+                >
+                  <Flag
+                    reverse
+                    spacing="space.01"
+                    img={
+                      <InfoCircleIcon color="ink.text-subdued" display="inline" variant="small" />
+                    }
+                  >
+                    {availableBalance}
+                  </Flag>
+                </BasicTooltip>
+              </styled.span>
+            </styled.h2>
           </SkeletonLoader>
         </Box>
         {children}

--- a/tests/page-object-models/onboarding.page.ts
+++ b/tests/page-object-models/onboarding.page.ts
@@ -42,6 +42,7 @@ export const testSoftwareAccountDefaultWalletState = {
   networks: { ids: [], entities: {}, currentNetworkId: 'mainnet' },
   ordinals: {},
   settings: {
+    discardedInscriptions: [],
     userSelectedTheme: 'system',
     dismissedMessages: [],
   },

--- a/tests/specs/ledger/ledger.spec.ts
+++ b/tests/specs/ledger/ledger.spec.ts
@@ -50,10 +50,7 @@ test.describe('App with Ledger', () => {
 
           await homePage.page.getByTestId(SettingsSelectors.CurrentAccountDisplayName).click();
 
-          await test
-            .expect(async () => await test.expect(requestPromise).rejects.toThrowError())
-            .toPass()
-            .catch();
+          test.expect(async () => await test.expect(requestPromise).rejects.toThrowError());
         });
       }
 


### PR DESCRIPTION
> Try out Leather build 67589f4 — [Extension build](https://github.com/leather-io/extension/actions/runs/12466805600), [Test report](https://leather-io.github.io/playwright-reports/feat/add-ignore-inscriptions-ui), [Storybook](https://feat/add-ignore-inscriptions-ui--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/add-ignore-inscriptions-ui)<!-- Sticky Header Marker -->

This PR adds more granular control for UTXOs. Now we track discarded UTXOs in setting slice, by `txid:vout:offset`. 

A user might discard an one inscription on a UTXO, but not the second one, on the same UTXO. A UTXO is only spendable if **all** inscriptions on it are discarded.

In the UI, there's a dropdown from which users can "unprotect" inscriptions. This helps users spend funds with trash BRC-20 inscriptions on them.

This feature only works for **native segwit inscriptions**. Protecting/unprotecting taproot inscriptions does nothing. The UI is functional but not perfect, e.g. how hover events work on the inscription cards.

Next year, I want to jump straight on a refactor of this work. Much code here should live elsewhere, and all UTXOs should be treated equal, regardless of payment type. 