### PR TITLE
refactor: minor sbtc updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "redux-persist": "6.0.0",
     "remark-gfm": "4.0.0",
     "rxjs": "7.8.1",
-    "sbtc": "0.3.1",
+    "sbtc": "0.3.2",
     "style-loader": "3.3.4",
     "ts-debounce": "4.0.0",
     "url": "0.11.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,8 +355,8 @@ importers:
         specifier: 7.8.1
         version: 7.8.1
       sbtc:
-        specifier: 0.3.1
-        version: 0.3.1(encoding@0.1.13)
+        specifier: 0.3.2
+        version: 0.3.2(encoding@0.1.13)
       style-loader:
         specifier: 3.3.4
         version: 3.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
@@ -14305,8 +14305,8 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  sbtc@0.3.1:
-    resolution: {integrity: sha512-dAd0hxgIS1qchzb6tWbBTgoYio/v0Rln9pq3L23cX52DBSI4WpoMr2MRsM8z3lORTeqhIPLd3Tn/IdB+jKYdIA==}
+  sbtc@0.3.2:
+    resolution: {integrity: sha512-NjU9vDz2d1XMBGplT9S1x2IRJTIbZX4wAq8TNEMFiUmaj7MVp/3cJTPHiHmS4P+hIHNfrHLUUoe/i4ToIkp5yw==}
 
   sc-errors@3.0.0:
     resolution: {integrity: sha512-rIqv2HTPb9DVreZwK/DV0ytRUqyw2DbDcoB9XTKjEQL7oMEQKsfPA8V8dGGr7p8ZYfmvaRIGZ4Wu5qwvs/hGDA==}
@@ -18321,7 +18321,7 @@ snapshots:
   '@btc-helpers/rpc@2.0.0(encoding@0.1.13)':
     dependencies:
       '@scure/base': 1.1.9
-      cross-fetch: 3.1.8(encoding@0.1.13)
+      cross-fetch: 3.2.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -34135,7 +34135,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  sbtc@0.3.1(encoding@0.1.13):
+  sbtc@0.3.2(encoding@0.1.13):
     dependencies:
       '@btc-helpers/rpc': 2.0.0(encoding@0.1.13)
       '@noble/secp256k1': 2.1.0

--- a/src/app/components/sbtc-deposit-status-item/sbtc-deposit-status-item.tsx
+++ b/src/app/components/sbtc-deposit-status-item/sbtc-deposit-status-item.tsx
@@ -2,7 +2,7 @@ import SbtcAvatarIconSrc from '@assets/avatars/sbtc-avatar-icon.png';
 import { HStack } from 'leather-styles/jsx';
 
 import { Avatar, Caption, Link, Title } from '@leather.io/ui';
-import { truncateMiddle } from '@leather.io/utils';
+import { satToBtc, truncateMiddle } from '@leather.io/utils';
 
 import { analytics } from '@shared/utils/analytics';
 
@@ -76,8 +76,7 @@ export function SbtcDepositTransactionItem({ deposit }: SbtcDepositTransactionIt
         </HStack>
       }
       txTitle={<Title textStyle="label.02">BTC → sBTC</Title>}
-      // Api is only returning 0 right now
-      txValue={''} // deposit.amount.toString()
+      txValue={deposit.amount > 0 ? satToBtc(deposit.amount).toString() : ''}
     />
   );
 }


### PR DESCRIPTION
> Try out Leather build a3a99cf — [Extension build](https://github.com/leather-io/extension/actions/runs/13421127671), [Test report](https://leather-io.github.io/playwright-reports/refactor/sbtc-updates), [Storybook](https://refactor/sbtc-updates--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/sbtc-updates)<!-- Sticky Header Marker -->

These should be the only 2 changes needed after looking over the merged Emily PR here:
https://github.com/stacks-network/sbtc/pull/1197

The sbtc lib update just involved changes to the `notifySbtc` method in the lib itself, included in this commit:
https://github.com/hirosystems/stacks.js/pull/1554/commits/a7d37da6e46a3034bc6e0cde4526786a3bfd1573

I am still checking the amount value for `0` bc it is hard to test if their change is working.