### PR TITLE
fix(web): use a local resource for sbtc logo image

### DIFF
--- a/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-item.tsx
+++ b/src/app/features/asset-list/stacks/sip10-token-asset-list/sip10-token-asset-item.tsx
@@ -1,3 +1,5 @@
+import SbtcAvatarIconSrc from '@assets/avatars/sbtc-avatar-icon.png';
+
 import type { CryptoAssetBalance, MarketData, Sip10CryptoAssetInfo } from '@leather.io/models';
 
 import { convertAssetBalanceToFiat } from '@app/common/asset-utils';
@@ -41,7 +43,9 @@ export function Sip10TokenAssetItem({
       <StacksAssetAvatar
         color="white"
         gradientString={contractId}
-        img={getSafeImageCanonicalUri(imageCanonicalUri, name)}
+        img={
+          symbol === 'sBTC' ? SbtcAvatarIconSrc : getSafeImageCanonicalUri(imageCanonicalUri, name)
+        }
       >
         {name[0]}
       </StacksAssetAvatar>


### PR DESCRIPTION
> Try out Leather build e21ace5 — [Extension build](https://github.com/leather-io/extension/actions/runs/14753484418), [Test report](https://leather-io.github.io/playwright-reports/fix/sbtc-logo), [Storybook](https://fix/sbtc-logo--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/sbtc-logo)<!-- Sticky Header Marker -->

This PR adds a check so that if the SIP-10 symbol is **sBTC**, we use a locally hosted **.png** image rather than rely on token metadata