### PR TITLE
feat: stx transfer sip9 nft, closes LEA-1964

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "@leather.io/models": "0.25.1",
     "@leather.io/provider": "1.0.0",
     "@leather.io/query": "2.27.0",
-    "@leather.io/rpc": "2.5.14",
+    "@leather.io/rpc": "2.6.6",
     "@leather.io/stacks": "1.5.20",
     "@leather.io/tokens": "0.12.11",
     "@leather.io/ui": "1.48.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: 2.27.0
         version: 2.27.0(encoding@0.1.13)(react@18.3.1)
       '@leather.io/rpc':
-        specifier: 2.5.14
-        version: 2.5.14(encoding@0.1.13)
+        specifier: 2.6.6
+        version: 2.6.6(encoding@0.1.13)
       '@leather.io/stacks':
         specifier: 1.5.20
         version: 1.5.20(encoding@0.1.13)
@@ -3364,6 +3364,9 @@ packages:
   '@leather.io/constants@0.16.0':
     resolution: {integrity: sha512-04yUXvJMKkRML8isgg5MAb20q3azYNRvNxYuNk4ye+1otjf9ZoPkvcMlAA+5y19N3hoMhBNAkbqHogH0WKLv/A==}
 
+  '@leather.io/constants@0.17.3':
+    resolution: {integrity: sha512-rcyRoegpi79BVc/7oLyeUNr0AJJKAVThZrI13v1GDz56HzmF08ThceZkdHjpgORHOpioYizHvXxJv6Tw2CNMbg==}
+
   '@leather.io/crypto@1.6.35':
     resolution: {integrity: sha512-VvqffR0LMU/XzlT598idHHFQHDzYnatQUphozWrfKy5l9UyyN4eny6UPH7bLxzgV3zVTNZq9VOxhTqua2ZhVXw==}
 
@@ -3378,6 +3381,9 @@ packages:
 
   '@leather.io/models@0.26.0':
     resolution: {integrity: sha512-+9UvZ9zrxLGSOKCoMYoLLy9CkCckcWpgh1iABPt8A0Y5mjmLgV5Ha4/PFLffrKCqDmusjFpISZV7gCGIcw98+Q==}
+
+  '@leather.io/models@0.26.3':
+    resolution: {integrity: sha512-7AGKf2lWuW9EVuZbAayQ7AqpXlnbnauw0VRYDKej17qu6kcj0oEU0UOf2OmG4uXlLR6bjEK5LUXeCUdTXYie5Q==}
 
   '@leather.io/panda-preset@0.8.10':
     resolution: {integrity: sha512-fDW5JePLKsIBldig7EI8h/Dz25Ux+I76e/9btQ6GQ27/sIil7c5/ztWqiHj7/dLcW7cT8EqB6IQtUpcUQhPVFw==}
@@ -3396,14 +3402,14 @@ packages:
   '@leather.io/rpc@2.5.10':
     resolution: {integrity: sha512-9girm347ekq1PWEpwSH7lkakYEU4VPFdM3kA2Va/MOmQXIp1ajRTN8eexhgiB3W7M/lPXYkX0qn0hQAiBshDVA==}
 
-  '@leather.io/rpc@2.5.14':
-    resolution: {integrity: sha512-0Fyy0aEcenRtqkxAc1qC2a1rpjOmVi8pkZZaNdglrmVLXvv46QDWApxHkc5FO0EC9aPGhnKR3KBFPhq8puikPg==}
-
   '@leather.io/rpc@2.5.6':
     resolution: {integrity: sha512-xPEkPC2n+VC1YssMv/NiHmQ6RyXGtT2DMDyQBfUnyr8Zc1NQ98gJbNyIihNl2XdFc1x9sNETP/3NJ3OwXLUIgg==}
 
   '@leather.io/rpc@2.6.0':
     resolution: {integrity: sha512-UhvvsQ4kdE/nr94bbSxJ05/AttkdQd7TNX3pNqUCD47/mmX62jS6dv5tSbqD7K56lu4CHTyoTQw2hJWkOTC7HQ==}
+
+  '@leather.io/rpc@2.6.6':
+    resolution: {integrity: sha512-/h1BdnO90tJCvmhczH6qhHRYZDscywL+CGp2f61OonJCJncWK0USvBJWt2tXVKZCXoK3Nfks85YJ1GEeYaRB8w==}
 
   '@leather.io/stacks@1.5.20':
     resolution: {integrity: sha512-A5TChq+iec6iVyCknz26VZMGhu2sx+pKsdwFKOLqut/P5DrQn4QcGWoG/pQIUZ7QqE3fsFxwnFBGLcVIpDNB3w==}
@@ -3428,6 +3434,9 @@ packages:
 
   '@leather.io/utils@0.27.1':
     resolution: {integrity: sha512-6/rcSIwN94WVF3Ok0D4imZNurw1gtO8G9C6pTMXmejL2U/YpbrdjhQG9S8xDYDUD7QFnM3jD3vlmGSOCuvanAA==}
+
+  '@leather.io/utils@0.27.5':
+    resolution: {integrity: sha512-5bBJ6T63EkW1/XqS3yVTNredD6qiuAeRxGf3zAoMLNwUhbnlnnop5AizezgW6pG8f1OtLJv4myz3BGxmOssAMQ==}
 
   '@ledgerhq/devices@8.4.2':
     resolution: {integrity: sha512-oWNTp3jCMaEvRHsXNYE/yo+PFMgXAJGFHLOU1UdE4/fYkniHbD9wdxwyZrZvrxr9hNw4/9wHiThyITwPtMzG7g==}
@@ -3481,11 +3490,19 @@ packages:
     resolution: {integrity: sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.8.1':
+    resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/hashes@1.1.5':
     resolution: {integrity: sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==}
 
   '@noble/hashes@1.5.0':
     resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.7.1':
+    resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/secp256k1@1.7.1':
@@ -5056,6 +5073,9 @@ packages:
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
+  '@scure/base@1.2.4':
+    resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
+
   '@scure/bip32@1.1.3':
     resolution: {integrity: sha512-dSH3+LCWONlSNQuF34xZrG6Xas7tp2jSSqHb/pMfXWM0vKE4JZOtK3uJfoWouUVW5IGlls75HkXmYLldZ8ySgQ==}
 
@@ -5070,6 +5090,9 @@ packages:
 
   '@scure/btc-signer@1.4.0':
     resolution: {integrity: sha512-uSZqmiWWm1+wflQbiob0CrzQSCwDO9MmAxqsqk+tkiRcUv8GbC3Ptv9/2nUbsoUBuPN/6mBQJ/KOBzHjc5Bgow==}
+
+  '@scure/btc-signer@1.6.0':
+    resolution: {integrity: sha512-qd6ciJE4Onk1xdQEdjPvRbLRrH7EddPZagMuZOFv77R/76EWixENd6nuoxqHNEPGRbS09rgAhhPgT7j0oQdi1A==}
 
   '@segment/analytics-core@1.6.0':
     resolution: {integrity: sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==}
@@ -12142,6 +12165,9 @@ packages:
 
   micro-packed@0.6.3:
     resolution: {integrity: sha512-VmVkyc7lIzAq/XCPFuLc/CwQ7Ehs5XDK3IwqsZHiBIDttAI9Gs7go6Lv4lNRuAIKrGKcRTtthFKUNyHS0S4wJQ==}
+
+  micro-packed@0.7.2:
+    resolution: {integrity: sha512-HJ/u8+tMzgrJVAl6P/4l8KGjJSA3SCZaRb1m4wpbovNScCSmVOGUYbkkcoPPcknCHWPpRAdjy+yqXqyQWf+k8g==}
 
   microdiff@1.3.2:
     resolution: {integrity: sha512-pKy60S2febliZIbwdfEQKTtL5bLNxOyiRRmD400gueYl9XcHyNGxzHSlJWn9IMHwYXT0yohPYL08+bGozVk8cQ==}
@@ -19608,6 +19634,10 @@ snapshots:
     dependencies:
       '@leather.io/models': 0.26.0
 
+  '@leather.io/constants@0.17.3':
+    dependencies:
+      '@leather.io/models': 0.26.3
+
   '@leather.io/crypto@1.6.35(encoding@0.1.13)':
     dependencies:
       '@leather.io/utils': 0.25.2(encoding@0.1.13)
@@ -19643,6 +19673,12 @@ snapshots:
       zod: 3.24.1
 
   '@leather.io/models@0.26.0':
+    dependencies:
+      '@stacks/stacks-blockchain-api-types': 7.8.2
+      bignumber.js: 9.1.2
+      zod: 3.24.1
+
+  '@leather.io/models@0.26.3':
     dependencies:
       '@stacks/stacks-blockchain-api-types': 7.8.2
       bignumber.js: 9.1.2
@@ -19720,17 +19756,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@leather.io/rpc@2.5.14(encoding@0.1.13)':
-    dependencies:
-      '@leather.io/models': 0.26.0
-      '@leather.io/utils': 0.27.1
-      '@scure/btc-signer': 1.4.0
-      '@stacks/network': 7.0.2(encoding@0.1.13)
-      '@stacks/transactions': 7.0.2(encoding@0.1.13)
-      zod: 3.24.1
-    transitivePeerDependencies:
-      - encoding
-
   '@leather.io/rpc@2.5.6(encoding@0.1.13)':
     dependencies:
       '@leather.io/models': 0.25.1
@@ -19745,6 +19770,17 @@ snapshots:
       '@leather.io/models': 0.26.0
       '@leather.io/utils': 0.27.1
       '@scure/btc-signer': 1.4.0
+      '@stacks/network': 7.0.2(encoding@0.1.13)
+      '@stacks/transactions': 7.0.2(encoding@0.1.13)
+      zod: 3.24.1
+    transitivePeerDependencies:
+      - encoding
+
+  '@leather.io/rpc@2.6.6(encoding@0.1.13)':
+    dependencies:
+      '@leather.io/models': 0.26.3
+      '@leather.io/utils': 0.27.5
+      '@scure/btc-signer': 1.6.0
       '@stacks/network': 7.0.2(encoding@0.1.13)
       '@stacks/transactions': 7.0.2(encoding@0.1.13)
       zod: 3.24.1
@@ -19877,6 +19913,12 @@ snapshots:
       '@leather.io/models': 0.26.0
       bignumber.js: 9.1.2
 
+  '@leather.io/utils@0.27.5':
+    dependencies:
+      '@leather.io/constants': 0.17.3
+      '@leather.io/models': 0.26.3
+      bignumber.js: 9.1.2
+
   '@ledgerhq/devices@8.4.2':
     dependencies:
       '@ledgerhq/errors': 6.18.0
@@ -19960,9 +20002,15 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.5.0
 
+  '@noble/curves@1.8.1':
+    dependencies:
+      '@noble/hashes': 1.7.1
+
   '@noble/hashes@1.1.5': {}
 
   '@noble/hashes@1.5.0': {}
+
+  '@noble/hashes@1.7.1': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -22606,6 +22654,8 @@ snapshots:
 
   '@scure/base@1.1.9': {}
 
+  '@scure/base@1.2.4': {}
+
   '@scure/bip32@1.1.3':
     dependencies:
       '@noble/hashes': 1.1.5
@@ -22634,6 +22684,13 @@ snapshots:
       '@noble/hashes': 1.5.0
       '@scure/base': 1.1.9
       micro-packed: 0.6.3
+
+  '@scure/btc-signer@1.6.0':
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/base': 1.2.4
+      micro-packed: 0.7.2
 
   '@segment/analytics-core@1.6.0':
     dependencies:
@@ -31548,6 +31605,10 @@ snapshots:
   micro-packed@0.6.3:
     dependencies:
       '@scure/base': 1.1.9
+
+  micro-packed@0.7.2:
+    dependencies:
+      '@scure/base': 1.2.4
 
   microdiff@1.3.2: {}
 

--- a/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.tsx
@@ -1,0 +1,27 @@
+import { stxTransferSip9Nft } from '@leather.io/rpc';
+import { isDefined } from '@leather.io/utils';
+
+import { useRpcSip30BroadcastTransaction } from '@app/common/rpc/use-rpc-sip30-broadcast-transaction';
+import { StacksHighFeeWarningContainer } from '@app/features/stacks-high-fee-warning/stacks-high-fee-warning-container';
+import { StacksTransactionSigner } from '@app/features/stacks-transaction-request/stacks-transaction-signer';
+import { useBreakOnNonCompliantEntity } from '@app/query/common/compliance-checker/compliance-checker.query';
+
+export function RpcStxTransferSip9Nft() {
+  const { onSignStacksTransaction, stacksTransaction, txPayload, txSender } =
+    useRpcSip30BroadcastTransaction(stxTransferSip9Nft.method);
+  const recipient = 'recipient' in txPayload ? txPayload.recipient : '';
+
+  useBreakOnNonCompliantEntity([txSender, recipient].filter(isDefined));
+
+  return (
+    <StacksHighFeeWarningContainer>
+      <StacksTransactionSigner
+        onSignStacksTransaction={onSignStacksTransaction}
+        isMultisig={false}
+        stacksTransaction={stacksTransaction}
+        disableFeeSelection={true}
+        disableNonceSelection={true}
+      />
+    </StacksHighFeeWarningContainer>
+  );
+}

--- a/src/app/routes/rpc-routes.tsx
+++ b/src/app/routes/rpc-routes.tsx
@@ -15,6 +15,7 @@ import { RpcStacksMessageSigning } from '@app/pages/rpc-sign-stacks-message/rpc-
 import { RpcStxCallContract } from '@app/pages/rpc-stx-call-contract/rpc-stx-call-contract';
 import { RpcStxDeployContract } from '@app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract';
 import { RpcStxSignTransaction } from '@app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction';
+import { RpcStxTransferSip9Nft } from '@app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft';
 import { RpcStxTransferSip10Ft } from '@app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft';
 import { RpcStxTransferStx } from '@app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx';
 import { AccountGate } from '@app/routes/account-gate';
@@ -117,6 +118,18 @@ export const rpcRequestRoutes = (
       element={
         <AccountGate>
           <RpcStxTransferStx />
+        </AccountGate>
+      }
+    >
+      {ledgerStacksTxSigningRoutes}
+      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
+    </Route>
+
+    <Route
+      path={RouteUrls.RpcStxTransferSip9Nft}
+      element={
+        <AccountGate>
+          <RpcStxTransferSip9Nft />
         </AccountGate>
       }
     >

--- a/src/background/messaging/messaging-utils.ts
+++ b/src/background/messaging/messaging-utils.ts
@@ -10,6 +10,7 @@ import {
   type baseStacksTransactionConfigSchema,
   createRpcErrorResponse,
 } from '@leather.io/rpc';
+import { getPrincipalFromAssetString } from '@leather.io/stacks';
 import { isDefined, isUndefined } from '@leather.io/utils';
 
 import { InternalMethods } from '@shared/message-types';
@@ -170,4 +171,11 @@ export function getStxDefaultMessageParamsToTransactionRequest(
   }
 
   return txRequest;
+}
+
+// TODO: Relocate to mono repo, we have this in services but not stacks pkg
+// See in services, getAddressFromAssetIdentifier
+export function getAddressFromAssetString(assetString: string) {
+  const principal = getPrincipalFromAssetString(assetString);
+  return principal.split('.')[0];
 }

--- a/src/background/messaging/rpc-message-handler.ts
+++ b/src/background/messaging/rpc-message-handler.ts
@@ -14,6 +14,7 @@ import {
   stxSignMessage,
   stxSignStructuredMessage,
   stxSignTransaction,
+  stxTransferSip9Nft,
   stxTransferSip10Ft,
   stxTransferStx,
   supportedMethods,
@@ -36,6 +37,7 @@ import {
 import { rpcStxCallContract } from './rpc-methods/stx-call-contract';
 import { rpcStxDeployContract } from './rpc-methods/stx-deploy-contract';
 import { rpcStxGetAddresses } from './rpc-methods/stx-get-addresses';
+import { rpcStxTransferSip9Nft } from './rpc-methods/stx-transfer-sip9-nft';
 import { rpcStxTransferSip10Ft } from './rpc-methods/stx-transfer-sip10-ft';
 import { rpcStxTransferStx } from './rpc-methods/stx-transfer-stx';
 import { rpcSupportedMethods } from './rpc-methods/supported-methods';
@@ -114,6 +116,11 @@ export async function rpcMessageHandler(message: RpcRequests, port: chrome.runti
 
     case stxTransferSip10Ft.method: {
       await rpcStxTransferSip10Ft(message, port);
+      break;
+    }
+
+    case stxTransferSip9Nft.method: {
+      await rpcStxTransferSip9Nft(message, port);
       break;
     }
 

--- a/src/shared/route-urls.ts
+++ b/src/shared/route-urls.ts
@@ -109,5 +109,6 @@ export enum RouteUrls {
   RpcStxCallContract = '/stx-call-contract',
   RpcStxDeployContract = '/stx-deploy-contract',
   RpcStxTransferStx = '/stx-transfer-stx',
+  RpcStxTransferSip9Nft = '/stx-transfer-sip9-nft',
   RpcStxTransferSip10Ft = '/stx-transfer-sip10-ft',
 }

--- a/src/shared/utils/post-conditions.ts
+++ b/src/shared/utils/post-conditions.ts
@@ -1,4 +1,4 @@
-import type { PostCondition } from '@stacks/transactions';
+import { type PostCondition, deserializeCV } from '@stacks/transactions';
 import BN from 'bn.js';
 
 import { formatAssetString } from '@leather.io/stacks';
@@ -19,5 +19,24 @@ export function makeFtPostCondition(options: FtPostConditionsOptions): PostCondi
     condition: 'eq',
     amount: new BN(amount, 10).toString(),
     asset: formatAssetString({ contractAddress, contractName, assetName: contractAssetName }),
+  };
+}
+
+interface NftPostConditionsOptions {
+  assetId: string;
+  contractAddress: string;
+  contractAssetName: string;
+  contractName: string;
+  stxAddress: string;
+}
+export function makeNftPostCondition(options: NftPostConditionsOptions): PostCondition {
+  const { assetId, contractAddress, contractAssetName, contractName, stxAddress } = options;
+
+  return {
+    type: 'nft-postcondition',
+    address: stxAddress,
+    condition: 'sent',
+    asset: formatAssetString({ contractAddress, contractName, assetName: contractAssetName }),
+    assetId: deserializeCV(assetId),
   };
 }

--- a/test-app/src/components/debugger.tsx
+++ b/test-app/src/components/debugger.tsx
@@ -8,7 +8,6 @@ import {
   stacksMainnetNetwork,
   stacksTestnetNetwork,
 } from '@common/utils';
-import { hexToBytes } from '@stacks/common';
 import { useConnect } from '@stacks/connect-react-jwt';
 import { STACKS_TESTNET } from '@stacks/network';
 import { type StacksTestnet } from '@stacks/network-v6';
@@ -86,8 +85,8 @@ export const Debugger = () => {
       condition: 'sent',
       asset: 'ST000000000000000000002AMW42H.bns::names',
       assetId: tupleCV({
-        name: bufferCV(hexToBytes('stella')),
-        namespace: bufferCV(hexToBytes('id')),
+        name: bufferCVFromString('stella'),
+        namespace: bufferCVFromString('id'),
       }),
     };
     await doContractCall({

--- a/tests/specs/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.spec.ts
+++ b/tests/specs/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.spec.ts
@@ -1,0 +1,68 @@
+import { BrowserContext, Page } from '@playwright/test';
+import { TEST_ACCOUNT_2_STX_ADDRESS } from '@tests/mocks/constants';
+
+import type { RpcParams, stxTransferSip10Ft } from '@leather.io/rpc';
+
+import { RpcErrorMessage } from '@shared/rpc/methods/validation.utils';
+
+import { test } from '../../fixtures/fixtures';
+
+test.describe('RPC: stx_transferSip10Ft', () => {
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await onboardingPage.signInWithTestAccount(extensionId);
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
+  });
+
+  function checkVisibleContent(context: BrowserContext) {
+    return async (buttonToPress: 'Cancel' | 'Confirm') => {
+      const popup = await context.waitForEvent('page');
+      await popup.waitForSelector('text="LEO"');
+      await popup.waitForSelector('text="0.001"');
+      await popup.waitForSelector('text="transfer"');
+      await popup.waitForSelector('text="SP1A…2CT6.leo-token"');
+      await popup.waitForSelector('text="SPXH3HNBPM5YP15VH16ZXZ9AX6CK289K3MCXRKCB"');
+      await popup.waitForSelector('text="none"');
+      await popup.waitForTimeout(500);
+      const btn = popup.locator('text="Confirm"');
+
+      if (buttonToPress === 'Confirm') {
+        await btn.click();
+      } else {
+        await popup.close();
+      }
+    };
+  }
+
+  function initiateSip30RpcTransferSip10Ft(page: Page) {
+    return async (params: RpcParams<typeof stxTransferSip10Ft>) =>
+      page.evaluate(
+        async params =>
+          (window as any).LeatherProvider.request('stx_transferSip10Ft', {
+            ...params,
+          }).catch((e: unknown) => e),
+        { ...params }
+      );
+  }
+
+  test('SIP-30 transfer sip10 fungible token', async ({ page, context }) => {
+    const [result] = await Promise.all([
+      initiateSip30RpcTransferSip10Ft(page)({
+        amount: 1000,
+        asset: 'SP1AY6K3PQV5MRT6R4S671NWW2FRVPKM0BR162CT6.leo-token::leo',
+        recipient: TEST_ACCOUNT_2_STX_ADDRESS,
+      }),
+      checkVisibleContent(context)('Cancel'),
+    ]);
+
+    delete result.id;
+
+    test.expect(result).toEqual({
+      jsonrpc: '2.0',
+      error: {
+        code: 4001,
+        message: RpcErrorMessage.UserRejectedSigning,
+      },
+    });
+  });
+});

--- a/tests/specs/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.spec.ts
+++ b/tests/specs/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.spec.ts
@@ -1,0 +1,67 @@
+import { BrowserContext, Page } from '@playwright/test';
+import { TEST_ACCOUNT_2_STX_ADDRESS } from '@tests/mocks/constants';
+
+import type { RpcParams, stxTransferSip9Nft } from '@leather.io/rpc';
+
+import { RpcErrorMessage } from '@shared/rpc/methods/validation.utils';
+
+import { test } from '../../fixtures/fixtures';
+
+test.describe('RPC: stx_transferSip9Nft', () => {
+  test.beforeEach(async ({ extensionId, globalPage, onboardingPage, page }) => {
+    await globalPage.setupAndUseApiCalls(extensionId);
+    await onboardingPage.signInWithTestAccount(extensionId);
+    await page.goto('localhost:3000', { waitUntil: 'networkidle' });
+  });
+
+  function checkVisibleContent(context: BrowserContext) {
+    return async (buttonToPress: 'Cancel' | 'Confirm') => {
+      const popup = await context.waitForEvent('page');
+      await popup.waitForSelector('text="LIV"');
+      await popup.waitForSelector('text="transfer"');
+      await popup.waitForSelector('text="SP2X…G3PJ.living-leather"');
+      await popup.waitForSelector('text="u647"');
+      await popup.waitForSelector('text="SPXH3HNBPM5YP15VH16ZXZ9AX6CK289K3MCXRKCB"');
+      await popup.waitForTimeout(500);
+      const btn = popup.locator('text="Confirm"');
+
+      if (buttonToPress === 'Confirm') {
+        await btn.click();
+      } else {
+        await popup.close();
+      }
+    };
+  }
+
+  function initiateSip30RpcTransferSip9Nft(page: Page) {
+    return async (params: RpcParams<typeof stxTransferSip9Nft>) =>
+      page.evaluate(
+        async params =>
+          (window as any).LeatherProvider.request('stx_transferSip9Nft', {
+            ...params,
+          }).catch((e: unknown) => e),
+        { ...params }
+      );
+  }
+
+  test('SIP-30 transfer sip9 non-fungible token', async ({ page, context }) => {
+    const [result] = await Promise.all([
+      initiateSip30RpcTransferSip9Nft(page)({
+        assetId: '0100000000000000000000000000000287', // serializeCV(uintCV(647))
+        asset: 'SP2XMGYYTA1KRBKBYJHTW8CFWB2QYZKZE4BMHG3PJ.living-leather::living-leather',
+        recipient: TEST_ACCOUNT_2_STX_ADDRESS,
+      }),
+      checkVisibleContent(context)('Cancel'),
+    ]);
+
+    delete result.id;
+
+    test.expect(result).toEqual({
+      jsonrpc: '2.0',
+      error: {
+        code: 4001,
+        message: RpcErrorMessage.UserRejectedSigning,
+      },
+    });
+  });
+});


### PR DESCRIPTION
> Try out Leather build 1dee9b2 — [Extension build](https://github.com/leather-io/extension/actions/runs/13529070215), [Test report](https://leather-io.github.io/playwright-reports/feat/stx-transfer-sip9-nft), [Storybook](https://feat/stx-transfer-sip9-nft--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/stx-transfer-sip9-nft)<!-- Sticky Header Marker -->

**Need to update rpc package here before merge**

This PR adds the `stx_transferSip9Nft` SIP-30 rpc request.

Successful test tx:
https://explorer.hiro.so/txid/0xe0c0484976989b6bbb470380fd8507e15951942440cdfb516f1daf61e3868d84?chain=mainnet