### PR TITLE
fix: has ledger keys

### DIFF
--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer.routes.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer.routes.tsx
@@ -3,7 +3,6 @@ import { Route } from 'react-router-dom';
 import { RouteUrls } from '@shared/route-urls';
 
 import { ledgerBitcoinTxSigningRoutes } from '@app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container';
-import { ConnectLedgerBitcoin } from '@app/features/ledger/generic-steps/connect-device/connect-ledger-bitcoin';
 import { AccountGate } from '@app/routes/account-gate';
 import { LedgerBitcoinGate } from '@app/routes/ledger-bitcoin-gate';
 
@@ -16,7 +15,7 @@ export const rpcSendTransferRoutes = (
     path={RouteUrls.RpcSendTransfer}
     element={
       <AccountGate>
-        <LedgerBitcoinGate fallback={<ConnectLedgerBitcoin />}>
+        <LedgerBitcoinGate>
           <RpcSendTransferContainer />
         </LedgerBitcoinGate>
       </AccountGate>

--- a/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.routes.tsx
+++ b/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.routes.tsx
@@ -4,7 +4,6 @@ import { RouteUrls } from '@shared/route-urls';
 
 import { BroadcastErrorSheet } from '@app/components/broadcast-error-dialog/broadcast-error-dialog';
 import { ledgerStacksTxSigningRoutes } from '@app/features/ledger/flows/stacks-tx-signing/ledger-sign-stacks-tx-container';
-import { ConnectLedgerStacks } from '@app/features/ledger/generic-steps/connect-device/connect-ledger-stacks';
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
 import { AccountGate } from '@app/routes/account-gate';
 import { LedgerStacksGate } from '@app/routes/ledger-stacks-gate';
@@ -18,7 +17,7 @@ export const rpcStxCallContractRoutes = (
     path={RouteUrls.RpcStxCallContract}
     element={
       <AccountGate>
-        <LedgerStacksGate fallback={<ConnectLedgerStacks />}>
+        <LedgerStacksGate>
           <RpcStxCallContractContainer />
         </LedgerStacksGate>
       </AccountGate>

--- a/src/app/routes/ledger-bitcoin-gate.tsx
+++ b/src/app/routes/ledger-bitcoin-gate.tsx
@@ -1,16 +1,16 @@
-import { BitcoinNativeSegwitAccountLoader } from '@app/components/loaders/bitcoin-account-loader';
-import { useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
+import { ConnectLedgerBitcoin } from '@app/features/ledger/generic-steps/connect-device/connect-ledger-bitcoin';
+import { useHasLedgerBitcoinKeys, useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
 
 interface LedgerBitcoinGateProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }
-export function LedgerBitcoinGate({ children, fallback }: LedgerBitcoinGateProps) {
+export function LedgerBitcoinGate({
+  children,
+  fallback = <ConnectLedgerBitcoin />,
+}: LedgerBitcoinGateProps) {
   const isLedger = useHasLedgerKeys();
-  if (!isLedger) return children;
-  return (
-    <BitcoinNativeSegwitAccountLoader current fallback={fallback}>
-      {() => children}
-    </BitcoinNativeSegwitAccountLoader>
-  );
+  const hasLedgerBitcoinKeys = useHasLedgerBitcoinKeys();
+  if (!isLedger || hasLedgerBitcoinKeys) return children;
+  return fallback;
 }

--- a/src/app/routes/ledger-stacks-gate.tsx
+++ b/src/app/routes/ledger-stacks-gate.tsx
@@ -1,14 +1,16 @@
-import { CurrentStacksAccountLoader } from '@app/components/loaders/stacks-account-loader';
-import { useHasLedgerKeys } from '@app/store/ledger/ledger.selectors';
+import { ConnectLedgerStacks } from '@app/features/ledger/generic-steps/connect-device/connect-ledger-stacks';
+import { useHasLedgerKeys, useHasLedgerStacksKeys } from '@app/store/ledger/ledger.selectors';
 
 interface LedgerStacksGateProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }
-export function LedgerStacksGate({ children, fallback }: LedgerStacksGateProps) {
+export function LedgerStacksGate({
+  children,
+  fallback = <ConnectLedgerStacks />,
+}: LedgerStacksGateProps) {
   const isLedger = useHasLedgerKeys();
-  if (!isLedger) return children;
-  return (
-    <CurrentStacksAccountLoader fallback={fallback}>{() => children}</CurrentStacksAccountLoader>
-  );
+  const hasLedgerStacksKeys = useHasLedgerStacksKeys();
+  if (!isLedger || hasLedgerStacksKeys) return children;
+  return fallback;
 }

--- a/src/app/store/ledger/ledger.selectors.ts
+++ b/src/app/store/ledger/ledger.selectors.ts
@@ -12,12 +12,38 @@ const selectNumberOfLedgerKeysPersisted = createSelector(selectLedger, ledger =>
   sumNumbers(Object.values(ledger).map(chain => Object.keys(chain.entities).length))
 );
 
+const selectNumberOfLedgerBitcoinKeysPersisted = createSelector(selectLedger, ledger =>
+  sumNumbers(Object.values(ledger.bitcoin).map(entities => Object.keys(entities).length))
+);
+
+const selectNumberOfLedgerStacksKeysPersisted = createSelector(selectLedger, ledger =>
+  sumNumbers(Object.values(ledger.stacks).map(entities => Object.keys(entities).length))
+);
+
 export const selectHasLedgerKeys = createSelector(selectNumberOfLedgerKeysPersisted, numOfKeys =>
   numOfKeys.isGreaterThan(0)
 );
 
+const selectHasLedgerBitcoinKeys = createSelector(
+  selectNumberOfLedgerBitcoinKeysPersisted,
+  numOfKeys => numOfKeys.isGreaterThan(0)
+);
+
+const selectHasLedgerStacksKeys = createSelector(
+  selectNumberOfLedgerStacksKeysPersisted,
+  numOfKeys => numOfKeys.isGreaterThan(0)
+);
+
 export function useHasLedgerKeys() {
   return useSelector(selectHasLedgerKeys);
+}
+
+export function useHasLedgerBitcoinKeys() {
+  return useSelector(selectHasLedgerBitcoinKeys);
+}
+
+export function useHasLedgerStacksKeys() {
+  return useSelector(selectHasLedgerStacksKeys);
 }
 
 export function useLedgerDeviceTargetId() {


### PR DESCRIPTION
> Try out Leather build d0bcfa7 — [Extension build](https://github.com/leather-io/extension/actions/runs/14716135965), [Test report](https://leather-io.github.io/playwright-reports/fix/check-ledger-keys), [Storybook](https://fix/check-ledger-keys--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/check-ledger-keys)<!-- Sticky Header Marker -->

This PR adds specific checks for Ledger Bitcoin and Stacks keys separately, so if that specific gate's keys are loaded already it can just return the children w/out the loader/fallback.