### PR TITLE
DRAFT: add asset context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "@noble/hashes": "1.5.0",
     "@noble/secp256k1": "2.1.0",
     "@octokit/types": "12.4.0",
+    "@radix-ui/react-context-menu": "^2.2.6",
     "@radix-ui/react-dialog": "1.0.5",
     "@radix-ui/react-dropdown-menu": "2.0.6",
     "@radix-ui/react-tooltip": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@noble/hashes": "1.5.0",
     "@noble/secp256k1": "2.1.0",
     "@octokit/types": "12.4.0",
-    "@radix-ui/react-context-menu": "^2.2.6",
+    "@radix-ui/react-context-menu": "2.2.6",
     "@radix-ui/react-dialog": "1.0.5",
     "@radix-ui/react-dropdown-menu": "2.0.6",
     "@radix-ui/react-tooltip": "1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         specifier: 12.4.0
         version: 12.4.0
       '@radix-ui/react-context-menu':
-        specifier: ^2.2.6
+        specifier: 2.2.6
         version: 2.2.6(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: 1.0.5
@@ -3177,9 +3177,6 @@ packages:
 
   '@floating-ui/core@1.6.8':
     resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
-
-  '@floating-ui/dom@1.6.10':
-    resolution: {integrity: sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==}
 
   '@floating-ui/dom@1.6.11':
     resolution: {integrity: sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==}
@@ -19566,11 +19563,6 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.8
 
-  '@floating-ui/dom@1.6.10':
-    dependencies:
-      '@floating-ui/core': 1.6.8
-      '@floating-ui/utils': 0.2.8
-
   '@floating-ui/dom@1.6.11':
     dependencies:
       '@floating-ui/core': 1.6.8
@@ -33923,7 +33915,7 @@ snapshots:
   react-remove-scroll-bar@2.3.6(@types/react@18.3.10)(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-style-singleton: 2.2.1(@types/react@18.3.10)(react@18.2.0)
+      react-style-singleton: 2.2.3(@types/react@18.3.10)(react@18.2.0)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.10
@@ -33931,7 +33923,7 @@ snapshots:
   react-remove-scroll-bar@2.3.6(@types/react@18.3.10)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-style-singleton: 2.2.1(@types/react@18.3.10)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.10)(react@18.3.1)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.10
@@ -33969,11 +33961,11 @@ snapshots:
   react-remove-scroll@2.5.7(@types/react@18.3.10)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-remove-scroll-bar: 2.3.6(@types/react@18.3.10)(react@18.3.1)
-      react-style-singleton: 2.2.1(@types/react@18.3.10)(react@18.3.1)
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.10)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.10)(react@18.3.1)
       tslib: 2.8.1
-      use-callback-ref: 1.3.2(@types/react@18.3.10)(react@18.3.1)
-      use-sidecar: 1.1.2(@types/react@18.3.10)(react@18.3.1)
+      use-callback-ref: 1.3.3(@types/react@18.3.10)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.10)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.10
 
@@ -34005,7 +33997,7 @@ snapshots:
       '@babel/runtime': 7.26.0
       '@emotion/cache': 11.13.1
       '@emotion/react': 11.13.3(@types/react@18.3.10)(react@18.3.1)
-      '@floating-ui/dom': 1.6.10
+      '@floating-ui/dom': 1.6.11
       '@types/react-transition-group': 4.4.11
       memoize-one: 6.0.0
       prop-types: 15.8.1
@@ -34037,6 +34029,14 @@ snapshots:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  react-style-singleton@2.2.3(@types/react@18.3.10)(react@18.2.0):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.2.0
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@octokit/types':
         specifier: 12.4.0
         version: 12.4.0
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: 1.0.5
         version: 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -167,7 +170,7 @@ importers:
         version: 1.2.8(react@18.3.1)
       '@storybook/addon-styling-webpack':
         specifier: 1.0.1
-        version: 1.0.1(storybook@8.4.4(prettier@3.3.3))(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 1.0.1(storybook@8.4.4(prettier@3.3.3))(webpack@5.94.0)
       '@styled-system/theme-get':
         specifier: 5.1.2
         version: 5.1.2
@@ -242,7 +245,7 @@ importers:
         version: 4.0.0(encoding@0.1.13)
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 7.1.2(webpack@5.94.0)
       dayjs:
         specifier: 1.11.8
         version: 1.11.8
@@ -362,7 +365,7 @@ importers:
         version: 0.3.2(encoding@0.1.13)
       style-loader:
         specifier: 3.3.4
-        version: 3.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 3.3.4(webpack@5.94.0)
       ts-debounce:
         specifier: 4.0.0
         version: 4.0.0
@@ -420,7 +423,7 @@ importers:
         version: 2.2.3
       '@mdx-js/loader':
         specifier: 3.0.0
-        version: 3.0.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 3.0.0(webpack@5.94.0)
       '@pandacss/dev':
         specifier: 0.46.1
         version: 0.46.1(jsdom@22.1.0)(typescript@5.4.5)
@@ -429,7 +432,7 @@ importers:
         version: 1.50.1
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.13
-        version: 0.5.13(@types/webpack@5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))(react-refresh@0.16.0)(type-fest@4.30.2)(webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.94.0))(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 0.5.13(@types/webpack@5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4))(react-refresh@0.16.0)(type-fest@4.30.2)(webpack-dev-server@4.15.1)(webpack-hot-middleware@2.26.1)(webpack@5.94.0)
       '@redux-devtools/cli':
         specifier: 4.0.0
         version: 4.0.0(@babel/core@7.26.7)(@reduxjs/toolkit@2.2.7(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react-dom@18.3.0)(@types/styled-components@5.1.34)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.26.7)(@babel/preset-env@7.26.9(@babel/core@7.26.7))(@types/react@18.3.10)(encoding@0.1.13)(react@18.2.0))
@@ -444,7 +447,7 @@ importers:
         version: 8.26.0(react@18.3.1)
       '@sentry/webpack-plugin':
         specifier: 2.17.0
-        version: 2.17.0(encoding@0.1.13)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 2.17.0(encoding@0.1.13)(webpack@5.94.0)
       '@stacks/connect-react-jwt':
         specifier: npm:@stacks/connect-react@22.2.0
         version: '@stacks/connect-react@22.2.0(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
@@ -468,7 +471,7 @@ importers:
         version: 8.4.4(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))
       '@storybook/addon-webpack5-compiler-swc':
         specifier: 1.0.5
-        version: 1.0.5(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 1.0.5(webpack@5.94.0)
       '@storybook/blocks':
         specifier: 8.4.4
         version: 8.4.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))
@@ -477,7 +480,7 @@ importers:
         version: 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)
       '@storybook/react-webpack5':
         specifier: 8.4.4
-        version: 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(@swc/core@1.7.18)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+        version: 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(@swc/core@1.7.18)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4)
       '@storybook/test':
         specifier: 8.4.4
         version: 8.4.4(storybook@8.4.4(prettier@3.3.3))
@@ -552,7 +555,7 @@ importers:
         version: 0.10.4
       '@types/webpack':
         specifier: 5.28.5
-        version: 5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+        version: 5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       '@types/zxcvbn':
         specifier: 4.4.5
         version: 4.4.5
@@ -585,7 +588,7 @@ importers:
         version: 2.2.2
       clean-webpack-plugin:
         specifier: 4.0.0
-        version: 4.0.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 4.0.0(webpack@5.94.0)
       concurrently:
         specifier: 8.2.2
         version: 8.2.2
@@ -594,7 +597,7 @@ importers:
         version: 7.0.2
       copy-webpack-plugin:
         specifier: 12.0.2
-        version: 12.0.2(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 12.0.2(webpack@5.94.0)
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -609,13 +612,13 @@ importers:
         version: 16.4.2
       dotenv-webpack:
         specifier: 8.1.0
-        version: 8.1.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 8.1.0(webpack@5.94.0)
       esbuild:
         specifier: 0.24.0
         version: 0.24.0
       esbuild-loader:
         specifier: 4.2.2
-        version: 4.2.2(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 4.2.2(webpack@5.94.0)
       eslint-plugin-deprecation:
         specifier: 2.0.0
         version: 2.0.0(eslint@8.56.0)(typescript@5.4.5)
@@ -633,13 +636,13 @@ importers:
         version: 0.11.1(eslint@8.56.0)(typescript@5.4.5)
       file-loader:
         specifier: 6.2.0
-        version: 6.2.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 6.2.0(webpack@5.94.0)
       generate-json-webpack-plugin:
         specifier: 2.0.0
         version: 2.0.0
       html-webpack-plugin:
         specifier: 5.6.0
-        version: 5.6.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 5.6.0(webpack@5.94.0)
       jsdom:
         specifier: 22.1.0
         version: 22.1.0
@@ -648,7 +651,7 @@ importers:
         version: 8.4.47
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(postcss@8.4.47)(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 8.1.1(postcss@8.4.47)(typescript@5.4.5)(webpack@5.94.0)
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -657,16 +660,16 @@ importers:
         version: 0.11.10
       progress-bar-webpack-plugin:
         specifier: 2.1.0
-        version: 2.1.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 2.1.0(webpack@5.94.0)
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.56.0)(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 12.0.1(eslint@8.56.0)(typescript@5.4.5)(webpack@5.94.0)
       schema-inspector:
         specifier: 2.0.2
         version: 2.0.2
       speed-measure-webpack-plugin:
         specifier: 1.5.0
-        version: 1.5.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+        version: 1.5.0(webpack@5.94.0)
       storybook:
         specifier: 8.4.4
         version: 8.4.4(prettier@3.3.3)
@@ -702,7 +705,7 @@ importers:
         version: 7.8.0(body-parser@1.20.3)
       webpack:
         specifier: 5.94.0
-        version: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+        version: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       webpack-bundle-analyzer:
         specifier: 4.10.2
         version: 4.10.2
@@ -3172,9 +3175,6 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@floating-ui/core@1.6.7':
-    resolution: {integrity: sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==}
-
   '@floating-ui/core@1.6.8':
     resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
 
@@ -3184,20 +3184,11 @@ packages:
   '@floating-ui/dom@1.6.11':
     resolution: {integrity: sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==}
 
-  '@floating-ui/react-dom@2.1.1':
-    resolution: {integrity: sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   '@floating-ui/react-dom@2.1.2':
     resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-
-  '@floating-ui/utils@0.2.7':
-    resolution: {integrity: sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==}
 
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
@@ -3713,6 +3704,9 @@ packages:
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
 
+  '@radix-ui/primitive@1.1.1':
+    resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
+
   '@radix-ui/react-accessible-icon@1.0.3':
     resolution: {integrity: sha512-duVGKeWPSUILr/MdlPxV+GeULTc2rS1aihGdQ3N2qCUPMgxYLxvAsHJM3mCVLF8d5eK+ympmB22mb1F3a5biNw==}
     peerDependencies:
@@ -3780,6 +3774,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.0':
     resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.2':
+    resolution: {integrity: sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3882,6 +3889,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.2':
+    resolution: {integrity: sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.0.1':
     resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
     peerDependencies:
@@ -3900,8 +3920,17 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-context-menu@2.2.1':
-    resolution: {integrity: sha512-wvMKKIeb3eOrkJ96s722vcidZ+2ZNfcYZWBPRHIB1VWrF+fiF851Io6LX0kmK5wTDQFKdulCCKJk2c3SBaQHvA==}
+  '@radix-ui/react-compose-refs@1.1.1':
+    resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.6':
+    resolution: {integrity: sha512-aUP99QZ3VU84NPsHeaFt4cQUNgJqFsLLOt/RbbWXszZ6MP0DpDyjkFZORr4RpAEx3sUBk+Kc8h13yGtC5Qw8dg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4010,6 +4039,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.5':
+    resolution: {integrity: sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dropdown-menu@2.0.6':
     resolution: {integrity: sha512-i6TuFOoWmLWq+M/eCLGd/bQ2HfAX1RJgvrBQ6AQLmzfvsLdefxbWu8G9zczcPFfcSPehz9GcpF6K9QYreFV8hA==}
     peerDependencies:
@@ -4041,6 +4083,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.1.1':
+    resolution: {integrity: sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-focus-scope@1.0.4':
     resolution: {integrity: sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==}
     peerDependencies:
@@ -4056,6 +4107,19 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.0':
     resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.2':
+    resolution: {integrity: sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4137,8 +4201,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-menu@2.1.1':
-    resolution: {integrity: sha512-oa3mXRRVjHi6DZu/ghuzdylyjaMXLymx83irM7hTxutQbD+7IhPKdMdRHD26Rm+kHRrWcrUkkRPv5pd47a2xFQ==}
+  '@radix-ui/react-menu@2.1.6':
+    resolution: {integrity: sha512-tBBb5CXDJW3t2mo9WlO7r6GTmWV0F0uzHZVFmlRmYpiSK1CDU5IKojP1pm7oknpBOrFZx/YgBRW9oorPO2S/Lg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4189,6 +4253,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.2':
+    resolution: {integrity: sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.0.4':
     resolution: {integrity: sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==}
     peerDependencies:
@@ -4204,6 +4281,19 @@ packages:
 
   '@radix-ui/react-portal@1.1.1':
     resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.4':
+    resolution: {integrity: sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4241,6 +4331,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.2':
+    resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@1.0.3':
     resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
     peerDependencies:
@@ -4256,6 +4359,19 @@ packages:
 
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4295,6 +4411,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.0':
     resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.2':
+    resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4395,6 +4524,15 @@ packages:
 
   '@radix-ui/react-slot@1.1.0':
     resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -13872,6 +14010,16 @@ packages:
       '@types/react':
         optional: true
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-remove-scroll@2.5.5:
     resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
     engines: {node: '>=10'}
@@ -13888,6 +14036,16 @@ packages:
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.6.3:
+    resolution: {integrity: sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -13922,6 +14080,16 @@ packages:
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -15595,6 +15763,16 @@ packages:
       '@types/react':
         optional: true
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-events@1.4.2:
     resolution: {integrity: sha512-CVgNgSl5dnJaHKirbWab6TtdxSnb+e5rfi4WybLFUTXweRyYO+kkBtECauHlUiZLghGTsCyRaSgOeWSETvgtmw==}
     peerDependencies:
@@ -15624,6 +15802,16 @@ packages:
     peerDependencies:
       '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -19374,29 +19562,19 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@floating-ui/core@1.6.7':
-    dependencies:
-      '@floating-ui/utils': 0.2.7
-
   '@floating-ui/core@1.6.8':
     dependencies:
       '@floating-ui/utils': 0.2.8
 
   '@floating-ui/dom@1.6.10':
     dependencies:
-      '@floating-ui/core': 1.6.7
-      '@floating-ui/utils': 0.2.7
+      '@floating-ui/core': 1.6.8
+      '@floating-ui/utils': 0.2.8
 
   '@floating-ui/dom@1.6.11':
     dependencies:
       '@floating-ui/core': 1.6.8
       '@floating-ui/utils': 0.2.8
-
-  '@floating-ui/react-dom@2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/dom': 1.6.10
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/react-dom@2.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -19409,8 +19587,6 @@ snapshots:
       '@floating-ui/dom': 1.6.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@floating-ui/utils@0.2.7': {}
 
   '@floating-ui/utils@0.2.8': {}
 
@@ -19449,7 +19625,7 @@ snapshots:
       '@graphql-tools/merge': 8.4.2(graphql@16.9.0)
       '@graphql-tools/utils': 9.2.1(graphql@16.9.0)
       graphql: 16.9.0
-      tslib: 2.7.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
 
   '@graphql-tools/utils@9.2.1(graphql@16.9.0)':
@@ -19952,11 +20128,11 @@ snapshots:
 
   '@mdn/browser-compat-data@5.3.14': {}
 
-  '@mdx-js/loader@3.0.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@mdx-js/loader@3.0.0(webpack@5.94.0)':
     dependencies:
       '@mdx-js/mdx': 3.0.1
       source-map: 0.7.4
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -20267,7 +20443,7 @@ snapshots:
     dependencies:
       playwright: 1.50.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.13(@types/webpack@5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))(react-refresh@0.16.0)(type-fest@4.30.2)(webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.94.0))(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.13(@types/webpack@5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4))(react-refresh@0.16.0)(type-fest@4.30.2)(webpack-dev-server@4.15.1)(webpack-hot-middleware@2.26.1)(webpack@5.94.0)':
     dependencies:
       ansi-html-community: 0.0.8
       core-js-pure: 3.38.1
@@ -20277,9 +20453,9 @@ snapshots:
       react-refresh: 0.16.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     optionalDependencies:
-      '@types/webpack': 5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      '@types/webpack': 5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       type-fest: 4.30.2
       webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.94.0)
       webpack-hot-middleware: 2.26.1
@@ -20334,6 +20510,8 @@ snapshots:
       '@babel/runtime': 7.26.0
 
   '@radix-ui/primitive@1.1.0': {}
+
+  '@radix-ui/primitive@1.1.1': {}
 
   '@radix-ui/react-accessible-icon@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -20409,6 +20587,15 @@ snapshots:
   '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-arrow@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -20532,6 +20719,18 @@ snapshots:
       '@types/react': 18.3.10
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-collection@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-compose-refs@1.0.1(@types/react@18.3.10)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -20558,12 +20757,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.10
 
-  '@radix-ui/react-context-menu@2.2.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-compose-refs@1.1.1(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.0
-      '@radix-ui/react-context': 1.1.0(@types/react@18.3.10)(react@18.3.1)
-      '@radix-ui/react-menu': 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  '@radix-ui/react-context-menu@2.2.6(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.6(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
@@ -20601,6 +20806,12 @@ snapshots:
   '@radix-ui/react-context@1.1.1(@types/react@18.3.10)(react@18.2.0)':
     dependencies:
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  '@radix-ui/react-context@1.1.1(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.10
 
@@ -20739,6 +20950,19 @@ snapshots:
       '@types/react': 18.3.10
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-dropdown-menu@2.0.6(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.25.4
@@ -20791,6 +21015,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.10
 
+  '@radix-ui/react-focus-guards@1.1.1(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
   '@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -20819,6 +21049,17 @@ snapshots:
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-focus-scope@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -20945,28 +21186,28 @@ snapshots:
       '@types/react': 18.3.10
       '@types/react-dom': 18.3.0
 
-  '@radix-ui/react-menu@2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-menu@2.1.6(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.0
-      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.10)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-direction': 1.1.0(@types/react@18.3.10)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.10)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-id': 1.1.0(@types/react@18.3.10)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       aria-hidden: 1.2.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-remove-scroll: 2.5.7(@types/react@18.3.10)(react@18.3.1)
+      react-remove-scroll: 2.6.3(@types/react@18.3.10)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.10
       '@types/react-dom': 18.3.0
@@ -21034,11 +21275,29 @@ snapshots:
 
   '@radix-ui/react-popper@1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-arrow': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-context': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/rect': 1.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-popper@1.2.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-use-rect': 1.1.0(@types/react@18.3.10)(react@18.3.1)
@@ -21080,6 +21339,16 @@ snapshots:
       '@types/react': 18.3.10
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-portal@1.1.4(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-presence@1.0.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -21105,6 +21374,16 @@ snapshots:
   '@radix-ui/react-presence@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-presence@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -21144,6 +21423,15 @@ snapshots:
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -21213,6 +21501,23 @@ snapshots:
       '@radix-ui/react-direction': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-id': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
@@ -21370,6 +21675,13 @@ snapshots:
   '@radix-ui/react-slot@1.1.0(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.10)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  '@radix-ui/react-slot@1.1.2(@types/react@18.3.10)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.10)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.10
@@ -21721,7 +22033,7 @@ snapshots:
       '@radix-ui/react-aspect-ratio': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-avatar': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-checkbox': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-context-menu': 2.2.1(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context-menu': 2.2.6(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-direction': 1.1.0(@types/react@18.3.10)(react@18.3.1)
       '@radix-ui/react-dropdown-menu': 2.0.6(@types/react-dom@18.3.0)(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22704,11 +23016,11 @@ snapshots:
       '@lukeed/uuid': 2.0.1
       '@segment/analytics-generic-utils': 1.2.0
       dset: 3.1.4
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@segment/analytics-generic-utils@1.2.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@segment/analytics-next@1.70.0(encoding@0.1.13)':
     dependencies:
@@ -22891,12 +23203,12 @@ snapshots:
     dependencies:
       '@sentry/types': 8.26.0
 
-  '@sentry/webpack-plugin@2.17.0(encoding@0.1.13)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@sentry/webpack-plugin@2.17.0(encoding@0.1.13)(webpack@5.94.0)':
     dependencies:
       '@sentry/bundler-plugin-core': 2.17.0(encoding@0.1.13)
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -23912,10 +24224,10 @@ snapshots:
       storybook: 8.4.4(prettier@3.3.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-styling-webpack@1.0.1(storybook@8.4.4(prettier@3.3.3))(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@storybook/addon-styling-webpack@1.0.1(storybook@8.4.4(prettier@3.3.3))(webpack@5.94.0)':
     dependencies:
       '@storybook/node-logger': 8.2.9(storybook@8.4.4(prettier@3.3.3))
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - storybook
 
@@ -23928,10 +24240,10 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.4.4(prettier@3.3.3)
 
-  '@storybook/addon-webpack5-compiler-swc@1.0.5(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@storybook/addon-webpack5-compiler-swc@1.0.5(webpack@5.94.0)':
     dependencies:
       '@swc/core': 1.7.18
-      swc-loader: 0.2.6(@swc/core@1.7.18)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      swc-loader: 0.2.6(@swc/core@1.7.18)(webpack@5.94.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - webpack
@@ -23946,7 +24258,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-webpack5@8.4.4(@swc/core@1.7.18)(esbuild@0.24.0)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))':
+  '@storybook/builder-webpack5@8.4.4(@swc/core@1.7.18)(esbuild@0.24.0)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 8.4.4(storybook@8.4.4(prettier@3.3.3))
       '@types/node': 22.9.0
@@ -23955,23 +24267,23 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      css-loader: 6.11.0(webpack@5.94.0)
       es-module-lexer: 1.5.4
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
-      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.4.5)(webpack@5.94.0)
+      html-webpack-plugin: 5.6.0(webpack@5.94.0)
       magic-string: 0.30.13
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
       storybook: 8.4.4(prettier@3.3.3)
-      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(esbuild@0.24.0)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      style-loader: 3.3.4(webpack@5.94.0)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(esbuild@0.24.0)(webpack@5.94.0)
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
-      webpack-dev-middleware: 5.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
+      webpack-dev-middleware: 5.3.4(webpack@5.94.0)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -24043,11 +24355,11 @@ snapshots:
     dependencies:
       storybook: 8.4.4(prettier@3.3.3)
 
-  '@storybook/preset-react-webpack@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(@swc/core@1.7.18)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))':
+  '@storybook/preset-react-webpack@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(@swc/core@1.7.18)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 8.4.4(storybook@8.4.4(prettier@3.3.3))
       '@storybook/react': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.4.5)(webpack@5.94.0)
       '@types/node': 22.9.0
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -24059,7 +24371,7 @@ snapshots:
       semver: 7.6.3
       storybook: 8.4.4(prettier@3.3.3)
       tsconfig-paths: 4.2.0
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -24074,7 +24386,7 @@ snapshots:
     dependencies:
       storybook: 8.4.4(prettier@3.3.3)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.4.5)(webpack@5.94.0)':
     dependencies:
       debug: 4.3.7(supports-color@5.5.0)
       endent: 2.1.0
@@ -24084,7 +24396,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.4.5)
       tslib: 2.8.1
       typescript: 5.4.5
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -24094,10 +24406,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.4.4(prettier@3.3.3)
 
-  '@storybook/react-webpack5@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(@swc/core@1.7.18)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))':
+  '@storybook/react-webpack5@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(@swc/core@1.7.18)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4)':
     dependencies:
-      '@storybook/builder-webpack5': 8.4.4(@swc/core@1.7.18)(esbuild@0.24.0)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
-      '@storybook/preset-react-webpack': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(@swc/core@1.7.18)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      '@storybook/builder-webpack5': 8.4.4(@swc/core@1.7.18)(esbuild@0.24.0)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(@swc/core@1.7.18)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)(webpack-cli@5.1.4)
       '@storybook/react': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.4.5)
       '@types/node': 22.9.0
       react: 18.3.1
@@ -24955,11 +25267,11 @@ snapshots:
       anymatch: 3.1.3
       source-map: 0.6.1
 
-  '@types/webpack@5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))':
+  '@types/webpack@5.28.5(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)':
     dependencies:
       '@types/node': 20.12.12
       tapable: 2.2.1
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -25466,19 +25778,19 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))(webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)
     optionalDependencies:
       webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.94.0)
@@ -26720,10 +27032,10 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
-  clean-webpack-plugin@4.0.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  clean-webpack-plugin@4.0.0(webpack@5.94.0):
     dependencies:
       del: 4.1.1
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   cli-boxes@3.0.0: {}
 
@@ -26976,7 +27288,7 @@ snapshots:
 
   cookie@0.6.0: {}
 
-  copy-webpack-plugin@12.0.2(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  copy-webpack-plugin@12.0.2(webpack@5.94.0):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -26984,7 +27296,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   core-js-compat@3.38.1:
     dependencies:
@@ -27148,7 +27460,7 @@ snapshots:
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  css-loader@6.11.0(webpack@5.94.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -27159,9 +27471,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
-  css-loader@7.1.2(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  css-loader@7.1.2(webpack@5.94.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -27172,7 +27484,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   css-prefers-color-scheme@10.0.0(postcss@8.4.47):
     dependencies:
@@ -27761,10 +28073,10 @@ snapshots:
     dependencies:
       dotenv: 16.4.5
 
-  dotenv-webpack@8.1.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  dotenv-webpack@8.1.0(webpack@5.94.0):
     dependencies:
       dotenv-defaults: 2.0.2
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   dotenv@16.4.5: {}
 
@@ -28080,12 +28392,12 @@ snapshots:
       get-value: 2.0.6
       sliced: 1.0.1
 
-  esbuild-loader@4.2.2(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  esbuild-loader@4.2.2(webpack@5.94.0):
     dependencies:
       esbuild: 0.21.5
       get-tsconfig: 4.8.1
       loader-utils: 2.0.4
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       webpack-sources: 1.4.3
 
   esbuild-register@3.6.0(esbuild@0.21.5):
@@ -28717,11 +29029,11 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
-  file-loader@6.2.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  file-loader@6.2.0(webpack@5.94.0):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   file-size@1.0.0: {}
 
@@ -28845,7 +29157,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.56.0)(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.56.0)(typescript@5.4.5)(webpack@5.94.0):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@types/json-schema': 7.0.15
@@ -28861,11 +29173,11 @@ snapshots:
       semver: 7.6.3
       tapable: 1.1.3
       typescript: 5.4.5
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     optionalDependencies:
       eslint: 8.56.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.4.5)(webpack@5.94.0):
     dependencies:
       '@babel/code-frame': 7.26.2
       chalk: 4.1.2
@@ -28880,7 +29192,7 @@ snapshots:
       semver: 7.6.3
       tapable: 2.2.1
       typescript: 5.4.5
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   form-data-encoder@2.1.4: {}
 
@@ -29519,7 +29831,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.31.6
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  html-webpack-plugin@5.6.0(webpack@5.94.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -29527,7 +29839,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -32904,14 +33216,14 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.4.47)
       postcss: 8.4.47
 
-  postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.4.5)(webpack@5.94.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.4.5)
       jiti: 1.21.6
       postcss: 8.4.47
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
@@ -33178,11 +33490,11 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress-bar-webpack-plugin@2.1.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  progress-bar-webpack-plugin@2.1.0(webpack@5.94.0):
     dependencies:
       chalk: 3.0.0
       progress: 2.0.3
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   progress@2.0.3: {}
 
@@ -33342,7 +33654,7 @@ snapshots:
       react: 18.3.1
       tween-functions: 1.2.0
 
-  react-dev-utils@12.0.1(eslint@8.56.0)(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  react-dev-utils@12.0.1(eslint@8.56.0)(typescript@5.4.5)(webpack@5.94.0):
     dependencies:
       '@babel/code-frame': 7.24.7
       address: 1.2.2
@@ -33353,7 +33665,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.56.0)(typescript@5.4.5)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.56.0)(typescript@5.4.5)(webpack@5.94.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -33368,7 +33680,7 @@ snapshots:
       shell-quote: 1.8.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -33624,6 +33936,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.10
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.10)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.10)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
   react-remove-scroll@2.5.5(@types/react@18.3.10)(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -33654,6 +33974,17 @@ snapshots:
       tslib: 2.8.1
       use-callback-ref: 1.3.2(@types/react@18.3.10)(react@18.3.1)
       use-sidecar: 1.1.2(@types/react@18.3.10)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  react-remove-scroll@2.6.3(@types/react@18.3.10)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.10)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.10)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.10)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.10)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.10
 
@@ -33705,6 +34036,14 @@ snapshots:
     dependencies:
       get-nonce: 1.0.1
       invariant: 2.2.4
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  react-style-singleton@2.2.3(@types/react@18.3.10)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
       react: 18.3.1
       tslib: 2.8.1
     optionalDependencies:
@@ -34565,7 +34904,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   socketcluster-client@19.2.2:
     dependencies:
@@ -34689,10 +35028,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  speed-measure-webpack-plugin@1.5.0(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  speed-measure-webpack-plugin@1.5.0(webpack@5.94.0):
     dependencies:
       chalk: 4.1.2
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   split2@4.2.0: {}
 
@@ -34934,9 +35273,9 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  style-loader@3.3.4(webpack@5.94.0):
     dependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   style-to-object@0.4.4:
     dependencies:
@@ -35021,18 +35360,18 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.0
 
-  swc-loader@0.2.6(@swc/core@1.7.18)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  swc-loader@0.2.6(@swc/core@1.7.18)(webpack@5.94.0):
     dependencies:
       '@swc/core': 1.7.18
       '@swc/counter': 0.1.3
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   symbol-tree@3.2.4: {}
 
   synckit@0.9.1:
     dependencies:
       '@pkgr/core': 0.1.1
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   tapable@1.1.3: {}
 
@@ -35093,14 +35432,14 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.7.18)(esbuild@0.24.0)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  terser-webpack-plugin@5.3.10(@swc/core@1.7.18)(esbuild@0.24.0)(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.6
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.7.18
       esbuild: 0.24.0
@@ -35713,6 +36052,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.10
 
+  use-callback-ref@1.3.3(@types/react@18.3.10)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
   use-events@1.4.2(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -35745,6 +36091,14 @@ snapshots:
       '@types/react': 18.3.10
 
   use-sidecar@1.1.2(@types/react@18.3.10)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.10
+
+  use-sidecar@1.1.3(@types/react@18.3.10)(react@18.3.1):
     dependencies:
       detect-node-es: 1.1.0
       react: 18.3.1
@@ -36052,9 +36406,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))(webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack@5.94.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.5
@@ -36063,20 +36417,20 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.94.0)
 
-  webpack-dev-middleware@5.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))):
+  webpack-dev-middleware@5.3.4(webpack@5.94.0):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
 
   webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.94.0):
     dependencies:
@@ -36108,10 +36462,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      webpack-dev-middleware: 5.3.4(webpack@5.94.0)
       ws: 8.17.1
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0))
+      webpack: 5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)
     transitivePeerDependencies:
       - bufferutil
@@ -36143,7 +36497,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)):
+  webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4):
     dependencies:
       '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.12.1
@@ -36165,7 +36519,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(esbuild@0.24.0)(webpack@5.94.0(@swc/core@1.7.18)(esbuild@0.24.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.7.18)(esbuild@0.24.0)(webpack@5.94.0)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/src/app/components/context-menu/asset-context-menu.tsx
+++ b/src/app/components/context-menu/asset-context-menu.tsx
@@ -1,20 +1,17 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import * as ContextMenu from '@radix-ui/react-context-menu';
-
-import { HStack } from 'leather-styles/jsx';
 import { css } from 'leather-styles/css';
+import { HStack } from 'leather-styles/jsx';
 
-import {
-  PaperPlaneIcon,
-  InboxIcon,
-  ArrowsRepeatLeftRightIcon,
-} from '@leather.io/ui';
+import { ArrowsRepeatLeftRightIcon, InboxIcon, PaperPlaneIcon } from '@leather.io/ui';
+
+import { analytics } from '@shared/utils/analytics';
 
 import { copyToClipboard } from '@app/common/utils/copy-to-clipboard';
 import { useToast } from '@app/features/toasts/use-toast';
 import { useConfigSwapsEnabled } from '@app/query/common/remote-config/remote-config.query';
-import { analytics } from '@shared/utils/analytics';
 
 interface AssetContextMenuProps {
   assetSymbol: string;
@@ -42,38 +39,34 @@ const menuItemStyles = css({
   outline: 'none',
   borderRadius: 'xs',
   _hover: {
-    backgroundColor: 'ink.component-background-hover'
+    backgroundColor: 'ink.component-background-hover',
   },
   '&[data-disabled]': {
     opacity: 0.5,
     cursor: 'not-allowed',
     _hover: {
-      backgroundColor: 'transparent'
-    }
-  }
+      backgroundColor: 'transparent',
+    },
+  },
 });
 
 const menuItemContentStyles = css({
   width: '100%',
   px: 'space.03',
   py: 'space.02',
-  gap: 'space.02'
+  gap: 'space.02',
 });
 
 interface AssetContextMenuItemProps {
   icon: React.ReactNode;
   label: string;
-  onClick?: () => void;
+  onClick?(): void;
   disabled?: boolean;
 }
 
 function AssetContextMenuItem({ icon, label, onClick, disabled }: AssetContextMenuItemProps) {
   return (
-    <ContextMenu.Item 
-      className={menuItemStyles}
-      onClick={onClick}
-      disabled={disabled}
-    >
+    <ContextMenu.Item className={menuItemStyles} onClick={onClick} disabled={disabled}>
       <HStack className={menuItemContentStyles}>
         {icon}
         {label}
@@ -82,9 +75,9 @@ function AssetContextMenuItem({ icon, label, onClick, disabled }: AssetContextMe
   );
 }
 
-export function AssetContextMenu({ 
-  assetSymbol, 
-  contractId, 
+export function AssetContextMenu({
+  assetSymbol,
+  contractId,
   address,
   children,
 }: AssetContextMenuProps) {
@@ -95,7 +88,7 @@ export function AssetContextMenu({
   const handleReceiveClick = async () => {
     // Track analytics based on asset type
     const lowerCaseSymbol = assetSymbol.toLowerCase();
-    
+
     if (lowerCaseSymbol === 'btc') {
       // For BTC, we need to include the type parameter
       void analytics.track('copy_btc_address_to_clipboard', { type: 'btc' });
@@ -103,23 +96,21 @@ export function AssetContextMenu({
       // For STX and other tokens, no second parameter is needed
       void analytics.track('copy_stx_address_to_clipboard');
     }
-    
+
     await copyToClipboard(address);
     toast.success('Address copied to clipboard');
   };
 
   return (
     <ContextMenu.Root>
-      <ContextMenu.Trigger asChild>
-        {children}
-      </ContextMenu.Trigger>
+      <ContextMenu.Trigger asChild>{children}</ContextMenu.Trigger>
       <ContextMenu.Portal>
         <ContextMenu.Content
           className={menuStyles}
           style={{
             zIndex: 999,
           }}
-          onPointerDownOutside={(e) => {
+          onPointerDownOutside={e => {
             e.preventDefault();
           }}
         >
@@ -141,17 +132,17 @@ export function AssetContextMenu({
               label="Swap"
               onClick={() => {
                 if (!isSwapEnabled) return;
-                
+
                 // Normalize the asset symbol for URL construction
                 // This handles special characters and ensures consistent casing
                 const normalizedSymbol = assetSymbol.toLowerCase().trim();
-                
+
                 // Determine chain based on normalized asset symbol
                 const chain = normalizedSymbol === 'btc' ? 'bitcoin' : 'stacks';
-                
+
                 // Construct the URL with the normalized symbol
                 const url = `/swap/${chain}/${normalizedSymbol}`;
-                
+
                 navigate(url);
               }}
               disabled={!isSwapEnabled}

--- a/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -126,7 +126,6 @@ export function CryptoAssetItemLayout({
       <DropdownMenu.Root open={isMenuOpen} onOpenChange={setIsMenuOpen}>
         <DropdownMenu.Trigger asChild>
           <Pressable
-            p="space.02"
             borderRadius="sm"
             _hover={{ bg: 'ink.component-background-hover' }}
             width="100%"
@@ -142,7 +141,9 @@ export function CryptoAssetItemLayout({
               setIsMenuOpen(true);
             }}
           >
-            {content}
+            <Box px="space.03" py="space.03">
+              {content}
+            </Box>
           </Pressable>
         </DropdownMenu.Trigger>
         {isMenuOpen && (

--- a/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -1,12 +1,12 @@
+import { useRef, useState } from 'react';
+
 import { sanitize } from 'dompurify';
 import { Box, Flex } from 'leather-styles/jsx';
-import { useRef, useState } from 'react';
 
 import type { Money } from '@leather.io/models';
 import {
   BulletSeparator,
   Caption,
-  DropdownMenu,
   ItemLayout,
   Pressable,
   SkeletonLoader,
@@ -14,12 +14,12 @@ import {
 } from '@leather.io/ui';
 
 import { useSpamFilterWithWhitelist } from '@app/common/spam-filter/use-spam-filter';
+import { AssetContextMenu } from '@app/components/context-menu/asset-context-menu';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
-import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
-import { AssetDropdownMenu } from '@app/features/asset-list/_components/asset-dropdown-menu';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
-import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useNativeSegwitAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
+import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
 
 import { parseCryptoAssetBalance } from './crypto-asset-item.layout.utils';
 
@@ -119,59 +119,44 @@ export function CryptoAssetItemLayout({
   );
 
   return (
-    <Box 
-      data-testid={sanitize(dataTestId)}
-      ref={menuRef}
-    >
-      <DropdownMenu.Root open={isMenuOpen} onOpenChange={setIsMenuOpen}>
-        <DropdownMenu.Trigger asChild>
-          <Pressable
-            className="group"
-            borderRadius="sm"
-            width="100%"
-            py="space.02"
-            position="relative"
-            _before={{
-              content: '""',
-              rounded: 'xs',
-              position: 'absolute',
-              top: '-space.01',
-              left: '-space.03',
-              bottom: '-space.01',
-              right: '-space.03',
-            }}
-            _hover={{
-              _before: {
-                bg: 'ink.component-background-hover',
-                borderColor: 'transparent',
-              }
-            }}
-            onClick={(e: React.MouseEvent) => {
-              if (onSelectAsset) {
-                onSelectAsset(availableBalance.symbol, contractId);
-                e.stopPropagation();
-                return;
-              }
-            }}
-            onContextMenu={(e: React.MouseEvent) => {
-              e.preventDefault();
-              setIsMenuOpen(true);
-            }}
-          >
-            {content}
-          </Pressable>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Portal>
-          {isMenuOpen && (
-            <AssetDropdownMenu
-              assetSymbol={availableBalance.symbol}
-              contractId={contractId}
-              address={address || ''}
-              onClose={() => setIsMenuOpen(false)}
-            />
-          )}
-        </DropdownMenu.Portal>
-      </DropdownMenu.Root>
+    <Box data-testid={sanitize(dataTestId)} ref={menuRef}>
+      <AssetContextMenu
+        assetSymbol={availableBalance.symbol}
+        contractId={contractId}
+        address={address || ''}
+      >
+        <Pressable
+          className="group"
+          borderRadius="sm"
+          width="100%"
+          py="space.02"
+          position="relative"
+          _before={{
+            content: '""',
+            rounded: 'xs',
+            position: 'absolute',
+            top: '-space.01',
+            left: '-space.03',
+            bottom: '-space.01',
+            right: '-space.03',
+          }}
+          _hover={{
+            _before: {
+              bg: 'ink.component-background-hover',
+              borderColor: 'transparent',
+            },
+          }}
+          onClick={(e: React.MouseEvent) => {
+            if (onSelectAsset) {
+              onSelectAsset(availableBalance.symbol, contractId);
+              e.stopPropagation();
+              return;
+            }
+          }}
+        >
+          {content}
+        </Pressable>
+      </AssetContextMenu>
     </Box>
   );
 }

--- a/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -16,7 +16,7 @@ import {
 import { useSpamFilterWithWhitelist } from '@app/common/spam-filter/use-spam-filter';
 import { PrivateTextLayout } from '@app/components/privacy/private-text.layout';
 import { BasicTooltip } from '@app/ui/components/tooltip/basic-tooltip';
-import { AssetContextMenu } from '@app/features/asset-list/_components/asset-context-menu';
+import { AssetDropdownMenu } from '@app/features/asset-list/_components/asset-dropdown-menu';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useNativeSegwitAccountIndexAddressIndexZero } from '@app/store/accounts/blockchain/bitcoin/native-segwit-account.hooks';
@@ -147,7 +147,7 @@ export function CryptoAssetItemLayout({
           </Pressable>
         </DropdownMenu.Trigger>
         {isMenuOpen && (
-          <AssetContextMenu
+          <AssetDropdownMenu
             assetSymbol={availableBalance.symbol}
             contractId={contractId}
             address={address || ''}

--- a/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
+++ b/src/app/components/crypto-asset-item/crypto-asset-item.layout.tsx
@@ -126,9 +126,26 @@ export function CryptoAssetItemLayout({
       <DropdownMenu.Root open={isMenuOpen} onOpenChange={setIsMenuOpen}>
         <DropdownMenu.Trigger asChild>
           <Pressable
+            className="group"
             borderRadius="sm"
-            _hover={{ bg: 'ink.component-background-hover' }}
             width="100%"
+            py="space.02"
+            position="relative"
+            _before={{
+              content: '""',
+              rounded: 'xs',
+              position: 'absolute',
+              top: '-space.01',
+              left: '-space.03',
+              bottom: '-space.01',
+              right: '-space.03',
+            }}
+            _hover={{
+              _before: {
+                bg: 'ink.component-background-hover',
+                borderColor: 'transparent',
+              }
+            }}
             onClick={(e: React.MouseEvent) => {
               if (onSelectAsset) {
                 onSelectAsset(availableBalance.symbol, contractId);
@@ -141,19 +158,19 @@ export function CryptoAssetItemLayout({
               setIsMenuOpen(true);
             }}
           >
-            <Box px="space.03" py="space.03">
-              {content}
-            </Box>
+            {content}
           </Pressable>
         </DropdownMenu.Trigger>
-        {isMenuOpen && (
-          <AssetDropdownMenu
-            assetSymbol={availableBalance.symbol}
-            contractId={contractId}
-            address={address || ''}
-            onClose={() => setIsMenuOpen(false)}
-          />
-        )}
+        <DropdownMenu.Portal>
+          {isMenuOpen && (
+            <AssetDropdownMenu
+              assetSymbol={availableBalance.symbol}
+              contractId={contractId}
+              address={address || ''}
+              onClose={() => setIsMenuOpen(false)}
+            />
+          )}
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
     </Box>
   );

--- a/src/app/features/asset-list/_components/asset-context-menu.tsx
+++ b/src/app/features/asset-list/_components/asset-context-menu.tsx
@@ -1,0 +1,131 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Flex } from 'leather-styles/jsx';
+import { css } from 'leather-styles/css';
+
+import {
+  PaperPlaneIcon,
+  InboxIcon,
+  ArrowsRepeatLeftRightIcon,
+  DropdownMenu,
+} from '@leather.io/ui';
+
+import { copyToClipboard } from '@app/common/utils/copy-to-clipboard';
+import { useToast } from '@app/features/toasts/use-toast';
+import { useConfigSwapsEnabled } from '@app/query/common/remote-config/remote-config.query';
+import { analytics } from '@shared/utils/analytics';
+
+interface AssetContextMenuProps {
+  assetSymbol: string;
+  contractId?: string;
+  address: string;
+  onClose?: () => void;
+}
+
+const menuStyles = css({
+  backgroundColor: 'ink.background-primary',
+  borderRadius: 'sm',
+  boxShadow: 'menu',
+  border: '1px solid',
+  borderColor: 'ink.border-default',
+  minWidth: '140px',
+  overflow: 'hidden',
+});
+
+const menuGroupStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'space.01'
+});
+
+const menuItemStyles = css({
+  opacity: 1,
+  width: '100%',
+  cursor: 'pointer',
+  display: 'block',
+  outline: 'none',
+  _hover: {
+    backgroundColor: 'ink.component-background-hover'
+  },
+  '&[data-disabled]': {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+    _hover: {
+      backgroundColor: 'transparent'
+    }
+  }
+});
+
+const menuItemContentStyles = css({
+  p: 'space.02'
+});
+
+export function AssetContextMenu({ 
+  assetSymbol, 
+  contractId, 
+  address,
+  onClose,
+}: AssetContextMenuProps) {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const isSwapEnabled = useConfigSwapsEnabled();
+
+  const handleReceiveClick = async () => {
+    const isBtcToken = assetSymbol.toLowerCase() === 'btc';
+    void analytics.track(isBtcToken ? 'copy_btc_address_to_clipboard' : 'copy_stx_address_to_clipboard');
+    await copyToClipboard(address);
+    toast.success('Address copied to clipboard');
+    onClose?.();
+  };
+
+  return (
+    <DropdownMenu.Content
+      className={menuStyles}
+      sideOffset={2}
+      align="start"
+      side="bottom"
+      style={{
+        zIndex: 999,
+      }}
+      avoidCollisions
+    >
+      <DropdownMenu.Group className={menuGroupStyles}>
+        <DropdownMenu.Item
+          className={menuItemStyles}
+          onClick={() => {
+            navigate(`/send/${assetSymbol}${contractId ? `/${contractId}` : ''}`);
+            onClose?.();
+          }}
+        >
+          <Flex alignItems="center" gap="space.01" opacity="inherit" className={menuItemContentStyles}>
+            <PaperPlaneIcon variant="small" />
+            Send
+          </Flex>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item 
+          className={menuItemStyles}
+          onClick={handleReceiveClick}
+        >
+          <Flex alignItems="center" gap="space.01" opacity="inherit" className={menuItemContentStyles}>
+            <InboxIcon variant="small" />
+            Receive
+          </Flex>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item 
+          className={menuItemStyles}
+          onClick={() => {
+            if (!isSwapEnabled) return;
+            navigate(`/swap/${assetSymbol}`);
+            onClose?.();
+          }}
+          disabled={!isSwapEnabled}
+        >
+          <Flex alignItems="center" gap="space.01" opacity="inherit" className={menuItemContentStyles}>
+            <ArrowsRepeatLeftRightIcon variant="small" />
+            Swap
+          </Flex>
+        </DropdownMenu.Item>
+      </DropdownMenu.Group>
+    </DropdownMenu.Content>
+  );
+}

--- a/src/app/features/asset-list/_components/asset-context-menu.tsx
+++ b/src/app/features/asset-list/_components/asset-context-menu.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
-import { Flex } from 'leather-styles/jsx';
+import { HStack } from 'leather-styles/jsx';
 import { css } from 'leather-styles/css';
 
 import {
@@ -30,12 +30,13 @@ const menuStyles = css({
   borderColor: 'ink.border-default',
   minWidth: '140px',
   overflow: 'hidden',
-});
-
-const menuGroupStyles = css({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'space.01'
+  // Override default padding
+  '& > div > div': {
+    padding: '0 !important'
+  },
+  '& > div > div > div': {
+    padding: '0 !important'
+  }
 });
 
 const menuItemStyles = css({
@@ -57,8 +58,33 @@ const menuItemStyles = css({
 });
 
 const menuItemContentStyles = css({
-  p: 'space.02'
+  width: '100%',
+  px: 'space.03',
+  py: 'space.02',
+  gap: 'space.02'
 });
+
+interface AssetContextMenuItemProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+function AssetContextMenuItem({ icon, label, onClick, disabled }: AssetContextMenuItemProps) {
+  return (
+    <DropdownMenu.Item 
+      className={menuItemStyles}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <HStack className={menuItemContentStyles}>
+        {icon}
+        {label}
+      </HStack>
+    </DropdownMenu.Item>
+  );
+}
 
 export function AssetContextMenu({ 
   assetSymbol, 
@@ -89,42 +115,30 @@ export function AssetContextMenu({
       }}
       avoidCollisions
     >
-      <DropdownMenu.Group className={menuGroupStyles}>
-        <DropdownMenu.Item
-          className={menuItemStyles}
+      <DropdownMenu.Group>
+        <AssetContextMenuItem
+          icon={<PaperPlaneIcon variant="small" />}
+          label="Send"
           onClick={() => {
             navigate(`/send/${assetSymbol}${contractId ? `/${contractId}` : ''}`);
             onClose?.();
           }}
-        >
-          <Flex alignItems="center" gap="space.01" opacity="inherit" className={menuItemContentStyles}>
-            <PaperPlaneIcon variant="small" />
-            Send
-          </Flex>
-        </DropdownMenu.Item>
-        <DropdownMenu.Item 
-          className={menuItemStyles}
+        />
+        <AssetContextMenuItem
+          icon={<InboxIcon variant="small" />}
+          label="Receive"
           onClick={handleReceiveClick}
-        >
-          <Flex alignItems="center" gap="space.01" opacity="inherit" className={menuItemContentStyles}>
-            <InboxIcon variant="small" />
-            Receive
-          </Flex>
-        </DropdownMenu.Item>
-        <DropdownMenu.Item 
-          className={menuItemStyles}
+        />
+        <AssetContextMenuItem
+          icon={<ArrowsRepeatLeftRightIcon variant="small" />}
+          label="Swap"
           onClick={() => {
             if (!isSwapEnabled) return;
             navigate(`/swap/${assetSymbol}`);
             onClose?.();
           }}
           disabled={!isSwapEnabled}
-        >
-          <Flex alignItems="center" gap="space.01" opacity="inherit" className={menuItemContentStyles}>
-            <ArrowsRepeatLeftRightIcon variant="small" />
-            Swap
-          </Flex>
-        </DropdownMenu.Item>
+        />
       </DropdownMenu.Group>
     </DropdownMenu.Content>
   );

--- a/src/app/features/asset-list/_components/asset-context-menu.tsx
+++ b/src/app/features/asset-list/_components/asset-context-menu.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as ContextMenu from '@radix-ui/react-context-menu';
+
+import { HStack } from 'leather-styles/jsx';
+import { css } from 'leather-styles/css';
+
+import {
+  PaperPlaneIcon,
+  InboxIcon,
+  ArrowsRepeatLeftRightIcon,
+} from '@leather.io/ui';
+
+import { copyToClipboard } from '@app/common/utils/copy-to-clipboard';
+import { useToast } from '@app/features/toasts/use-toast';
+import { useConfigSwapsEnabled } from '@app/query/common/remote-config/remote-config.query';
+import { analytics } from '@shared/utils/analytics';
+
+interface AssetContextMenuProps {
+  assetSymbol: string;
+  contractId?: string;
+  address: string;
+  children: React.ReactNode;
+}
+
+const menuStyles = css({
+  backgroundColor: 'ink.background-primary',
+  borderRadius: 'sm',
+  boxShadow: 'menu',
+  border: '1px solid',
+  borderColor: 'ink.border-default',
+  minWidth: '140px',
+  overflow: 'hidden',
+  padding: 'space.01',
+});
+
+const menuItemStyles = css({
+  opacity: 1,
+  width: '100%',
+  cursor: 'pointer',
+  display: 'block',
+  outline: 'none',
+  borderRadius: 'xs',
+  _hover: {
+    backgroundColor: 'ink.component-background-hover'
+  },
+  '&[data-disabled]': {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+    _hover: {
+      backgroundColor: 'transparent'
+    }
+  }
+});
+
+const menuItemContentStyles = css({
+  width: '100%',
+  px: 'space.03',
+  py: 'space.02',
+  gap: 'space.02'
+});
+
+interface AssetContextMenuItemProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+function AssetContextMenuItem({ icon, label, onClick, disabled }: AssetContextMenuItemProps) {
+  return (
+    <ContextMenu.Item 
+      className={menuItemStyles}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <HStack className={menuItemContentStyles}>
+        {icon}
+        {label}
+      </HStack>
+    </ContextMenu.Item>
+  );
+}
+
+export function AssetContextMenu({ 
+  assetSymbol, 
+  contractId, 
+  address,
+  children,
+}: AssetContextMenuProps) {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const isSwapEnabled = useConfigSwapsEnabled();
+
+  const handleReceiveClick = async () => {
+    // Track analytics based on asset type
+    const lowerCaseSymbol = assetSymbol.toLowerCase();
+    
+    if (lowerCaseSymbol === 'btc') {
+      // For BTC, we need to include the type parameter
+      void analytics.track('copy_btc_address_to_clipboard', { type: 'btc' });
+    } else {
+      // For STX and other tokens, no second parameter is needed
+      void analytics.track('copy_stx_address_to_clipboard');
+    }
+    
+    await copyToClipboard(address);
+    toast.success('Address copied to clipboard');
+  };
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>
+        {children}
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content
+          className={menuStyles}
+          style={{
+            zIndex: 999,
+          }}
+          onPointerDownOutside={(e) => {
+            e.preventDefault();
+          }}
+        >
+          <ContextMenu.Group>
+            <AssetContextMenuItem
+              icon={<PaperPlaneIcon variant="small" />}
+              label="Send"
+              onClick={() => {
+                navigate(`/send/${assetSymbol}${contractId ? `/${contractId}` : ''}`);
+              }}
+            />
+            <AssetContextMenuItem
+              icon={<InboxIcon variant="small" />}
+              label="Receive"
+              onClick={handleReceiveClick}
+            />
+            <AssetContextMenuItem
+              icon={<ArrowsRepeatLeftRightIcon variant="small" />}
+              label="Swap"
+              onClick={() => {
+                if (!isSwapEnabled) return;
+                
+                // Normalize the asset symbol for URL construction
+                // This handles special characters and ensures consistent casing
+                const normalizedSymbol = assetSymbol.toLowerCase().trim();
+                
+                // Determine chain based on normalized asset symbol
+                const chain = normalizedSymbol === 'btc' ? 'bitcoin' : 'stacks';
+                
+                // Construct the URL with the normalized symbol
+                const url = `/swap/${chain}/${normalizedSymbol}`;
+                
+                navigate(url);
+              }}
+              disabled={!isSwapEnabled}
+            />
+          </ContextMenu.Group>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  );
+}

--- a/src/app/features/asset-list/_components/asset-dropdown-menu.tsx
+++ b/src/app/features/asset-list/_components/asset-dropdown-menu.tsx
@@ -1,25 +1,21 @@
 import { useNavigate } from 'react-router-dom';
 
-import { HStack } from 'leather-styles/jsx';
 import { css } from 'leather-styles/css';
+import { HStack } from 'leather-styles/jsx';
 
-import {
-  PaperPlaneIcon,
-  InboxIcon,
-  ArrowsRepeatLeftRightIcon,
-  DropdownMenu,
-} from '@leather.io/ui';
+import { ArrowsRepeatLeftRightIcon, DropdownMenu, InboxIcon, PaperPlaneIcon } from '@leather.io/ui';
+
+import { analytics } from '@shared/utils/analytics';
 
 import { copyToClipboard } from '@app/common/utils/copy-to-clipboard';
 import { useToast } from '@app/features/toasts/use-toast';
 import { useConfigSwapsEnabled } from '@app/query/common/remote-config/remote-config.query';
-import { analytics } from '@shared/utils/analytics';
 
 interface AssetDropdownMenuProps {
   assetSymbol: string;
   contractId?: string;
   address: string;
-  onClose?: () => void;
+  onClose?(): void;
 }
 
 const menuStyles = css({
@@ -32,11 +28,11 @@ const menuStyles = css({
   overflow: 'hidden',
   // Override default padding
   '& > div > div': {
-    padding: '0 !important'
+    padding: '0 !important',
   },
   '& > div > div > div': {
-    padding: '0 !important'
-  }
+    padding: '0 !important',
+  },
 });
 
 const menuItemStyles = css({
@@ -46,38 +42,34 @@ const menuItemStyles = css({
   display: 'block',
   outline: 'none',
   _hover: {
-    backgroundColor: 'ink.component-background-hover'
+    backgroundColor: 'ink.component-background-hover',
   },
   '&[data-disabled]': {
     opacity: 0.5,
     cursor: 'not-allowed',
     _hover: {
-      backgroundColor: 'transparent'
-    }
-  }
+      backgroundColor: 'transparent',
+    },
+  },
 });
 
 const menuItemContentStyles = css({
   width: '100%',
   px: 'space.03',
   py: 'space.02',
-  gap: 'space.02'
+  gap: 'space.02',
 });
 
 interface AssetDropdownMenuItemProps {
   icon: React.ReactNode;
   label: string;
-  onClick?: () => void;
+  onClick?(): void;
   disabled?: boolean;
 }
 
 function AssetDropdownMenuItem({ icon, label, onClick, disabled }: AssetDropdownMenuItemProps) {
   return (
-    <DropdownMenu.Item 
-      className={menuItemStyles}
-      onClick={onClick}
-      disabled={disabled}
-    >
+    <DropdownMenu.Item className={menuItemStyles} onClick={onClick} disabled={disabled}>
       <HStack className={menuItemContentStyles}>
         {icon}
         {label}
@@ -86,9 +78,9 @@ function AssetDropdownMenuItem({ icon, label, onClick, disabled }: AssetDropdown
   );
 }
 
-export function AssetDropdownMenu({ 
-  assetSymbol, 
-  contractId, 
+export function AssetDropdownMenu({
+  assetSymbol,
+  contractId,
   address,
   onClose,
 }: AssetDropdownMenuProps) {
@@ -99,7 +91,7 @@ export function AssetDropdownMenu({
   const handleReceiveClick = async () => {
     // Track analytics based on asset type
     const lowerCaseSymbol = assetSymbol.toLowerCase();
-    
+
     if (lowerCaseSymbol === 'btc') {
       // For BTC, we need to include the type parameter
       void analytics.track('copy_btc_address_to_clipboard', { type: 'btc' });
@@ -107,7 +99,7 @@ export function AssetDropdownMenu({
       // For STX and other tokens, no second parameter is needed
       void analytics.track('copy_stx_address_to_clipboard');
     }
-    
+
     await copyToClipboard(address);
     toast.success('Address copied to clipboard');
     onClose?.();
@@ -123,7 +115,7 @@ export function AssetDropdownMenu({
         zIndex: 999,
       }}
       avoidCollisions
-      onPointerDownOutside={(e) => {
+      onPointerDownOutside={e => {
         e.preventDefault();
         onClose?.();
       }}
@@ -147,21 +139,17 @@ export function AssetDropdownMenu({
           label="Swap"
           onClick={() => {
             if (!isSwapEnabled) return;
-            
-            // Add debugging for problematic tokens
-            console.log('Attempting to swap asset:', assetSymbol);
-            
+
             // Normalize the asset symbol for URL construction
             // This handles special characters and ensures consistent casing
             const normalizedSymbol = assetSymbol.toLowerCase().trim();
-            
+
             // Determine chain based on normalized asset symbol
             const chain = normalizedSymbol === 'btc' ? 'bitcoin' : 'stacks';
-            
+
             // Construct the URL with the normalized symbol
             const url = `/swap/${chain}/${normalizedSymbol}`;
-            
-            console.log('Navigating to swap URL:', url);
+
             navigate(url);
             onClose?.();
           }}

--- a/src/app/features/asset-list/_components/asset-dropdown-menu.tsx
+++ b/src/app/features/asset-list/_components/asset-dropdown-menu.tsx
@@ -123,6 +123,10 @@ export function AssetDropdownMenu({
         zIndex: 999,
       }}
       avoidCollisions
+      onPointerDownOutside={(e) => {
+        e.preventDefault();
+        onClose?.();
+      }}
     >
       <DropdownMenu.Group>
         <AssetDropdownMenuItem
@@ -143,8 +147,22 @@ export function AssetDropdownMenu({
           label="Swap"
           onClick={() => {
             if (!isSwapEnabled) return;
-            const chain = assetSymbol.toLowerCase() === 'btc' ? 'bitcoin' : 'stacks';
-            navigate(`/swap/${chain}/${assetSymbol.toLowerCase()}`);
+            
+            // Add debugging for problematic tokens
+            console.log('Attempting to swap asset:', assetSymbol);
+            
+            // Normalize the asset symbol for URL construction
+            // This handles special characters and ensures consistent casing
+            const normalizedSymbol = assetSymbol.toLowerCase().trim();
+            
+            // Determine chain based on normalized asset symbol
+            const chain = normalizedSymbol === 'btc' ? 'bitcoin' : 'stacks';
+            
+            // Construct the URL with the normalized symbol
+            const url = `/swap/${chain}/${normalizedSymbol}`;
+            
+            console.log('Navigating to swap URL:', url);
+            navigate(url);
             onClose?.();
           }}
           disabled={!isSwapEnabled}

--- a/src/app/features/asset-list/_components/asset-dropdown-menu.tsx
+++ b/src/app/features/asset-list/_components/asset-dropdown-menu.tsx
@@ -143,7 +143,8 @@ export function AssetDropdownMenu({
           label="Swap"
           onClick={() => {
             if (!isSwapEnabled) return;
-            navigate(`/swap/${assetSymbol}`);
+            const chain = assetSymbol.toLowerCase() === 'btc' ? 'bitcoin' : 'stacks';
+            navigate(`/swap/${chain}/${assetSymbol.toLowerCase()}`);
             onClose?.();
           }}
           disabled={!isSwapEnabled}

--- a/src/app/features/asset-list/asset-list.tsx
+++ b/src/app/features/asset-list/asset-list.tsx
@@ -57,7 +57,7 @@ export function AssetList({
   const isReadOnly = variant === 'read-only';
 
   return (
-    <Stack>
+    <Stack px="space.00">
       {showUnmanageableTokens && (
         <BitcoinNativeSegwitAccountLoader
           current

--- a/src/app/features/asset-list/manage-tokens/manage-tokens.tsx
+++ b/src/app/features/asset-list/manage-tokens/manage-tokens.tsx
@@ -14,8 +14,26 @@ export function ManageTokens() {
   return (
     <>
       <Pressable
+        className="group"
         data-testid={HomePageSelectors.ManageTokensBtn}
         mt="space.04"
+        py="space.02"
+        position="relative"
+        _before={{
+          content: '""',
+          rounded: 'xs',
+          position: 'absolute',
+          top: '-space.01',
+          left: '-space.03',
+          bottom: '-space.01',
+          right: '-space.03',
+        }}
+        _hover={{
+          _before: {
+            bg: 'ink.component-background-hover',
+            borderColor: 'transparent',
+          }
+        }}
         onClick={() => {
           setShowManageTokens(!showManageTokens);
         }}

--- a/src/app/features/asset-list/manage-tokens/manage-tokens.tsx
+++ b/src/app/features/asset-list/manage-tokens/manage-tokens.tsx
@@ -32,7 +32,7 @@ export function ManageTokens() {
           _before: {
             bg: 'ink.component-background-hover',
             borderColor: 'transparent',
-          }
+          },
         }}
         onClick={() => {
           setShowManageTokens(!showManageTokens);

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
@@ -46,7 +46,7 @@ export function useStxSendForm() {
   const sendMaxBalance = useMemo(
     () =>
       convertAmountToBaseUnit(
-        availableBalance.amount.minus(stxFees?.estimates[1].fee.amount || 0),
+        availableBalance.amount.minus(stxFees?.estimates?.[1]?.fee?.amount || 0),
         STX_DECIMALS
       ),
     [availableBalance.amount, stxFees?.estimates]

--- a/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/stx/use-stx-send-form.tsx
@@ -43,14 +43,10 @@ export function useStxSendForm() {
   const { data: balance } = filteredBalanceQuery;
   const availableBalance = balance?.availableUnlockedBalance ?? createMoney(0, 'STX');
 
-  const sendMaxBalance = useMemo(
-    () =>
-      convertAmountToBaseUnit(
-        availableBalance.amount.minus(stxFees?.estimates?.[1]?.fee?.amount || 0),
-        STX_DECIMALS
-      ),
-    [availableBalance.amount, stxFees?.estimates]
-  );
+  const sendMaxBalance = useMemo(() => {
+    const standardFee = stxFees?.estimates[1]?.fee.amount || 0;
+    return convertAmountToBaseUnit(availableBalance.amount.minus(standardFee), STX_DECIMALS);
+  }, [availableBalance.amount, stxFees?.estimates]);
 
   const { initialValues, checkFormValidation, recipient, memo, nonce } = useStacksCommonSendForm({
     symbol: 'STX',

--- a/src/app/pages/swap/hooks/use-swap-route-params.ts
+++ b/src/app/pages/swap/hooks/use-swap-route-params.ts
@@ -13,73 +13,53 @@ export function useSwapRouteParams<T extends BaseSwapContext<T>>() {
   const { base, quote } = useParams();
 
   useEffect(() => {
-    // Debug token issues
-    console.log('Swap route params:', { base, quote, chain: swapData.chain });
-    console.log('Available base assets:', swapData.swappableAssetsBase.map(a => a.name));
-    
+    // Process route parameters for swap
     if (!isCrossChainSwap && swapData.chain === 'bitcoin') onSetIsCrossChainSwap(true);
+
     if (base) {
       // Enhanced asset matching with normalization and fallback options
       // First try exact match
-      let baseAsset = swapData.swappableAssetsBase.find(asset => 
-        asset.name === base
-      );
-      
+      let baseAsset = swapData.swappableAssetsBase.find(asset => asset.name === base);
+
       // If not found, try case-insensitive match
       if (!baseAsset) {
-        baseAsset = swapData.swappableAssetsBase.find(asset => 
-          asset.name.toLowerCase() === base.toLowerCase()
+        baseAsset = swapData.swappableAssetsBase.find(
+          asset => asset.name.toLowerCase() === base.toLowerCase()
         );
       }
-      
-      // If still not found, try matching by symbol
+
+      // If still not found, try matching by token ID for tokens
       if (!baseAsset) {
-        baseAsset = swapData.swappableAssetsBase.find(asset => 
-          asset.name.toLowerCase().includes(base.toLowerCase()) || 
-          (asset.fallback && asset.fallback.toLowerCase() === base.toLowerCase())
+        baseAsset = swapData.swappableAssetsBase.find(
+          asset => asset.tokenId?.toLowerCase() === base.toLowerCase()
         );
       }
-      
-      if (!baseAsset) {
-        console.error(`Base asset not found: ${base}`);
-        console.log('Available assets:', swapData.swappableAssetsBase.map(a => ({ name: a.name, tokenId: a.tokenId })));
-      } else {
-        console.log('Found base asset:', baseAsset.name, baseAsset.tokenId);
-      }
-      
+
       void setFieldValue('swapAssetBase', baseAsset);
     }
+
     if (quote) {
       // Enhanced asset matching with normalization and fallback options
       // First try exact match
-      let quoteAsset = swapData.swappableAssetsQuote.find(asset => 
-        asset.name === quote
-      );
-      
+      let quoteAsset = swapData.swappableAssetsQuote.find(asset => asset.name === quote);
+
       // If not found, try case-insensitive match
       if (!quoteAsset) {
-        quoteAsset = swapData.swappableAssetsQuote.find(asset => 
-          asset.name.toLowerCase() === quote.toLowerCase()
+        quoteAsset = swapData.swappableAssetsQuote.find(
+          asset => asset.name.toLowerCase() === quote.toLowerCase()
         );
       }
-      
-      // If still not found, try matching by symbol
+
+      // If still not found, try matching by token ID for tokens
       if (!quoteAsset) {
-        quoteAsset = swapData.swappableAssetsQuote.find(asset => 
-          asset.name.toLowerCase().includes(quote.toLowerCase()) || 
-          (asset.fallback && asset.fallback.toLowerCase() === quote.toLowerCase())
+        quoteAsset = swapData.swappableAssetsQuote.find(
+          asset => asset.tokenId?.toLowerCase() === quote.toLowerCase()
         );
       }
-      
-      if (!quoteAsset) {
-        console.error(`Quote asset not found: ${quote}`);
-        console.log('Available quote assets:', swapData.swappableAssetsQuote.map(a => ({ name: a.name, tokenId: a.tokenId })));
-      } else {
-        console.log('Found quote asset:', quoteAsset.name, quoteAsset.tokenId);
-      }
-      
+
       void setFieldValue('swapAssetQuote', quoteAsset);
     }
+
     void validateForm();
   }, [base, isCrossChainSwap, onSetIsCrossChainSwap, quote, setFieldValue, swapData, validateForm]);
 }

--- a/src/app/pages/swap/hooks/use-swap-route-params.ts
+++ b/src/app/pages/swap/hooks/use-swap-route-params.ts
@@ -13,17 +13,73 @@ export function useSwapRouteParams<T extends BaseSwapContext<T>>() {
   const { base, quote } = useParams();
 
   useEffect(() => {
+    // Debug token issues
+    console.log('Swap route params:', { base, quote, chain: swapData.chain });
+    console.log('Available base assets:', swapData.swappableAssetsBase.map(a => a.name));
+    
     if (!isCrossChainSwap && swapData.chain === 'bitcoin') onSetIsCrossChainSwap(true);
-    if (base)
-      void setFieldValue(
-        'swapAssetBase',
-        swapData.swappableAssetsBase.find(asset => asset.name === base)
+    if (base) {
+      // Enhanced asset matching with normalization and fallback options
+      // First try exact match
+      let baseAsset = swapData.swappableAssetsBase.find(asset => 
+        asset.name === base
       );
-    if (quote)
-      void setFieldValue(
-        'swapAssetQuote',
-        swapData.swappableAssetsQuote.find(asset => asset.name === quote)
+      
+      // If not found, try case-insensitive match
+      if (!baseAsset) {
+        baseAsset = swapData.swappableAssetsBase.find(asset => 
+          asset.name.toLowerCase() === base.toLowerCase()
+        );
+      }
+      
+      // If still not found, try matching by symbol
+      if (!baseAsset) {
+        baseAsset = swapData.swappableAssetsBase.find(asset => 
+          asset.name.toLowerCase().includes(base.toLowerCase()) || 
+          (asset.fallback && asset.fallback.toLowerCase() === base.toLowerCase())
+        );
+      }
+      
+      if (!baseAsset) {
+        console.error(`Base asset not found: ${base}`);
+        console.log('Available assets:', swapData.swappableAssetsBase.map(a => ({ name: a.name, tokenId: a.tokenId })));
+      } else {
+        console.log('Found base asset:', baseAsset.name, baseAsset.tokenId);
+      }
+      
+      void setFieldValue('swapAssetBase', baseAsset);
+    }
+    if (quote) {
+      // Enhanced asset matching with normalization and fallback options
+      // First try exact match
+      let quoteAsset = swapData.swappableAssetsQuote.find(asset => 
+        asset.name === quote
       );
+      
+      // If not found, try case-insensitive match
+      if (!quoteAsset) {
+        quoteAsset = swapData.swappableAssetsQuote.find(asset => 
+          asset.name.toLowerCase() === quote.toLowerCase()
+        );
+      }
+      
+      // If still not found, try matching by symbol
+      if (!quoteAsset) {
+        quoteAsset = swapData.swappableAssetsQuote.find(asset => 
+          asset.name.toLowerCase().includes(quote.toLowerCase()) || 
+          (asset.fallback && asset.fallback.toLowerCase() === quote.toLowerCase())
+        );
+      }
+      
+      if (!quoteAsset) {
+        console.error(`Quote asset not found: ${quote}`);
+        console.log('Available quote assets:', swapData.swappableAssetsQuote.map(a => ({ name: a.name, tokenId: a.tokenId })));
+      } else {
+        console.log('Found quote asset:', quoteAsset.name, quoteAsset.tokenId);
+      }
+      
+      void setFieldValue('swapAssetQuote', quoteAsset);
+    }
     void validateForm();
   }, [base, isCrossChainSwap, onSetIsCrossChainSwap, quote, setFieldValue, swapData, validateForm]);
 }


### PR DESCRIPTION
> Try out Leather build c29215c — [Extension build](https://github.com/leather-io/extension/actions/runs/13640423470), [Test report](https://leather-io.github.io/playwright-reports/asset-actions), [Storybook](https://asset-actions--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=asset-actions)<!-- Sticky Header Marker -->

Introduces a context menu to the home/assets view, allowing users to access token-based actions via left-click. The goal is to provide a lightweight interaction until full token detail views are implemented.

- Left-click triggers a context menu with quick actions
- Saves time and reduces cognitive load for common token interactions
- Implemented using Radix menus (overridden to support left-click)
