### PR TITLE
feat: disable bitcoin tx notifications

### DIFF
--- a/src/app/features/address-monitor/use-sync-address-monitor.ts
+++ b/src/app/features/address-monitor/use-sync-address-monitor.ts
@@ -9,6 +9,7 @@ import { sendMessage } from '@shared/messages';
 import { useMonitorableAddresses } from '@app/features/address-monitor/use-monitorable-addresses';
 import type { MonitoredAddress } from '@background/monitors/address-monitor';
 
+// ts-unused-exports:disable-next-line
 export function useSyncAddressMonitor() {
   const addresses = useMonitorableAddresses();
   const prevAddresses = useRef<MonitoredAddress[]>([]);

--- a/src/app/features/container/container.tsx
+++ b/src/app/features/container/container.tsx
@@ -19,7 +19,6 @@ import { useOnWalletLock } from '@app/routes/hooks/use-on-wallet-lock';
 import { useAppDispatch, useHasStateRehydrated } from '@app/store';
 import { stxChainSlice } from '@app/store/chains/stx-chain.slice';
 
-import { useSyncAddressMonitor } from '../address-monitor/use-sync-address-monitor';
 import { useRestoreFormState } from '../popup-send-form-restoration/use-restore-form-state';
 
 export function Container() {
@@ -29,7 +28,8 @@ export function Container() {
   const dispatch = useAppDispatch();
 
   const hasStateRehydrated = useHasStateRehydrated();
-  useSyncAddressMonitor();
+  // TODO: Remove comment to enable Bitcoin Tx notifications
+  // useSyncAddressMonitor();
   useOnWalletLock(() => closeWindow());
   useOnSignOut(() => closeWindow());
   useRestoreFormState();

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -13,7 +13,6 @@ import {
   isLegacyMessage,
 } from './messaging/legacy/legacy-external-message-handler';
 import { rpcMessageHandler } from './messaging/rpc-message-handler';
-import { initAddressMonitor } from './monitors/address-monitor';
 
 initContextMenuActions();
 warnUsersAboutDevToolsDangers();
@@ -61,6 +60,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return true;
 });
 
-initAddressMonitor().catch(e => {
-  logger.error('Unable to Initialise Address Monitor: ', e);
-});
+// TODO: Remove comment to enable Bitcoin Tx notifications
+// initAddressMonitor().catch(e => {
+//   logger.error('Unable to Initialise Address Monitor: ', e);
+// });

--- a/src/background/monitors/address-monitor.ts
+++ b/src/background/monitors/address-monitor.ts
@@ -17,7 +17,7 @@ export interface AddressMonitor {
 }
 
 const monitors: AddressMonitor[] = [];
-
+// ts-unused-exports:disable-next-line
 export async function initAddressMonitor() {
   const addresses = await readMonitoredAddressStore();
   monitors.push(createBitcoinTransactionMonitor(addresses));


### PR DESCRIPTION
> Try out Leather build 15c5498 — [Extension build](https://github.com/leather-io/extension/actions/runs/13287784922), [Test report](https://leather-io.github.io/playwright-reports/feat/disable-btc-notifications), [Storybook](https://feat/disable-btc-notifications--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/disable-btc-notifications)<!-- Sticky Header Marker -->

Disables address monitoring and Bitcoin Tx Notification functionality for release.

Comment flags points at which functionality can be reinstated:
`// TODO: Remove comment to enable Bitcoin Tx notifications`

Temporarily muted unused export checks.
`// ts-unused-exports:disable-next-line`