### PR TITLE
feat: `network` param support, getAddresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "@leather.io/models": "0.27.0",
     "@leather.io/provider": "1.0.0",
     "@leather.io/query": "2.29.1",
-    "@leather.io/rpc": "2.6.6",
+    "@leather.io/rpc": "2.7.2",
     "@leather.io/stacks": "1.6.4",
     "@leather.io/tokens": "0.12.11",
     "@leather.io/ui": "1.48.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: 2.29.1
         version: 2.29.1(encoding@0.1.13)(react@18.3.1)
       '@leather.io/rpc':
-        specifier: 2.6.6
-        version: 2.6.6(encoding@0.1.13)
+        specifier: 2.7.2
+        version: 2.7.2(encoding@0.1.13)
       '@leather.io/stacks':
         specifier: 1.6.4
         version: 1.6.4(encoding@0.1.13)
@@ -338,7 +338,7 @@ importers:
         version: 1.2.4(react@18.3.1)
       react-qr-code:
         specifier: 2.0.12
-        version: 2.0.12(react-native-svg@15.11.1(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1))(react@18.3.1)
+        version: 2.0.12(react-native-svg@15.11.2(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1))(react@18.3.1)
       react-redux:
         specifier: 9.1.2
         version: 9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1)
@@ -3364,9 +3364,6 @@ packages:
   '@leather.io/constants@0.16.0':
     resolution: {integrity: sha512-04yUXvJMKkRML8isgg5MAb20q3azYNRvNxYuNk4ye+1otjf9ZoPkvcMlAA+5y19N3hoMhBNAkbqHogH0WKLv/A==}
 
-  '@leather.io/constants@0.17.3':
-    resolution: {integrity: sha512-rcyRoegpi79BVc/7oLyeUNr0AJJKAVThZrI13v1GDz56HzmF08ThceZkdHjpgORHOpioYizHvXxJv6Tw2CNMbg==}
-
   '@leather.io/constants@0.17.4':
     resolution: {integrity: sha512-Ymtou2wQcVf8b8zbeevjzSRY6mkzNy33neOXg3dtla/awk8PFmJQwFx/7tKBGwOzva6qmwAwiz4OHeTBMfjXhA==}
 
@@ -3384,9 +3381,6 @@ packages:
 
   '@leather.io/models@0.26.0':
     resolution: {integrity: sha512-+9UvZ9zrxLGSOKCoMYoLLy9CkCckcWpgh1iABPt8A0Y5mjmLgV5Ha4/PFLffrKCqDmusjFpISZV7gCGIcw98+Q==}
-
-  '@leather.io/models@0.26.3':
-    resolution: {integrity: sha512-7AGKf2lWuW9EVuZbAayQ7AqpXlnbnauw0VRYDKej17qu6kcj0oEU0UOf2OmG4uXlLR6bjEK5LUXeCUdTXYie5Q==}
 
   '@leather.io/models@0.27.0':
     resolution: {integrity: sha512-BOg8bwvYjYLeBwHsb6xo12KRDkVTHAIdJzy4czzxbNkpmwKiES47jeLW/RQFDUfyVYG4tg7HB1fuKJx/rdWU3Q==}
@@ -3411,11 +3405,11 @@ packages:
   '@leather.io/rpc@2.6.0':
     resolution: {integrity: sha512-UhvvsQ4kdE/nr94bbSxJ05/AttkdQd7TNX3pNqUCD47/mmX62jS6dv5tSbqD7K56lu4CHTyoTQw2hJWkOTC7HQ==}
 
-  '@leather.io/rpc@2.6.6':
-    resolution: {integrity: sha512-/h1BdnO90tJCvmhczH6qhHRYZDscywL+CGp2f61OonJCJncWK0USvBJWt2tXVKZCXoK3Nfks85YJ1GEeYaRB8w==}
-
   '@leather.io/rpc@2.6.8':
     resolution: {integrity: sha512-y4DSYbNqz7gHt3b0TlV4JuV/6dZYMGUtdzOmvbvYcU4gpFBpFSomzOz79Q/smN2/fexVxudWwmvXnPWiFxQrqQ==}
+
+  '@leather.io/rpc@2.7.2':
+    resolution: {integrity: sha512-elyVG4Wme2zxCc2GbTw+4e0YOTqOfmQUEMHfxx8IBKjPAh3wIJGpllrazAFMCZqUgPonP7DgxOTpxEEhkgs6gQ==}
 
   '@leather.io/stacks@1.6.4':
     resolution: {integrity: sha512-WoOHuGHGXuVYUh6H1xKdsrv9hW1dLw68mbUPF+BcMzCfp/aRBzPN0XI2RhzAeTfEW5ne2UrlfeR4qI8MDG08lQ==}
@@ -3434,9 +3428,6 @@ packages:
 
   '@leather.io/utils@0.27.1':
     resolution: {integrity: sha512-6/rcSIwN94WVF3Ok0D4imZNurw1gtO8G9C6pTMXmejL2U/YpbrdjhQG9S8xDYDUD7QFnM3jD3vlmGSOCuvanAA==}
-
-  '@leather.io/utils@0.27.5':
-    resolution: {integrity: sha512-5bBJ6T63EkW1/XqS3yVTNredD6qiuAeRxGf3zAoMLNwUhbnlnnop5AizezgW6pG8f1OtLJv4myz3BGxmOssAMQ==}
 
   '@leather.io/utils@0.27.6':
     resolution: {integrity: sha512-fppUHy5nWaCTyiPviP4u6jxJVK2HRUFnJ+6h/axXd7qDODnEjBHMAdE95FvwmTBAOoo241QGKZCqFPI18RJ8cw==}
@@ -13420,8 +13411,8 @@ packages:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.2:
-    resolution: {integrity: sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==}
+  postcss@8.5.3:
+    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.2:
@@ -13783,8 +13774,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-svg@15.11.1:
-    resolution: {integrity: sha512-Qmwx/yJKt+AHUr4zjxx/Q69qwKtRfr1+uIfFMQoq3WFRhqU76aL9db1DyvPiY632DAsVGba1pHf92OZPkpjrdQ==}
+  react-native-svg@15.11.2:
+    resolution: {integrity: sha512-+YfF72IbWQUKzCIydlijV1fLuBsQNGMT6Da2kFlo1sh+LE3BIm/2Q7AR1zAAR6L0BFLi1WaQPLfFUC9bNZpOmw==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -19639,10 +19630,6 @@ snapshots:
     dependencies:
       '@leather.io/models': 0.26.0
 
-  '@leather.io/constants@0.17.3':
-    dependencies:
-      '@leather.io/models': 0.26.3
-
   '@leather.io/constants@0.17.4':
     dependencies:
       '@leather.io/models': 0.27.0
@@ -19680,12 +19667,6 @@ snapshots:
       zod: 3.24.1
 
   '@leather.io/models@0.26.0':
-    dependencies:
-      '@stacks/stacks-blockchain-api-types': 7.8.2
-      bignumber.js: 9.1.2
-      zod: 3.24.1
-
-  '@leather.io/models@0.26.3':
     dependencies:
       '@stacks/stacks-blockchain-api-types': 7.8.2
       bignumber.js: 9.1.2
@@ -19780,10 +19761,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@leather.io/rpc@2.6.6(encoding@0.1.13)':
+  '@leather.io/rpc@2.6.8(encoding@0.1.13)':
     dependencies:
-      '@leather.io/models': 0.26.3
-      '@leather.io/utils': 0.27.5
+      '@leather.io/models': 0.27.0
+      '@leather.io/utils': 0.27.6
       '@scure/btc-signer': 1.6.0
       '@stacks/network': 7.0.2(encoding@0.1.13)
       '@stacks/transactions': 7.0.2(encoding@0.1.13)
@@ -19791,7 +19772,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@leather.io/rpc@2.6.8(encoding@0.1.13)':
+  '@leather.io/rpc@2.7.2(encoding@0.1.13)':
     dependencies:
       '@leather.io/models': 0.27.0
       '@leather.io/utils': 0.27.6
@@ -19901,12 +19882,6 @@ snapshots:
     dependencies:
       '@leather.io/constants': 0.16.0
       '@leather.io/models': 0.26.0
-      bignumber.js: 9.1.2
-
-  '@leather.io/utils@0.27.5':
-    dependencies:
-      '@leather.io/constants': 0.17.3
-      '@leather.io/models': 0.26.3
       bignumber.js: 9.1.2
 
   '@leather.io/utils@0.27.6':
@@ -25370,7 +25345,7 @@ snapshots:
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.2
+      postcss: 8.5.3
       source-map-js: 1.2.1
     optional: true
 
@@ -33093,7 +33068,7 @@ snapshots:
       picocolors: 1.1.0
       source-map-js: 1.2.1
 
-  postcss@8.5.2:
+  postcss@8.5.3:
     dependencies:
       nanoid: 3.3.4
       picocolors: 1.1.1
@@ -33498,7 +33473,7 @@ snapshots:
       react: 18.2.0
       react-native: 0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.3.1)
 
-  react-native-svg@15.11.1(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1):
+  react-native-svg@15.11.2(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1):
     dependencies:
       css-select: 5.1.0
       css-tree: 1.1.3
@@ -33571,13 +33546,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-qr-code@2.0.12(react-native-svg@15.11.1(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1))(react@18.3.1):
+  react-qr-code@2.0.12(react-native-svg@15.11.2(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1))(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
       qr.js: 0.0.0
       react: 18.3.1
     optionalDependencies:
-      react-native-svg: 15.11.1(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1)
+      react-native-svg: 15.11.2(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1)
 
   react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))(react@18.3.1)(redux@4.2.1):
     dependencies:

--- a/src/app/pages/rpc-get-addresses/use-get-addresses.ts
+++ b/src/app/pages/rpc-get-addresses/use-get-addresses.ts
@@ -1,28 +1,48 @@
 import { bytesToHex } from '@stacks/common';
+import { z } from 'zod';
 
 import { ecdsaPublicKeyToSchnorr } from '@leather.io/bitcoin';
-import { type BtcAddress, createRpcSuccessResponse } from '@leather.io/rpc';
+import {
+  type BtcAddress,
+  type StxAddress,
+  createRequestEncoder,
+  createRpcSuccessResponse,
+  getAddresses,
+  stxGetAddresses,
+} from '@leather.io/rpc';
 
 import { logger } from '@shared/logger';
 import { analytics } from '@shared/utils/analytics';
 
 import { focusTabAndWindow } from '@app/common/focus-tab';
+import { initialSearchParams } from '@app/common/initial-search-params';
 import { useRpcRequestParams } from '@app/common/rpc/use-rpc-request';
 import { useCurrentAccountNativeSegwitSigner } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
 import { useCurrentAccountTaprootSigner } from '@app/store/accounts/blockchain/bitcoin/taproot-account.hooks';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useAppPermissions } from '@app/store/app-permissions/app-permissions.slice';
 
+// We reuse this flow for both of these requsts, so here we make a union of two
+// possible requests
+const getAddressesRequests = z.union([getAddresses.request, stxGetAddresses.request]);
+const { decode } = createRequestEncoder(getAddressesRequests);
+
+function useGetAddressesParams() {
+  const { tabId, origin } = useRpcRequestParams();
+  const request = initialSearchParams.get('rpcRequest');
+  if (!request) throw new Error('Missing rpcRequest');
+  return { tabId, origin, request: decode(request) };
+}
+
 export function useGetAddresses() {
   const permissions = useAppPermissions();
-  const { tabId, origin, requestId } = useRpcRequestParams();
-
+  const { tabId, origin, request } = useGetAddressesParams();
   const createNativeSegwitSigner = useCurrentAccountNativeSegwitSigner();
   const createTaprootSigner = useCurrentAccountTaprootSigner();
   const stacksAccount = useCurrentStacksAccount();
 
   function focusInitatingTab() {
-    void analytics.track('user_clicked_requested_by_link', { endpoint: 'getAddresses' });
+    void analytics.track('user_clicked_requested_by_link', { endpoint: request.method });
     focusTabAndWindow(tabId);
   }
 
@@ -71,18 +91,18 @@ export function useGetAddresses() {
       if (stacksAccount) {
         const stacksAddressResponse = {
           symbol: 'STX',
-          address: stacksAccount.address ?? '',
-          publicKey: stacksAccount.stxPublicKey ?? '',
-        };
+          address: stacksAccount.address,
+          publicKey: stacksAccount.stxPublicKey,
+        } satisfies StxAddress;
 
         keysToIncludeInResponse.push(stacksAddressResponse);
       }
 
       chrome.tabs.sendMessage(
         tabId,
-        createRpcSuccessResponse('getAddresses', {
-          id: requestId,
-          result: { addresses: keysToIncludeInResponse as any },
+        createRpcSuccessResponse(request.method, {
+          id: request.id,
+          result: { addresses: keysToIncludeInResponse },
         })
       );
     },

--- a/src/app/store/app-permissions/app-permissions.slice.ts
+++ b/src/app/store/app-permissions/app-permissions.slice.ts
@@ -3,7 +3,10 @@ import { useDispatch } from 'react-redux';
 
 import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 
+import type { BitcoinNetworkModes } from '@leather.io/models';
+
 import { useCurrentAccountIndex } from '../accounts/account';
+import { useCurrentNetwork } from '../networks/networks.selectors';
 
 interface AppPermission {
   origin: string;
@@ -11,6 +14,7 @@ interface AppPermission {
   // has given permission
   requestedAccounts?: string;
   accountIndex: number;
+  networkMode: BitcoinNetworkModes;
 }
 const appPermissionsAdapter = createEntityAdapter<AppPermission, string>({
   selectId: permission => permission.origin,
@@ -27,6 +31,7 @@ export const appPermissionsSlice = createSlice({
 export function useAppPermissions() {
   const dispatch = useDispatch();
   const currentAccountIndex = useCurrentAccountIndex();
+  const currentNetwork = useCurrentNetwork();
 
   return useMemo(
     () => ({
@@ -37,10 +42,11 @@ export function useAppPermissions() {
             origin: url,
             requestedAccounts: new Date().toISOString(),
             accountIndex: currentAccountIndex,
+            networkMode: currentNetwork.chain.bitcoin.mode,
           })
         );
       },
     }),
-    [currentAccountIndex, dispatch]
+    [currentAccountIndex, currentNetwork.chain.bitcoin.mode, dispatch]
   );
 }

--- a/tests/specs/rpc-get-addresses/get-addresses.spec.ts
+++ b/tests/specs/rpc-get-addresses/get-addresses.spec.ts
@@ -65,10 +65,10 @@ async function interceptRequestPopup(context: BrowserContext) {
   return context.waitForEvent('page');
 }
 
-async function initiateGetAddresses(page: Page, eventName: GetAddressesMethods) {
+async function initiateGetAddresses(page: Page, eventName: GetAddressesMethods, params?: any) {
   return page.evaluate(
-    async eventName => (window as any).LeatherProvider?.request(eventName),
-    eventName
+    async ({ eventName, params }) => (window as any).LeatherProvider?.request(eventName, params),
+    { eventName, params }
   );
 }
 
@@ -145,6 +145,21 @@ getAddressesMethods.forEach(method => {
             await test.expect(popup.getByTestId('get-addresses-approve-button')).toBeVisible();
             await clickConnectLeatherButton(popup);
             await test.expect(getAddressesPromise).resolves.toMatchObject(expectedResult);
+          });
+
+          test('it returns testnet addresses with the network param set', async ({
+            page,
+            context,
+          }) => {
+            await page.goto('localhost:3000');
+            const getAddressesPromise = initiateGetAddresses(page, method, { network: 'testnet' });
+            const popup = await interceptRequestPopup(context);
+            await clickConnectLeatherButton(popup);
+
+            const result = await getAddressesPromise;
+            test
+              .expect(result.result.addresses[0].address)
+              .toEqual('tb1q4qgnjewwun2llgken94zqjrx5kpqqycaz5522d');
           });
 
           test('it returns the second accounts data after changing account', async ({


### PR DESCRIPTION
> Try out Leather build bbc739e — [Extension build](https://github.com/leather-io/extension/actions/runs/13630939584), [Test report](https://leather-io.github.io/playwright-reports/fix/network-get-addresses), [Storybook](https://fix/network-get-addresses--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/network-get-addresses)<!-- Sticky Header Marker -->

This PR adds support for `network` in both `getAddresses` and `stx_getAddresses` requests, and adds a test for testnet.