### PR TITLE
fix: sip30 success response, closes #6152

### DIFF
--- a/src/app/common/rpc/use-rpc-sip30-broadcast-transaction.ts
+++ b/src/app/common/rpc/use-rpc-sip30-broadcast-transaction.ts
@@ -17,7 +17,10 @@ import {
   type GenerateUnsignedTransactionOptions,
   generateUnsignedTransaction,
 } from '@app/common/transactions/stacks/generate-unsigned-txs';
-import { getTxSenderAddress } from '@app/common/transactions/stacks/transaction.utils';
+import {
+  StacksTransactionActionType,
+  getTxSenderAddress,
+} from '@app/common/transactions/stacks/transaction.utils';
 import { useStacksBroadcastTransaction } from '@app/features/stacks-transaction-request/hooks/use-stacks-broadcast-transaction';
 import { useCurrentStacksAccount } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { useCurrentStacksNetworkState } from '@app/store/networks/networks.hooks';
@@ -51,8 +54,8 @@ export function useRpcSip30BroadcastTransaction(method: RpcMethodNames) {
   const txPayload = useLegacyTxPayloadFromRpcRequest();
   const stacksTransaction = useUnsignedStacksTransaction(txPayload);
   const { stacksBroadcastTransaction } = useStacksBroadcastTransaction({
+    actionType: StacksTransactionActionType.RpcRequest,
     token: '',
-    showSummaryPage: false,
   });
 
   return useMemo(

--- a/src/app/common/transactions/stacks/transaction.utils.ts
+++ b/src/app/common/transactions/stacks/transaction.utils.ts
@@ -125,4 +125,5 @@ export function isPendingTx(tx: StacksTx) {
 export enum StacksTransactionActionType {
   Cancel = 'cancel',
   IncreaseFee = 'increase-fee',
+  RpcRequest = 'rpc-request',
 }


### PR DESCRIPTION
> Try out Leather build f787316 — [Extension build](https://github.com/leather-io/extension/actions/runs/13772014035), [Test report](https://leather-io.github.io/playwright-reports/fix/sip30-txid-response), [Storybook](https://fix/sip30-txid-response--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/sip30-txid-response)<!-- Sticky Header Marker -->

This fixed the window closing early for me, it was still hitting the `finalizeTxSignature` in `handlePreviewSuccess`, so we just need to avoid it completely and route to the activity feed. There is no need to even go into that function if not showing the summary.

I am totally refactoring away from this hook in my current work.