### PR TITLE
refactor: use sbtc lib deposit defaults

### DIFF
--- a/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
+++ b/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
@@ -5,6 +5,7 @@ import { bytesToHex } from '@noble/hashes/utils';
 import * as btc from '@scure/btc-signer';
 import type { P2Ret, P2TROut } from '@scure/btc-signer/payment';
 import {
+  DEFAULT_RECLAIM_LOCK_TIME,
   MAINNET,
   REGTEST,
   SbtcApiClientMainnet,
@@ -34,10 +35,6 @@ import { useCurrentNetwork } from '@app/store/networks/networks.selectors';
 
 import type { BitcoinSwapContext } from '../providers/bitcoin-swap-provider';
 import type { SubmitSwapArgs } from '../swap.context';
-
-// Also set as defaults in sbtc lib
-export const defaultMaxSignerFee = 80_000;
-const reclaimLockTime = 144;
 
 export interface SbtcDeposit {
   address: string;
@@ -95,7 +92,7 @@ export function useSbtcDepositTransaction(signer: Signer<P2Ret>, utxos: UtxoResp
           stacksAddress: stacksAccount.address,
           signersPublicKey: await client.fetchSignersPublicKey(),
           maxSignerFee: swapData.maxSignerFee,
-          reclaimLockTime,
+          reclaimLockTime: DEFAULT_RECLAIM_LOCK_TIME,
           reclaimPublicKey: bytesToHex(signer.publicKey).slice(2),
         });
 

--- a/src/app/pages/swap/providers/bitcoin-swap-provider.tsx
+++ b/src/app/pages/swap/providers/bitcoin-swap-provider.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 
 import type { P2Ret } from '@scure/btc-signer/payment';
 import BigNumber from 'bignumber.js';
+import { DEFAULT_MAX_SIGNER_FEE } from 'sbtc';
 
 import type { UtxoResponseItem } from '@leather.io/query';
 import { createMoney } from '@leather.io/utils';
@@ -10,7 +11,7 @@ import type { Signer } from '@app/store/accounts/blockchain/bitcoin/bitcoin-sign
 
 import { SwapForm } from '../form/swap-form';
 import { useAllSwappableAssets } from '../hooks/use-all-swappable-assets';
-import { type SbtcDeposit, defaultMaxSignerFee } from '../hooks/use-sbtc-deposit-transaction';
+import { type SbtcDeposit } from '../hooks/use-sbtc-deposit-transaction';
 import { SwapProvider } from '../swap-provider';
 import type { BaseSwapContext } from '../swap.context';
 import { useBitcoinSwap } from './use-bitcoin-swap';
@@ -35,7 +36,7 @@ export function BitcoinSwapProvider({ signer, utxos }: BitcoinSwapProviderProps)
       initialData={{
         chain: 'bitcoin',
         fee: createMoney(new BigNumber(0), 'BTC'),
-        maxSignerFee: defaultMaxSignerFee,
+        maxSignerFee: DEFAULT_MAX_SIGNER_FEE,
         protocol: 'sBTC Protocol',
         signer,
         swappableAssetsBase: allSwappableAssets,


### PR DESCRIPTION
> Try out Leather build b07804c — [Extension build](https://github.com/leather-io/extension/actions/runs/13546186077), [Test report](https://leather-io.github.io/playwright-reports/refactor/sbtc-deposit-tx-defaults), [Storybook](https://refactor/sbtc-deposit-tx-defaults--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/sbtc-deposit-tx-defaults)<!-- Sticky Header Marker -->

We were asked by the sbtc team to use the sbtc lib defaults for now for consistency.