### PR TITLE
feat: ledger bitcoin gate

### DIFF
--- a/src/app/features/ledger/generic-steps/connect-device/connect-ledger-bitcoin.tsx
+++ b/src/app/features/ledger/generic-steps/connect-device/connect-ledger-bitcoin.tsx
@@ -1,0 +1,42 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { Sheet, SheetHeader } from '@leather.io/ui';
+
+import { RouteUrls } from '@shared/route-urls';
+import { closeWindow } from '@shared/utils';
+
+import { whenPageMode } from '@app/common/utils';
+import { openIndexPageInNewTab } from '@app/common/utils/open-in-new-tab';
+
+import { immediatelyAttemptLedgerConnection } from '../../hooks/use-when-reattempt-ledger-connection';
+import { ConnectLedger } from './connect-ledger';
+
+export function ConnectLedgerBitcoin() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  function onConnectBitcoin() {
+    return whenPageMode({
+      full() {
+        navigate('bitcoin/connect-your-ledger', {
+          replace: true,
+          state: {
+            [immediatelyAttemptLedgerConnection]: true,
+            backgroundLocation: { pathname: RouteUrls.Home },
+            fromLocation: location,
+          },
+        });
+      },
+      popup() {
+        void openIndexPageInNewTab(RouteUrls.Home);
+        closeWindow();
+      },
+    });
+  }
+
+  return (
+    <Sheet isShowing header={<SheetHeader />} onClose={() => navigate('../')}>
+      <ConnectLedger connectBitcoin={onConnectBitcoin()} showInstructions />
+    </Sheet>
+  );
+}

--- a/src/app/features/ledger/generic-steps/connect-device/connect-ledger-stacks.tsx
+++ b/src/app/features/ledger/generic-steps/connect-device/connect-ledger-stacks.tsx
@@ -1,0 +1,42 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { Sheet, SheetHeader } from '@leather.io/ui';
+
+import { RouteUrls } from '@shared/route-urls';
+import { closeWindow } from '@shared/utils';
+
+import { whenPageMode } from '@app/common/utils';
+import { openIndexPageInNewTab } from '@app/common/utils/open-in-new-tab';
+
+import { immediatelyAttemptLedgerConnection } from '../../hooks/use-when-reattempt-ledger-connection';
+import { ConnectLedger } from './connect-ledger';
+
+export function ConnectLedgerStacks() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  function onConnectStacks() {
+    return whenPageMode({
+      full() {
+        navigate('stacks/connect-your-ledger', {
+          replace: true,
+          state: {
+            [immediatelyAttemptLedgerConnection]: true,
+            backgroundLocation: { pathname: RouteUrls.Home },
+            fromLocation: location,
+          },
+        });
+      },
+      popup() {
+        void openIndexPageInNewTab(RouteUrls.Home);
+        closeWindow();
+      },
+    });
+  }
+
+  return (
+    <Sheet isShowing header={<SheetHeader />} onClose={() => navigate('../')}>
+      <ConnectLedger connectStacks={onConnectStacks()} showInstructions />
+    </Sheet>
+  );
+}

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer.routes.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer.routes.tsx
@@ -3,7 +3,9 @@ import { Route } from 'react-router-dom';
 import { RouteUrls } from '@shared/route-urls';
 
 import { ledgerBitcoinTxSigningRoutes } from '@app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container';
+import { ConnectLedgerBitcoin } from '@app/features/ledger/generic-steps/connect-device/connect-ledger-bitcoin';
 import { AccountGate } from '@app/routes/account-gate';
+import { LedgerBitcoinGate } from '@app/routes/ledger-bitcoin-gate';
 
 import { FeeEditor } from '../../features/fee-editor/fee-editor';
 import { RpcSendTransfer } from './rpc-send-transfer';
@@ -14,7 +16,9 @@ export const rpcSendTransferRoutes = (
     path={RouteUrls.RpcSendTransfer}
     element={
       <AccountGate>
-        <RpcSendTransferContainer />
+        <LedgerBitcoinGate fallback={<ConnectLedgerBitcoin />}>
+          <RpcSendTransferContainer />
+        </LedgerBitcoinGate>
       </AccountGate>
     }
   >

--- a/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.routes.tsx
+++ b/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.routes.tsx
@@ -4,8 +4,10 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { BroadcastErrorSheet } from '@app/components/broadcast-error-dialog/broadcast-error-dialog';
 import { ledgerStacksTxSigningRoutes } from '@app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container';
+import { ConnectLedgerStacks } from '@app/features/ledger/generic-steps/connect-device/connect-ledger-stacks';
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
 import { AccountGate } from '@app/routes/account-gate';
+import { LedgerStacksGate } from '@app/routes/ledger-stacks-gate';
 
 import { FeeEditor } from '../../features/fee-editor/fee-editor';
 import { RpcStxCallContract } from './rpc-stx-call-contract';
@@ -16,7 +18,9 @@ export const rpcStxCallContractRoutes = (
     path={RouteUrls.RpcStxCallContract}
     element={
       <AccountGate>
-        <RpcStxCallContractContainer />
+        <LedgerStacksGate fallback={<ConnectLedgerStacks />}>
+          <RpcStxCallContractContainer />
+        </LedgerStacksGate>
       </AccountGate>
     }
   >

--- a/src/app/routes/account-gate.tsx
+++ b/src/app/routes/account-gate.tsx
@@ -23,7 +23,7 @@ export function AccountGate({ children }: AccountGateProps) {
   const hasDefaultInMemorySecretKey = useHasDefaultInMemoryWalletSecretKey();
 
   const isLedger = useHasLedgerKeys();
-  if (isLedger) return <>{children}</>;
+  if (isLedger) return children;
 
   if (shouldNavigateToOnboardingStartPage(currentKeyDetails))
     return <Navigate to={RouteUrls.Onboarding} />;
@@ -31,5 +31,5 @@ export function AccountGate({ children }: AccountGateProps) {
   if (shouldNavigateToUnlockWalletPage(hasDefaultInMemorySecretKey))
     return <Navigate to={RouteUrls.Unlock} />;
 
-  return <>{children}</>;
+  return children;
 }

--- a/src/app/routes/ledger-bitcoin-gate.tsx
+++ b/src/app/routes/ledger-bitcoin-gate.tsx
@@ -1,0 +1,13 @@
+import { BitcoinNativeSegwitAccountLoader } from '@app/components/loaders/bitcoin-account-loader';
+
+interface LedgerBitcoinGateProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+export function LedgerBitcoinGate({ children, fallback }: LedgerBitcoinGateProps) {
+  return (
+    <BitcoinNativeSegwitAccountLoader current fallback={fallback}>
+      {() => children}
+    </BitcoinNativeSegwitAccountLoader>
+  );
+}

--- a/src/app/routes/ledger-stacks-gate.tsx
+++ b/src/app/routes/ledger-stacks-gate.tsx
@@ -1,0 +1,11 @@
+import { CurrentStacksAccountLoader } from '@app/components/loaders/stacks-account-loader';
+
+interface LedgerStacksGateProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+export function LedgerStacksGate({ children, fallback }: LedgerStacksGateProps) {
+  return (
+    <CurrentStacksAccountLoader fallback={fallback}>{() => children}</CurrentStacksAccountLoader>
+  );
+}


### PR DESCRIPTION
> Try out Leather build 476c7ad — [Extension build](https://github.com/leather-io/extension/actions/runs/14711005746), [Test report](https://leather-io.github.io/playwright-reports/feat/ledger-bitcoin-gate), [Storybook](https://feat/ledger-bitcoin-gate--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/ledger-bitcoin-gate)<!-- Sticky Header Marker -->

I ran into an issue with calling `sendTransfer` and no Bitcoin keys loaded. I think this has existed for awhile, but wanted to propose a new `LedgerBitcoinGate` to try and mitigate some of these errors with Ledger. cc @kyranjamie and @markmhendrickson for your thoughts.

Right now, I'm using something previously created called `ConnectLedgerStart` that will detect the request popup and force the user into the full page view to connect Bitcoin on their Ledger. We could also create routes specific to the popup if helpful for the rpc flows with Approver UX?

![Screenshot 2025-04-26 at 1 24 16 PM](https://github.com/user-attachments/assets/45cbe954-e680-48d3-861c-a805ee150e7e)

The user will now see this, but clicking on the button will close the popup and route them to the home page...
![Screenshot 2025-04-27 at 12 19 40 PM](https://github.com/user-attachments/assets/72009198-93e4-41fe-9fa4-61994030e437)
