### PR TITLE
ci: production deploy environment

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -38,6 +38,7 @@ jobs:
   publish-chrome-extension:
     name: Publish Chrome extension
     runs-on: ubuntu-24.04
+    environment: production
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - extract-version


### PR DESCRIPTION
> Try out Leather build 3244638 — [Extension build](https://github.com/leather-io/extension/actions/runs/13783439130), [Test report](https://leather-io.github.io/playwright-reports/ci/use-github-environments), [Storybook](https://ci/use-github-environments--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci/use-github-environments)<!-- Sticky Header Marker -->

This PR adds the production environment label to the chrome publish job. This workflow is likely the most critical internal process we have.

Any developer with `write` permissions to our `main` branch is able to push code for deployment to our production environment.

I haven't tested this flow yet—we can during next push to prod—but I believe this ensures prod deploys have to be approved from one in the list below


<img width="793" alt="image" src="https://github.com/user-attachments/assets/0fc4c7fd-eaf9-4aa5-a0fc-2ae3ed445c5c" />
