### PR TITLE
test: flakey test because exact values can change while test is running

### DIFF
--- a/tests/specs/settings/settings.spec.ts
+++ b/tests/specs/settings/settings.spec.ts
@@ -93,6 +93,6 @@ test.describe('Settings menu', () => {
 
     await test
       .expect(homePage.page.getByTestId(SharedComponentsSelectors.AccountCardBalanceText))
-      .toHaveText(visibleBalanceText!);
+      .not.toContainText('***');
   });
 });


### PR DESCRIPTION
> Try out Leather build 3d443d7 — [Extension build](https://github.com/leather-io/extension/actions/runs/12928533230), [Test report](https://leather-io.github.io/playwright-reports/test/fix-flaky-price-test), [Storybook](https://test/fix-flaky-price-test--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=test/fix-flaky-price-test)<!-- Sticky Header Marker -->

Fixes issue with a recurring failing test that is too strict in that it checks for an exact value that may change.