### PR TITLE
fix rendering the correct src20 image, closes LEA-1993

### DIFF
--- a/src/app/components/collectibles/src20-image.tsx
+++ b/src/app/components/collectibles/src20-image.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+import { css } from 'leather-styles/css';
+
+import { Eye1ClosedIcon } from '@leather.io/ui';
+
+interface Src20ImageProps {
+  alt?: string;
+  src: string;
+}
+export function Src20Image(props: Src20ImageProps) {
+  const { alt, src } = props;
+  const [isError, setIsError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [width, setWidth] = useState(0);
+
+  if (isError) return <Eye1ClosedIcon />;
+
+  return (
+    <img
+      alt={alt}
+      onError={() => setIsError(true)}
+      loading="lazy"
+      onLoad={event => {
+        const target = event.target as HTMLImageElement;
+        setWidth(target.naturalWidth);
+        setIsLoading(false);
+      }}
+      src={src}
+      className={css({
+        width: 'xl',
+        aspectRatio: '1 / 1',
+        borderRadius: '100%',
+        objectFit: 'cover',
+        // display: 'none' breaks onLoad event firing
+        opacity: isLoading ? '0' : '1',
+        imageRendering: width <= 40 ? 'pixelated' : 'auto',
+      })}
+    />
+  );
+}

--- a/src/app/components/src20/src20-image.tsx
+++ b/src/app/components/src20/src20-image.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { css } from 'leather-styles/css';
 
-import { Eye1ClosedIcon } from '@leather.io/ui';
+import { Src20AvatarIcon } from '@leather.io/ui';
 
 interface Src20ImageProps {
   alt?: string;
@@ -14,7 +14,7 @@ export function Src20Image(props: Src20ImageProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [width, setWidth] = useState(0);
 
-  if (isError) return <Eye1ClosedIcon />;
+  if (isError) return <Src20AvatarIcon />;
 
   return (
     <img
@@ -29,7 +29,6 @@ export function Src20Image(props: Src20ImageProps) {
       src={src}
       className={css({
         width: 'xl',
-        aspectRatio: '1 / 1',
         borderRadius: '100%',
         objectFit: 'cover',
         // display: 'none' breaks onLoad event firing

--- a/src/app/features/asset-list/bitcoin/src20-token-asset-list/src20-token-asset-list.tsx
+++ b/src/app/features/asset-list/bitcoin/src20-token-asset-list/src20-token-asset-list.tsx
@@ -4,10 +4,9 @@ import { Src20AvatarIcon } from '@leather.io/ui';
 import { getAssetDisplayName } from '@leather.io/utils';
 
 import { useManageTokens } from '@app/common/hooks/use-manage-tokens';
-import { CollectibleImage } from '@app/components/collectibles/collectible-image';
-import { Src20Image } from '@app/components/collectibles/src20-image';
 import { CryptoAssetItem } from '@app/components/crypto-asset-item/crypto-asset-item';
 import type { Src20TokenAssetDetails } from '@app/components/loaders/src20-tokens-loader';
+import { Src20Image } from '@app/components/src20/src20-image';
 import { useIsPrivateMode } from '@app/store/settings/settings.selectors';
 
 import type { AssetRightElementVariant } from '../../asset-list';

--- a/src/app/features/asset-list/bitcoin/src20-token-asset-list/src20-token-asset-list.tsx
+++ b/src/app/features/asset-list/bitcoin/src20-token-asset-list/src20-token-asset-list.tsx
@@ -5,6 +5,7 @@ import { getAssetDisplayName } from '@leather.io/utils';
 
 import { useManageTokens } from '@app/common/hooks/use-manage-tokens';
 import { CollectibleImage } from '@app/components/collectibles/collectible-image';
+import { Src20Image } from '@app/components/collectibles/src20-image';
 import { CryptoAssetItem } from '@app/components/crypto-asset-item/crypto-asset-item';
 import type { Src20TokenAssetDetails } from '@app/components/loaders/src20-tokens-loader';
 import { useIsPrivateMode } from '@app/store/settings/settings.selectors';
@@ -36,13 +37,7 @@ export function Src20TokenAssetList({
     const key = `${token.info.id}${i}`;
     const captionLeft = getAssetDisplayName(token.info).toUpperCase();
     const icon = token.info.deploy_img ? (
-      <CollectibleImage
-        alt={token.info.symbol}
-        icon={<Src20AvatarIcon size="lg" />}
-        src={token.info.deploy_img}
-        title={`# ${token.info.id}`}
-        subtitle={`# ${token.info.symbol}`}
-      />
+      <Src20Image src={token.info.deploy_img} />
     ) : (
       <Src20AvatarIcon />
     );


### PR DESCRIPTION
> Try out Leather build 0a41114 — [Extension build](https://github.com/leather-io/extension/actions/runs/12817142957), [Test report](https://leather-io.github.io/playwright-reports/will/fix-src20-image), [Storybook](https://will/fix-src20-image--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=will/fix-src20-image)<!-- Sticky Header Marker -->

Specifically fixes the layout of the SRC-20 tokens in this list (before / after use different tokens, but the change is applied to any SRC-20)

## Before:
<img width="924" alt="Screenshot 2025-01-16 at 11 56 31 AM" src="https://github.com/user-attachments/assets/c9e6d276-5e2d-433e-90c9-bdd3dfa40cfc" />


## After:
<img width="897" alt="Screenshot 2025-01-16 at 11 58 40 AM" src="https://github.com/user-attachments/assets/28bd175a-6d19-4730-b9a9-6de205a02b13" />
