### PR TITLE
feat: implement tx notification settings toggle, closes LEA-2145

### DIFF
--- a/src/app/features/address-monitor/use-sync-address-monitor.ts
+++ b/src/app/features/address-monitor/use-sync-address-monitor.ts
@@ -7,24 +7,26 @@ import { InternalMethods } from '@shared/message-types';
 import { sendMessage } from '@shared/messages';
 
 import { useMonitorableAddresses } from '@app/features/address-monitor/use-monitorable-addresses';
+import { useIsNotificationsEnabled } from '@app/store/settings/settings.selectors';
 import type { MonitoredAddress } from '@background/monitors/address-monitor';
 
-// ts-unused-exports:disable-next-line
 export function useSyncAddressMonitor() {
+  const isNotificationsEnabled = useIsNotificationsEnabled();
   const addresses = useMonitorableAddresses();
   const prevAddresses = useRef<MonitoredAddress[]>([]);
 
   useEffect(() => {
-    if (addresses && !isEqual(addresses, prevAddresses.current)) {
-      prevAddresses.current = addresses;
+    const monitorableAddresses = isNotificationsEnabled ? addresses : [];
+    if (monitorableAddresses && !isEqual(monitorableAddresses, prevAddresses.current)) {
+      prevAddresses.current = monitorableAddresses;
 
-      logger.debug('Syncing Monitored Addresses: ', addresses);
+      logger.debug(`Syncing ${monitorableAddresses?.length} Monitored Addresses: `);
       sendMessage({
         method: InternalMethods.AddressMonitorUpdated,
         payload: {
-          addresses,
+          addresses: monitorableAddresses,
         },
       });
     }
-  }, [addresses]);
+  }, [addresses, isNotificationsEnabled]);
 }

--- a/src/app/features/container/container.tsx
+++ b/src/app/features/container/container.tsx
@@ -19,6 +19,7 @@ import { useOnWalletLock } from '@app/routes/hooks/use-on-wallet-lock';
 import { useAppDispatch, useHasStateRehydrated } from '@app/store';
 import { stxChainSlice } from '@app/store/chains/stx-chain.slice';
 
+import { useSyncAddressMonitor } from '../address-monitor/use-sync-address-monitor';
 import { useRestoreFormState } from '../popup-send-form-restoration/use-restore-form-state';
 
 export function Container() {
@@ -28,8 +29,7 @@ export function Container() {
   const dispatch = useAppDispatch();
 
   const hasStateRehydrated = useHasStateRehydrated();
-  // TODO: Remove comment to enable Bitcoin Tx notifications
-  // useSyncAddressMonitor();
+  useSyncAddressMonitor();
   useOnWalletLock(() => closeWindow());
   useOnSignOut(() => closeWindow());
   useRestoreFormState();

--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -7,6 +7,8 @@ import { Flex, Stack, styled } from 'leather-styles/jsx';
 
 import {
   ArrowsRepeatLeftRightIcon,
+  BellAlarmIcon,
+  BellIcon,
   Caption,
   DropdownMenu,
   ExitIcon,
@@ -39,10 +41,17 @@ import { SignOut } from '@app/features/settings/sign-out/sign-out-confirm';
 import { ThemeSheet } from '@app/features/settings/theme/theme-dialog';
 import { useLedgerDeviceTargetId } from '@app/store/ledger/ledger.selectors';
 import { useCurrentNetworkId } from '@app/store/networks/networks.selectors';
-import { useTogglePrivateMode } from '@app/store/settings/settings.actions';
-import { useIsPrivateMode } from '@app/store/settings/settings.selectors';
+import {
+  useToggleNotificationsEnabled,
+  useTogglePrivateMode,
+} from '@app/store/settings/settings.actions';
+import {
+  useIsNotificationsEnabled,
+  useIsPrivateMode,
+} from '@app/store/settings/settings.selectors';
 
 import { extractDeviceNameFromKnownTargetIds } from '../ledger/utils/generic-ledger-utils';
+import { useToast } from '../toasts/use-toast';
 import { AdvancedMenuItems } from './components/advanced-menu-items';
 import { LedgerDeviceItemRow } from './components/ledger-item-row';
 
@@ -73,9 +82,14 @@ export function Settings({
   const isPrivateMode = useIsPrivateMode();
   const togglePrivateMode = useTogglePrivateMode();
 
+  const isNotificationsEnabled = useIsNotificationsEnabled();
+  const toggleNotificationsEnabled = useToggleNotificationsEnabled();
+
   const location = useLocation();
 
   const { isPressed: showAdvancedMenuOptions } = useModifierKey('alt', 120);
+
+  const toast = useToast();
 
   const bottomGroupItems = useMemo(
     () =>
@@ -206,6 +220,22 @@ export function Settings({
                 <Flag img={isPrivateMode ? <Eye1ClosedIcon /> : <Eye1Icon />}>
                   <Flex justifyContent="space-between" textStyle="label.02">
                     Toggle privacy
+                  </Flex>
+                </Flag>
+              </DropdownMenu.Item>
+
+              <DropdownMenu.Item
+                data-testid={SettingsSelectors.ToggleNotifications}
+                onSelect={() => {
+                  toggleNotificationsEnabled();
+                  toast.info(
+                    isNotificationsEnabled ? 'Notifications disabled' : 'Notifications enabled'
+                  );
+                }}
+              >
+                <Flag img={isNotificationsEnabled ? <BellAlarmIcon /> : <BellIcon />}>
+                  <Flex justifyContent="space-between" textStyle="label.02">
+                    Toggle notifications
                   </Flex>
                 </Flag>
               </DropdownMenu.Item>

--- a/src/app/store/settings/settings.actions.ts
+++ b/src/app/store/settings/settings.actions.ts
@@ -13,3 +13,8 @@ export function useTogglePrivateMode() {
   const dispatch = useDispatch();
   return () => dispatch(settingsActions.togglePrivateMode());
 }
+
+export function useToggleNotificationsEnabled() {
+  const dispatch = useDispatch();
+  return () => dispatch(settingsActions.toggleNotificationsEnabled());
+}

--- a/src/app/store/settings/settings.selectors.ts
+++ b/src/app/store/settings/settings.selectors.ts
@@ -32,6 +32,15 @@ export function useIsPrivateMode() {
   return useSelector(selectIsPrivateMode);
 }
 
+const selectIsNotificationsEnabled = createSelector(
+  selectSettings,
+  state => state.isNotificationsEnabled ?? false
+);
+
+export function useIsNotificationsEnabled() {
+  return useSelector(selectIsNotificationsEnabled);
+}
+
 const selectDiscardedInscriptions = createSelector(
   selectSettings,
   state => state.discardedInscriptions

--- a/src/app/store/settings/settings.slice.ts
+++ b/src/app/store/settings/settings.slice.ts
@@ -6,6 +6,7 @@ interface InitialState {
   userSelectedTheme: UserSelectedTheme;
   dismissedMessages: string[];
   isPrivateMode?: boolean;
+  isNotificationsEnabled?: boolean;
   bypassInscriptionChecks?: boolean;
   discardedInscriptions: string[];
 }
@@ -32,6 +33,9 @@ export const settingsSlice = createSlice({
     },
     togglePrivateMode(state) {
       state.isPrivateMode = !state.isPrivateMode;
+    },
+    toggleNotificationsEnabled(state) {
+      state.isNotificationsEnabled = !state.isNotificationsEnabled;
     },
     dangerouslyChosenToBypassAllInscriptionChecks(state) {
       state.bypassInscriptionChecks = true;

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -14,6 +14,7 @@ import {
   isLegacyMessage,
 } from './messaging/legacy/legacy-external-message-handler';
 import { rpcMessageHandler } from './messaging/rpc-message-handler';
+import { initAddressMonitor } from './monitors/address-monitor';
 
 initContextMenuActions();
 warnUsersAboutDevToolsDangers();
@@ -61,7 +62,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return true;
 });
 
-// TODO: Remove comment to enable Bitcoin Tx notifications
-// initAddressMonitor().catch(e => {
-//   logger.error('Unable to Initialise Address Monitor: ', e);
-// });
+initAddressMonitor().catch(e => {
+  logger.error('Unable to Initialise Address Monitor: ', e);
+});

--- a/src/background/monitors/address-monitor.ts
+++ b/src/background/monitors/address-monitor.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { z } from 'zod';
 
 import { createBitcoinTransactionMonitor } from './address-monitors/bitcoin-transaction-monitor';
@@ -17,7 +16,7 @@ export interface AddressMonitor {
 }
 
 const monitors: AddressMonitor[] = [];
-// ts-unused-exports:disable-next-line
+
 export async function initAddressMonitor() {
   const addresses = await readMonitoredAddressStore();
   monitors.push(createBitcoinTransactionMonitor(addresses));

--- a/tests/selectors/settings.selectors.ts
+++ b/tests/selectors/settings.selectors.ts
@@ -26,4 +26,5 @@ export enum SettingsSelectors {
   SwitchAccountItemIndex = 'switch-account-item-[index]',
   OpenWalletInNewTab = 'open-wallet-in-new-tab',
   TogglePrivacy = 'toggle-privacy',
+  ToggleNotifications = 'toggle-notifications',
 }


### PR DESCRIPTION
> Try out Leather build ebe7f2f — [Extension build](https://github.com/leather-io/extension/actions/runs/13418297937), [Test report](https://leather-io.github.io/playwright-reports/feat/notification-settings-ui), [Storybook](https://feat/notification-settings-ui--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/notification-settings-ui)<!-- Sticky Header Marker -->

This PR adds a "toggle notifications" setting that controls the Bitcoin transaction notification feature [originally implemented here](https://github.com/leather-io/extension/pull/6095).