### PR TITLE
fix: chrome rejection, segment issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "@scure/bip32": "1.6.2",
     "@scure/bip39": "1.5.4",
     "@scure/btc-signer": "1.6.0",
-    "@segment/analytics-next": "1.70.0",
+    "@segment/analytics-next": "1.81.0",
     "@sentry/browser": "9.13.0",
     "@sentry/tracing": "7.120.3",
     "@stacks/auth": "7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: 1.6.0
         version: 1.6.0
       '@segment/analytics-next':
-        specifier: 1.70.0
-        version: 1.70.0(encoding@0.1.13)
+        specifier: 1.81.0
+        version: 1.81.0(encoding@0.1.13)
       '@sentry/browser':
         specifier: 9.13.0
         version: 9.13.0
@@ -4691,14 +4691,17 @@ packages:
   '@scure/btc-signer@1.6.0':
     resolution: {integrity: sha512-qd6ciJE4Onk1xdQEdjPvRbLRrH7EddPZagMuZOFv77R/76EWixENd6nuoxqHNEPGRbS09rgAhhPgT7j0oQdi1A==}
 
-  '@segment/analytics-core@1.6.0':
-    resolution: {integrity: sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==}
+  '@segment/analytics-core@1.8.1':
+    resolution: {integrity: sha512-EYcdBdhfi1pOYRX+Sf5orpzzYYFmDHTEu6+w0hjXpW5bWkWct+Nv6UJg1hF4sGDKEQjpZIinLTpQ4eioFM4KeQ==}
 
   '@segment/analytics-generic-utils@1.2.0':
     resolution: {integrity: sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==}
 
-  '@segment/analytics-next@1.70.0':
-    resolution: {integrity: sha512-6pAnJfnhv33lCvIuvMcxco4XXt09tBOog5IcWM2/T3HPeSpg9rigm4qRLpNLEgv40BGRhHC3szHsY9z9oF6peQ==}
+  '@segment/analytics-next@1.81.0':
+    resolution: {integrity: sha512-N267sNhJKGCviRAs/uQCC5TuP73WVDnd8xBDrsUHvM1J4qdDkSXT+KsoQbveQZV2fFUoLypuZ6nBP/MC5unTvg==}
+
+  '@segment/analytics-page-tools@1.0.0':
+    resolution: {integrity: sha512-o9OVB91qLB9qb0Bw1HfjmWm5AnrMNULRjx++4lBqLt8InKRX1urrRBparVlpj+yJA0sckN5ZcsfazRLuPgBYDQ==}
 
   '@segment/analytics.js-video-plugins@0.2.1':
     resolution: {integrity: sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==}
@@ -4714,10 +4717,6 @@ packages:
 
   '@segment/loosely-validate-event@2.0.0':
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
-
-  '@segment/tsub@2.0.0':
-    resolution: {integrity: sha512-NzkBK8GwPsyQ74AceLjENbUoaFrObnzEKOX4ko2wZDuIyK+DnDm3B//8xZYI2LCKt+wUD55l6ygfjCoVs8RMWw==}
-    hasBin: true
 
   '@sentry-internal/browser-utils@9.13.0':
     resolution: {integrity: sha512-uZcbwcGI49oPC/YDEConJ+3xi2mu0TsVsDiMQKb6JoSc33KH37wq2IwXJb9nakzKJXxyMNemb44r8irAswjItw==}
@@ -4957,517 +4956,6 @@ packages:
 
   '@stacks/wallet-sdk@7.0.2':
     resolution: {integrity: sha512-hUVfdxpQXgspaaPab+KplypMjXw8xX73I20Bw79lE9L/CgEyMDw/AwauhH+ukhwGH0E4BbEy0Ezg6WfRVFo9Dw==}
-
-  '@stdlib/array-float32@0.0.6':
-    resolution: {integrity: sha512-QgKT5UaE92Rv7cxfn7wBKZAlwFFHPla8eXsMFsTGt5BiL4yUy36lwinPUh4hzybZ11rw1vifS3VAPuk6JP413Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/array-float64@0.0.6':
-    resolution: {integrity: sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/array-uint16@0.0.6':
-    resolution: {integrity: sha512-/A8Tr0CqJ4XScIDRYQawosko8ha1Uy+50wsTgJhjUtXDpPRp7aUjmxvYkbe7Rm+ImYYbDQVix/uCiPAFQ8ed4Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/array-uint32@0.0.6':
-    resolution: {integrity: sha512-2hFPK1Fg7obYPZWlGDjW9keiIB6lXaM9dKmJubg/ergLQCsJQJZpYsG6mMAfTJi4NT1UF4jTmgvyKD+yf0D9cA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/array-uint8@0.0.7':
-    resolution: {integrity: sha512-qYJQQfGKIcky6TzHFIGczZYTuVlut7oO+V8qUBs7BJC9TwikVnnOmb3hY3jToY4xaoi5p9OvgdJKPInhyIhzFg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-has-float32array-support@0.0.8':
-    resolution: {integrity: sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-has-float64array-support@0.0.8':
-    resolution: {integrity: sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-has-node-buffer-support@0.0.8':
-    resolution: {integrity: sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-has-own-property@0.0.7':
-    resolution: {integrity: sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-has-symbol-support@0.0.8':
-    resolution: {integrity: sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-has-tostringtag-support@0.0.9':
-    resolution: {integrity: sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-has-uint16array-support@0.0.8':
-    resolution: {integrity: sha512-vqFDn30YrtzD+BWnVqFhB130g3cUl2w5AdOxhIkRkXCDYAM5v7YwdNMJEON+D4jI8YB4D5pEYjqKweYaCq4nyg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-has-uint32array-support@0.0.8':
-    resolution: {integrity: sha512-tJtKuiFKwFSQQUfRXEReOVGXtfdo6+xlshSfwwNWXL1WPP2LrceoiUoQk7zMCMT6VdbXgGH92LDjVcPmSbH4Xw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-has-uint8array-support@0.0.8':
-    resolution: {integrity: sha512-ie4vGTbAS/5Py+LLjoSQi0nwtYBp+WKk20cMYCzilT0rCsBI/oez0RqHrkYYpmt4WaJL4eJqC+/vfQ5NsI7F5w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-is-array@0.0.7':
-    resolution: {integrity: sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-big-endian@0.0.7':
-    resolution: {integrity: sha512-BvutsX84F76YxaSIeS5ZQTl536lz+f+P7ew68T1jlFqxBhr4v7JVYFmuf24U040YuK1jwZ2sAq+bPh6T09apwQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-is-boolean@0.0.8':
-    resolution: {integrity: sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-buffer@0.0.8':
-    resolution: {integrity: sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-float32array@0.0.8':
-    resolution: {integrity: sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-float64array@0.0.8':
-    resolution: {integrity: sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-function@0.0.8':
-    resolution: {integrity: sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-little-endian@0.0.7':
-    resolution: {integrity: sha512-SPObC73xXfDXY0dOewXR0LDGN3p18HGzm+4K8azTj6wug0vpRV12eB3hbT28ybzRCa6TAKUjwM/xY7Am5QzIlA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-is-number@0.0.7':
-    resolution: {integrity: sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-object-like@0.0.8':
-    resolution: {integrity: sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-object@0.0.8':
-    resolution: {integrity: sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-plain-object@0.0.7':
-    resolution: {integrity: sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-regexp-string@0.0.9':
-    resolution: {integrity: sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/assert-is-regexp@0.0.7':
-    resolution: {integrity: sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-string@0.0.8':
-    resolution: {integrity: sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-uint16array@0.0.8':
-    resolution: {integrity: sha512-M+qw7au+qglRXcXHjvoUZVLlGt1mPjuKudrVRto6KL4+tDsP2j+A89NDP3Fz8/XIUD+5jhj+65EOKHSMvDYnng==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-uint32array@0.0.8':
-    resolution: {integrity: sha512-cnZi2DicYcplMnkJ3dBxBVKsRNFjzoGpmG9A6jXq4KH5rFl52SezGAXSVY9o5ZV7bQGaF5JLyCLp6n9Y74hFGg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-is-uint8array@0.0.8':
-    resolution: {integrity: sha512-8cqpDQtjnJAuVtRkNAktn45ixq0JHaGJxVsSiK79k7GRggvMI6QsbzO6OvcLnZ/LimD42FmgbLd13Yc2esDmZw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/assert-tools-array-function@0.0.7':
-    resolution: {integrity: sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/buffer-ctor@0.0.7':
-    resolution: {integrity: sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/buffer-from-string@0.0.8':
-    resolution: {integrity: sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/cli-ctor@0.0.3':
-    resolution: {integrity: sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/complex-float32@0.0.7':
-    resolution: {integrity: sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/complex-float64@0.0.8':
-    resolution: {integrity: sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/complex-reim@0.0.6':
-    resolution: {integrity: sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/complex-reimf@0.0.1':
-    resolution: {integrity: sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-exponent-bias@0.0.8':
-    resolution: {integrity: sha512-IzBJQw9hYgWCki7VoC/zJxEA76Nmf8hmY+VkOWnJ8IyfgTXClgY8tfDGS1cc4l/hCOEllxGp9FRvVdn24A5tKQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-high-word-abs-mask@0.0.1':
-    resolution: {integrity: sha512-1vy8SUyMHFBwqUUVaZFA7r4/E3cMMRKSwsaa/EZ15w7Kmc01W/ZmaaTLevRcIdACcNgK+8i8813c8H7LScXNcQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-high-word-exponent-mask@0.0.8':
-    resolution: {integrity: sha512-z28/EQERc0VG7N36bqdvtrRWjFc8600PKkwvl/nqx6TpKAzMXNw55BS1xT4C28Sa9Z7uBWeUj3UbIFedbkoyMw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-high-word-sign-mask@0.0.1':
-    resolution: {integrity: sha512-hmTr5caK1lh1m0eyaQqt2Vt3y+eEdAx57ndbADEbXhxC9qSGd0b4bLSzt/Xp4MYBYdQkHAE/BlkgUiRThswhCg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-max-base2-exponent-subnormal@0.0.8':
-    resolution: {integrity: sha512-YGBZykSiXFebznnJfWFDwhho2Q9xhUWOL+X0lZJ4ItfTTo40W6VHAyNYz98tT/gJECFype0seNzzo1nUxCE7jQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-max-base2-exponent@0.0.8':
-    resolution: {integrity: sha512-xBAOtso1eiy27GnTut2difuSdpsGxI8dJhXupw0UukGgvy/3CSsyNm+a1Suz/dhqK4tPOTe5QboIdNMw5IgXKQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-min-base2-exponent-subnormal@0.0.8':
-    resolution: {integrity: sha512-bt81nBus/91aEqGRQBenEFCyWNsf8uaxn4LN1NjgkvY92S1yVxXFlC65fJHsj9FTqvyZ+uj690/gdMKUDV3NjQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-ninf@0.0.8':
-    resolution: {integrity: sha512-bn/uuzCne35OSLsQZJlNrkvU1/40spGTm22g1+ZI1LL19J8XJi/o4iupIHRXuLSTLFDBqMoJlUNphZlWQ4l8zw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-pinf@0.0.8':
-    resolution: {integrity: sha512-I3R4rm2cemoMuiDph07eo5oWZ4ucUtpuK73qBJiJPDQKz8fSjSe4wJBAigq2AmWYdd7yJHsl5NJd8AgC6mP5Qw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-float64-smallest-normal@0.0.8':
-    resolution: {integrity: sha512-Qwxpn5NA3RXf+mQcffCWRcsHSPTUQkalsz0+JDpblDszuz2XROcXkOdDr5LKgTAUPIXsjOgZzTsuRONENhsSEg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-uint16-max@0.0.7':
-    resolution: {integrity: sha512-7TPoku7SlskA67mAm7mykIAjeEnkQJemw1cnKZur0mT5W4ryvDR6iFfL9xBiByVnWYq/+ei7DHbOv6/2b2jizw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-uint32-max@0.0.7':
-    resolution: {integrity: sha512-8+NK0ewqc1vnEZNqzwFJgFSy3S543Eft7i8WyW/ygkofiqEiLAsujvYMHzPAB8/3D+PYvjTSe37StSwRwvQ6uw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/constants-uint8-max@0.0.7':
-    resolution: {integrity: sha512-fqV+xds4jgwFxwWu08b8xDuIoW6/D4/1dtEjZ1sXVeWR7nf0pjj1cHERq4kdkYxsvOGu+rjoR3MbjzpFc4fvSw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/fs-exists@0.0.8':
-    resolution: {integrity: sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/fs-read-file@0.0.8':
-    resolution: {integrity: sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/fs-resolve-parent-path@0.0.8':
-    resolution: {integrity: sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/math-base-assert-is-infinite@0.0.9':
-    resolution: {integrity: sha512-JuPDdmxd+AtPWPHu9uaLvTsnEPaZODZk+zpagziNbDKy8DRiU1cy+t+QEjB5WizZt0A5MkuxDTjZ/8/sG5GaYQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/math-base-assert-is-nan@0.0.8':
-    resolution: {integrity: sha512-m+gCVBxLFW8ZdAfdkATetYMvM7sPFoMKboacHjb1pe21jHQqVb+/4bhRSDg6S7HGX7/8/bSzEUm9zuF7vqK5rQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/math-base-napi-binary@0.0.8':
-    resolution: {integrity: sha512-B8d0HBPhfXefbdl/h0h5c+lM2sE+/U7Fb7hY/huVeoQtBtEx0Jbx/qKvPSVxMjmWCKfWlbPpbgKpN5GbFgLiAg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/math-base-napi-unary@0.0.9':
-    resolution: {integrity: sha512-2WNKhjCygkGMp0RgjaD7wAHJTqPZmuVW7yPOc62Tnz2U+Ad8q/tcOcN+uvq2dtKsAGr1HDMIQxZ/XrrThMePyA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/math-base-special-abs@0.0.6':
-    resolution: {integrity: sha512-FaaMUnYs2qIVN3kI5m/qNlBhDnjszhDOzEhxGEoQWR/k0XnxbCsTyjNesR2DkpiKuoAXAr9ojoDe2qBYdirWoQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/math-base-special-copysign@0.0.7':
-    resolution: {integrity: sha512-7Br7oeuVJSBKG8BiSk/AIRFTBd2sbvHdV3HaqRj8tTZHX8BQomZ3Vj4Qsiz3kPyO4d6PpBLBTYlGTkSDlGOZJA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/math-base-special-ldexp@0.0.5':
-    resolution: {integrity: sha512-RLRsPpCdcJZMhwb4l4B/FsmGfEPEWAsik6KYUkUSSHb7ok/gZWt8LgVScxGMpJMpl5IV0v9qG4ZINVONKjX5KA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/number-ctor@0.0.7':
-    resolution: {integrity: sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/number-float64-base-exponent@0.0.6':
-    resolution: {integrity: sha512-wLXsG+cvynmapoffmj5hVNDH7BuHIGspBcTCdjPaD+tnqPDIm03qV5Z9YBhDh91BdOCuPZQ8Ovu2WBpX+ySeGg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/number-float64-base-from-words@0.0.6':
-    resolution: {integrity: sha512-r0elnekypCN831aw9Gp8+08br8HHAqvqtc5uXaxEh3QYIgBD/QM5qSb3b7WSAQ0ZxJJKdoykupODWWBkWQTijg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/number-float64-base-get-high-word@0.0.6':
-    resolution: {integrity: sha512-jSFSYkgiG/IzDurbwrDKtWiaZeSEJK8iJIsNtbPG1vOIdQMRyw+t0bf3Kf3vuJu/+bnSTvYZLqpCO6wzT/ve9g==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/number-float64-base-normalize@0.0.9':
-    resolution: {integrity: sha512-+rm7RQJEj8zHkqYFE2a6DgNQSB5oKE/IydHAajgZl40YB91BoYRYf/ozs5/tTwfy2Fc04+tIpSfFtzDr4ZY19Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/number-float64-base-to-float32@0.0.7':
-    resolution: {integrity: sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/number-float64-base-to-words@0.0.7':
-    resolution: {integrity: sha512-7wsYuq+2MGp9rAkTnQ985rah7EJI9TfgHrYSSd4UIu4qIjoYmWIKEhIDgu7/69PfGrls18C3PxKg1pD/v7DQTg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/os-byte-order@0.0.7':
-    resolution: {integrity: sha512-rRJWjFM9lOSBiIX4zcay7BZsqYBLoE32Oz/Qfim8cv1cN1viS5D4d3DskRJcffw7zXDnG3oZAOw5yZS0FnlyUg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/os-float-word-order@0.0.7':
-    resolution: {integrity: sha512-gXIcIZf+ENKP7E41bKflfXmPi+AIfjXW/oU+m8NbP3DQasqHaZa0z5758qvnbO8L1lRJb/MzLOkIY8Bx/0cWEA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/process-cwd@0.0.8':
-    resolution: {integrity: sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/process-read-stdin@0.0.7':
-    resolution: {integrity: sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/regexp-eol@0.0.7':
-    resolution: {integrity: sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/regexp-extended-length-path@0.0.7':
-    resolution: {integrity: sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/regexp-function-name@0.0.7':
-    resolution: {integrity: sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/regexp-regexp@0.0.8':
-    resolution: {integrity: sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/streams-node-stdin@0.0.7':
-    resolution: {integrity: sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/string-base-format-interpolate@0.0.4':
-    resolution: {integrity: sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/string-base-format-tokenize@0.0.4':
-    resolution: {integrity: sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/string-format@0.0.3':
-    resolution: {integrity: sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/string-lowercase@0.0.9':
-    resolution: {integrity: sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/string-replace@0.0.11':
-    resolution: {integrity: sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/types@0.0.14':
-    resolution: {integrity: sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-constructor-name@0.0.8':
-    resolution: {integrity: sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-convert-path@0.0.8':
-    resolution: {integrity: sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/utils-define-nonenumerable-read-only-property@0.0.7':
-    resolution: {integrity: sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-define-property@0.0.9':
-    resolution: {integrity: sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-escape-regexp-string@0.0.9':
-    resolution: {integrity: sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-get-prototype-of@0.0.7':
-    resolution: {integrity: sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-global@0.0.7':
-    resolution: {integrity: sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-library-manifest@0.0.8':
-    resolution: {integrity: sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    hasBin: true
-
-  '@stdlib/utils-native-class@0.0.8':
-    resolution: {integrity: sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-next-tick@0.0.8':
-    resolution: {integrity: sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-noop@0.0.14':
-    resolution: {integrity: sha512-A5faFEUfszMgd93RCyB+aWb62hQxgP+dZ/l9rIOwNWbIrCYNwSuL4z50lNJuatnwwU4BQ4EjQr+AmBsnvuLcyQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-regexp-from-string@0.0.9':
-    resolution: {integrity: sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@stdlib/utils-type-of@0.0.8':
-    resolution: {integrity: sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==}
-    engines: {node: '>=0.10.0', npm: '>2.7.0'}
-    os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
 
   '@stencil/core@2.22.3':
     resolution: {integrity: sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==}
@@ -8589,9 +8077,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -14467,9 +13952,6 @@ packages:
 
   tiny-case@1.0.3:
     resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
-
-  tiny-hashes@1.0.1:
-    resolution: {integrity: sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -20762,17 +20244,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.10
 
-  '@redux-devtools/app-core@1.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@18.3.1)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/app-core@1.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@18.3.1)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/react': 11.14.0(@types/react@18.3.20)(react@18.3.1)
       '@redux-devtools/chart-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/core': 4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/inspector-monitor': 6.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
-      '@redux-devtools/inspector-monitor-test-tab': 4.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
-      '@redux-devtools/inspector-monitor-trace-tab': 4.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
+      '@redux-devtools/inspector-monitor-test-tab': 4.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/inspector-monitor-trace-tab': 4.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
       '@redux-devtools/log-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1)
-      '@redux-devtools/rtk-query-monitor': 5.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/rtk-query-monitor': 5.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@redux-devtools/slider-monitor': 5.1.1(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@redux-devtools/ui': 1.4.0(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
@@ -20793,10 +20275,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/app@6.2.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/app@6.2.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.20)(react@18.3.1)
-      '@redux-devtools/app-core': 1.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@18.3.1)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/app-core': 1.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux-persist@6.0.0(react@18.3.1)(redux@5.0.1))(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@redux-devtools/ui': 1.4.0(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       '@types/react': 18.3.20
@@ -20830,7 +20312,7 @@ snapshots:
     dependencies:
       '@apollo/server': 4.11.3(encoding@0.1.13)(graphql@16.10.0)
       '@emotion/react': 11.14.0(@types/react@18.3.20)(react@18.3.1)
-      '@redux-devtools/app': 6.2.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@redux-devtools/app': 6.2.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       '@reduxjs/toolkit': 2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       '@types/react': 18.3.20
       body-parser: 1.20.3
@@ -20878,7 +20360,7 @@ snapshots:
       react-redux: 9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1)
       redux: 5.0.1
 
-  '@redux-devtools/inspector-monitor-test-tab@4.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/inspector-monitor-test-tab@4.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/react': 11.14.0(@types/react@18.3.20)(react@18.3.1)
@@ -20899,7 +20381,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redux-devtools/inspector-monitor-trace-tab@4.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)':
+  '@redux-devtools/inspector-monitor-trace-tab@4.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/inspector-monitor@6.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)':
     dependencies:
       '@babel/code-frame': 8.0.0-alpha.17
       '@babel/runtime': 7.27.0
@@ -20972,7 +20454,7 @@ snapshots:
       - immutable
       - utf-8-validate
 
-  '@redux-devtools/rtk-query-monitor@5.1.1(@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
+  '@redux-devtools/rtk-query-monitor@5.1.1(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@redux-devtools/core@4.1.1(react-redux@9.2.0(@types/react@18.3.20)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux@5.0.1))(@reduxjs/toolkit@2.6.1(react-redux@9.1.2(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@types/react@18.3.20)(@types/styled-components@5.1.34)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/react': 11.14.0(@types/react@18.3.20)(react@18.3.1)
@@ -21228,7 +20710,7 @@ snapshots:
       '@scure/base': 1.2.4
       micro-packed: 0.7.2
 
-  '@segment/analytics-core@1.6.0':
+  '@segment/analytics-core@1.8.1':
     dependencies:
       '@lukeed/uuid': 2.0.1
       '@segment/analytics-generic-utils': 1.2.0
@@ -21239,14 +20721,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@segment/analytics-next@1.70.0(encoding@0.1.13)':
+  '@segment/analytics-next@1.81.0(encoding@0.1.13)':
     dependencies:
       '@lukeed/uuid': 2.0.1
-      '@segment/analytics-core': 1.6.0
+      '@segment/analytics-core': 1.8.1
       '@segment/analytics-generic-utils': 1.2.0
+      '@segment/analytics-page-tools': 1.0.0
       '@segment/analytics.js-video-plugins': 0.2.1
       '@segment/facade': 3.4.10
-      '@segment/tsub': 2.0.0
       dset: 3.1.4
       js-cookie: 3.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -21254,7 +20736,10 @@ snapshots:
       unfetch: 4.2.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
+
+  '@segment/analytics-page-tools@1.0.0':
+    dependencies:
+      tslib: 2.8.1
 
   '@segment/analytics.js-video-plugins@0.2.1':
     dependencies:
@@ -21277,15 +20762,6 @@ snapshots:
     dependencies:
       component-type: 1.2.2
       join-component: 1.1.0
-
-  '@segment/tsub@2.0.0':
-    dependencies:
-      '@stdlib/math-base-special-ldexp': 0.0.5
-      dlv: 1.1.3
-      dset: 3.1.4
-      tiny-hashes: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@sentry-internal/browser-utils@9.13.0':
     dependencies:
@@ -21707,624 +21183,6 @@ snapshots:
       zone-file: 2.0.0-beta.3
     transitivePeerDependencies:
       - encoding
-
-  '@stdlib/array-float32@0.0.6':
-    dependencies:
-      '@stdlib/assert-has-float32array-support': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/array-float64@0.0.6':
-    dependencies:
-      '@stdlib/assert-has-float64array-support': 0.0.8
-
-  '@stdlib/array-uint16@0.0.6':
-    dependencies:
-      '@stdlib/assert-has-uint16array-support': 0.0.8
-
-  '@stdlib/array-uint32@0.0.6':
-    dependencies:
-      '@stdlib/assert-has-uint32array-support': 0.0.8
-
-  '@stdlib/array-uint8@0.0.7':
-    dependencies:
-      '@stdlib/assert-has-uint8array-support': 0.0.8
-
-  '@stdlib/assert-has-float32array-support@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-float32array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/constants-float64-pinf': 0.0.8
-      '@stdlib/fs-read-file': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/assert-has-float64array-support@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-float64array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-has-node-buffer-support@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-buffer': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-has-own-property@0.0.7': {}
-
-  '@stdlib/assert-has-symbol-support@0.0.8':
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-has-tostringtag-support@0.0.9':
-    dependencies:
-      '@stdlib/assert-has-symbol-support': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-has-uint16array-support@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-uint16array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/constants-uint16-max': 0.0.7
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-has-uint32array-support@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-uint32array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/constants-uint32-max': 0.0.7
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-has-uint8array-support@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-uint8array': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/constants-uint8-max': 0.0.7
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-is-array@0.0.7':
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-big-endian@0.0.7':
-    dependencies:
-      '@stdlib/array-uint16': 0.0.6
-      '@stdlib/array-uint8': 0.0.7
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-is-boolean@0.0.8':
-    dependencies:
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-buffer@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-object-like': 0.0.8
-
-  '@stdlib/assert-is-float32array@0.0.8':
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-float64array@0.0.8':
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-function@0.0.8':
-    dependencies:
-      '@stdlib/utils-type-of': 0.0.8
-
-  '@stdlib/assert-is-little-endian@0.0.7':
-    dependencies:
-      '@stdlib/array-uint16': 0.0.6
-      '@stdlib/array-uint8': 0.0.7
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/assert-is-number@0.0.7':
-    dependencies:
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-      '@stdlib/number-ctor': 0.0.7
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-object-like@0.0.8':
-    dependencies:
-      '@stdlib/assert-tools-array-function': 0.0.7
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-
-  '@stdlib/assert-is-object@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-array': 0.0.7
-
-  '@stdlib/assert-is-plain-object@0.0.7':
-    dependencies:
-      '@stdlib/assert-has-own-property': 0.0.7
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-object': 0.0.8
-      '@stdlib/utils-get-prototype-of': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-regexp-string@0.0.9':
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-read-stdin': 0.0.7
-      '@stdlib/regexp-eol': 0.0.7
-      '@stdlib/regexp-regexp': 0.0.8
-      '@stdlib/streams-node-stdin': 0.0.7
-
-  '@stdlib/assert-is-regexp@0.0.7':
-    dependencies:
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-string@0.0.8':
-    dependencies:
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-uint16array@0.0.8':
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-uint32array@0.0.8':
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-is-uint8array@0.0.8':
-    dependencies:
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/assert-tools-array-function@0.0.7':
-    dependencies:
-      '@stdlib/assert-is-array': 0.0.7
-
-  '@stdlib/buffer-ctor@0.0.7':
-    dependencies:
-      '@stdlib/assert-has-node-buffer-support': 0.0.8
-
-  '@stdlib/buffer-from-string@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/buffer-ctor': 0.0.7
-      '@stdlib/string-format': 0.0.3
-
-  '@stdlib/cli-ctor@0.0.3':
-    dependencies:
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-noop': 0.0.14
-      minimist: 1.2.8
-
-  '@stdlib/complex-float32@0.0.7':
-    dependencies:
-      '@stdlib/assert-is-number': 0.0.7
-      '@stdlib/number-float64-base-to-float32': 0.0.7
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-define-property': 0.0.9
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/complex-float64@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-number': 0.0.7
-      '@stdlib/complex-float32': 0.0.7
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-define-property': 0.0.9
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/complex-reim@0.0.6':
-    dependencies:
-      '@stdlib/array-float64': 0.0.6
-      '@stdlib/complex-float64': 0.0.8
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/complex-reimf@0.0.1':
-    dependencies:
-      '@stdlib/array-float32': 0.0.6
-      '@stdlib/complex-float32': 0.0.7
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-exponent-bias@0.0.8':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-high-word-abs-mask@0.0.1':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-high-word-exponent-mask@0.0.8':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-high-word-sign-mask@0.0.1':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-max-base2-exponent-subnormal@0.0.8':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-max-base2-exponent@0.0.8':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-min-base2-exponent-subnormal@0.0.8':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-ninf@0.0.8':
-    dependencies:
-      '@stdlib/number-ctor': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-pinf@0.0.8':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-float64-smallest-normal@0.0.8':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/constants-uint16-max@0.0.7': {}
-
-  '@stdlib/constants-uint32-max@0.0.7': {}
-
-  '@stdlib/constants-uint8-max@0.0.7': {}
-
-  '@stdlib/fs-exists@0.0.8':
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-cwd': 0.0.8
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-
-  '@stdlib/fs-read-file@0.0.8':
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-
-  '@stdlib/fs-resolve-parent-path@0.0.8':
-    dependencies:
-      '@stdlib/assert-has-own-property': 0.0.7
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-plain-object': 0.0.7
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-exists': 0.0.8
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-cwd': 0.0.8
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-
-  '@stdlib/math-base-assert-is-infinite@0.0.9':
-    dependencies:
-      '@stdlib/constants-float64-ninf': 0.0.8
-      '@stdlib/constants-float64-pinf': 0.0.8
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/math-base-assert-is-nan@0.0.8':
-    dependencies:
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/math-base-napi-binary@0.0.8':
-    dependencies:
-      '@stdlib/complex-float32': 0.0.7
-      '@stdlib/complex-float64': 0.0.8
-      '@stdlib/complex-reim': 0.0.6
-      '@stdlib/complex-reimf': 0.0.1
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/math-base-napi-unary@0.0.9':
-    dependencies:
-      '@stdlib/complex-float32': 0.0.7
-      '@stdlib/complex-float64': 0.0.8
-      '@stdlib/complex-reim': 0.0.6
-      '@stdlib/complex-reimf': 0.0.1
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/math-base-special-abs@0.0.6':
-    dependencies:
-      '@stdlib/math-base-napi-unary': 0.0.9
-      '@stdlib/number-float64-base-to-words': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/math-base-special-copysign@0.0.7':
-    dependencies:
-      '@stdlib/constants-float64-high-word-abs-mask': 0.0.1
-      '@stdlib/constants-float64-high-word-sign-mask': 0.0.1
-      '@stdlib/math-base-napi-binary': 0.0.8
-      '@stdlib/number-float64-base-from-words': 0.0.6
-      '@stdlib/number-float64-base-get-high-word': 0.0.6
-      '@stdlib/number-float64-base-to-words': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/math-base-special-ldexp@0.0.5':
-    dependencies:
-      '@stdlib/constants-float64-exponent-bias': 0.0.8
-      '@stdlib/constants-float64-max-base2-exponent': 0.0.8
-      '@stdlib/constants-float64-max-base2-exponent-subnormal': 0.0.8
-      '@stdlib/constants-float64-min-base2-exponent-subnormal': 0.0.8
-      '@stdlib/constants-float64-ninf': 0.0.8
-      '@stdlib/constants-float64-pinf': 0.0.8
-      '@stdlib/math-base-assert-is-infinite': 0.0.9
-      '@stdlib/math-base-assert-is-nan': 0.0.8
-      '@stdlib/math-base-special-copysign': 0.0.7
-      '@stdlib/number-float64-base-exponent': 0.0.6
-      '@stdlib/number-float64-base-from-words': 0.0.6
-      '@stdlib/number-float64-base-normalize': 0.0.9
-      '@stdlib/number-float64-base-to-words': 0.0.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/number-ctor@0.0.7': {}
-
-  '@stdlib/number-float64-base-exponent@0.0.6':
-    dependencies:
-      '@stdlib/constants-float64-exponent-bias': 0.0.8
-      '@stdlib/constants-float64-high-word-exponent-mask': 0.0.8
-      '@stdlib/number-float64-base-get-high-word': 0.0.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/number-float64-base-from-words@0.0.6':
-    dependencies:
-      '@stdlib/array-float64': 0.0.6
-      '@stdlib/array-uint32': 0.0.6
-      '@stdlib/assert-is-little-endian': 0.0.7
-      '@stdlib/number-float64-base-to-words': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/number-float64-base-get-high-word@0.0.6':
-    dependencies:
-      '@stdlib/array-float64': 0.0.6
-      '@stdlib/array-uint32': 0.0.6
-      '@stdlib/assert-is-little-endian': 0.0.7
-      '@stdlib/number-float64-base-to-words': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/number-float64-base-normalize@0.0.9':
-    dependencies:
-      '@stdlib/constants-float64-smallest-normal': 0.0.8
-      '@stdlib/math-base-assert-is-infinite': 0.0.9
-      '@stdlib/math-base-assert-is-nan': 0.0.8
-      '@stdlib/math-base-special-abs': 0.0.6
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/number-float64-base-to-float32@0.0.7':
-    dependencies:
-      '@stdlib/array-float32': 0.0.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/number-float64-base-to-words@0.0.7':
-    dependencies:
-      '@stdlib/array-float64': 0.0.6
-      '@stdlib/array-uint32': 0.0.6
-      '@stdlib/assert-is-little-endian': 0.0.7
-      '@stdlib/os-byte-order': 0.0.7
-      '@stdlib/os-float-word-order': 0.0.7
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/os-byte-order@0.0.7':
-    dependencies:
-      '@stdlib/assert-is-big-endian': 0.0.7
-      '@stdlib/assert-is-little-endian': 0.0.7
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/os-float-word-order@0.0.7':
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/os-byte-order': 0.0.7
-      '@stdlib/utils-library-manifest': 0.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/process-cwd@0.0.8':
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-
-  '@stdlib/process-read-stdin@0.0.7':
-    dependencies:
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/buffer-ctor': 0.0.7
-      '@stdlib/buffer-from-string': 0.0.8
-      '@stdlib/streams-node-stdin': 0.0.7
-      '@stdlib/utils-next-tick': 0.0.8
-
-  '@stdlib/regexp-eol@0.0.7':
-    dependencies:
-      '@stdlib/assert-has-own-property': 0.0.7
-      '@stdlib/assert-is-boolean': 0.0.8
-      '@stdlib/assert-is-plain-object': 0.0.7
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-
-  '@stdlib/regexp-extended-length-path@0.0.7':
-    dependencies:
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-
-  '@stdlib/regexp-function-name@0.0.7':
-    dependencies:
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-
-  '@stdlib/regexp-regexp@0.0.8':
-    dependencies:
-      '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-
-  '@stdlib/streams-node-stdin@0.0.7': {}
-
-  '@stdlib/string-base-format-interpolate@0.0.4': {}
-
-  '@stdlib/string-base-format-tokenize@0.0.4': {}
-
-  '@stdlib/string-format@0.0.3':
-    dependencies:
-      '@stdlib/string-base-format-interpolate': 0.0.4
-      '@stdlib/string-base-format-tokenize': 0.0.4
-
-  '@stdlib/string-lowercase@0.0.9':
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-read-stdin': 0.0.7
-      '@stdlib/streams-node-stdin': 0.0.7
-      '@stdlib/string-format': 0.0.3
-
-  '@stdlib/string-replace@0.0.11':
-    dependencies:
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/assert-is-regexp': 0.0.7
-      '@stdlib/assert-is-regexp-string': 0.0.9
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-read-stdin': 0.0.7
-      '@stdlib/regexp-eol': 0.0.7
-      '@stdlib/streams-node-stdin': 0.0.7
-      '@stdlib/string-format': 0.0.3
-      '@stdlib/utils-escape-regexp-string': 0.0.9
-      '@stdlib/utils-regexp-from-string': 0.0.9
-
-  '@stdlib/types@0.0.14': {}
-
-  '@stdlib/utils-constructor-name@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-buffer': 0.0.8
-      '@stdlib/regexp-function-name': 0.0.7
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/utils-convert-path@0.0.8':
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-read-file': 0.0.8
-      '@stdlib/process-read-stdin': 0.0.7
-      '@stdlib/regexp-eol': 0.0.7
-      '@stdlib/regexp-extended-length-path': 0.0.7
-      '@stdlib/streams-node-stdin': 0.0.7
-      '@stdlib/string-lowercase': 0.0.9
-      '@stdlib/string-replace': 0.0.11
-
-  '@stdlib/utils-define-nonenumerable-read-only-property@0.0.7':
-    dependencies:
-      '@stdlib/types': 0.0.14
-      '@stdlib/utils-define-property': 0.0.9
-
-  '@stdlib/utils-define-property@0.0.9':
-    dependencies:
-      '@stdlib/types': 0.0.14
-
-  '@stdlib/utils-escape-regexp-string@0.0.9':
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/string-format': 0.0.3
-
-  '@stdlib/utils-get-prototype-of@0.0.7':
-    dependencies:
-      '@stdlib/assert-is-function': 0.0.8
-      '@stdlib/utils-native-class': 0.0.8
-
-  '@stdlib/utils-global@0.0.7':
-    dependencies:
-      '@stdlib/assert-is-boolean': 0.0.8
-
-  '@stdlib/utils-library-manifest@0.0.8':
-    dependencies:
-      '@stdlib/cli-ctor': 0.0.3
-      '@stdlib/fs-resolve-parent-path': 0.0.8
-      '@stdlib/utils-convert-path': 0.0.8
-      debug: 2.6.9
-      resolve: 1.22.10
-    transitivePeerDependencies:
-      - supports-color
-
-  '@stdlib/utils-native-class@0.0.8':
-    dependencies:
-      '@stdlib/assert-has-own-property': 0.0.7
-      '@stdlib/assert-has-tostringtag-support': 0.0.9
-
-  '@stdlib/utils-next-tick@0.0.8': {}
-
-  '@stdlib/utils-noop@0.0.14': {}
-
-  '@stdlib/utils-regexp-from-string@0.0.9':
-    dependencies:
-      '@stdlib/assert-is-string': 0.0.8
-      '@stdlib/regexp-regexp': 0.0.8
-      '@stdlib/string-format': 0.0.3
-
-  '@stdlib/utils-type-of@0.0.8':
-    dependencies:
-      '@stdlib/utils-constructor-name': 0.0.8
-      '@stdlib/utils-global': 0.0.7
 
   '@stencil/core@2.22.3': {}
 
@@ -26109,8 +24967,6 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  dlv@1.1.3: {}
 
   dns-packet@5.6.1:
     dependencies:
@@ -33440,8 +32296,6 @@ snapshots:
   tildify@2.0.0: {}
 
   tiny-case@1.0.3: {}
-
-  tiny-hashes@1.0.1: {}
 
   tiny-invariant@1.3.3: {}
 

--- a/scripts/dummy-segment-parse-cdn.js
+++ b/scripts/dummy-segment-parse-cdn.js
@@ -1,0 +1,88 @@
+// This file is a copy of the `parse-cdn.js` file in the
+// `@segment/analytics-next` package Since this package tries to fetch remote
+// scripts, we have to override it to prevent chrome store rejections.
+// Issue opened in their repo https://github.com/segmentio/analytics-next/issues/1283
+import { embeddedWriteKey } from './embedded-write-key';
+import { getGlobalAnalytics } from './global-analytics-helper';
+
+var analyticsScriptRegex = /(https:\/\/.*)\/analytics\.js\/v1\/(?:.*?)\/(?:platform|analytics.*)?/;
+var getCDNUrlFromScriptTag = function () {
+  var cdn;
+  var scripts = Array.prototype.slice.call(document.querySelectorAll('script'));
+  scripts.forEach(function (s) {
+    var _a;
+    var src = (_a = s.getAttribute('src')) !== null && _a !== void 0 ? _a : '';
+    var result = analyticsScriptRegex.exec(src);
+    if (result && result[1]) {
+      cdn = result[1];
+    }
+  });
+  return cdn;
+};
+var _globalCDN; // set globalCDN as in-memory singleton
+var getGlobalCDNUrl = function () {
+  var _a;
+  var result =
+    _globalCDN !== null && _globalCDN !== void 0
+      ? _globalCDN
+      : (_a = getGlobalAnalytics()) === null || _a === void 0
+        ? void 0
+        : _a._cdn;
+  return result;
+};
+export var setGlobalCDNUrl = function (cdn) {
+  var globalAnalytics = getGlobalAnalytics();
+  if (globalAnalytics) {
+    globalAnalytics._cdn = cdn;
+  }
+  _globalCDN = cdn;
+};
+export var getCDN = function () {
+  var globalCdnUrl = getGlobalCDNUrl();
+  if (globalCdnUrl) return globalCdnUrl;
+  var cdnFromScriptTag = getCDNUrlFromScriptTag();
+  if (cdnFromScriptTag) {
+    return cdnFromScriptTag;
+  } else {
+    // it's possible that the CDN is not found in the page because:
+    // - the script is loaded through a proxy
+    // - the script is removed after execution
+    // in this case, we fall back to the default Segment CDN
+    return 'https://cdn.segment.com';
+  }
+};
+export var getNextIntegrationsURL = function () {
+  var cdn = getCDN();
+  return ''.concat(cdn, '/next-integrations');
+};
+/**
+ * Replaces the CDN URL in the script tag with the one from Analytics.js 1.0
+ *
+ * @returns the path to Analytics JS 1.0
+ **/
+export function getLegacyAJSPath() {
+  return '';
+  // var _a, _b, _c;
+  // var writeKey =
+  //   (_a = embeddedWriteKey()) !== null && _a !== void 0
+  //     ? _a
+  //     : (_b = getGlobalAnalytics()) === null || _b === void 0
+  //       ? void 0
+  //       : _b._writeKey;
+  // var scripts = Array.prototype.slice.call(document.querySelectorAll('script'));
+  // var path = undefined;
+  // for (var _i = 0, scripts_1 = scripts; _i < scripts_1.length; _i++) {
+  //   var s = scripts_1[_i];
+  //   var src = (_c = s.getAttribute('src')) !== null && _c !== void 0 ? _c : '';
+  //   var result = analyticsScriptRegex.exec(src);
+  //   if (result && result[1]) {
+  //     path = src;
+  //     break;
+  //   }
+  // }
+  // if (path) {
+  //   return path.replace('analytics.min.js', 'analytics.classic.js');
+  // }
+  // return 'https://cdn.segment.com/analytics.js/v1/'.concat(writeKey, '/analytics.classic.js');
+}
+//# sourceMappingURL=parse-cdn.js.map

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -86,7 +86,7 @@ const aliases = {
   '@stacks/wallet-sdk': '@stacks/wallet-sdk/dist/esm',
   'leather-styles': path.resolve('leather-styles'),
   'react': path.resolve('./node_modules/react'),
-  'react-dom': path.resolve('./node_modules/react-dom')
+  'react-dom': path.resolve('./node_modules/react-dom'),
 };
 
 export const config = {
@@ -234,6 +234,10 @@ export const config = {
       resourceRegExp: /^\.\/wordlists\/(?!english)/,
       contextRegExp: /bip39\/src$/,
     }),
+    new webpack.NormalModuleReplacementPlugin(
+      /@segment\/analytics-next\/dist\/pkg\/lib\/parse-cdn\.js$/,
+      path.resolve(__dirname, '../scripts/dummy-segment-parse-cdn.js')
+    ),
     new HtmlWebpackPlugin({
       template: path.join(SRC_ROOT_PATH, '../', 'public', 'html', 'index.html'),
       filename: 'index.html',


### PR DESCRIPTION
> Try out Leather build 805d747 — [Extension build](https://github.com/leather-io/extension/actions/runs/14731557283), [Test report](https://leather-io.github.io/playwright-reports/fix/segment-related-chrome-rejection), [Storybook](https://fix/segment-related-chrome-rejection--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/segment-related-chrome-rejection)<!-- Sticky Header Marker -->

This PR does a pretty dirty job of bypassing the code in the Segment library that caused our latest Chrome store rejection.

I've copied the pre-built file, removed the remote code method, and aliased it in the webpack config, then checked for all instances of this file in our own `dist/` output, to verify the stubbed method. 