### PR TITLE
ci: behaviours for needs: labels

### DIFF
--- a/.github/workflows/all-checks-pass.yml
+++ b/.github/workflows/all-checks-pass.yml
@@ -1,7 +1,13 @@
 name: All checks pass
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
 
 jobs:
   all-checks:

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -1,0 +1,24 @@
+name: PR Label Guard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+
+jobs:
+  check-needs-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'PR missing information'
+        if: contains(join(github.event.pull_request.labels.*.name, ' '), 'needs:')
+        run: |
+          echo "::error::PR build failed due to unmet requirements. See labels added."
+          exit 1
+
+      - name: PR build passed
+        run: |
+          echo "PR build passed. All requirements met ✅"
+          exit 0

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 'PR missing information'
         if: contains(join(github.event.pull_request.labels.*.name, ' '), 'needs:')
         run: |
-          echo "::error::PR build failed due to unmet requirements. See labels added."
+          echo "::error::PR build failed due to unmet requirements. All labels prefixed with `needs:` should be addressed. Once the change is made and the PR is updated you may remove the label."
           exit 1
 
       - name: PR build passed


### PR DESCRIPTION
> Try out Leather build 50b1226 — [Extension build](https://github.com/leather-io/extension/actions/runs/13672500962), [Test report](https://leather-io.github.io/playwright-reports/ci/label-check-for-prs), [Storybook](https://ci/label-check-for-prs--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci/label-check-for-prs)<!-- Sticky Header Marker -->

This PR adds a feature where, if a PR has a `needs:*` label on it, the build fails. Only when all `needs:` prefixed labels are removed, can the PR be merged.

**Motivation**
We want to encourage team members to be as descriptive as possible when delivering work. It's easy to focus on the task at hand, and not put as much effort into the PR body, but this makes the changes opaque and leaves it to other team members to dig into the code to understand the changes. Of course they should check code anyway, but the changes should still be summarised in the body.

A good pull request description goes beyond summarising changes. It discusses the problem being solved, which contextualises the solution. It considers how these changes impact the rest of the code, discusses other solutions, and why this solution is the best way to solve the problem.

Feel free to add a `needs:` label to this PR to test, or because my description is inadequate somehow. Your choice! I encourage everyone use this liberally.

Long since forgotten, we do have a [Definition of Done](https://www.notion.so/trustmachines/a8e557def169449cb64104dd57611a20?v=a984d47b82c94e8fac9297736774331d&pvs=4) in Notion, I encourage everyone to read.