### PR TITLE
fix: prevent signed commits warning

### DIFF
--- a/.github/workflows/audit-signed-commits.yml
+++ b/.github/workflows/audit-signed-commits.yml
@@ -1,6 +1,6 @@
 name: Check signed commits
 on:
-  pull_request_target:
+  pull_request:
     branches-ignore:
       - 'release/*'
 permissions:


### PR DESCRIPTION
> Try out Leather build 70ba501 — [Extension build](https://github.com/leather-io/extension/actions/runs/14773092529), [Test report](https://leather-io.github.io/playwright-reports/fix/commit-signing-issue), [Storybook](https://fix/commit-signing-issue--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/commit-signing-issue)<!-- Sticky Header Marker -->

Should ignore release branches