### PR TITLE
fix(stacks): default to clarity 3, closes #5983

### DIFF
--- a/src/app/common/transactions/stacks/generate-unsigned-txs.ts
+++ b/src/app/common/transactions/stacks/generate-unsigned-txs.ts
@@ -7,6 +7,9 @@ import {
 import { StacksNetwork } from '@stacks/network';
 import {
   AnchorMode,
+  ClarityVersion,
+  type UnsignedContractCallOptions,
+  type UnsignedContractDeployOptions,
   deserializeCV,
   makeUnsignedContractCall,
   makeUnsignedContractDeploy,
@@ -69,7 +72,7 @@ function generateUnsignedContractCallTx(args: GenerateUnsignedContractCallTxArgs
     postConditions: getPostConditions(postConditions),
     network,
     sponsored,
-  };
+  } satisfies UnsignedContractCallOptions;
   return makeUnsignedContractCall(options);
 }
 
@@ -90,7 +93,9 @@ function generateUnsignedContractDeployTx(args: GenerateUnsignedContractDeployTx
     postConditionMode: postConditionMode,
     postConditions: getPostConditions(postConditions),
     network,
-  };
+    clarityVersion: ClarityVersion.Clarity3,
+  } satisfies UnsignedContractDeployOptions;
+
   return makeUnsignedContractDeploy(options);
 }
 


### PR DESCRIPTION
> Try out Leather build 8939971 — [Extension build](https://github.com/leather-io/extension/actions/runs/12708867212), [Test report](https://leather-io.github.io/playwright-reports/fix/default-clarity-3), [Storybook](https://fix/default-clarity-3--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/default-clarity-3)<!-- Sticky Header Marker -->

Closes https://github.com/leather-io/extension/issues/5983

I hadn't noticed until just now that being able to change clarity version was added in Stacks.js@6.17.0, the one before the major version upgrade.

This PR defaults to using the latest clarity version for all contract deploys.