### PR TITLE
feat: add rpc send transfer test

### DIFF
--- a/tests/mocks/mock-bitcoin-tx.ts
+++ b/tests/mocks/mock-bitcoin-tx.ts
@@ -1,0 +1,13 @@
+import type { Page } from '@playwright/test';
+
+import { BITCOIN_API_BASE_URL_TESTNET3 } from '@leather.io/models';
+
+import { mockMainnetNsTransactionsTestAccount } from './mock-utxos';
+
+export async function mockTestAccountBtcBroadcastTransaction(page: Page) {
+  await page.route(`${BITCOIN_API_BASE_URL_TESTNET3}/tx`, route =>
+    route.fulfill({
+      body: mockMainnetNsTransactionsTestAccount[0].txid,
+    })
+  );
+}

--- a/tests/mocks/mock-utxos.ts
+++ b/tests/mocks/mock-utxos.ts
@@ -42,7 +42,8 @@ export const mockUtxosListWithRunes = [
     value: 546,
   },
 ];
-const mockMainnetNsTransactionsTestAccount = [
+
+export const mockMainnetNsTransactionsTestAccount = [
   {
     txid: '58d44000884f0ba4cdcbeb1ac082e6c802d300c16b0d3251738e8cf6a57397ce',
     version: 2,

--- a/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
+++ b/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
@@ -1,0 +1,87 @@
+import { BrowserContext, Page } from '@playwright/test';
+import { TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS } from '@tests/mocks/constants';
+import { mockTestAccountBtcBroadcastTransaction } from '@tests/mocks/mock-bitcoin-tx';
+
+import { RpcSendTransferParams } from '@leather.io/rpc';
+
+import { test } from '../../fixtures/fixtures';
+
+const baseParams = {
+  recipients: [
+    {
+      address: TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
+      amount: '800',
+    },
+    {
+      address: TEST_TESTNET_ACCOUNT_2_BTC_ADDRESS,
+      amount: '900',
+    },
+  ],
+  network: 'testnet',
+};
+
+test.describe('Send transfer (RPC)', () => {
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await onboardingPage.signInWithTestAccount(extensionId);
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
+  });
+
+  function clickActionButton(context: BrowserContext) {
+    return async (buttonToPress: 'Cancel' | 'Approve') => {
+      const popup = await context.waitForEvent('page');
+      await popup.waitForTimeout(1000);
+      const btn = popup.locator(`text="${buttonToPress}"`);
+      await btn.click();
+    };
+  }
+
+  async function mockPopupRequests(context: BrowserContext) {
+    const popup = await context.waitForEvent('page');
+    await mockTestAccountBtcBroadcastTransaction(popup);
+  }
+
+  function openSendTransfer(page: Page) {
+    return async (params: RpcSendTransferParams) =>
+      page.evaluate(
+        async params =>
+          (window as any).LeatherProvider?.request('sendTransfer', {
+            ...params,
+          }).catch((e: unknown) => e),
+        { ...params }
+      );
+  }
+
+  test('that the request can be broadcasted', async ({ page, context }) => {
+    void mockPopupRequests(context);
+
+    const [result] = await Promise.all([
+      openSendTransfer(page)(baseParams),
+      clickActionButton(context)('Approve'),
+    ]);
+
+    delete result.id;
+
+    test.expect(result).toEqual({
+      jsonrpc: '2.0',
+      result: { txid: '58d44000884f0ba4cdcbeb1ac082e6c802d300c16b0d3251738e8cf6a57397ce' },
+    });
+  });
+
+  test('that the request can be cancelled', async ({ page, context }) => {
+    const [result] = await Promise.all([
+      openSendTransfer(page)(baseParams),
+      clickActionButton(context)('Cancel'),
+    ]);
+
+    delete result.id;
+
+    test.expect(result).toEqual({
+      jsonrpc: '2.0',
+      error: {
+        code: 4001,
+        message: 'User rejected signing the transaction',
+      },
+    });
+  });
+});


### PR DESCRIPTION
> Try out Leather build 431694f — [Extension build](https://github.com/leather-io/extension/actions/runs/12514341819), [Test report](https://leather-io.github.io/playwright-reports/feat/btc-send-transfer-test), [Storybook](https://feat/btc-send-transfer-test--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/btc-send-transfer-test)<!-- Sticky Header Marker -->

This pr adds simple rpc btc send transfer test, which checks if tx can be submitted/rejected
will add test for checking data and fees selection later