### PR TITLE
fix: issue with broken summary page, closes #6152

### DIFF
--- a/src/app/common/rpc/use-rpc-sip30-broadcast-transaction.ts
+++ b/src/app/common/rpc/use-rpc-sip30-broadcast-transaction.ts
@@ -50,7 +50,10 @@ export function useRpcSip30BroadcastTransaction(method: RpcMethodNames) {
   const { origin, requestId, tabId } = useRpcRequestParams();
   const txPayload = useLegacyTxPayloadFromRpcRequest();
   const stacksTransaction = useUnsignedStacksTransaction(txPayload);
-  const { stacksBroadcastTransaction } = useStacksBroadcastTransaction({ token: '' });
+  const { stacksBroadcastTransaction } = useStacksBroadcastTransaction({
+    token: '',
+    showSummaryPage: false,
+  });
 
   return useMemo(
     () => ({

--- a/src/app/common/transactions/stacks/transaction.utils.ts
+++ b/src/app/common/transactions/stacks/transaction.utils.ts
@@ -125,5 +125,4 @@ export function isPendingTx(tx: StacksTx) {
 export enum StacksTransactionActionType {
   Cancel = 'cancel',
   IncreaseFee = 'increase-fee',
-  RpcRequest = 'rpc-request',
 }

--- a/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
@@ -64,7 +64,7 @@ function LedgerSignBitcoinTxContainer() {
 
   useEffect(() => () => setUnsignedTransaction(null), []);
 
-  const chain = 'bitcoin' as const;
+  const chain = 'bitcoin';
 
   const { signTransaction, latestDeviceResponse, awaitingDeviceConnection } =
     useLedgerSignTx<BitcoinApp>({

--- a/src/app/features/stacks-transaction-request/hooks/use-stacks-broadcast-transaction.tsx
+++ b/src/app/features/stacks-transaction-request/hooks/use-stacks-broadcast-transaction.tsx
@@ -49,7 +49,6 @@ export function useStacksBroadcastTransaction({
 
   const isCancelTransaction = actionType === StacksTransactionActionType.Cancel;
   const isIncreaseFeeTransaction = actionType === StacksTransactionActionType.IncreaseFee;
-  const isRpcRequest = actionType === StacksTransactionActionType.RpcRequest;
 
   const broadcastTransactionFn = useSubmitTransactionCallback({
     loadingKey: LoadingKeys.SUBMIT_STACKS_TRANSACTION,
@@ -68,7 +67,7 @@ export function useStacksBroadcastTransaction({
         });
       }
       if (txId) {
-        if (isCancelTransaction || isIncreaseFeeTransaction || isRpcRequest) {
+        if (isCancelTransaction || isIncreaseFeeTransaction) {
           navigate(RouteUrls.Activity);
           return;
         }
@@ -106,7 +105,6 @@ export function useStacksBroadcastTransaction({
               handlePreviewSuccess(signedTx, txId);
               if (isCancelTransaction) return toast.success('Transaction cancelled successfully');
               if (isIncreaseFeeTransaction) return toast.success('Fee increased successfully');
-              if (isRpcRequest) return toast.success('Transaction submitted!');
               return;
             },
             replaceByFee: false,
@@ -141,7 +139,7 @@ export function useStacksBroadcastTransaction({
     tabId,
     isCancelTransaction,
     isIncreaseFeeTransaction,
-    isRpcRequest,
+    showSummaryPage,
     navigate,
     token,
     formSentSummaryTxState,

--- a/src/app/features/stacks-transaction-request/hooks/use-stacks-broadcast-transaction.tsx
+++ b/src/app/features/stacks-transaction-request/hooks/use-stacks-broadcast-transaction.tsx
@@ -31,11 +31,13 @@ interface UseStacksBroadcastTransactionArgs {
   actionType?: StacksTransactionActionType;
   decimals?: number;
   token: CryptoCurrency;
+  showSummaryPage?: boolean;
 }
 export function useStacksBroadcastTransaction({
   actionType,
   decimals,
   token,
+  showSummaryPage = true,
 }: UseStacksBroadcastTransactionArgs) {
   const signStacksTransaction = useSignStacksTransaction();
   const [isBroadcasting, setIsBroadcasting] = useState(false);
@@ -71,13 +73,14 @@ export function useStacksBroadcastTransaction({
           return;
         }
 
-        navigate(
-          RouteUrls.SentStxTxSummary.replace(':symbol', token.toLowerCase()).replace(
-            ':txId',
-            `${txId}`
-          ),
-          formSentSummaryTxState ? formSentSummaryTxState(txId, signedTx, decimals) : {}
-        );
+        if (showSummaryPage)
+          navigate(
+            RouteUrls.SentStxTxSummary.replace(':symbol', token.toLowerCase()).replace(
+              ':txId',
+              `${txId}`
+            ),
+            formSentSummaryTxState ? formSentSummaryTxState(txId, signedTx, decimals) : {}
+          );
       }
     }
 


### PR DESCRIPTION
> Try out Leather build 1c84a5a — [Extension build](https://github.com/leather-io/extension/actions/runs/13607007923), [Test report](https://leather-io.github.io/playwright-reports/fix/broken-summary-page), [Storybook](https://fix/broken-summary-page--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/broken-summary-page)<!-- Sticky Header Marker -->

This is very much a workaround, but deals with the broadcast feature that couples way too much unrelated behaviours.