### PR TITLE
feat: add sip10s to account total balance

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -100,7 +100,7 @@
     "sponsorshipsEnabled": true,
     "sponsorshipApiUrl": {
       "mainnet": "https://sponsor.leather.io",
-      "testnet": "http://testnet-13-60-14-218.nip.io"
+      "testnet": "https://sponsor-testnet.leather.io"
     },
     "contracts": {
       "mainnet": {

--- a/src/app/common/hooks/balance/use-sip10-balance.tsx
+++ b/src/app/common/hooks/balance/use-sip10-balance.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+
+import type { Money } from '@leather.io/models';
+import {
+  baseCurrencyAmountInQuote,
+  createMoney,
+  isDefined,
+  isMoneyGreaterThanZero,
+  sumMoney,
+} from '@leather.io/utils';
+
+import { useSip10FiatMarketData } from '../use-calculate-sip10-fiat-value';
+import { useCombinedFilteredSip10Tokens } from '../use-filtered-sip10-tokens';
+import { type AssetFilter, useManageTokens } from '../use-manage-tokens';
+
+interface UseSip10ManagedTokensBalanceArgs {
+  stxAddress: string;
+  assetFilter?: AssetFilter;
+}
+
+export function useSip10ManagedTokensBalance({
+  stxAddress,
+  assetFilter = 'all',
+}: UseSip10ManagedTokensBalanceArgs) {
+  const { getTokenMarketData } = useSip10FiatMarketData();
+  const { allTokens = [], supportedTokens } = useCombinedFilteredSip10Tokens({
+    address: stxAddress,
+    filter: 'all',
+  });
+  const { filterTokens } = useManageTokens();
+  const preEnabledTokensIds = supportedTokens.map(t => t.info.contractId);
+  const managedTokens = filterTokens({
+    tokens: allTokens,
+    filter: assetFilter,
+    getTokenId: t => t.info.contractId,
+    preEnabledTokensIds,
+  });
+
+  const balance = useMemo(() => {
+    const baseBalance: Money = createMoney(0, 'USD');
+    return sumMoney([
+      baseBalance,
+      ...managedTokens
+        .map(token => {
+          const tokenMarketData = getTokenMarketData(
+            token.info.contractId,
+            token.balance.availableBalance.symbol
+          );
+          if (
+            !tokenMarketData ||
+            !token.balance.availableBalance ||
+            !isMoneyGreaterThanZero(tokenMarketData.price)
+          )
+            return;
+          return baseCurrencyAmountInQuote(token.balance.availableBalance, tokenMarketData);
+        })
+        .filter(isDefined),
+    ]);
+  }, [managedTokens, getTokenMarketData]);
+
+  return balance;
+}

--- a/src/app/common/hooks/balance/use-total-balance.tsx
+++ b/src/app/common/hooks/balance/use-total-balance.tsx
@@ -8,6 +8,8 @@ import { baseCurrencyAmountInQuote, createMoney, i18nFormatCurrency } from '@lea
 
 import { useBtcCryptoAssetBalanceNativeSegwit } from '@app/query/bitcoin/balance/btc-balance-native-segwit.hooks';
 
+import { useSip10ManagedTokensBalance } from './use-sip10-balance';
+
 interface UseTotalBalanceArgs {
   btcAddress: string;
   stxAddress: string;
@@ -38,12 +40,18 @@ export function useTotalBalance({ btcAddress, stxAddress }: UseTotalBalanceArgs)
     isLoadingAdditionalData: isLoadingAdditionalDataBtcBalance,
   } = useBtcCryptoAssetBalanceNativeSegwit(btcAddress);
 
+  // get sip10 balance
+  const sip10BalanceUsd = useSip10ManagedTokensBalance({ stxAddress, assetFilter: 'enabled' });
+
   return useMemo(() => {
     // calculate total balance
     const stxUsdAmount = baseCurrencyAmountInQuote(stxBalance, stxMarketData);
     const btcUsdAmount = baseCurrencyAmountInQuote(btcBalance.availableBalance, btcMarketData);
 
-    const totalBalance = { ...stxUsdAmount, amount: stxUsdAmount.amount.plus(btcUsdAmount.amount) };
+    const totalBalance = {
+      ...stxUsdAmount,
+      amount: stxUsdAmount.amount.plus(btcUsdAmount.amount).plus(sip10BalanceUsd.amount),
+    };
     return {
       isFetching: isFetchingStxBalance || isFetchingBtcBalance,
       isLoading: isLoadingStxBalance || isLoadingBtcBalance,
@@ -73,5 +81,6 @@ export function useTotalBalance({ btcAddress, stxAddress }: UseTotalBalanceArgs)
     isLoadingAdditionalDataStxBalance,
     stxAddress,
     btcAddress,
+    sip10BalanceUsd,
   ]);
 }


### PR DESCRIPTION
> Try out Leather build 5fbcb4b — [Extension build](https://github.com/leather-io/extension/actions/runs/12464569844), [Test report](https://leather-io.github.io/playwright-reports/feat/total-balance-add-sip10), [Storybook](https://feat/total-balance-add-sip10--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/total-balance-add-sip10)<!-- Sticky Header Marker -->

PR adds SIP10 tokens to the home and account selection total balance.

Integrates dynamically with Managed Tokens to only include enabled tokens.


https://github.com/user-attachments/assets/a2ecba7e-51ed-48db-8853-1a74a1c6e531

