### PR TITLE
fix: return children if not ledger

### DIFF
--- a/src/app/routes/ledger-bitcoin-gate.tsx
+++ b/src/app/routes/ledger-bitcoin-gate.tsx
@@ -1,10 +1,13 @@
 import { BitcoinNativeSegwitAccountLoader } from '@app/components/loaders/bitcoin-account-loader';
+import { useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
 
 interface LedgerBitcoinGateProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }
 export function LedgerBitcoinGate({ children, fallback }: LedgerBitcoinGateProps) {
+  const isLedger = useHasLedgerKeys();
+  if (!isLedger) return children;
   return (
     <BitcoinNativeSegwitAccountLoader current fallback={fallback}>
       {() => children}

--- a/src/app/routes/ledger-stacks-gate.tsx
+++ b/src/app/routes/ledger-stacks-gate.tsx
@@ -1,10 +1,13 @@
 import { CurrentStacksAccountLoader } from '@app/components/loaders/stacks-account-loader';
+import { useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
 
 interface LedgerStacksGateProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }
 export function LedgerStacksGate({ children, fallback }: LedgerStacksGateProps) {
+  const isLedger = useHasLedgerKeys();
+  if (!isLedger) return children;
   return (
     <CurrentStacksAccountLoader fallback={fallback}>{() => children}</CurrentStacksAccountLoader>
   );


### PR DESCRIPTION
> Try out Leather build 5a95075 — [Extension build](https://github.com/leather-io/extension/actions/runs/14713492956), [Test report](https://leather-io.github.io/playwright-reports/fix/ledger-gates), [Storybook](https://fix/ledger-gates--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/ledger-gates)<!-- Sticky Header Marker -->

There was a flashing of the view to connect ledger while the Stacks account loaded bc I forgot to return children here if not Ledger.