### PR TITLE
feat(rpc): stx_getAddresses

### DIFF
--- a/src/background/messaging/rpc-message-handler.ts
+++ b/src/background/messaging/rpc-message-handler.ts
@@ -13,6 +13,7 @@ import { rpcSendTransfer } from './rpc-methods/send-transfer';
 import { rpcSignMessage } from './rpc-methods/sign-message';
 import { rpcSignPsbt } from './rpc-methods/sign-psbt';
 import { rpcSignStacksMessage } from './rpc-methods/sign-stacks-message';
+import { rpcStxGetAddresses } from './rpc-methods/stx-get-addresses';
 import { rpcSupportedMethods } from './rpc-methods/supported-methods';
 
 export async function rpcMessageHandler(message: WalletRequests, port: chrome.runtime.Port) {
@@ -59,6 +60,11 @@ export async function rpcMessageHandler(message: WalletRequests, port: chrome.ru
 
     case 'stx_signMessage': {
       await rpcSignStacksMessage(message, port);
+      break;
+    }
+
+    case 'stx_getAddresses': {
+      await rpcStxGetAddresses(message, port);
       break;
     }
 

--- a/src/background/messaging/rpc-methods/get-addresses.ts
+++ b/src/background/messaging/rpc-methods/get-addresses.ts
@@ -1,4 +1,4 @@
-import { type GetAddressesRequest, RpcErrorCode } from '@leather.io/rpc';
+import { type LeatherRpcMethodMap, type MethodNames, RpcErrorCode } from '@leather.io/rpc';
 
 import { RouteUrls } from '@shared/route-urls';
 import { makeRpcErrorResponse } from '@shared/rpc/rpc-methods';
@@ -10,20 +10,26 @@ import {
 } from '../messaging-utils';
 import { trackRpcRequestSuccess } from '../rpc-message-handler';
 
-export async function rpcGetAddresses(message: GetAddressesRequest, port: chrome.runtime.Port) {
-  const { urlParams, tabId } = makeSearchParamsWithDefaults(port, [['requestId', message.id]]);
-  const { id } = await triggerRequestWindowOpen(RouteUrls.RpcGetAddresses, urlParams);
-  void trackRpcRequestSuccess({ endpoint: message.method });
+export function makeRpcAddressesMessageListener<T extends MethodNames>(
+  eventName: 'getAddresses' | 'stx_getAddresses'
+) {
+  return async (message: LeatherRpcMethodMap[T]['request'], port: chrome.runtime.Port) => {
+    const { urlParams, tabId } = makeSearchParamsWithDefaults(port, [['requestId', message.id]]);
+    const { id } = await triggerRequestWindowOpen(RouteUrls.RpcGetAddresses, urlParams);
+    void trackRpcRequestSuccess({ endpoint: message.method });
 
-  listenForPopupClose({
-    tabId,
-    id,
-    response: makeRpcErrorResponse('getAddresses', {
-      id: message.id,
-      error: {
-        code: RpcErrorCode.USER_REJECTION,
-        message: 'User rejected request to get addresses',
-      },
-    }),
-  });
+    listenForPopupClose({
+      tabId,
+      id,
+      response: makeRpcErrorResponse(eventName, {
+        id: message.id,
+        error: {
+          code: RpcErrorCode.USER_REJECTION,
+          message: 'User rejected request to get addresses',
+        },
+      }),
+    });
+  };
 }
+
+export const rpcGetAddresses = makeRpcAddressesMessageListener('getAddresses');

--- a/src/background/messaging/rpc-methods/stx-get-addresses.ts
+++ b/src/background/messaging/rpc-methods/stx-get-addresses.ts
@@ -1,0 +1,4 @@
+import { makeRpcAddressesMessageListener } from './get-addresses';
+
+// Method simply clones behaviour of getAddresses action
+export const rpcStxGetAddresses = makeRpcAddressesMessageListener('stx_getAddresses');


### PR DESCRIPTION
> Try out Leather build 134c548 — [Extension build](https://github.com/leather-io/extension/actions/runs/13159152005), [Test report](https://leather-io.github.io/playwright-reports/feat/stx-get-addresses), [Storybook](https://feat/stx-get-addresses--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/stx-get-addresses)<!-- Sticky Header Marker -->

Closes LEA-1958 
 
This PR adds `stx_getAddresses` effectively identical to `getAddresses`.

Definitely want to investigate some more advanced message passing structure. We've managed with the simple set up so far. But now we have evolving, more advance requirements, I think another pass at it might be warranted. 

Refactored `getAddresses` tests to run again for `stx_getAddresses`