### PR TITLE
fix: allow users to send btc to themselves, ref leather-io/extension#5349

### DIFF
--- a/package.json
+++ b/package.json
@@ -386,7 +386,7 @@
     "wrap-ansi": "7.0.0",
     "webpack-dev-middleware": "5.3.4",
     "eslint": "8.56.0",
-    "path-to-regexp": "0.1.10",
+    "path-to-regexp": "0.1.12",
     "rollup": "4.22.4",
     "ws": "8.17.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   wrap-ansi: 7.0.0
   webpack-dev-middleware: 5.3.4
   eslint: 8.56.0
-  path-to-regexp: 0.1.10
+  path-to-regexp: 0.1.12
   rollup: 4.22.4
   ws: 8.17.1
   levelup>semver: 5.7.2
@@ -12819,8 +12819,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -28123,7 +28123,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.11.0
       range-parser: 1.2.1
@@ -32022,7 +32022,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-to-regexp@0.1.10: {}
+  path-to-regexp@0.1.12: {}
 
   path-type@4.0.0: {}
 

--- a/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/use-btc-send-form.tsx
@@ -14,7 +14,6 @@ import { BitcoinSendFormValues } from '@shared/models/form.model';
 
 import { formatPrecisionError } from '@app/common/error-formatters';
 import { useOnMount } from '@app/common/hooks/use-on-mount';
-import { notCurrentAddressValidator } from '@app/common/validation/forms/address-validators';
 import {
   btcInsufficientBalanceValidator,
   btcMinimumSpendValidator,
@@ -27,7 +26,6 @@ import {
 import { useUpdatePersistedSendFormValues } from '@app/features/popup-send-form-restoration/use-update-persisted-send-form-values';
 import { useCurrentNativeSegwitUtxos } from '@app/query/bitcoin/address/utxos-by-address.hooks';
 import { useCurrentBtcCryptoAssetBalanceNativeSegwit } from '@app/query/bitcoin/balance/btc-balance-native-segwit.hooks';
-import { useCurrentAccountNativeSegwitIndexZeroSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import { useCalculateMaxBitcoinSpend } from '../../family/bitcoin/hooks/use-calculate-max-spend';
@@ -37,7 +35,6 @@ export function useBtcSendForm() {
   const [isSendingMax, setIsSendingMax] = useState(false);
   const formRef = useRef<FormikProps<BitcoinSendFormValues>>(null);
   const currentNetwork = useCurrentNetwork();
-  const nativeSegwitSigner = useCurrentAccountNativeSegwitIndexZeroSigner();
   const { data: utxos = [], filteredUtxosQuery } = useCurrentNativeSegwitUtxos();
   const { balance } = useCurrentBtcCryptoAssetBalanceNativeSegwit();
   const sendFormNavigate = useSendFormNavigate();
@@ -76,7 +73,6 @@ export function useBtcSendForm() {
       recipient: nonEmptyStringValidator()
         .concat(btcAddressValidator())
         .concat(btcAddressNetworkValidator(currentNetwork.chain.bitcoin.mode))
-        .concat(notCurrentAddressValidator(nativeSegwitSigner.address || ''))
         .concat(
           complianceValidator(
             btcAddressValidator(),


### PR DESCRIPTION
> Try out Leather build d46796b — [Extension build](https://github.com/leather-io/extension/actions/runs/12990395404), [Test report](https://leather-io.github.io/playwright-reports/feat/5349/utxo-consolidation), [Storybook](https://feat/5349/utxo-consolidation--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/5349/utxo-consolidation)<!-- Sticky Header Marker -->

This PR removes validation blocking users from sending BTC to the same address it comes from therefore enabling UTXO consolidation 