### PR TITLE
fix: broadcasting to default stacks network

### DIFF
--- a/src/app/store/networks/networks.hooks.ts
+++ b/src/app/store/networks/networks.hooks.ts
@@ -73,6 +73,9 @@ export function useCurrentStacksNetworkState(): StacksNetwork {
         [ChainId.Mainnet]: TransactionVersion.Mainnet,
         [ChainId.Testnet]: TransactionVersion.Testnet,
       }),
+      client: {
+        baseUrl: currentNetwork.chain.stacks.url,
+      },
       chainId: currentNetwork.chain.stacks.subnetChainId ?? currentNetwork.chain.stacks.chainId,
       bnsLookupUrl: currentNetwork.chain.stacks.url || '',
     }),

--- a/tests/mocks/mock-stacks-txs.ts
+++ b/tests/mocks/mock-stacks-txs.ts
@@ -174,7 +174,7 @@ export async function mockStacksBroadcastTransactionV6(page: Page) {
 }
 
 export async function mockStacksBroadcastTransaction(page: Page) {
-  await page.route(`**/api.mainnet.hiro.so/v2/transactions`, route =>
+  await page.route(`**/api.hiro.so/v2/transactions`, route =>
     route.fulfill({
       body: '9b709768122e6c62a37b087106cc9c23280ed6242b565484b6cc4e6a43ae1155',
     })


### PR DESCRIPTION
> Try out Leather build 4ffcbf2 — [Extension build](https://github.com/leather-io/extension/actions/runs/13607579201), [Test report](https://leather-io.github.io/playwright-reports/fix/broadcast-network), [Storybook](https://fix/broadcast-network--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/broadcast-network)<!-- Sticky Header Marker -->

Fixes bug reported by @markmhendrickson https://trustmachines.slack.com/archives/C05114YP8CV/p1740120535304409