### PR TITLE
fix: close window on sip30 broadcast success

### DIFF
--- a/src/app/features/rpc-transaction-request/hooks/use-rpc-broadcast-stacks-transaction.ts
+++ b/src/app/features/rpc-transaction-request/hooks/use-rpc-broadcast-stacks-transaction.ts
@@ -4,10 +4,11 @@ import { useNavigate } from 'react-router-dom';
 import type { StacksTransactionWire, TxBroadcastResultRejected } from '@stacks/transactions';
 
 import { type RpcMethodNames, createRpcSuccessResponse } from '@leather.io/rpc';
-import { isString } from '@leather.io/utils';
+import { delay, isString } from '@leather.io/utils';
 
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
+import { closeWindow } from '@shared/utils';
 
 import { getErrorMessage } from '@app/common/get-error-message';
 import { useRpcRequestParams } from '@app/common/hooks/use-rpc-request-params';
@@ -54,6 +55,8 @@ export function useRpcBroadcastStacksTransaction(method: RpcMethodNames) {
       onSetIsBroadcasting(true);
       await stacksBroadcastTransaction({ network, signedTx, onError, onSuccess });
       onSetIsBroadcasting(false);
+      await delay(500);
+      closeWindow();
     },
     [
       method,

--- a/src/app/pages/rpc-send-transfer/use-rpc-send-transfer-actions.tsx
+++ b/src/app/pages/rpc-send-transfer/use-rpc-send-transfer-actions.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { createRpcSuccessResponse } from '@leather.io/rpc';
+import { delay } from '@leather.io/utils';
 
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
@@ -79,6 +80,8 @@ export function useRpcSendTransferActions() {
             );
 
             setIsSubmitted(true);
+            await delay(500);
+            closeWindow();
           },
           onError,
         });


### PR DESCRIPTION
> Try out Leather build b3c1995 — [Extension build](https://github.com/leather-io/extension/actions/runs/14498808511), [Test report](https://leather-io.github.io/playwright-reports/fix/sip30-broadcast-success), [Storybook](https://fix/sip30-broadcast-success--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/sip30-broadcast-success)<!-- Sticky Header Marker -->

This PR adds a short delay to see the success state of the button, and then closes the window automatically until we implement the flows for broadcast states.