### PR TITLE
fix: turn off promo card for release

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -181,5 +181,5 @@
       "max": 2000000
     }
   },
-  "promoCardEnabled": true
+  "promoCardEnabled": false
 }

--- a/src/app/features/promo-card/promo-card.tsx
+++ b/src/app/features/promo-card/promo-card.tsx
@@ -7,6 +7,10 @@ import { useConfigPromoCardEnabled } from '@app/query/common/remote-config/remot
 interface PromoCardContentProps extends FlagProps {}
 
 function PromoCardLayout(props: PromoCardContentProps) {
+  // Hardcoded colors needed to bypass theme
+  const backgroundColor = '#1B1A17';
+  const borderColor = '#554D44';
+  const textColor = '#F5F1ED';
   return (
     <Flag
       cursor="pointer"
@@ -19,23 +23,20 @@ function PromoCardLayout(props: PromoCardContentProps) {
           mr="space.02"
         />
       }
-      background="ink.action-primary-default"
+      background={backgroundColor}
       borderRadius={8}
+      border="2px solid"
+      borderColor={borderColor}
       mt="space.05"
       pt="space.02"
       px="space.02"
       {...props}
     >
       <Box pl="space.03" pt="space.02" pb="space.04">
-        <styled.h3
-          textStyle="heading.05"
-          fontSize="17px"
-          lineHeight={1.4}
-          color="ink.background-primary"
-        >
+        <styled.h3 textStyle="heading.05" fontSize="17px" lineHeight={1.4} color={textColor}>
           Grow your Bitcoin
         </styled.h3>
-        <styled.p textStyle="label.03" mt="space.01" color="ink.background-primary">
+        <styled.p textStyle="label.03" mt="space.01" color={textColor}>
           Our new web app is live and built to help you earn with Bitcoin.
         </styled.p>
       </Box>


### PR DESCRIPTION
> Try out Leather build 0de135a — [Extension build](https://github.com/leather-io/extension/actions/runs/15141363037), [Test report](https://leather-io.github.io/playwright-reports/fix/promo-card-false), [Storybook](https://fix/promo-card-false--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/promo-card-false)<!-- Sticky Header Marker -->

