### PR TITLE
fix: provide feedback to user while broadcasting, closes #6193

### DIFF
--- a/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
+++ b/src/app/pages/send/send-crypto-asset-form/form/btc/btc-send-form-confirmation.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { hexToBytes } from '@noble/hashes/utils';
@@ -55,6 +55,7 @@ function useBtcSendFormConfirmationState() {
 }
 
 export function BtcSendFormConfirmation() {
+  const [isBroadcasting, setIsBroadcasting] = useState(false);
   const navigate = useNavigate();
   const { tx, recipient, fee, arrivesIn, feeRowValue } = useBtcSendFormConfirmationState();
 
@@ -63,7 +64,7 @@ export function BtcSendFormConfirmation() {
   const { filteredUtxosQuery } = useCurrentNativeSegwitUtxos();
 
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
-  const { broadcastTx, isBroadcasting } = useBitcoinBroadcastTransaction();
+  const { broadcastTx } = useBitcoinBroadcastTransaction();
 
   const decodedTx = decodeBitcoinTx(transaction.hex);
 
@@ -85,6 +86,7 @@ export function BtcSendFormConfirmation() {
   const utxosOfSpendableInscriptions = useInscribedSpendableUtxos();
 
   async function initiateTransaction() {
+    setIsBroadcasting(true);
     await broadcastTx({
       skipSpendableCheckUtxoIds: utxosOfSpendableInscriptions.map(utxo => utxo.txid),
       tx: transaction.hex,
@@ -114,6 +116,7 @@ export function BtcSendFormConfirmation() {
         nav.toErrorPage(e);
       },
     });
+    setIsBroadcasting(false);
   }
 
   function formBtcTxSummaryState(txId: string) {

--- a/tests/specs/settings/settings.spec.ts
+++ b/tests/specs/settings/settings.spec.ts
@@ -77,22 +77,14 @@ test.describe('Settings menu', () => {
   test('that menu item can toggle privacy', async ({ page, homePage }) => {
     const visibleBalanceText = await homePage.page
       .getByTestId(SharedComponentsSelectors.AccountCardBalanceText)
-      .textContent();
+      .innerText();
     test.expect(visibleBalanceText).toBeTruthy();
 
     await homePage.clickSettingsButton();
     await page.getByTestId(SettingsSelectors.TogglePrivacy).click();
 
-    // just checks that the balance text changed (don't care about the implementation)
     await test
       .expect(homePage.page.getByTestId(SharedComponentsSelectors.AccountCardBalanceText))
-      .not.toHaveText(visibleBalanceText!);
-
-    await homePage.clickSettingsButton();
-    await page.getByTestId(SettingsSelectors.TogglePrivacy).click();
-
-    await test
-      .expect(homePage.page.getByTestId(SharedComponentsSelectors.AccountCardBalanceText))
-      .not.toContainText('***');
+      .toContainText('***');
   });
 });


### PR DESCRIPTION
> Try out Leather build 51c4fb3 — [Extension build](https://github.com/leather-io/extension/actions/runs/14048664390), [Test report](https://leather-io.github.io/playwright-reports/fix/send-btc-is-broadcasting), [Storybook](https://fix/send-btc-is-broadcasting--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/send-btc-is-broadcasting)<!-- Sticky Header Marker -->

Not sure this should close the issue, but `https://ordinals-explorer.generative.xyz/` which we scrape during the utxo check for inscriptions is down. This happens in the broadcast hook before we set `isBroadcasting` to true, so the user never gets feedback during the long wait.

Also, prob the culprit behind the test here starting to fail during that check: https://github.com/leather-io/extension/pull/6192

We need to revisit the utxo inscription check code once the query hook is back in the extension.