### PR TITLE
fix: btc recipient validation, closes LEA-2126

### DIFF
--- a/src/shared/forms/address-validators.ts
+++ b/src/shared/forms/address-validators.ts
@@ -6,7 +6,7 @@ import { isEmptyString, isUndefined } from '@leather.io/utils';
 
 import { FormErrorMessages } from '@shared/error-messages';
 
-export function nonEmptyStringValidator(message = FormErrorMessages.AddressRequired) {
+export function nonEmptyStringValidator(message = '') {
   return yup.string().test({
     message,
     test: value => value !== undefined && value.trim() !== '',


### PR DESCRIPTION
> Try out Leather build f766f44 — [Extension build](https://github.com/leather-io/extension/actions/runs/13510979203), [Test report](https://leather-io.github.io/playwright-reports/fix/btc-send-form-recipient), [Storybook](https://fix/btc-send-form-recipient--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/btc-send-form-recipient)<!-- Sticky Header Marker -->

@alter-eggo can you double check this, I think you added it and I'm unaware of this validation. If I remove the default message the bug is fixed, is this ok to remove?