### PR TITLE
test: use debug helper to set higher account index

### DIFF
--- a/tests/page-object-models/onboarding.page.ts
+++ b/tests/page-object-models/onboarding.page.ts
@@ -10,10 +10,6 @@ import { RouteUrls } from '@shared/route-urls';
 
 const TEST_ACCOUNT_SECRET_KEY = process.env.TEST_ACCOUNT_SECRET_KEY ?? '';
 
-async function pauseForStateToBeSet() {
-  return delay(2000);
-}
-
 // If default wallet state changes, we'll need to update this
 export const testSoftwareAccountDefaultWalletState = {
   chains: { stx: { default: { highestAccountIndex: 0, currentAccountIndex: 0 } } },
@@ -323,26 +319,7 @@ export class OnboardingPage {
       iterationCounter.increment();
     } while (!(await isSignedIn()));
 
-    await this.createNewAccount();
-    await this.createNewAccount();
-    await this.selectFirstAccount();
-    await pauseForStateToBeSet();
-  }
-
-  async createNewAccount() {
-    await this.page.getByTestId('switch-account-trigger').click();
-    await this.page.getByTestId('switch-account-item-0').isVisible();
-    const dialog = this.page.getByRole('dialog');
-    await this.page.getByTestId('create-account-btn').click();
-    await dialog.waitFor({ state: 'detached' });
-  }
-
-  async selectFirstAccount() {
-    await this.page.getByTestId('switch-account-trigger').click();
-    await this.page.getByTestId('switch-account-item-0').isVisible();
-    const dialog = this.page.getByRole('dialog');
-    await this.page.getByTestId('switch-account-item-0').click();
-    await dialog.waitFor({ state: 'detached' });
+    await this.page.evaluate(() => window.debug.setHighestAccountIndex(2));
   }
 
   /**


### PR DESCRIPTION
> Try out Leather build 532e5ea — [Extension build](https://github.com/leather-io/extension/actions/runs/12831202584), [Test report](https://leather-io.github.io/playwright-reports/test/speed-up-account-making), [Storybook](https://test/speed-up-account-making--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=test/speed-up-account-making)<!-- Sticky Header Marker -->

Recently in [`a3484ce` (#6013)](https://github.com/leather-io/extension/pull/6013/commits/a3484ceb485c987f4d2741f4d545744f40ce86a8) I introduced a fix owing to gaia being down, that required each test to create 3 accounts. 

This slows down the tests quite a lot, so here I use the helper utility to set the highest known account index.