### PR TITLE
fix: improve account look up speed

### DIFF
--- a/src/app/common/account-restoration/account-restore.spec.ts
+++ b/src/app/common/account-restoration/account-restore.spec.ts
@@ -1,6 +1,17 @@
 import { recurseAccountsForActivity } from './account-restore';
 
 describe(recurseAccountsForActivity.name, () => {
+  test('case of account with activity at 6th index only', async () => {
+    const mockHasActivityFn = vi.fn().mockImplementation((index: number) => {
+      if (index <= 3) return true;
+      return false;
+    });
+    const result = await recurseAccountsForActivity({
+      doesAddressHaveActivityFn: mockHasActivityFn,
+    });
+    expect(result).toBe(3);
+  });
+
   test('case of account with activity at 10th index only', async () => {
     const mockHasActivityFn = vi.fn().mockImplementation((index: number) => {
       if (index === 10) return true;
@@ -11,7 +22,7 @@ describe(recurseAccountsForActivity.name, () => {
     });
     expect(result).toBe(10);
     // Index + Min accounts to check + 1
-    expect(mockHasActivityFn.mock.calls.length).toBe(31);
+    expect(mockHasActivityFn.mock.calls.length).toBe(35);
   });
 
   test('case of account with activity until 80th account', async () => {
@@ -23,6 +34,6 @@ describe(recurseAccountsForActivity.name, () => {
       doesAddressHaveActivityFn: mockHasActivityFn,
     });
     expect(result).toBe(79);
-    expect(mockHasActivityFn.mock.calls.length).toBe(54);
+    expect(mockHasActivityFn.mock.calls.length).toBe(55);
   });
 });

--- a/src/app/store/software-keys/software-key.actions.ts
+++ b/src/app/store/software-keys/software-key.actions.ts
@@ -77,6 +77,8 @@ function setWalletEncryptionPassword(args: {
     // and the user shouldn't have to wait before being directed to homepage.
     logger.info('Initiating recursive account activity lookup');
     try {
+      const start = performance.now();
+
       void recurseAccountsForActivity({
         async doesAddressHaveActivityFn(index) {
           const stxAddress = getStacksAddressByIndex(
@@ -92,8 +94,12 @@ function setWalletEncryptionPassword(args: {
           return hasStxBalance || hasNames || hasBtcBalance;
         },
       }).then(recursiveActivityIndex => {
-        logger.info('Found account activity at higher index', { recursiveActivityIndex });
         dispatch(stxChainSlice.actions.restoreAccountIndex(recursiveActivityIndex));
+        const end = performance.now();
+        logger.info('Found account activity at higher index', {
+          recursiveActivityIndex,
+          time: (end - start) / 1000 + ' seconds',
+        });
       });
     } catch (e) {
       // Errors during account restore are non-critical and can fail silently


### PR DESCRIPTION
> Try out Leather build eb2c9be — [Extension build](https://github.com/leather-io/extension/actions/runs/13630740485), [Test report](https://leather-io.github.io/playwright-reports/perf/account-lookup), [Storybook](https://perf/account-lookup--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=perf/account-lookup)<!-- Sticky Header Marker -->

@314159265359879 this makes a pretty significant improvement to account look up perf. 

I started looking at showing a loader, but this is a little bit more complex as we need to go and adjust state such that we know whether it's a new account or one being restored (so we don't show loader for new accounts).

Further changes like moving to bg script would be great, but this alone is an improvement.