### PR TITLE
fix: handle negative balance in swaps

### DIFF
--- a/src/app/query/stacks/balance/account-balance.hooks.ts
+++ b/src/app/query/stacks/balance/account-balance.hooks.ts
@@ -63,8 +63,7 @@ export function useStxCryptoAssetBalance(address: string) {
 
 export function useStxAvailableUnlockedBalance(address: string) {
   const stxBalance = useStxCryptoAssetBalance(address);
-
-  return stxBalance.filteredBalanceQuery.data?.unlockedBalance ?? createMoney(0, 'STX');
+  return stxBalance.filteredBalanceQuery.data?.availableUnlockedBalance ?? createMoney(0, 'STX');
 }
 
 export function useStacksAccountBalanceFungibleTokens(address: string) {

--- a/src/app/query/stacks/balance/account-balance.utils.ts
+++ b/src/app/query/stacks/balance/account-balance.utils.ts
@@ -23,7 +23,10 @@ export function createStxCryptoAssetBalance(
 
   return {
     availableBalance: subtractMoney(totalBalance, outboundBalance),
-    availableUnlockedBalance: subtractMoney(unlockedBalance, outboundBalance),
+    // Temporary fix for negative balances returning from the API
+    availableUnlockedBalance: unlockedBalance.amount.isPositive()
+      ? subtractMoney(unlockedBalance, outboundBalance)
+      : createMoney(0, 'STX'),
     inboundBalance,
     lockedBalance: createMoney(stxMoney.locked.amount, 'STX'),
     outboundBalance,


### PR DESCRIPTION
> Try out Leather build 46594a5 — [Extension build](https://github.com/leather-io/extension/actions/runs/15190789844), [Test report](https://leather-io.github.io/playwright-reports/fix/negative-unlocked-balance), [Storybook](https://fix/negative-unlocked-balance--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/negative-unlocked-balance)<!-- Sticky Header Marker -->

I ran into a bug with swaps not loading with the availableUnlocked STX balance coming in negative from an api bug:
https://github.com/hirosystems/stacks-blockchain-api/issues/2267

This PR fixes it, and it appears we were using the `unlockedBalance` in many places rather than the `availableUnlockedBalance` which subtracts out outbound txs.