### PR TITLE
feat: enable notifications by default

### DIFF
--- a/src/app/store/settings/settings.slice.ts
+++ b/src/app/store/settings/settings.slice.ts
@@ -15,6 +15,7 @@ const initialState: InitialState = {
   userSelectedTheme: 'system',
   dismissedMessages: [],
   discardedInscriptions: [],
+  isNotificationsEnabled: true,
 };
 
 export const settingsSlice = createSlice({


### PR DESCRIPTION
> Try out Leather build f134b0e — [Extension build](https://github.com/leather-io/extension/actions/runs/13434059322), [Test report](https://leather-io.github.io/playwright-reports/feat/enable-notifications-default), [Storybook](https://feat/enable-notifications-default--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/enable-notifications-default)<!-- Sticky Header Marker -->

Enables the notifications setting by default.