### PR TITLE
fix(rpc): use SIP-30 format for `stx_signTransaction`

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "@leather.io/eslint-config": "0.7.0",
     "@leather.io/panda-preset": "0.8.0",
     "@leather.io/prettier-config": "0.6.0",
-    "@leather.io/rpc": "2.4.0",
+    "@leather.io/rpc": "2.5.3",
     "@ls-lint/ls-lint": "2.2.3",
     "@mdx-js/loader": "3.0.0",
     "@pandacss/dev": "0.46.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,8 +415,8 @@ importers:
         specifier: 0.6.0
         version: 0.6.0(@vue/compiler-sfc@3.5.13)
       '@leather.io/rpc':
-        specifier: 2.4.0
-        version: 2.4.0(encoding@0.1.13)
+        specifier: 2.5.3
+        version: 2.5.3(encoding@0.1.13)
       '@ls-lint/ls-lint':
         specifier: 2.2.3
         version: 2.2.3
@@ -7943,8 +7943,8 @@ packages:
   caniuse-lite@1.0.30001680:
     resolution: {integrity: sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==}
 
-  caniuse-lite@1.0.30001692:
-    resolution: {integrity: sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==}
+  caniuse-lite@1.0.30001695:
+    resolution: {integrity: sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==}
 
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -9105,8 +9105,8 @@ packages:
   electron-to-chromium@1.5.63:
     resolution: {integrity: sha512-ddeXKuY9BHo/mw145axlyWjlJ1UBt4WK3AlvkT7W2AbqfRQoacVoRUCF6wL3uIx/8wT9oLKXzI+rFqHHscByaA==}
 
-  electron-to-chromium@1.5.82:
-    resolution: {integrity: sha512-Zq16uk1hfQhyGx5GpwPAYDwddJuSGhtRhgOA2mCxANYaDT79nAeGnaXogMGng4KqLaJUVnOnuL0+TDop9nLOiA==}
+  electron-to-chromium@1.5.86:
+    resolution: {integrity: sha512-/D7GAAaCRBQFBBcop6SfAAGH37djtpWkOuYhyAajw0l5vsfeSsUQYxaFPwr1c/mC/flARCDdKFo5gpFqNI+18w==}
 
   electron@27.3.11:
     resolution: {integrity: sha512-E1SiyEoI8iW5LW/MigCr7tJuQe7+0105UjqY7FkmCD12e2O6vtUbQ0j05HaBh2YgvkcEVgvQ2A8suIq5b5m6Gw==}
@@ -25919,8 +25919,8 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001692
-      electron-to-chromium: 1.5.82
+      caniuse-lite: 1.0.30001695
+      electron-to-chromium: 1.5.86
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
 
@@ -26125,7 +26125,7 @@ snapshots:
 
   caniuse-lite@1.0.30001680: {}
 
-  caniuse-lite@1.0.30001692: {}
+  caniuse-lite@1.0.30001695: {}
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
 
@@ -27349,7 +27349,7 @@ snapshots:
 
   electron-to-chromium@1.5.63: {}
 
-  electron-to-chromium@1.5.82: {}
+  electron-to-chromium@1.5.86: {}
 
   electron@27.3.11:
     dependencies:

--- a/src/app/pages/rpc-sign-stacks-transaction/use-rpc-sign-stacks-transaction.ts
+++ b/src/app/pages/rpc-sign-stacks-transaction/use-rpc-sign-stacks-transaction.ts
@@ -54,9 +54,8 @@ export function useRpcSignStacksTransaction() {
       stacksTransaction.setNonce(nonce);
 
       const signedTransaction = await signStacksTx(stacksTransaction);
-      if (!signedTransaction) {
-        throw new Error('Error signing stacks transaction');
-      }
+
+      if (!signedTransaction) throw new Error('Error signing stacks transaction');
 
       chrome.tabs.sendMessage(
         tabId,
@@ -64,6 +63,7 @@ export function useRpcSignStacksTransaction() {
           id: requestId,
           result: {
             txHex: bytesToHex(signedTransaction.serialize()),
+            transaction: bytesToHex(signedTransaction.serialize()),
           },
         })
       );

--- a/src/app/store/app-permissions/app-permissions.slice.ts
+++ b/src/app/store/app-permissions/app-permissions.slice.ts
@@ -3,11 +3,14 @@ import { useDispatch } from 'react-redux';
 
 import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 
+import { useCurrentAccountIndex } from '../accounts/account';
+
 interface AppPermission {
   origin: string;
   // Very simple permission system. If property exists with date, user
   // has given permission
   requestedAccounts?: string;
+  accountIndex: number;
 }
 const appPermissionsAdapter = createEntityAdapter<AppPermission, string>({
   selectId: permission => permission.origin,
@@ -23,6 +26,7 @@ export const appPermissionsSlice = createSlice({
 
 export function useAppPermissions() {
   const dispatch = useDispatch();
+  const currentAccountIndex = useCurrentAccountIndex();
 
   return useMemo(
     () => ({
@@ -32,10 +36,11 @@ export function useAppPermissions() {
           appPermissionsSlice.actions.updatePermission({
             origin: url,
             requestedAccounts: new Date().toISOString(),
+            accountIndex: currentAccountIndex,
           })
         );
       },
     }),
-    [dispatch]
+    [currentAccountIndex, dispatch]
   );
 }

--- a/src/shared/rpc/methods/sign-stacks-transaction.ts
+++ b/src/shared/rpc/methods/sign-stacks-transaction.ts
@@ -1,19 +1,11 @@
-import { StacksNetworks } from '@stacks/network';
-import { z } from 'zod';
+import { stxSignTransactionRequestParamsSchema } from '@leather.io/rpc';
 
 import { formatValidationErrors, getRpcParamErrors, validateRpcParams } from './validation.utils';
 
-const rpcSignStacksTransactionParamsSchema = z.object({
-  stxAddress: z.string().optional(),
-  txHex: z.string(),
-  attachment: z.string().optional(),
-  network: z.enum(StacksNetworks).optional(),
-});
-
 export function validateRpcSignStacksTransactionParams(obj: unknown) {
-  return validateRpcParams(obj, rpcSignStacksTransactionParamsSchema);
+  return validateRpcParams(obj, stxSignTransactionRequestParamsSchema);
 }
 
 export function getRpcSignStacksTransactionParamErrors(obj: unknown) {
-  return formatValidationErrors(getRpcParamErrors(obj, rpcSignStacksTransactionParamsSchema));
+  return formatValidationErrors(getRpcParamErrors(obj, stxSignTransactionRequestParamsSchema));
 }


### PR DESCRIPTION
> Try out Leather build fe8a131 — [Extension build](https://github.com/leather-io/extension/actions/runs/12951051715), [Test report](https://leather-io.github.io/playwright-reports/refactor/stx-sign-transaction), [Storybook](https://refactor/stx-sign-transaction--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/stx-sign-transaction)<!-- Sticky Header Marker -->

Adding SIP-30 for `stx_signTransaction` while maintaining backwards compatibility with existing API params.

https://linear.app/leather-io/issue/LEA-1970/apply-new-stx-signtransaction-params-without-breaking-changes