### PR TITLE
ci: ensure all checks pass

### DIFF
--- a/.github/workflows/all-checks-pass.yml
+++ b/.github/workflows/all-checks-pass.yml
@@ -1,0 +1,14 @@
+name: All checks pass
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  allchecks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+
+    steps:
+      - uses: wechuli/allcheckspassed@v1


### PR DESCRIPTION
> Try out Leather build 129df46 — [Extension build](https://github.com/leather-io/extension/actions/runs/13455809239), [Test report](https://leather-io.github.io/playwright-reports/ci/all-checks-pass), [Storybook](https://ci/all-checks-pass--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci/all-checks-pass)<!-- Sticky Header Marker -->

This CI change sets a single action that groups the result of all others, such that our branch rules can state a single rule that must pass before merging. 

This should prevent very naughty merges of failed builds. 


| Before | After |
|--------|--------|
| <img width="728" alt="image" src="https://github.com/user-attachments/assets/2d87ab07-41c6-4ef3-a50d-04dfade1024b" /> | <img width="728" alt="image" src="https://github.com/user-attachments/assets/a422e463-778f-4873-8eff-831a9e6d9968" /> |


