### PR TITLE
ci: don't run signed checks on release

### DIFF
--- a/.github/workflows/audit-signed-commits.yml
+++ b/.github/workflows/audit-signed-commits.yml
@@ -1,5 +1,8 @@
 name: Check signed commits
-on: pull_request_target
+on:
+  pull_request_target:
+    branches-ignore:
+      - 'release/*'
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
> Try out Leather build c126872 — [Extension build](https://github.com/leather-io/extension/actions/runs/14759467429), [Test report](https://leather-io.github.io/playwright-reports/ci/release-ci), [Storybook](https://ci/release-ci--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci/release-ci)<!-- Sticky Header Marker -->

causing release build fails