### PR TITLE
chore: enable web app banner

### DIFF
--- a/config/wallet-config.json
+++ b/config/wallet-config.json
@@ -181,5 +181,5 @@
       "max": 2000000
     }
   },
-  "promoCardEnabled": false
+  "promoCardEnabled": true
 }


### PR DESCRIPTION
> Try out Leather build 4d3a677 — [Extension build](https://github.com/leather-io/extension/actions/runs/15163542072), [Test report](https://leather-io.github.io/playwright-reports/chore/enable-web-app-banner), [Storybook](https://chore/enable-web-app-banner--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/enable-web-app-banner)<!-- Sticky Header Marker -->

This PR enables the web app banner w/out triggering a release.