### PR TITLE
fix: failing onboarding integration test

### DIFF
--- a/tests/page-object-models/onboarding.page.ts
+++ b/tests/page-object-models/onboarding.page.ts
@@ -45,6 +45,7 @@ export const testSoftwareAccountDefaultWalletState = {
     discardedInscriptions: [],
     userSelectedTheme: 'system',
     dismissedMessages: [],
+    isNotificationsEnabled: true,
   },
   manageTokens: { entities: {}, ids: [] },
   _persist: { version: 2, rehydrated: true },


### PR DESCRIPTION
> Try out Leather build c26260c — [Extension build](https://github.com/leather-io/extension/actions/runs/13455594748), [Test report](https://leather-io.github.io/playwright-reports/fix/failing-integration-test), [Storybook](https://fix/failing-integration-test--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/failing-integration-test)<!-- Sticky Header Marker -->

Need to add new default notifications setting to test state object.

Caused by: https://github.com/leather-io/extension/pull/6130