### PR TITLE
fix: add default for post condition mode

### DIFF
--- a/src/app/common/transactions/stacks/generate-unsigned-txs.ts
+++ b/src/app/common/transactions/stacks/generate-unsigned-txs.ts
@@ -78,7 +78,7 @@ function generateUnsignedContractDeployTx(args: GenerateUnsignedContractDeployTx
     nonce: initNonce(nonce)?.toString(),
     fee: new BN(fee, 10)?.toString(),
     publicKey,
-    postConditionMode,
+    postConditionMode: postConditionMode ?? PostConditionMode.Deny,
     postConditions: getPostConditions(postConditions?.map(pc => ensurePostConditionWireFormat(pc))),
     network,
     clarityVersion: ClarityVersion.Clarity3,


### PR DESCRIPTION
> Try out Leather build 3f399fe — [Extension build](https://github.com/leather-io/extension/actions/runs/13373272887), [Test report](https://leather-io.github.io/playwright-reports/fix/post-condition-mode), [Storybook](https://fix/post-condition-mode--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/post-condition-mode)<!-- Sticky Header Marker -->

This was causing `stx_deployContract` to hit an error trying to generate the unsigned tx.

**Needs to be merged / reset release**