### PR TITLE
fix: enable web app banner

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -181,5 +181,5 @@
       "max": 2000000
     }
   },
-  "promoCardEnabled": false
+  "promoCardEnabled": true
 }


### PR DESCRIPTION
> Try out Leather build 9ef16e8 — [Extension build](https://github.com/leather-io/extension/actions/runs/15163425790), [Test report](https://leather-io.github.io/playwright-reports/fix/enable-web-app-banner), [Storybook](https://fix/enable-web-app-banner--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/enable-web-app-banner)<!-- Sticky Header Marker -->

This PR can be merged w/out a release to show the web app banner.