### PR TITLE
fix: sbtc limits schema, closes LEA-2185

### DIFF
--- a/src/app/query/sbtc/sbtc-limits.query.ts
+++ b/src/app/query/sbtc/sbtc-limits.query.ts
@@ -18,10 +18,10 @@ export const defaultSbtcLimits = {
 };
 
 const sbtcLimitsResponseSchema = z.object({
-  pegCap: z.number(),
-  perDepositCap: z.number(),
-  perDepositMinimum: z.number(),
-  perWithdrawalCap: z.number(),
+  pegCap: z.number().nullable(),
+  perDepositCap: z.number().nullable(),
+  perDepositMinimum: z.number().nullable(),
+  perWithdrawalCap: z.number().nullable(),
   accountCaps: z.record(z.any()),
 });
 


### PR DESCRIPTION
> Try out Leather build 6a28e0c — [Extension build](https://github.com/leather-io/extension/actions/runs/13533861886), [Test report](https://leather-io.github.io/playwright-reports/fix/sbtc-limits), [Storybook](https://fix/sbtc-limits--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/sbtc-limits)<!-- Sticky Header Marker -->

sbtc team fixed their response so our UI isn't broken, but we need to allow `nullable` values here.