### PR TITLE
fix: issue with zindex over iframe inscriptions

### DIFF
--- a/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -128,7 +128,7 @@ export function Inscription({ inscription }: InscriptionProps) {
           position="absolute"
           right="space.03"
           top="space.03"
-          zIndex="90"
+          zIndex="900"
         >
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
@@ -141,7 +141,7 @@ export function Inscription({ inscription }: InscriptionProps) {
                 icon={<EllipsisVIcon variant="small" />}
               />
             </DropdownMenu.Trigger>
-            <DropdownMenu.Content side="bottom" style={{ marginRight: '96px' }}>
+            <DropdownMenu.Content side="bottom">
               <DropdownMenu.Item onClick={() => openInscriptionUrl(inscription.number)}>
                 <Flag img={<ExternalLinkIcon variant="small" />}>Open original</Flag>
               </DropdownMenu.Item>


### PR DESCRIPTION
> Try out Leather build 27a976c — [Extension build](https://github.com/leather-io/extension/actions/runs/12469413241), [Test report](https://leather-io.github.io/playwright-reports/fix/zindex-issue), [Storybook](https://fix/zindex-issue--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/zindex-issue)<!-- Sticky Header Marker -->

Was a bit to quick to change zindex without testing. Increasing ensures its above the iframe inscriptions 

re https://trustmachines.slack.com/archives/C05114YP8CV/p1734968738355959?thread_ts=1734967172.562709&cid=C05114YP8CV 

cc/ @brandonmarshall-tm 