### PR TITLE
feat: make notifications permissions optional

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -69,7 +69,8 @@ const manifest = {
   manifest_version: 3,
   author: 'Leather Wallet, LLC',
   description: 'Leather Bitcoin Wallet - Your Bitcoin Wallet for DeFi, NFTs, Ordinals, and dApps',
-  permissions: ['contextMenus', 'storage', 'unlimitedStorage', 'notifications'],
+  permissions: ['contextMenus', 'storage', 'unlimitedStorage'],
+  optional_permissions: ['notifications'],
   commands: {
     _execute_browser_action: {
       suggested_key: {

--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -124,6 +124,41 @@ export function Settings({
     [canLockWallet, hasKeys, lockWallet, navigate, showAdvancedMenuOptions, showSignOut, walletType]
   );
 
+  const handleNotificationsSettingSelect = () => {
+    if (!isNotificationsEnabled) {
+      chrome.permissions.contains(
+        {
+          permissions: ['notifications'],
+        },
+        result => {
+          if (result) {
+            // extension already has permission
+            toggleNotificationsEnabled();
+            toast.success('Notifications enabled');
+          } else {
+            chrome.permissions.request(
+              {
+                permissions: ['notifications'],
+              },
+              granted => {
+                if (granted) {
+                  // permission granted
+                  toggleNotificationsEnabled();
+                  toast.success('Notifications enabled');
+                } else {
+                  toast.error('Permission denied');
+                }
+              }
+            );
+          }
+        }
+      );
+    } else {
+      toggleNotificationsEnabled();
+      toast.info('Notifications disabled');
+    }
+  };
+
   return (
     <>
       <DropdownMenu.Root>
@@ -226,12 +261,7 @@ export function Settings({
 
               <DropdownMenu.Item
                 data-testid={SettingsSelectors.ToggleNotifications}
-                onSelect={() => {
-                  toggleNotificationsEnabled();
-                  toast.info(
-                    isNotificationsEnabled ? 'Notifications disabled' : 'Notifications enabled'
-                  );
-                }}
+                onSelect={handleNotificationsSettingSelect}
               >
                 <Flag img={isNotificationsEnabled ? <BellAlarmIcon /> : <BellIcon />}>
                   <Flex justifyContent="space-between" textStyle="label.02">


### PR DESCRIPTION
> Try out Leather build 1568423 — [Extension build](https://github.com/leather-io/extension/actions/runs/13430651121), [Test report](https://leather-io.github.io/playwright-reports/feat/notifications-optional-permissions), [Storybook](https://feat/notifications-optional-permissions--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/notifications-optional-permissions)<!-- Sticky Header Marker -->

Changes the chrome extension notifications permission to optional in the manifest and prompts user for permission only after selecting the notification settings menu item.


https://github.com/user-attachments/assets/b4262253-3aa1-477d-b134-52ce85a0e2c9

