### PR TITLE
fix: sbtc swap updates and bugs

### DIFF
--- a/src/app/features/activity-list/activity-list.utils.ts
+++ b/src/app/features/activity-list/activity-list.utils.ts
@@ -2,8 +2,11 @@ import { AddressTransactionWithTransfers } from '@stacks/stacks-blockchain-api-t
 
 import type { BitcoinTx } from '@leather.io/models';
 
-import {
+import type { SbtcDeposit } from '@app/query/sbtc/sbtc-deposits.query';
+
+import type {
   TransactionListBitcoinTx,
+  TransactionListSbtcDeposit,
   TransactionListStacksTx,
 } from './components/transaction-list/transaction-list.model';
 
@@ -21,6 +24,13 @@ function createStacksTxTypeWrapper(tx: AddressTransactionWithTransfers): Transac
   };
 }
 
+function createSbtcDepositTxTypeWrapper(deposit: SbtcDeposit): TransactionListSbtcDeposit {
+  return {
+    blockchain: 'bitcoin-stacks',
+    deposit,
+  };
+}
+
 export function convertBitcoinTxsToListType(txs?: BitcoinTx[]) {
   if (!txs) return [];
   const confirmedTxs = txs.filter(tx => tx.status.confirmed);
@@ -30,4 +40,9 @@ export function convertBitcoinTxsToListType(txs?: BitcoinTx[]) {
 export function convertStacksTxsToListType(txs?: AddressTransactionWithTransfers[]) {
   if (!txs) return [];
   return txs.map(tx => createStacksTxTypeWrapper(tx));
+}
+
+export function convertSbtcDepositToListType(deposits?: SbtcDeposit[]) {
+  if (!deposits) return [];
+  return deposits.map(deposit => createSbtcDepositTxTypeWrapper(deposit));
 }

--- a/src/app/features/activity-list/components/pending-transaction-list/pending-transaction-list.tsx
+++ b/src/app/features/activity-list/components/pending-transaction-list/pending-transaction-list.tsx
@@ -5,18 +5,18 @@ import type { BitcoinTx } from '@leather.io/models';
 import { BitcoinTransactionItem } from '@app/components/bitcoin-transaction-item/bitcoin-transaction-item';
 import { SbtcDepositTransactionItem } from '@app/components/sbtc-deposit-status-item/sbtc-deposit-status-item';
 import { StacksTransactionItem } from '@app/components/stacks-transaction-item/stacks-transaction-item';
-import type { SbtcDepositInfo } from '@app/query/sbtc/sbtc-deposits.query';
+import type { SbtcDeposit } from '@app/query/sbtc/sbtc-deposits.query';
 
 import { PendingTransactionListLayout } from './pending-transaction-list.layout';
 
 interface PendingTransactionListProps {
   bitcoinTxs: BitcoinTx[];
-  sBtcDeposits: SbtcDepositInfo[];
+  sbtcDeposits: SbtcDeposit[];
   stacksTxs: MempoolTransaction[];
 }
 export function PendingTransactionList({
   bitcoinTxs,
-  sBtcDeposits,
+  sbtcDeposits,
   stacksTxs,
 }: PendingTransactionListProps) {
   return (
@@ -24,7 +24,7 @@ export function PendingTransactionList({
       {bitcoinTxs.map(tx => (
         <BitcoinTransactionItem key={tx.txid} transaction={tx} />
       ))}
-      {sBtcDeposits.map(deposit => (
+      {sbtcDeposits.map(deposit => (
         <SbtcDepositTransactionItem key={deposit.bitcoinTxid} deposit={deposit} />
       ))}
       {stacksTxs.map(tx => (

--- a/src/app/features/activity-list/components/transaction-list/transaction-list-item.tsx
+++ b/src/app/features/activity-list/components/transaction-list/transaction-list-item.tsx
@@ -1,3 +1,5 @@
+import { SbtcDepositTransactionItem } from '@app/components/sbtc-deposit-status-item/sbtc-deposit-status-item';
+
 import { BitcoinTransaction } from './bitcoin-transaction/bitcoin-transaction';
 import { StacksTransaction } from './stacks-transaction/stacks-transaction';
 import { TransactionListTxs } from './transaction-list.model';
@@ -11,6 +13,8 @@ export function TransactionListItem({ tx }: TransactionListItemProps) {
       return <BitcoinTransaction transaction={tx.transaction} />;
     case 'stacks':
       return <StacksTransaction transaction={tx.transaction} />;
+    case 'bitcoin-stacks':
+      return <SbtcDepositTransactionItem deposit={tx.deposit} />;
     default:
       return null;
   }

--- a/src/app/features/activity-list/components/transaction-list/transaction-list.model.ts
+++ b/src/app/features/activity-list/components/transaction-list/transaction-list.model.ts
@@ -1,15 +1,25 @@
 import { AddressTransactionWithTransfers } from '@stacks/stacks-blockchain-api-types';
 
-import type { BitcoinTx, Blockchain } from '@leather.io/models';
+import type { BitcoinTx } from '@leather.io/models';
+
+import type { SbtcDeposit } from '@app/query/sbtc/sbtc-deposits.query';
 
 export interface TransactionListBitcoinTx {
-  blockchain: Extract<Blockchain, 'bitcoin'>;
+  blockchain: 'bitcoin';
   transaction: BitcoinTx;
 }
 
 export interface TransactionListStacksTx {
-  blockchain: Extract<Blockchain, 'stacks'>;
+  blockchain: 'stacks';
   transaction: AddressTransactionWithTransfers;
 }
 
-export type TransactionListTxs = TransactionListBitcoinTx | TransactionListStacksTx;
+export interface TransactionListSbtcDeposit {
+  blockchain: 'bitcoin-stacks';
+  deposit: SbtcDeposit;
+}
+
+export type TransactionListTxs =
+  | TransactionListBitcoinTx
+  | TransactionListStacksTx
+  | TransactionListSbtcDeposit;

--- a/src/app/features/activity-list/components/transaction-list/transaction-list.tsx
+++ b/src/app/features/activity-list/components/transaction-list/transaction-list.tsx
@@ -5,19 +5,25 @@ import { Box } from 'leather-styles/jsx';
 import { useTransactionListRender } from './hooks/use-transaction-list-render';
 import { TransactionListItem } from './transaction-list-item';
 import { TransactionListLayout } from './transaction-list.layout';
-import { TransactionListBitcoinTx, TransactionListStacksTx } from './transaction-list.model';
+import type {
+  TransactionListBitcoinTx,
+  TransactionListSbtcDeposit,
+  TransactionListStacksTx,
+} from './transaction-list.model';
 import { createTxDateFormatList, getTransactionId } from './transaction-list.utils';
 import { TransactionsByDateLayout } from './transactions-by-date.layout';
 
 interface TransactionListProps {
   bitcoinTxs: TransactionListBitcoinTx[];
   stacksTxs: TransactionListStacksTx[];
+  sbtcDeposits: TransactionListSbtcDeposit[];
   currentBitcoinAddress: string;
 }
 
 export function TransactionList({
   bitcoinTxs,
   stacksTxs,
+  sbtcDeposits,
   currentBitcoinAddress,
 }: TransactionListProps) {
   const { intersectionSentinel, visibleTxsNum } = useTransactionListRender({
@@ -25,8 +31,10 @@ export function TransactionList({
   });
   const txsGroupedByDate = useMemo(
     () =>
-      bitcoinTxs.length || stacksTxs.length ? createTxDateFormatList(bitcoinTxs, stacksTxs) : [],
-    [bitcoinTxs, stacksTxs]
+      bitcoinTxs.length || stacksTxs.length || sbtcDeposits.length
+        ? createTxDateFormatList(bitcoinTxs, stacksTxs, sbtcDeposits)
+        : [],
+    [bitcoinTxs, sbtcDeposits, stacksTxs]
   );
 
   const groupedByDateTxsLength = useMemo(() => {

--- a/src/app/features/activity-list/components/transaction-list/transaction-list.utils.ts
+++ b/src/app/features/activity-list/components/transaction-list/transaction-list.utils.ts
@@ -3,8 +3,9 @@ import dayjs from 'dayjs';
 import { isUndefined } from '@leather.io/utils';
 
 import { displayDate, isoDateToLocalDateSafe, todaysIsoDate } from '@app/common/date-utils';
-import {
+import type {
   TransactionListBitcoinTx,
+  TransactionListSbtcDeposit,
   TransactionListStacksTx,
   TransactionListTxs,
 } from '@app/features/activity-list/components/transaction-list/transaction-list.model';
@@ -30,6 +31,8 @@ function getTransactionTime(listTx: TransactionListTxs) {
         listTx.transaction.tx.burn_block_time_iso ||
         listTx.transaction.tx.parent_burn_block_time_iso
       );
+    case 'bitcoin-stacks':
+      return listTx.deposit.block?.burn_block_time_iso;
     default:
       return undefined;
   }
@@ -51,6 +54,8 @@ function getTransactionBlockHeight(listTx: TransactionListTxs) {
       return listTx.transaction.status.block_height;
     case 'stacks':
       return listTx.transaction.tx.block_height;
+    case 'bitcoin-stacks':
+      return listTx.deposit.block?.height ?? listTx.deposit.lastUpdateHeight;
     default:
       return undefined;
   }
@@ -141,10 +146,11 @@ function sortGroupedTransactions(
 
 export function createTxDateFormatList(
   bitcoinTxs: TransactionListBitcoinTx[],
-  stacksTxs: TransactionListStacksTx[]
+  stacksTxs: TransactionListStacksTx[],
+  sbtcDeposits: TransactionListSbtcDeposit[]
 ) {
   const formattedTxs = formatTxDateMapAsList(
-    groupTxsByDateMap([...bitcoinTxs, ...filterDuplicateStacksTxs(stacksTxs)])
+    groupTxsByDateMap([...bitcoinTxs, ...filterDuplicateStacksTxs(stacksTxs), ...sbtcDeposits])
   );
   return sortGroupedTransactions(formattedTxs);
 }

--- a/src/app/pages/swap/bitflow-swap.utils.ts
+++ b/src/app/pages/swap/bitflow-swap.utils.ts
@@ -57,7 +57,7 @@ export function getCrossChainSwapSubmissionData(values: SwapFormValues): SwapSub
     feeType: BtcFeeType.Standard,
     liquidityFee: 0,
     maxSignerFee: 0,
-    protocol: 'Bitcoin L2 Labs',
+    protocol: 'sBTC Protocol',
     dexPath: [],
     router: [values.swapAssetBase, values.swapAssetQuote].filter(isDefined),
     slippage: 0,

--- a/src/app/pages/swap/components/swap-details/swap-detail.layout.tsx
+++ b/src/app/pages/swap/components/swap-details/swap-detail.layout.tsx
@@ -4,16 +4,19 @@ import { Box, HStack, styled } from 'leather-styles/jsx';
 
 import { InfoCircleIcon } from '@leather.io/ui';
 
+import { openInNewTab } from '@app/common/utils/open-in-new-tab';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
 interface SwapDetailLayoutProps {
   dataTestId?: string;
+  moreInfoUrl?: string;
   title: string;
   tooltipLabel?: string;
   value: ReactNode;
 }
 export function SwapDetailLayout({
   dataTestId,
+  moreInfoUrl,
   title,
   tooltipLabel,
   value,
@@ -30,6 +33,11 @@ export function SwapDetailLayout({
               <InfoCircleIcon variant="small" />
             </Box>
           </BasicTooltip>
+        ) : null}
+        {moreInfoUrl ? (
+          <styled.button onClick={() => openInNewTab(moreInfoUrl)} type="button">
+            <InfoCircleIcon variant="small" />
+          </styled.button>
         ) : null}
       </HStack>
       <styled.span data-testid={dataTestId} textStyle="label.02">

--- a/src/app/pages/swap/components/swap-details/swap-details.tsx
+++ b/src/app/pages/swap/components/swap-details/swap-details.tsx
@@ -7,7 +7,7 @@ import {
   convertAmountToBaseUnit,
   createMoney,
   createMoneyFromDecimal,
-  formatMoneyPadded,
+  formatMoney,
   isDefined,
   isUndefined,
   satToBtc,
@@ -31,11 +31,12 @@ function RouteNames(props: { swapSubmissionData: SwapSubmissionData }) {
   });
 }
 
+const sbtcMoreInfoUrl = 'https://github.com/stacks-network/sbtc-bridge';
 const sponsoredFeeLabel =
   'Sponsorship may not apply when you have pending transactions. In such cases, if you choose to proceed, the associated costs will be deducted from your balance.';
 
 export function SwapDetails() {
-  const { swapSubmissionData } = useSwapContext();
+  const { isCrossChainSwap, swapSubmissionData } = useSwapContext();
 
   if (
     isUndefined(swapSubmissionData) ||
@@ -46,7 +47,7 @@ export function SwapDetails() {
 
   const maxSignerFee = satToBtc(swapSubmissionData.maxSignerFee ?? 0);
 
-  const formattedMinToReceive = formatMoneyPadded(
+  const formattedMinToReceive = formatMoney(
     createMoneyFromDecimal(
       new BigNumber(swapSubmissionData.swapAmountQuote)
         .times(1 - swapSubmissionData.slippage)
@@ -69,6 +70,7 @@ export function SwapDetails() {
     <SwapDetailsLayout>
       <SwapDetailLayout
         dataTestId={SwapSelectors.SwapDetailsProtocol}
+        moreInfoUrl={isCrossChainSwap ? sbtcMoreInfoUrl : undefined}
         title="Powered by"
         value={getFormattedPoweredBy()}
       />

--- a/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
+++ b/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
@@ -37,7 +37,7 @@ import type { SwapSubmissionData } from '../swap.context';
 
 // Also set as defaults in sbtc lib
 const maxSignerFee = 80_000;
-const reclaimLockTime = 144;
+const reclaimLockTime = 12;
 
 interface SbtcDeposit {
   address: string;

--- a/src/app/pages/swap/hooks/use-swap-assets-from-route.ts
+++ b/src/app/pages/swap/hooks/use-swap-assets-from-route.ts
@@ -9,7 +9,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { useSwapContext } from '../swap.context';
 
 export function useSwapAssetsFromRoute() {
-  const { swappableAssetsBase, swappableAssetsQuote } = useSwapContext();
+  const { onSetIsCrossChainSwap, swappableAssetsBase, swappableAssetsQuote } = useSwapContext();
   const { setFieldValue, values, validateForm } = useFormikContext<SwapFormValues>();
   const { base, quote } = useParams();
   const navigate = useNavigate();
@@ -32,10 +32,12 @@ export function useSwapAssetsFromRoute() {
         'swapAssetQuote',
         swappableAssetsQuote.find(asset => asset.name === quote)
       );
+    if (base === 'BTC') onSetIsCrossChainSwap(true);
     void validateForm();
   }, [
     base,
     navigate,
+    onSetIsCrossChainSwap,
     quote,
     setFieldValue,
     swappableAssetsBase,

--- a/src/app/pages/swap/hooks/use-swap-form.tsx
+++ b/src/app/pages/swap/hooks/use-swap-form.tsx
@@ -79,6 +79,19 @@ export function useSwapForm() {
         },
       })
       .test({
+        message: 'Decimal precision not supported',
+        test(value) {
+          if (!value || isFetchingExchangeRate) return true;
+          const { swapAssetBase } = this.parent;
+          const numStr = value.toString();
+          if (numStr.includes('e')) {
+            const exponent = Math.abs(parseInt(value.toExponential().split('e')[1], 10));
+            if (exponent > swapAssetBase.balance.decimals) return false;
+          }
+          return true;
+        },
+      })
+      .test({
         message: `Min amount is ${convertAmountToBaseUnit(sBtcDepositCapMin).toString()} BTC`,
         test(value) {
           if (!isCrossChainSwap) return true;

--- a/src/app/query/sbtc/get-stacks-block.query.ts
+++ b/src/app/query/sbtc/get-stacks-block.query.ts
@@ -1,0 +1,53 @@
+import { useQueries } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { getHiroApiRateLimiter } from '@leather.io/query';
+
+import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
+
+export interface StacksBlock {
+  canonical: boolean;
+  height: number;
+  hash: string;
+  block_time: number;
+  block_time_iso: string;
+  index_block_hash: string;
+  parent_block_hash: string;
+  parent_index_block_hash: string;
+  burn_block_time: number;
+  burn_block_time_iso: string;
+  burn_block_hash: string;
+  burn_block_height: number;
+  miner_txid: string;
+  tx_count: number;
+  execution_cost_read_count: number;
+  execution_cost_read_length: number;
+  execution_cost_runtime: number;
+  execution_cost_write_count: number;
+  execution_cost_write_length: number;
+}
+
+async function getStacksBlock(basePath: string, block: number): Promise<StacksBlock> {
+  const rateLimiter = getHiroApiRateLimiter(basePath);
+  const resp = await rateLimiter.add(() => axios.get(`${basePath}/extended/v2/blocks/${block}`), {
+    priority: 3,
+    throwOnTimeout: true,
+  });
+  return resp.data;
+}
+
+function makeGetStacksBlockQuery(basePath: string, block: number) {
+  return {
+    queryKey: ['get-stacks-block', block],
+    async queryFn() {
+      return getStacksBlock(basePath, block);
+    },
+  };
+}
+
+export function useGetStacksBlocks(blocks: number[]) {
+  const network = useCurrentNetwork();
+  return useQueries({
+    queries: blocks.map(block => makeGetStacksBlockQuery(network.chain.stacks.url, block)),
+  });
+}


### PR DESCRIPTION
> Try out Leather build 1ed6f9c — [Extension build](https://github.com/leather-io/extension/actions/runs/12445862373), [Test report](https://leather-io.github.io/playwright-reports/fix/sbtc-swap-bugs), [Storybook](https://fix/sbtc-swap-bugs--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/sbtc-swap-bugs)<!-- Sticky Header Marker -->

- Fixes swaps coming from earn, using openSwap
- Adds confirmed and failed states to activity list
- Adds reclaim button to failed deposits
- Updates protocol label in swap review and links to sbtc-bridge in GH
- Removed trailing decimals from swap review
- Fixed exponential number in swap amount field

From earn...
![Screenshot 2024-12-19 at 9 30 44 AM](https://github.com/user-attachments/assets/142edb32-0ba3-4de9-a086-7562f85392a4)

Confirmed deposit in feed...
![Screenshot 2024-12-20 at 11 52 30 AM](https://github.com/user-attachments/assets/01394820-93f4-48aa-bb92-efaebfcf3709)

Failed deposit in feed...
![Screenshot 2024-12-20 at 12 21 56 PM](https://github.com/user-attachments/assets/aaa16cea-e66a-4988-b7fb-e257d5bef14c)

Protocol and removed trailing decimals...
![Screenshot 2024-12-20 at 2 43 49 PM](https://github.com/user-attachments/assets/7899f7ed-1269-4137-a4c8-9fe523c34905)

Exponential number fixed...
![Screenshot 2024-12-19 at 1 44 26 PM](https://github.com/user-attachments/assets/71ebfe20-b663-4c50-88a5-8464ed026207)
