### PR TITLE
fix: inscriptions settings btn and available balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "@leather.io/constants": "0.13.5",
     "@leather.io/crypto": "1.6.14",
     "@leather.io/models": "0.24.0",
-    "@leather.io/query": "2.26.9",
+    "@leather.io/query": "2.26.10",
     "@leather.io/stacks": "1.4.0",
     "@leather.io/tokens": "0.12.1",
     "@leather.io/ui": "1.44.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: 0.24.0
         version: 0.24.0
       '@leather.io/query':
-        specifier: 2.26.9
-        version: 2.26.9(encoding@0.1.13)(react@18.3.1)
+        specifier: 2.26.10
+        version: 2.26.10(encoding@0.1.13)(react@18.3.1)
       '@leather.io/stacks':
         specifier: 1.4.0
         version: 1.4.0(encoding@0.1.13)
@@ -3284,8 +3284,8 @@ packages:
   '@leather.io/bitcoin@0.17.0':
     resolution: {integrity: sha512-Nc4Bl2HWmxWvgIXbpa6Gs8EpqR1UJHDzXPu+R+2TIyOsjxFoGXoIQwLohxySnQa4i0UodrCXBrqDOqOTHtwbMQ==}
 
-  '@leather.io/bitcoin@0.19.8':
-    resolution: {integrity: sha512-gqTD8Mtp8cYPcvQd0DnzFNz/uXbghpadPvB8rtB467g4fbjswW/52lOKzazrzNrl+CmQXuCKep4NrTBgTBRNpg==}
+  '@leather.io/bitcoin@0.19.9':
+    resolution: {integrity: sha512-gCc4AcOtv0gAgdMATBlHBBQU0k+Ut3uY9mkhNRQV8ISl2f3sOhLbjN2DAbddpsL77W2+OYFGCDeBVdNjElXsyw==}
 
   '@leather.io/constants@0.13.5':
     resolution: {integrity: sha512-FOh/F/g8WepB8HfoTXsMB/BYcm/F6INPEpyEZc3ljzaN0mLwVLO1kwgMTFU9Pq7tQlITvyWiyGHcB7OYovLoUQ==}
@@ -3326,8 +3326,8 @@ packages:
   '@leather.io/prettier-config@0.6.0':
     resolution: {integrity: sha512-QBKtLanfxFxXBlR58U/j8a6lBI0xzJzqqi36fXpGVp+9mJoEf6Ro6xrtFrixjW6seY6EOva4OApVnnPBsvOC/w==}
 
-  '@leather.io/query@2.26.9':
-    resolution: {integrity: sha512-ijmVE6RoiU+kZY5ApvwkZ5IAXWGZFl18AG2/YBveZNc5ExKjlNnunfqp1UFxE62REwkp8sGIWSsnZpysNosAHw==}
+  '@leather.io/query@2.26.10':
+    resolution: {integrity: sha512-GhOHwDQVkqP5IgM6qzItOrSssN29X6WDQ9YFsvls7a2dA00NB0emSZ+YGM3KNsn6ppXPJJNzwpIhtmGWX/yKlA==}
     peerDependencies:
       react: '*'
 
@@ -19127,7 +19127,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@leather.io/bitcoin@0.19.8(encoding@0.1.13)':
+  '@leather.io/bitcoin@0.19.9(encoding@0.1.13)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.0.2
       '@leather.io/constants': 0.15.2
@@ -19233,11 +19233,11 @@ snapshots:
       - '@vue/compiler-sfc'
       - supports-color
 
-  '@leather.io/query@2.26.9(encoding@0.1.13)(react@18.3.1)':
+  '@leather.io/query@2.26.10(encoding@0.1.13)(react@18.3.1)':
     dependencies:
       '@fungible-systems/zone-file': 2.0.0
       '@hirosystems/token-metadata-api-client': 1.2.0(encoding@0.1.13)
-      '@leather.io/bitcoin': 0.19.8(encoding@0.1.13)
+      '@leather.io/bitcoin': 0.19.9(encoding@0.1.13)
       '@leather.io/constants': 0.15.2
       '@leather.io/models': 0.24.2
       '@leather.io/rpc': 2.4.1(encoding@0.1.13)

--- a/src/app/features/collectibles/components/bitcoin/inscription.tsx
+++ b/src/app/features/collectibles/components/bitcoin/inscription.tsx
@@ -124,6 +124,9 @@ export function Inscription({ inscription }: InscriptionProps) {
       <Box opacity={hasInscriptionBeenDiscarded(inscription) ? 0.5 : 1}>{content}</Box>
       {isHovered && (
         <Box
+          border="1px solid"
+          borderColor="ink.text-primary"
+          borderRadius="2px"
           bg="ink.background-primary"
           position="absolute"
           right="space.03"
@@ -136,9 +139,6 @@ export function Inscription({ inscription }: InscriptionProps) {
                 _focus={{ outline: 'focus' }}
                 _hover={{ bg: 'ink.component-background-hover' }}
                 bg="ink.background-primary"
-                border="1px solid"
-                borderColor="ink.text-primary"
-                borderRadius="2px"
                 transform="rotate(90deg)"
                 color="ink.action-primary-default"
                 icon={<EllipsisVIcon />}

--- a/src/app/pages/home/components/account-actions.tsx
+++ b/src/app/pages/home/components/account-actions.tsx
@@ -1,10 +1,8 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { ChainID } from '@stacks/transactions';
 import { HomePageSelectors } from '@tests/selectors/home.selectors';
 import { Box, Flex } from 'leather-styles/jsx';
 
-import { whenStacksChainId } from '@leather.io/stacks';
 import { ArrowsRepeatLeftRightIcon, CreditCardIcon, IconButton, InboxIcon } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
@@ -16,7 +14,6 @@ import {
 import { useCurrentAccountNativeSegwitIndexZeroSignerNullable } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
-import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
 import { SendButton } from './send-button';
@@ -29,7 +26,6 @@ export function AccountActions() {
   const stacksAccount = useCurrentStacksAccount();
   const currentBtcSigner = useCurrentAccountNativeSegwitIndexZeroSignerNullable();
   const btcAccount = currentBtcSigner?.address;
-  const currentNetwork = useCurrentNetwork();
   const { isTestnet } = useCurrentNetworkState();
 
   const swapsEnabled = useConfigSwapsEnabled();
@@ -57,28 +53,8 @@ export function AccountActions() {
           onClick={() => navigate(RouteUrls.FundChooseCurrency)}
         />
       )}
-      {whenStacksChainId(currentNetwork.chain.stacks.chainId)({
-        [ChainID.Mainnet]: (
-          <BasicTooltip
-            label={swapsEnabled ? '' : <SwapsDisabledTooltipLabel />}
-            side="left"
-            asChild
-          >
-            <Box display="flex">
-              <IconButton
-                data-testid={HomePageSelectors.SwapBtn}
-                disabled={swapsBtnDisabled}
-                icon={<ArrowsRepeatLeftRightIcon />}
-                label="Swap"
-                onClick={() =>
-                  navigate(RouteUrls.Swap.replace(':base', 'STX').replace(':quote', ''))
-                }
-              />
-            </Box>
-          </BasicTooltip>
-        ),
-        // Temporary for sBTC testing
-        [ChainID.Testnet]: (
+      <BasicTooltip label={swapsEnabled ? '' : <SwapsDisabledTooltipLabel />} side="left" asChild>
+        <Box display="flex">
           <IconButton
             data-testid={HomePageSelectors.SwapBtn}
             disabled={swapsBtnDisabled}
@@ -86,8 +62,8 @@ export function AccountActions() {
             label="Swap"
             onClick={() => navigate(RouteUrls.Swap.replace(':base', 'STX').replace(':quote', ''))}
           />
-        ),
-      })}
+        </Box>
+      </BasicTooltip>
     </Flex>
   );
 }

--- a/src/app/pages/home/components/account-actions.tsx
+++ b/src/app/pages/home/components/account-actions.tsx
@@ -15,6 +15,7 @@ import {
 } from '@app/query/common/remote-config/remote-config.query';
 import { useCurrentAccountNativeSegwitIndexZeroSignerNullable } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+import { useCurrentNetworkState } from '@app/store/networks/networks.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
@@ -29,8 +30,10 @@ export function AccountActions() {
   const currentBtcSigner = useCurrentAccountNativeSegwitIndexZeroSignerNullable();
   const btcAccount = currentBtcSigner?.address;
   const currentNetwork = useCurrentNetwork();
+  const { isTestnet } = useCurrentNetworkState();
+
   const swapsEnabled = useConfigSwapsEnabled();
-  const swapsBtnDisabled = !swapsEnabled || !stacksAccount;
+  const swapsBtnDisabled = !swapsEnabled || !stacksAccount || isTestnet;
 
   const receivePath = isBitcoinEnabled
     ? RouteUrls.Receive

--- a/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stacks/stacks-common-send-form.tsx
@@ -44,7 +44,6 @@ export function StacksCommonSendForm({
   amountField,
   selectedAssetField,
   fees,
-
   availableTokenBalance,
 }: StacksCommonSendFormProps) {
   const navigate = useNavigate();

--- a/src/app/query/bitcoin/balance/btc-balance-native-segwit.hooks.ts
+++ b/src/app/query/bitcoin/balance/btc-balance-native-segwit.hooks.ts
@@ -44,7 +44,7 @@ export function useBtcCryptoAssetBalanceNativeSegwit(address: string) {
       ...defaultZeroValues,
       totalBalance: createMoney(sumNumbers(totalUtxosQuery.data.map(utxo => utxo.value)), 'BTC'),
       availableBalance: createMoney(
-        // Here we add back in the utxos that are spending beacuse they've been discarded
+        // Here we add back in the utxos that are spending because they've been discarded
         sumNumbers(
           [
             ...filterOutNativeSegwitInscriptions(totalUtxosQuery.data),

--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -21,7 +21,7 @@ import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
 import { BasicTooltip } from '../tooltip/basic-tooltip';
 
 const availableBalanceTooltipLabel =
-  'Total balance minus locked amounts, outbound transfers, protected collectibles and uneconomical UTXOs';
+  'Total balance minus locked amounts, outbound transfers, protected collectibles and uneconomical UTXOs.';
 
 interface AccountCardProps {
   name: string;

--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -21,7 +21,7 @@ import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
 import { BasicTooltip } from '../tooltip/basic-tooltip';
 
 const availableBalanceTooltipLabel =
-  'Total balance minus outbound transfers, protected collectibles and uneconomical UTXOs.';
+  'Total balance minus locked amounts, outbound transfers, protected collectibles and uneconomical UTXOs';
 
 interface AccountCardProps {
   name: string;

--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -21,7 +21,7 @@ import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
 import { BasicTooltip } from '../tooltip/basic-tooltip';
 
 const availableBalanceTooltipLabel =
-  'Total balance minus locked amounts, outbound transfers, protected collectibles and uneconomical UTXOs.';
+  'Total balance minus locked amounts, outbound transfers, protected collectibles and uneconomical UTXOs';
 
 interface AccountCardProps {
   name: string;

--- a/tests/page-object-models/onboarding.page.ts
+++ b/tests/page-object-models/onboarding.page.ts
@@ -12,7 +12,7 @@ const TEST_ACCOUNT_SECRET_KEY = process.env.TEST_ACCOUNT_SECRET_KEY ?? '';
 
 // If default wallet state changes, we'll need to update this
 export const testSoftwareAccountDefaultWalletState = {
-  chains: { stx: { default: { highestAccountIndex: 1, currentAccountIndex: 0 } } },
+  chains: { stx: { default: { highestAccountIndex: 2, currentAccountIndex: 0 } } },
   appPermissions: {
     entities: {},
     ids: [],


### PR DESCRIPTION
> Try out Leather build 3a1b17e — [Extension build](https://github.com/leather-io/extension/actions/runs/12679067195), [Test report](https://leather-io.github.io/playwright-reports/fix/inscriptions-settings-btn), [Storybook](https://fix/inscriptions-settings-btn--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/inscriptions-settings-btn)<!-- Sticky Header Marker -->

this pr fixes:
- available balance tooltip text
- disable swaps on testnet
- updates query package to prevent infinite brc20 request, [related pr](https://github.com/leather-io/mono/pull/785)
-  inscription settings btn styles:

![Screenshot 2024-12-27 at 18 57 12](https://github.com/user-attachments/assets/2e59750e-c6ff-48b9-9307-0f9112326d77)

