### PR TITLE
fix: possible issue introduced with testnet4

### DIFF
--- a/src/app/store/networks/networks.utils.ts
+++ b/src/app/store/networks/networks.utils.ts
@@ -3,8 +3,10 @@ import { ChainID } from '@stacks/transactions';
 import {
   BITCOIN_API_BASE_URL_MAINNET,
   BITCOIN_API_BASE_URL_TESTNET3,
+  type BitcoinNetwork,
   type NetworkConfiguration,
   bitcoinNetworkToNetworkMode,
+  bitcoinNetworks,
 } from '@leather.io/models';
 
 import { PersistedNetworkConfiguration } from './networks.slice';
@@ -64,6 +66,10 @@ function checkBitcoinNetworkProperties(
   }
 }
 
+function isValidBitcoinNetwork(network: string): network is BitcoinNetwork {
+  return bitcoinNetworks.includes(network as BitcoinNetwork);
+}
+
 export function transformNetworkStateToMultichainStucture(
   state: Record<string, PersistedNetworkConfiguration>
 ) {
@@ -82,14 +88,16 @@ export function transformNetworkStateToMultichainStucture(
             chain: {
               stacks: {
                 blockchain: 'stacks',
-                url: url,
+                url,
                 chainId,
                 subnetChainId,
               },
               bitcoin: {
                 blockchain: 'bitcoin',
-                bitcoinNetwork: bitcoinNetwork ?? 'testnet',
-                mode: bitcoinNetworkToNetworkMode(bitcoinNetwork ?? 'testnet'),
+                bitcoinNetwork: isValidBitcoinNetwork(bitcoinNetwork) ? bitcoinNetwork : 'testnet4',
+                mode: isValidBitcoinNetwork(bitcoinNetwork)
+                  ? bitcoinNetworkToNetworkMode(bitcoinNetwork)
+                  : 'testnet',
                 bitcoinUrl: bitcoinUrl ?? BITCOIN_API_BASE_URL_TESTNET3,
               },
             },


### PR DESCRIPTION
> Try out Leather build f9841a9 — [Extension build](https://github.com/leather-io/extension/actions/runs/12830235985), [Test report](https://leather-io.github.io/playwright-reports/fix/possible-network-stale-state), [Storybook](https://fix/possible-network-stale-state--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/possible-network-stale-state)<!-- Sticky Header Marker -->

In auditing https://github.com/leather-io/extension/issues/6067 I've found some code that could be problematic.

Users of past versions of Leather that have added custom networks, may run into a stale state issue where they have `testnet` persisted as a local network, but only `testnet3` or `testnet4` are valid values in the current prod build.

This PR blindly attempts to fix this possible issue by checking that the state is a valid value.