### PR TITLE
fix: stacks js v6 mock broadcast tx for swaps

### DIFF
--- a/tests/mocks/mock-stacks-txs.ts
+++ b/tests/mocks/mock-stacks-txs.ts
@@ -165,6 +165,14 @@ export async function mockStacksPendingTransaction(page: Page) {
   );
 }
 
+export async function mockStacksBroadcastTransactionV6(page: Page) {
+  await page.route(`**/api.hiro.so/v2/transactions`, route =>
+    route.fulfill({
+      body: '9b709768122e6c62a37b087106cc9c23280ed6242b565484b6cc4e6a43ae1155',
+    })
+  );
+}
+
 export async function mockStacksBroadcastTransaction(page: Page) {
   await page.route(`**/api.mainnet.hiro.so/v2/transactions`, route =>
     route.fulfill({

--- a/tests/specs/swap/swap.spec.ts
+++ b/tests/specs/swap/swap.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { mockStacksBroadcastTransaction } from '@tests/mocks/mock-stacks-txs';
+import { mockStacksBroadcastTransactionV6 } from '@tests/mocks/mock-stacks-txs';
 
 import { test } from '../../fixtures/fixtures';
 
@@ -8,7 +8,7 @@ test.describe('Swaps', () => {
     test.setTimeout(60_000);
 
     await globalPage.setupAndUseApiCalls(extensionId);
-    await mockStacksBroadcastTransaction(globalPage.page);
+    await mockStacksBroadcastTransactionV6(globalPage.page);
     await onboardingPage.signInWithTestAccount(extensionId);
     await homePage.swapButton.click();
     await swapPage.waitForSwapPageReady();


### PR DESCRIPTION
> Try out Leather build 1722723 — [Extension build](https://github.com/leather-io/extension/actions/runs/13163466539), [Test report](https://leather-io.github.io/playwright-reports/fix/stacks-js-v6-mock), [Storybook](https://fix/stacks-js-v6-mock--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/stacks-js-v6-mock)<!-- Sticky Header Marker -->

@kyranjamie not sure why the swaps test passed on the upgrade branch once this was changed bc ended up failing on my new branch. We still need this mock for swaps using v6 atm.