### PR TITLE
fix: prevent tab index to embedded elements

### DIFF
--- a/src/app/components/collectibles/collectible-iframe.tsx
+++ b/src/app/components/collectibles/collectible-iframe.tsx
@@ -29,6 +29,7 @@ export function CollectibleIframe({ icon, src, ...props }: CollectibleIframeProp
         src={src}
         width="100%"
         zIndex={99}
+        tabIndex={-1}
       />
     </CollectibleItemLayout>
   );


### PR DESCRIPTION
> Try out Leather build b2a8fa4 — [Extension build](https://github.com/leather-io/extension/actions/runs/13182577078), [Test report](https://leather-io.github.io/playwright-reports/fix/prevent-tab-index-iframe), [Storybook](https://fix/prevent-tab-index-iframe--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/prevent-tab-index-iframe)<!-- Sticky Header Marker -->

Ensure keyboard controls cannot access iframes