### PR TITLE
fix: zero nonce not getting set, closes LEA-2201

### DIFF
--- a/src/app/components/nonce-setter.tsx
+++ b/src/app/components/nonce-setter.tsx
@@ -3,6 +3,7 @@ import { useAsync } from 'react-async-hook';
 import { useFormikContext } from 'formik';
 
 import { useNextNonce } from '@leather.io/query';
+import { isDefined } from '@leather.io/utils';
 
 import {
   StacksSendFormValues,
@@ -20,7 +21,7 @@ export function NonceSetter() {
   const { data: nextNonce } = useNextNonce(stxAddress);
 
   useAsync(async () => {
-    if (nextNonce?.nonce && !touched.nonce && values.nonce !== nextNonce.nonce) {
+    if (isDefined(nextNonce?.nonce) && !touched.nonce && values.nonce !== nextNonce?.nonce) {
       return await setFieldValue('nonce', nextNonce?.nonce);
     }
     return;

--- a/src/app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog.tsx
+++ b/src/app/features/dialogs/edit-nonce-dialog/edit-nonce-dialog.tsx
@@ -25,6 +25,7 @@ export function EditNonceSheet() {
   const { search } = useLocation();
 
   useOnMount(() => setLoadedNextNonce(values.nonce));
+
   const onGoBack = useCallback(() => {
     if (search) {
       return navigate('..' + search, { replace: true });

--- a/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.tsx
@@ -19,8 +19,6 @@ export function RpcStxTransferSip10Ft() {
         onSignStacksTransaction={onSignStacksTransaction}
         isMultisig={false}
         stacksTransaction={stacksTransaction}
-        disableFeeSelection={true}
-        disableNonceSelection={true}
       />
     </StacksHighFeeWarningContainer>
   );

--- a/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.tsx
@@ -19,8 +19,6 @@ export function RpcStxTransferSip9Nft() {
         onSignStacksTransaction={onSignStacksTransaction}
         isMultisig={false}
         stacksTransaction={stacksTransaction}
-        disableFeeSelection={true}
-        disableNonceSelection={true}
       />
     </StacksHighFeeWarningContainer>
   );

--- a/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx.tsx
+++ b/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx.tsx
@@ -19,8 +19,6 @@ export function RpcStxTransferStx() {
         onSignStacksTransaction={onSignStacksTransaction}
         isMultisig={false}
         stacksTransaction={stacksTransaction}
-        disableFeeSelection={true}
-        disableNonceSelection={true}
       />
     </StacksHighFeeWarningContainer>
   );

--- a/src/app/routes/rpc-routes.tsx
+++ b/src/app/routes/rpc-routes.tsx
@@ -22,6 +22,8 @@ import { AccountGate } from '@app/routes/account-gate';
 
 import { SuspenseLoadingSpinner } from './app-routes';
 
+const editNonceSheetRoute = <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />;
+
 export const rpcRequestRoutes = (
   <>
     <Route
@@ -85,8 +87,8 @@ export const rpcRequestRoutes = (
         </AccountGate>
       }
     >
+      {editNonceSheetRoute}
       {ledgerStacksTxSigningRoutes}
-      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
     </Route>
 
     <Route
@@ -97,8 +99,8 @@ export const rpcRequestRoutes = (
         </AccountGate>
       }
     >
+      {editNonceSheetRoute}
       {ledgerStacksTxSigningRoutes}
-      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
     </Route>
 
     <Route
@@ -109,8 +111,8 @@ export const rpcRequestRoutes = (
         </AccountGate>
       }
     >
+      {editNonceSheetRoute}
       {ledgerStacksTxSigningRoutes}
-      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
     </Route>
 
     <Route
@@ -121,8 +123,8 @@ export const rpcRequestRoutes = (
         </AccountGate>
       }
     >
+      {editNonceSheetRoute}
       {ledgerStacksTxSigningRoutes}
-      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
     </Route>
 
     <Route
@@ -133,8 +135,8 @@ export const rpcRequestRoutes = (
         </AccountGate>
       }
     >
+      {editNonceSheetRoute}
       {ledgerStacksTxSigningRoutes}
-      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
     </Route>
 
     <Route
@@ -145,8 +147,8 @@ export const rpcRequestRoutes = (
         </AccountGate>
       }
     >
+      {editNonceSheetRoute}
       {ledgerStacksTxSigningRoutes}
-      <Route path={RouteUrls.EditNonce} element={<EditNonceSheet />} />
     </Route>
   </>
 );


### PR DESCRIPTION
> Try out Leather build 8cd977c — [Extension build](https://github.com/leather-io/extension/actions/runs/13629629677), [Test report](https://leather-io.github.io/playwright-reports/fix/call-contract-nonce), [Storybook](https://fix/call-contract-nonce--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/call-contract-nonce)<!-- Sticky Header Marker -->

This PR fixes a bug that surfaced with the SIP-30 methods but must have existed previously with fresh accounts. The bug was also present in our send form. The `NonceSetter` we use, which we should revisit, was interpreting `0` as false and not setting it on load, so once it hit the broadcast route for `stx_callContract` it was undefined and errored on `.setNonce()` as is described in the reported issue.