### PR TITLE
fix(rpc): remove default account for 'getAddresses' flow

### DIFF
--- a/src/background/messaging/legacy/legacy-external-message-handler.ts
+++ b/src/background/messaging/legacy/legacy-external-message-handler.ts
@@ -11,9 +11,9 @@ import { getLegacyTransactionPayloadFromToken } from '@shared/utils/legacy-reque
 
 import { queueAnalyticsRequest } from '@background/background-analytics';
 import {
+  createConnectingAppSearchParamsWithLastKnownAccount,
   listenForOriginTabClose,
   listenForPopupClose,
-  makeSearchParamsWithDefaults,
   triggerRequestPopupWindowOpen,
 } from '@background/messaging/rpc-request-utils';
 
@@ -66,7 +66,7 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.authenticationRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.authenticationRequest });
 
-      const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['authRequest', payload],
         ['flow', ExternalMethods.authenticationRequest],
       ]);
@@ -84,7 +84,7 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.transactionRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.transactionRequest });
 
-      const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['request', payload],
         ['flow', ExternalMethods.transactionRequest],
         ...getNetworkParamsFromPayload(payload),
@@ -103,7 +103,7 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.signatureRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.signatureRequest });
 
-      const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['request', payload],
         ['messageType', 'utf8'],
         ['flow', ExternalMethods.signatureRequest],
@@ -123,7 +123,7 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.structuredDataSignatureRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.structuredDataSignatureRequest });
 
-      const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
         ['request', payload],
         ['messageType', 'structured'],
         ['flow', ExternalMethods.structuredDataSignatureRequest],
@@ -143,7 +143,9 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.profileUpdateRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.profileUpdateRequest });
 
-      const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [['request', payload]]);
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+        ['request', payload],
+      ]);
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.ProfileUpdateRequest, urlParams);
       listenForPopupClose({
@@ -158,7 +160,9 @@ export async function handleLegacyExternalMethodFormat(
     case ExternalMethods.psbtRequest: {
       void trackLegacyRequestInitiated({ method: ExternalMethods.psbtRequest });
 
-      const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [['request', payload]]);
+      const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
+        ['request', payload],
+      ]);
 
       const { id } = await triggerRequestPopupWindowOpen(RouteUrls.PsbtRequest, urlParams);
       listenForPopupClose({

--- a/src/background/messaging/rpc-helpers.ts
+++ b/src/background/messaging/rpc-helpers.ts
@@ -6,7 +6,7 @@ import { queueAnalyticsRequest } from '@background/background-analytics';
 
 import {
   RequestParams,
-  makeSearchParamsWithDefaults,
+  createConnectingAppSearchParamsWithLastKnownAccount,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from './rpc-request-utils';
@@ -25,7 +25,10 @@ export async function handleRpcMessage({
 }: HandleRpcMessageArgs) {
   void trackRpcRequestSuccess({ endpoint: request.method });
 
-  const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, requestParams);
+  const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+    port,
+    requestParams
+  );
   const { id } = await triggerRequestPopupWindowOpen(path, urlParams);
 
   sendErrorResponseOnUserPopupClose({ tabId, id, request });

--- a/src/background/messaging/rpc-methods/get-addresses.ts
+++ b/src/background/messaging/rpc-methods/get-addresses.ts
@@ -5,7 +5,7 @@ import { RouteUrls } from '@shared/route-urls';
 import { trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
-  makeSearchParamsWithDefaults,
+  createConnectingAppMetadataSearchParams,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
@@ -14,7 +14,7 @@ const sharedGetAddressesHandler = async (
   request: RpcRequest<typeof getAddresses> | RpcRequest<typeof stxGetAddresses>,
   port: chrome.runtime.Port
 ) => {
-  const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [
+  const { urlParams, tabId } = createConnectingAppMetadataSearchParams(port, [
     ['requestId', request.id],
     ['rpcRequest', encodeBase64Json(request)],
   ]);

--- a/src/background/messaging/rpc-methods/open-swap.ts
+++ b/src/background/messaging/rpc-methods/open-swap.ts
@@ -5,10 +5,13 @@ import { replaceRouteParams } from '@shared/utils/replace-route-params';
 
 import { trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
-import { makeSearchParamsWithDefaults, triggerSwapWindowOpen } from '../rpc-request-utils';
+import {
+  createConnectingAppSearchParamsWithLastKnownAccount,
+  triggerSwapWindowOpen,
+} from '../rpc-request-utils';
 
 export const openSwapHandler = defineRpcRequestHandler(openSwap.method, async (request, port) => {
-  const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [
+  const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
     ['requestId', request.id],
   ]);
   const { base = 'STX', quote } = request?.params || {};

--- a/src/background/messaging/rpc-methods/open.ts
+++ b/src/background/messaging/rpc-methods/open.ts
@@ -12,13 +12,13 @@ import { getRootState, sendMissingStateErrorToTab } from '@shared/storage/get-ro
 import { openNewTabWithWallet, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
+  createConnectingAppSearchParamsWithLastKnownAccount,
   getHostnameFromPort,
-  makeSearchParamsWithDefaults,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
 
 export const openHandler = defineRpcRequestHandler(open.method, async (request, port) => {
-  const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, [
+  const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
     ['requestId', request.id],
   ]);
 

--- a/src/background/messaging/rpc-methods/send-transfer.ts
+++ b/src/background/messaging/rpc-methods/send-transfer.ts
@@ -20,8 +20,8 @@ import { trackRpcRequestError, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   RequestParams,
+  createConnectingAppSearchParamsWithLastKnownAccount,
   getTabIdFromPort,
-  makeSearchParamsWithDefaults,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
@@ -82,7 +82,10 @@ export const sendTransferHandler = defineRpcRequestHandler(
       requestParams.push(['accountIndex', params.account.toString()]);
     }
 
-    const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, requestParams);
+    const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+      port,
+      requestParams
+    );
 
     const { id } = await triggerRequestPopupWindowOpen(RouteUrls.RpcSendTransfer, urlParams);
 

--- a/src/background/messaging/rpc-methods/sign-message.ts
+++ b/src/background/messaging/rpc-methods/sign-message.ts
@@ -17,8 +17,8 @@ import { trackRpcRequestError, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   RequestParams,
+  createConnectingAppSearchParamsWithLastKnownAccount,
   getTabIdFromPort,
-  makeSearchParamsWithDefaults,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
@@ -87,7 +87,10 @@ export const signMessageHandler = defineRpcRequestHandler(
       requestParams.push(['accountIndex', (request.params as any).account.toString()]);
     }
 
-    const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, requestParams);
+    const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+      port,
+      requestParams
+    );
     const { id } = await triggerRequestPopupWindowOpen(RouteUrls.RpcSignBip322Message, urlParams);
 
     sendErrorResponseOnUserPopupClose({ tabId, id, request });

--- a/src/background/messaging/rpc-methods/sign-psbt.ts
+++ b/src/background/messaging/rpc-methods/sign-psbt.ts
@@ -15,8 +15,8 @@ import { trackRpcRequestError, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   RequestParams,
+  createConnectingAppSearchParamsWithLastKnownAccount,
   getTabIdFromPort,
-  makeSearchParamsWithDefaults,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
@@ -102,7 +102,10 @@ export const signPsbtHandler = defineRpcRequestHandler(signPsbt.method, async (r
 
   void trackRpcRequestSuccess({ endpoint: request.method });
 
-  const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, requestParams);
+  const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+    port,
+    requestParams
+  );
 
   const { id } = await triggerRequestPopupWindowOpen(RouteUrls.RpcSignPsbt, urlParams);
 

--- a/src/background/messaging/rpc-methods/sign-stacks-message.ts
+++ b/src/background/messaging/rpc-methods/sign-stacks-message.ts
@@ -20,8 +20,8 @@ import { trackRpcRequestError, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   RequestParams,
+  createConnectingAppSearchParamsWithLastKnownAccount,
   getTabIdFromPort,
-  makeSearchParamsWithDefaults,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
@@ -61,7 +61,10 @@ async function handleRpcSignStacksMessage(
 
   void trackRpcRequestSuccess({ endpoint: method });
 
-  const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, requestParams);
+  const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+    port,
+    requestParams
+  );
 
   const { id } = await triggerRequestPopupWindowOpen(RouteUrls.RpcStacksSignature, urlParams);
   sendErrorResponseOnUserPopupClose({ tabId, id, request });

--- a/src/background/messaging/rpc-methods/stx-call-contract.ts
+++ b/src/background/messaging/rpc-methods/stx-call-contract.ts
@@ -11,8 +11,8 @@ import { RpcErrorMessage } from '@shared/rpc/methods/validation.utils';
 import { trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
+  createConnectingAppSearchParamsWithLastKnownAccount,
   listenForPopupClose,
-  makeSearchParamsWithDefaults,
   triggerRequestPopupWindowOpen,
   validateRequestParams,
 } from '../rpc-request-utils';
@@ -29,7 +29,7 @@ export const stxCallContractHandler = defineRpcRequestHandler(
       schema: stxCallContract.params,
     });
     if (status === 'failure') return;
-    const { tabId, urlParams } = await makeSearchParamsWithDefaults(port, [
+    const { tabId, urlParams } = await createConnectingAppSearchParamsWithLastKnownAccount(port, [
       ['requestId', request.id],
       ['rpcRequest', encodeBase64Json(request)],
     ]);

--- a/src/background/messaging/rpc-methods/stx-sign-transaction.ts
+++ b/src/background/messaging/rpc-methods/stx-sign-transaction.ts
@@ -31,9 +31,9 @@ import { trackRpcRequestError, trackRpcRequestSuccess } from '../rpc-helpers';
 import { defineRpcRequestHandler } from '../rpc-message-handler';
 import {
   RequestParams,
+  createConnectingAppSearchParamsWithLastKnownAccount,
   encodePostConditions,
   getTabIdFromPort,
-  makeSearchParamsWithDefaults,
   sendErrorResponseOnUserPopupClose,
   triggerRequestPopupWindowOpen,
 } from '../rpc-request-utils';
@@ -182,7 +182,10 @@ export const stxSignTransactionHandler = defineRpcRequestHandler(
 
     if (isDefined(request.params.network)) requestParams.push(['network', request.params.network]);
 
-    const { urlParams, tabId } = await makeSearchParamsWithDefaults(port, requestParams);
+    const { urlParams, tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(
+      port,
+      requestParams
+    );
 
     const { id } = await triggerRequestPopupWindowOpen(RouteUrls.RpcStxSignTransaction, urlParams);
     sendErrorResponseOnUserPopupClose({ tabId, id, request });

--- a/src/background/messaging/rpc-methods/supported-methods.ts
+++ b/src/background/messaging/rpc-methods/supported-methods.ts
@@ -1,12 +1,12 @@
 import { createRpcSuccessResponse, supportedMethods } from '@leather.io/rpc';
 
 import { defineRpcRequestHandler } from '../rpc-message-handler';
-import { makeSearchParamsWithDefaults } from '../rpc-request-utils';
+import { createConnectingAppSearchParamsWithLastKnownAccount } from '../rpc-request-utils';
 
 export const supportedMethodsHandler = defineRpcRequestHandler(
   supportedMethods.method,
   async (request, port) => {
-    const { tabId } = await makeSearchParamsWithDefaults(port);
+    const { tabId } = await createConnectingAppSearchParamsWithLastKnownAccount(port);
     chrome.tabs.sendMessage(
       tabId,
       createRpcSuccessResponse(supportedMethods.method, {

--- a/src/background/messaging/rpc-request-utils.ts
+++ b/src/background/messaging/rpc-request-utils.ts
@@ -105,23 +105,30 @@ export function listenForOriginTabClose({ tabId }: ListenForOriginTabCloseArgs) 
 
 export type RequestParams = [string, string][];
 
-export async function makeSearchParamsWithDefaults(
+export function createConnectingAppMetadataSearchParams(
   port: chrome.runtime.Port,
   otherParams: RequestParams = []
 ) {
   const urlParams = new URLSearchParams();
-  // All actions must have a corresponding `origin` and `tabId`
   const origin = getOriginFromPort(port);
   const tabId = getTabIdFromPort(port);
   urlParams.set('origin', origin ?? '');
   urlParams.set('tabId', tabId.toString());
+  otherParams.forEach(([key, value]) => urlParams.append(key, value));
+  return { urlParams, origin, tabId };
+}
+
+export async function createConnectingAppSearchParamsWithLastKnownAccount(
+  port: chrome.runtime.Port,
+  otherParams: RequestParams = []
+) {
+  const { urlParams, origin, tabId } = createConnectingAppMetadataSearchParams(port, otherParams);
   if (origin) {
     const appPermissions = await getPermissionsByOrigin(getHostnameFromPort(port));
     if (appPermissions) {
       urlParams.set('accountIndex', appPermissions.accountIndex.toString());
     }
   }
-  otherParams.forEach(([key, value]) => urlParams.append(key, value));
   return { urlParams, origin, tabId };
 }
 


### PR DESCRIPTION
> Try out Leather build ac1c892 — [Extension build](https://github.com/leather-io/extension/actions/runs/14774946563), [Test report](https://leather-io.github.io/playwright-reports/fix/default-account-bug), [Storybook](https://fix/default-account-bug--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/default-account-bug)<!-- Sticky Header Marker -->

In https://github.com/leather-io/extension/pull/6217 I added the functionality that, _for all RPC flows_, we set the `accountIndex` to the one that the `origin` connected to. 

This had the unintended consequence that, for the `getAddresses` flow, we also default to the last known account. Meaning that, when disconnecting from an app and reconnecting, we'd fix them to the last known account, preventing them from changing account index and connecting with another. 

In this PR, I make an exception for the `getAddresses` flow, such that we don't set the `accountIndex` search param, and the account can be changed. This will update the account index, and I believe all the other flows should work correctly.