### PR TITLE
fix: update fn arg serialization, closes LEA-2166

### DIFF
--- a/src/background/messaging/rpc-methods/stx-sign-transaction.ts
+++ b/src/background/messaging/rpc-methods/stx-sign-transaction.ts
@@ -82,7 +82,7 @@ function transactionPayloadToTransactionRequest(
         stacksTransaction.payload.contractAddress
       );
       transactionRequest.functionArgs = stacksTransaction.payload.functionArgs.map(arg =>
-        Buffer.from(serializeCV(arg)).toString('hex')
+        serializeCV(arg)
       );
       transactionRequest.functionName = stacksTransaction.payload.functionName.content;
       break;


### PR DESCRIPTION
> Try out Leather build 611e177 — [Extension build](https://github.com/leather-io/extension/actions/runs/13463415629), [Test report](https://leather-io.github.io/playwright-reports/fix/stx-sign-transaction), [Storybook](https://fix/stx-sign-transaction--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/stx-sign-transaction)<!-- Sticky Header Marker -->

Fixes linked reported bug with functionArg deserialization after stacks.js upgrade.