### PR TITLE
fix(rpc): prevent opening on fail

### DIFF
--- a/.github/workflows/all-checks-pass.yml
+++ b/.github/workflows/all-checks-pass.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  allchecks:
+  all-checks:
     runs-on: ubuntu-latest
     permissions:
       checks: read

--- a/src/app/common/hooks/use-submit-stx-transaction.ts
+++ b/src/app/common/hooks/use-submit-stx-transaction.ts
@@ -10,7 +10,6 @@ import { analytics } from '@shared/utils/analytics';
 import { getErrorMessage } from '@app/common/get-error-message';
 import { useRefreshAllAccountData } from '@app/common/hooks/account/use-refresh-all-account-data';
 import { useLoading } from '@app/common/hooks/use-loading';
-import { safelyFormatHexTxid } from '@app/common/utils/safe-handle-txid';
 import { useToast } from '@app/features/toasts/use-toast';
 import { useCurrentStacksNetworkState } from '@app/store/networks/networks.hooks';
 
@@ -56,11 +55,10 @@ export function useSubmitTransactionCallback({ loadingKey }: UseSubmitTransactio
           void analytics.track('broadcast_transaction', {
             symbol: 'stx',
           });
-          const txid = safelyFormatHexTxid(response.txid);
-          onSuccess(txid);
+          onSuccess(response.txid);
           setIsIdle();
           await refreshAccountData(timeForApiToUpdate);
-          return { txid, transaction };
+          return { txid: response.txid, transaction };
         } catch (error) {
           logger.error('Transaction callback', { error });
           onError(isError(error) ? error : { name: '', message: '' });

--- a/src/app/features/address-monitor/use-sync-address-monitor.ts
+++ b/src/app/features/address-monitor/use-sync-address-monitor.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef } from 'react';
 
 import isEqual from 'lodash.isequal';
 
-import { logger } from '@shared/logger';
 import { InternalMethods } from '@shared/message-types';
 import { sendMessage } from '@shared/messages';
 
@@ -19,8 +18,6 @@ export function useSyncAddressMonitor() {
     const monitorableAddresses = isNotificationsEnabled ? addresses : [];
     if (monitorableAddresses && !isEqual(monitorableAddresses, prevAddresses.current)) {
       prevAddresses.current = monitorableAddresses;
-
-      logger.debug(`Syncing ${monitorableAddresses?.length} Monitored Addresses: `);
       sendMessage({
         method: InternalMethods.AddressMonitorUpdated,
         payload: {

--- a/src/app/features/stacks-transaction-request/hooks/use-stacks-transaction-summary.ts
+++ b/src/app/features/stacks-transaction-request/hooks/use-stacks-transaction-summary.ts
@@ -1,5 +1,4 @@
 import {
-  type AddressWire,
   ClarityType,
   ContractCallPayload,
   IntCV,
@@ -27,9 +26,9 @@ import {
 
 import { removeTrailingNullCharacters } from '@app/common/utils';
 
-function safeAddressToString(address: AddressWire) {
+function safeAddressToString(address: string) {
   try {
-    return addressToString(address);
+    return addressToString(createAddress(address));
   } catch (error) {
     return '';
   }
@@ -59,11 +58,13 @@ export function useStacksTransactionSummary(token: CryptoCurrency) {
     };
   }
 
+  // This function violates the rule of not pre-formatting data
   function formReviewTxSummary(tx: StacksTransactionWire, symbol = 'STX', decimals = 6) {
     if (symbol !== 'STX') {
       return formSip10TxSummary(tx, symbol, decimals);
     }
 
+    // WARNING: this is a very dangerous type cast as it can totally be another tx type...
     const payload = tx.payload as TokenTransferPayloadWire;
     const txValue = payload.amount;
     const fee = tx.auth.spendingCondition.fee;
@@ -71,7 +72,7 @@ export function useStacksTransactionSummary(token: CryptoCurrency) {
     const memoDisplayText = removeTrailingNullCharacters(memoContent) || 'No memo';
 
     return {
-      recipient: safeAddressToString(createAddress(payload?.recipient?.value)),
+      recipient: safeAddressToString(payload?.recipient?.value),
       fee: formatMoney(convertToMoneyTypeWithDefaultOfZero('STX', Number(fee))),
       totalSpend: formatMoney(
         convertToMoneyTypeWithDefaultOfZero('STX', Number(txValue) + Number(fee))

--- a/src/background/messaging/internal-methods/message-handler.ts
+++ b/src/background/messaging/internal-methods/message-handler.ts
@@ -20,6 +20,11 @@ async function removeFormState(tabId: number) {
 // Remove any persisted form state when a tab is closed
 chrome.tabs.onRemoved.addListener(tabId => removeFormState(tabId));
 
+function logInternalMessage(message: { method: string }) {
+  if (['persist/REHYDRATE', 'persist/PERSIST'].includes(message.method)) return;
+  logger.debug('Internal message', message);
+}
+
 export async function internalBackgroundMessageHandler(
   message: BackgroundMessages,
   sender: chrome.runtime.MessageSender,
@@ -30,7 +35,8 @@ export async function internalBackgroundMessageHandler(
     sendResponse();
     return;
   }
-  logger.debug('Internal message', message);
+
+  logInternalMessage(message);
 
   switch (message.method) {
     case InternalMethods.AddressMonitorUpdated:

--- a/src/background/messaging/messaging-utils.ts
+++ b/src/background/messaging/messaging-utils.ts
@@ -101,6 +101,8 @@ export function encodePostConditions(postConditions: PostConditionWire[]) {
   return postConditions.map(pc => serializePostConditionWire(pc));
 }
 
+type ValidationResult = 'success' | 'failure';
+
 interface ValidateRequestParamsArgs {
   id: string;
   method: RpcMethodNames;
@@ -114,7 +116,7 @@ export function validateRequestParams({
   params,
   port,
   schema,
-}: ValidateRequestParamsArgs) {
+}: ValidateRequestParamsArgs): { status: ValidationResult } {
   if (isUndefined(params)) {
     void trackRpcRequestError({ endpoint: method, error: RpcErrorMessage.UndefinedParams });
     chrome.tabs.sendMessage(
@@ -124,7 +126,7 @@ export function validateRequestParams({
         error: { code: RpcErrorCode.INVALID_REQUEST, message: RpcErrorMessage.UndefinedParams },
       })
     );
-    return;
+    return { status: 'failure' };
   }
 
   if (!validateRpcParams(params, schema)) {
@@ -140,8 +142,9 @@ export function validateRequestParams({
         },
       })
     );
-    return;
+    return { status: 'failure' };
   }
+  return { status: 'success' };
 }
 
 type BaseStacksTransactionRpcParams = z.infer<typeof baseStacksTransactionConfigSchema>;

--- a/src/background/messaging/rpc-methods/stx-call-contract.ts
+++ b/src/background/messaging/rpc-methods/stx-call-contract.ts
@@ -33,13 +33,14 @@ export async function rpcStxCallContract(
   port: chrome.runtime.Port
 ) {
   const { id: requestId, method, params } = message;
-  validateRequestParams({
+  const { status } = validateRequestParams({
     id: requestId,
     method,
     params,
     port,
     schema: stxCallContract.params,
   });
+  if (status === 'failure') return;
   const requestParams: RequestParams = [
     ['requestId', requestId],
     ['request', createUnsecuredToken(getMessageParamsToTransactionRequest(message.params))],

--- a/src/background/messaging/rpc-methods/stx-call-contract.ts
+++ b/src/background/messaging/rpc-methods/stx-call-contract.ts
@@ -45,6 +45,8 @@ export async function rpcStxCallContract(
     ['requestId', requestId],
     ['request', createUnsecuredToken(getMessageParamsToTransactionRequest(message.params))],
   ];
+  if (params.network) requestParams.push(['network', params.network]);
+
   return handleRpcMessage({
     method: message.method,
     path: RouteUrls.RpcStxCallContract,

--- a/src/background/messaging/rpc-methods/stx-deploy-contract.ts
+++ b/src/background/messaging/rpc-methods/stx-deploy-contract.ts
@@ -30,13 +30,14 @@ export async function rpcStxDeployContract(
   port: chrome.runtime.Port
 ) {
   const { id: requestId, method, params } = message;
-  validateRequestParams({
+  const { status } = validateRequestParams({
     id: requestId,
     method,
     params,
     port,
     schema: stxDeployContract.params,
   });
+  if (status === 'failure') return;
   const request = getMessageParamsToTransactionRequest(params);
   const requestParams: RequestParams = [
     ['requestId', requestId],

--- a/src/background/messaging/rpc-methods/stx-deploy-contract.ts
+++ b/src/background/messaging/rpc-methods/stx-deploy-contract.ts
@@ -43,6 +43,7 @@ export async function rpcStxDeployContract(
     ['requestId', requestId],
     ['request', createUnsecuredToken(request)],
   ];
+  if (params.network) requestParams.push(['network', params.network]);
   return handleRpcMessage({
     method: message.method,
     path: RouteUrls.RpcStxDeployContract,

--- a/src/background/messaging/rpc-methods/stx-transfer-sip10-ft.ts
+++ b/src/background/messaging/rpc-methods/stx-transfer-sip10-ft.ts
@@ -76,13 +76,15 @@ export async function rpcStxTransferSip10Ft(
   port: chrome.runtime.Port
 ) {
   const { id: requestId, method, params } = message;
-  validateRequestParams({
+
+  const { status } = validateRequestParams({
     id: requestId,
     method,
     params,
     port,
     schema: stxTransferSip10Ft.params,
   });
+  if (status === 'failure') return;
   const txRequest = await getMessageParamsToTransactionRequest(params);
   const requestParams: RequestParams = [
     ['requestId', requestId],

--- a/src/background/messaging/rpc-methods/stx-transfer-sip9-nft.ts
+++ b/src/background/messaging/rpc-methods/stx-transfer-sip9-nft.ts
@@ -87,6 +87,7 @@ export async function rpcStxTransferSip9Nft(
     ['requestId', requestId],
     ['request', createUnsecuredToken(txRequest)],
   ];
+  if (params.network) requestParams.push(['network', params.network]);
   return handleRpcMessage({
     method: message.method,
     path: RouteUrls.RpcStxTransferSip9Nft,

--- a/src/background/messaging/rpc-methods/stx-transfer-sip9-nft.ts
+++ b/src/background/messaging/rpc-methods/stx-transfer-sip9-nft.ts
@@ -74,13 +74,14 @@ export async function rpcStxTransferSip9Nft(
   port: chrome.runtime.Port
 ) {
   const { id: requestId, method, params } = message;
-  validateRequestParams({
+  const { status } = validateRequestParams({
     id: requestId,
     method,
     params,
     port,
     schema: stxTransferSip9Nft.params,
   });
+  if (status === 'failure') return;
   const txRequest = await getMessageParamsToTransactionRequest(params);
   const requestParams: RequestParams = [
     ['requestId', requestId],

--- a/src/background/messaging/rpc-methods/stx-transfer-stx.ts
+++ b/src/background/messaging/rpc-methods/stx-transfer-stx.ts
@@ -29,13 +29,14 @@ export async function rpcStxTransferStx(
   port: chrome.runtime.Port
 ) {
   const { id: requestId, method, params } = message;
-  validateRequestParams({
+  const { status } = validateRequestParams({
     id: requestId,
     method,
     params,
     port,
     schema: stxTransferStx.params,
   });
+  if (status === 'failure') return;
   const request = getMessageParamsToTransactionRequest(params);
   const requestParams: RequestParams = [
     ['requestId', requestId],


### PR DESCRIPTION
> Try out Leather build 33c86d9 — [Extension build](https://github.com/leather-io/extension/actions/runs/13654321023), [Test report](https://leather-io.github.io/playwright-reports/fix/prevent-opening-on-error), [Storybook](https://fix/prevent-opening-on-error--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/prevent-opening-on-error)<!-- Sticky Header Marker -->

Noticed in testing that the popup opens even when the request validation fails. Added handling for this in the new requests, though, I think we can come up with a better API for sharing validation logic between requests. 