### PR TITLE
ci: enforce gpg commits for leather-bot

### DIFF
--- a/.github/workflows/update-leather-packages.yml
+++ b/.github/workflows/update-leather-packages.yml
@@ -21,6 +21,14 @@ jobs:
         id: update-packages
         run: echo output=$(pnpm update "@leather.io/*" --latest | grep -v '^Progress') >> $GITHUB_OUTPUT
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.LEATHER_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.LEATHER_BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
@@ -30,6 +38,7 @@ jobs:
           title: '[bot] ci: update npm packages'
           committer: 'leather-bot <leather-bot@users.noreply.github.com>'
           author: 'leather-bot <leather-bot@users.noreply.github.com>'
+          signoff: true
           body: |
             Updating packages
 


### PR DESCRIPTION
> Try out Leather build 09cbc46 — [Extension build](https://github.com/leather-io/extension/actions/runs/14127308088), [Test report](https://leather-io.github.io/playwright-reports/chore/leatherbot-gpg-commits), [Storybook](https://chore/leatherbot-gpg-commits--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/leatherbot-gpg-commits)<!-- Sticky Header Marker -->

I made a start on adding GPG commits for `leather-bot` but I don't have access to add a secret. Can you please help me finish this @camerow ? 