### PR TITLE
refactor: rpc requests account signer

### DIFF
--- a/src/app/components/rpc-transaction-request/transaction-recipients.layout.tsx
+++ b/src/app/components/rpc-transaction-request/transaction-recipients.layout.tsx
@@ -1,5 +1,5 @@
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
-import { HStack, styled } from 'leather-styles/jsx';
+import { HStack } from 'leather-styles/jsx';
 
 import type { Money } from '@leather.io/models';
 import { AddressDisplayer, Approver, ItemLayout, UserIcon } from '@leather.io/ui';
@@ -32,9 +32,7 @@ export function TransactionRecipientsLayout({
 
     return (
       <Approver.Section key={address}>
-        <Approver.Subheader>
-          <styled.span textStyle="label.01">You'll send</styled.span>
-        </Approver.Subheader>
+        <Approver.Subheader>You'll send</Approver.Subheader>
 
         <ItemLayout
           img={avatar}
@@ -46,9 +44,7 @@ export function TransactionRecipientsLayout({
 
         <Divider mt="space.05" mb="space.04" />
 
-        <Approver.Subheader>
-          <styled.span textStyle="label.01">To address</styled.span>
-        </Approver.Subheader>
+        <Approver.Subheader>To address</Approver.Subheader>
         <HStack key={address} alignItems="center" gap="space.04" pb="space.03">
           <IconWrapper>
             <UserIcon />

--- a/src/app/features/rpc-transaction-request/signing-account-card/signing-account-card.tsx
+++ b/src/app/features/rpc-transaction-request/signing-account-card/signing-account-card.tsx
@@ -10,18 +10,18 @@ import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { useStacksAccounts } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { AccountAvatarItem } from '@app/ui/components/account/account-avatar/account-avatar-item';
 
-interface TransactionAccountSignerProps {
+interface SigningAccountCardProps {
   address: React.ReactNode;
   availableBalance: Money;
   fiatBalance: Money;
   isLoadingBalance: boolean;
 }
-export function TransactionAccountSigner({
+export function SigningAccountCard({
   address,
   availableBalance,
   fiatBalance,
   isLoadingBalance,
-}: TransactionAccountSignerProps) {
+}: SigningAccountCardProps) {
   const index = useCurrentAccountIndex();
   const stacksAccounts = useStacksAccounts();
 
@@ -48,7 +48,6 @@ export function TransactionAccountSigner({
       <Approver.Subheader>With account</Approver.Subheader>
       <Box mb="space.03">
         <ItemLayout
-          showChevron
           img={<AccountAvatarItem index={index} publicKey="" name="" />}
           titleLeft={<AccountNameLayout isLoading={isLoadingName}>{name}</AccountNameLayout>}
           captionLeft={address}

--- a/src/app/features/rpc-transaction-request/stacks/contract-call/contract-call-details.layout.tsx
+++ b/src/app/features/rpc-transaction-request/stacks/contract-call/contract-call-details.layout.tsx
@@ -47,9 +47,7 @@ export function ContractCallDetailsLayout({
   if (!contractAbi) {
     return (
       <Approver.Section>
-        <Approver.Subheader>
-          <styled.span textStyle="label.01">Contract</styled.span>
-        </Approver.Subheader>
+        <Approver.Subheader>Contract</Approver.Subheader>
         <styled.span textStyle="caption.01" color="red.action-primary-default">
           Not a valid contract
         </styled.span>
@@ -60,9 +58,7 @@ export function ContractCallDetailsLayout({
   if (!contractFunction) {
     return (
       <Approver.Section>
-        <Approver.Subheader>
-          <styled.span textStyle="label.01">Contract</styled.span>
-        </Approver.Subheader>
+        <Approver.Subheader>Contract</Approver.Subheader>
         <styled.span textStyle="caption.01" color="red.action-primary-default">
           Function not found
         </styled.span>
@@ -73,9 +69,7 @@ export function ContractCallDetailsLayout({
   return (
     <>
       <Approver.Section>
-        <Approver.Subheader>
-          <styled.span textStyle="label.01">Contract</styled.span>
-        </Approver.Subheader>
+        <Approver.Subheader>Contract</Approver.Subheader>
         <Stack gap="space.04">
           <Stack _hover={{ cursor: 'pointer' }} gap="space.02" onClick={onClickContractAddress}>
             <styled.span color="ink.text-subdued" textStyle="caption.01">
@@ -101,9 +95,7 @@ export function ContractCallDetailsLayout({
         </Stack>
       </Approver.Section>
       <Approver.Section>
-        <Approver.Subheader>
-          <styled.span textStyle="label.01">Contract arguments</styled.span>
-        </Approver.Subheader>
+        <Approver.Subheader>Contract arguments</Approver.Subheader>
         <FunctionArgumentList fn={contractFunction} fnArgs={functionArgs} />
       </Approver.Section>
     </>

--- a/src/app/features/rpc-transaction-request/stacks/contract-deploy/contract-deploy-details.layout.tsx
+++ b/src/app/features/rpc-transaction-request/stacks/contract-deploy/contract-deploy-details.layout.tsx
@@ -18,9 +18,7 @@ export function ContractDeployDetailsLayout({
   return (
     <>
       <Approver.Section>
-        <Approver.Subheader>
-          <styled.span textStyle="label.01">Contract</styled.span>
-        </Approver.Subheader>
+        <Approver.Subheader>Contract</Approver.Subheader>
         <Stack gap="space.04">
           <Stack gap="space.02">
             <styled.span color="ink.text-subdued" textStyle="caption.01">
@@ -40,9 +38,7 @@ export function ContractDeployDetailsLayout({
         </Stack>
       </Approver.Section>
       <Approver.Section>
-        <Approver.Subheader>
-          <styled.span textStyle="label.01">Code</styled.span>
-        </Approver.Subheader>
+        <Approver.Subheader>Code</Approver.Subheader>
         <Highlighter code={codeBody} prism={Prism} language="clarity" />
       </Approver.Section>
     </>

--- a/src/app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout.tsx
+++ b/src/app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout.tsx
@@ -3,7 +3,6 @@ import {
   type PostConditionModeName,
   type PostConditionWire,
 } from '@stacks/transactions';
-import { styled } from 'leather-styles/jsx';
 
 import { ensurePostConditionWireFormat } from '@leather.io/stacks';
 import { Approver } from '@leather.io/ui';
@@ -25,9 +24,7 @@ export function PostConditionsDetailsLayout({
 
   return (
     <Approver.Section>
-      <Approver.Subheader>
-        <styled.span textStyle="label.01">Post conditions</styled.span>
-      </Approver.Subheader>
+      <Approver.Subheader>Post conditions</Approver.Subheader>
       {postConditions.length ? (
         <PostConditionList
           postConditions={postConditions.map(pc => ensurePostConditionWireFormat(pc))}

--- a/src/app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer.tsx
+++ b/src/app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer.tsx
@@ -1,7 +1,7 @@
 import { Box, styled } from 'leather-styles/jsx';
 
 import type { Money } from '@leather.io/models';
-import { Approver, Caption, ItemLayout, Pressable, SkeletonLoader } from '@leather.io/ui';
+import { Approver, Caption, ItemLayout, SkeletonLoader } from '@leather.io/ui';
 import { formatDustUsdAmounts, formatMoneyPadded, i18nFormatCurrency } from '@leather.io/utils';
 
 import { useAccountDisplayName } from '@app/common/hooks/account/use-account-names';
@@ -10,20 +10,18 @@ import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { useStacksAccounts } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
 import { AccountAvatarItem } from '@app/ui/components/account/account-avatar/account-avatar-item';
 
-interface SwitchAccountTriggerProps {
+interface TransactionAccountSignerProps {
   address: React.ReactNode;
   availableBalance: Money;
   fiatBalance: Money;
   isLoadingBalance: boolean;
-  onSwitchAccount(): void;
 }
-export function SwitchAccountTrigger({
+export function TransactionAccountSigner({
   address,
   availableBalance,
   fiatBalance,
   isLoadingBalance,
-  onSwitchAccount,
-}: SwitchAccountTriggerProps) {
+}: TransactionAccountSignerProps) {
   const index = useCurrentAccountIndex();
   const stacksAccounts = useStacksAccounts();
 
@@ -49,16 +47,14 @@ export function SwitchAccountTrigger({
     <Approver.Section>
       <Approver.Subheader>With account</Approver.Subheader>
       <Box mb="space.03">
-        <Pressable onClick={onSwitchAccount}>
-          <ItemLayout
-            showChevron
-            img={<AccountAvatarItem index={index} publicKey="" name="" />}
-            titleLeft={<AccountNameLayout isLoading={isLoadingName}>{name}</AccountNameLayout>}
-            captionLeft={address}
-            titleRight={titleRight}
-            captionRight={captionRight}
-          />
-        </Pressable>
+        <ItemLayout
+          showChevron
+          img={<AccountAvatarItem index={index} publicKey="" name="" />}
+          titleLeft={<AccountNameLayout isLoading={isLoadingName}>{name}</AccountNameLayout>}
+          captionLeft={address}
+          titleRight={titleRight}
+          captionRight={captionRight}
+        />
       </Box>
     </Approver.Section>
   );

--- a/src/app/features/rpc-transaction-request/use-rpc-transaction-request.tsx
+++ b/src/app/features/rpc-transaction-request/use-rpc-transaction-request.tsx
@@ -18,7 +18,6 @@ export interface RpcTransactionRequest {
   status: TransactionStatus;
   onClickRequestedByLink(method: RpcMethodNames): void;
   onSetTransactionStatus(status: TransactionStatus): void;
-  onUserActivatesSwitchAccount(): void;
 }
 
 export function useRpcTransactionRequest(): RpcTransactionRequest {
@@ -44,6 +43,5 @@ export function useRpcTransactionRequest(): RpcTransactionRequest {
     status,
     onClickRequestedByLink,
     onSetTransactionStatus: (status: TransactionStatus) => setStatus(status),
-    onUserActivatesSwitchAccount: () => {},
   };
 }

--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -147,7 +147,7 @@ export function Settings({
               )}
               {hasKeys && toggleSwitchAccount && (
                 <DropdownMenu.Item
-                  data-testid={SettingsSelectors.SwitchAccountTrigger}
+                  data-testid={SettingsSelectors.TransactionAccountSigner}
                   onSelect={toggleSwitchAccount}
                 >
                   <Flag img={<ArrowsRepeatLeftRightIcon />} textStyle="label.02">

--- a/src/app/features/settings/settings.tsx
+++ b/src/app/features/settings/settings.tsx
@@ -147,7 +147,7 @@ export function Settings({
               )}
               {hasKeys && toggleSwitchAccount && (
                 <DropdownMenu.Item
-                  data-testid={SettingsSelectors.TransactionAccountSigner}
+                  data-testid={SettingsSelectors.SigningAccountCard}
                   onSelect={toggleSwitchAccount}
                 >
                   <Flag img={<ArrowsRepeatLeftRightIcon />} textStyle="label.02">

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer-container.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer-container.tsx
@@ -2,7 +2,6 @@ import { Outlet, useNavigate } from 'react-router-dom';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { BitcoinUtxosLoader } from '@app/components/loaders/bitcoin-utxos-loader';
 import { BitcoinFeeEditorProvider } from '@app/features/fee-editor/bitcoin/bitcoin-fee-editor.provider';
 import { useCurrentBtcCryptoAssetBalanceNativeSegwit } from '@app/query/bitcoin/balance/btc-balance-native-segwit.hooks';
@@ -13,7 +12,6 @@ import { useRpcSendTransfer } from './use-rpc-send-transfer';
 
 export function RpcSendTransferContainer() {
   const sendTransferState = useRpcSendTransfer();
-  const { toggleSwitchAccount } = useSwitchAccountSheet();
   const btcMarketData = useCryptoCurrencyMarketDataMeanAverage('BTC');
   const btcBalance = useCurrentBtcCryptoAssetBalanceNativeSegwit();
 
@@ -37,7 +35,6 @@ export function RpcSendTransferContainer() {
             value={{
               ...sendTransferState,
               isLoadingBalance: btcBalance.isLoadingAllData,
-              onUserActivatesSwitchAccount: toggleSwitchAccount,
               utxos,
             }}
           >

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer.context.ts
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer.context.ts
@@ -17,7 +17,6 @@ interface RpcSendTransferContext extends RpcTransactionRequestContext {
   recipients: TransferRecipient[];
   recipientAddresses: string[];
   utxos: UtxoResponseItem[];
-  onUserActivatesSwitchAccount(): void;
 }
 
 const rpcSendTransferContext = createContext<RpcSendTransferContext | null>(null);

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer.tsx
@@ -18,7 +18,7 @@ import { TransactionRecipientsLayout } from '@app/components/rpc-transaction-req
 import { TransactionWrapper } from '@app/components/rpc-transaction-request/transaction-wrapper';
 import { FeeEditor } from '@app/features/fee-editor/fee-editor';
 import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context';
-import { SwitchAccountTrigger } from '@app/features/rpc-transaction-request/switch-account-trigger/switch-account-trigger';
+import { TransactionAccountSigner } from '@app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer';
 import { useBreakOnNonCompliantEntity } from '@app/query/common/compliance-checker/compliance-checker.query';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 
@@ -29,15 +29,8 @@ export function RpcSendTransfer() {
   const index = useCurrentAccountIndex();
   const { availableBalance, isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
     useFeeEditorContext();
-  const {
-    recipients,
-    recipientAddresses,
-    amount,
-    origin,
-    isLoadingBalance,
-    tabId,
-    onUserActivatesSwitchAccount,
-  } = useRpcSendTransferContext();
+  const { recipients, recipientAddresses, amount, origin, isLoadingBalance, tabId } =
+    useRpcSendTransferContext();
 
   const convertToFiatAmount = useConvertCryptoCurrencyToFiatAmount('BTC');
 
@@ -69,12 +62,11 @@ export function RpcSendTransfer() {
               focusTabAndWindow(tabId);
             }}
           />
-          <SwitchAccountTrigger
+          <TransactionAccountSigner
             address={<AccountBitcoinAddress index={index} />}
             availableBalance={availableBalance}
             fiatBalance={convertToFiatAmount(availableBalance)}
             isLoadingBalance={isLoadingBalance}
-            onSwitchAccount={onUserActivatesSwitchAccount}
           />
           <TransactionRecipientsLayout
             title="Bitcoin"

--- a/src/app/pages/rpc-send-transfer/rpc-send-transfer.tsx
+++ b/src/app/pages/rpc-send-transfer/rpc-send-transfer.tsx
@@ -18,7 +18,7 @@ import { TransactionRecipientsLayout } from '@app/components/rpc-transaction-req
 import { TransactionWrapper } from '@app/components/rpc-transaction-request/transaction-wrapper';
 import { FeeEditor } from '@app/features/fee-editor/fee-editor';
 import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context';
-import { TransactionAccountSigner } from '@app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer';
+import { SigningAccountCard } from '@app/features/rpc-transaction-request/signing-account-card/signing-account-card';
 import { useBreakOnNonCompliantEntity } from '@app/query/common/compliance-checker/compliance-checker.query';
 import { useCurrentAccountIndex } from '@app/store/accounts/account';
 
@@ -62,7 +62,7 @@ export function RpcSendTransfer() {
               focusTabAndWindow(tabId);
             }}
           />
-          <TransactionAccountSigner
+          <SigningAccountCard
             address={<AccountBitcoinAddress index={index} />}
             availableBalance={availableBalance}
             fiatBalance={convertToFiatAmount(availableBalance)}

--- a/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract-container.tsx
+++ b/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract-container.tsx
@@ -6,7 +6,6 @@ import { isDefined } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { getTxSenderAddress } from '@app/common/transactions/stacks/transaction.utils';
 import { StacksNonceLoader } from '@app/components/loaders/stacks-nonce-loader';
 import { StxBalanceLoader } from '@app/components/loaders/stx-balance-loader';
@@ -29,7 +28,6 @@ export function RpcStxCallContractContainer({ account }: RpcStxCallContractConta
   const request = useRpcTransactionRequest();
   const network = useCurrentStacksNetworkState();
   const stxMarketData = useCryptoCurrencyMarketDataMeanAverage('STX');
-  const { toggleSwitchAccount } = useSwitchAccountSheet();
   const navigate = useNavigate();
 
   const txOptionsForFeeEstimation = useMemo(
@@ -74,7 +72,6 @@ export function RpcStxCallContractContainer({ account }: RpcStxCallContractConta
                   <StacksRpcTransactionRequestProvider
                     value={{
                       ...request,
-                      onUserActivatesSwitchAccount: toggleSwitchAccount,
                       isLoadingBalance: isLoadingAdditionalData,
                       address: account.address,
                       publicKey: account.stxPublicKey,

--- a/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.tsx
+++ b/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.tsx
@@ -14,11 +14,11 @@ import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
 import { useNonceEditorContext } from '@app/features/nonce-editor/nonce-editor.context';
 import { RpcTransactionRequestLayout } from '@app/features/rpc-transaction-request/rpc-transaction-request.layout';
+import { SigningAccountCard } from '@app/features/rpc-transaction-request/signing-account-card/signing-account-card';
 import { ContractCallDetailsLayout } from '@app/features/rpc-transaction-request/stacks/contract-call/contract-call-details.layout';
 import { PostConditionsDetailsLayout } from '@app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
-import { TransactionAccountSigner } from '@app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer';
 import { TransactionActionsWithSpend } from '@app/features/rpc-transaction-request/transaction-actions/transaction-actions-with-spend';
 
 import {
@@ -70,7 +70,7 @@ export function RpcStxCallContract() {
         )}
         postConditionMode={txOptionsForBroadcast.postConditionMode}
       />
-      <TransactionAccountSigner
+      <SigningAccountCard
         address={<AccountStacksAddress />}
         availableBalance={availableBalance}
         fiatBalance={convertToFiatAmount(availableBalance)}

--- a/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.tsx
+++ b/src/app/pages/rpc-stx-call-contract/rpc-stx-call-contract.tsx
@@ -7,6 +7,8 @@ import {
 } from '@leather.io/stacks';
 import { createMoney } from '@leather.io/utils';
 
+import { useConvertCryptoCurrencyToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
+import { AccountStacksAddress } from '@app/components/account/account-stacks-address';
 import { FeeEditor } from '@app/features/fee-editor/fee-editor';
 import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context';
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
@@ -16,6 +18,7 @@ import { ContractCallDetailsLayout } from '@app/features/rpc-transaction-request
 import { PostConditionsDetailsLayout } from '@app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
+import { TransactionAccountSigner } from '@app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer';
 import { TransactionActionsWithSpend } from '@app/features/rpc-transaction-request/transaction-actions/transaction-actions-with-spend';
 
 import {
@@ -25,10 +28,11 @@ import {
 
 export function RpcStxCallContract() {
   const { isLoadingBalance, network, publicKey } = useStacksRpcTransactionRequestContext();
-  const { isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
+  const { availableBalance, isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
     useFeeEditorContext();
   const { nonce, onUserActivatesNonceEditor } = useNonceEditorContext();
   const signAndBroadcastTransaction = useSignAndBroadcastStacksTransaction(stxCallContract.method);
+  const convertToFiatAmount = useConvertCryptoCurrencyToFiatAmount('STX');
 
   const rpcRequest = useMemo(() => getDecodedRpcStxCallContractRequest(), []);
   const txOptionsForBroadcast = useMemo(
@@ -65,6 +69,12 @@ export function RpcStxCallContract() {
           ensurePostConditionWireFormat(pc)
         )}
         postConditionMode={txOptionsForBroadcast.postConditionMode}
+      />
+      <TransactionAccountSigner
+        address={<AccountStacksAddress />}
+        availableBalance={availableBalance}
+        fiatBalance={convertToFiatAmount(availableBalance)}
+        isLoadingBalance={isLoadingBalance}
       />
       <ContractCallDetailsLayout
         contractAddress={txOptionsForBroadcast.contractAddress}

--- a/src/app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract-container.tsx
+++ b/src/app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract-container.tsx
@@ -6,7 +6,6 @@ import { isDefined } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { getTxSenderAddress } from '@app/common/transactions/stacks/transaction.utils';
 import { StacksNonceLoader } from '@app/components/loaders/stacks-nonce-loader';
 import { StxBalanceLoader } from '@app/components/loaders/stx-balance-loader';
@@ -29,7 +28,6 @@ export function RpcStxDeployContractContainer({ account }: RpcStxDeployContractC
   const request = useRpcTransactionRequest();
   const network = useCurrentStacksNetworkState();
   const stxMarketData = useCryptoCurrencyMarketDataMeanAverage('STX');
-  const { toggleSwitchAccount } = useSwitchAccountSheet();
   const navigate = useNavigate();
 
   const txOptionsForFeeEstimation = useMemo(
@@ -73,7 +71,6 @@ export function RpcStxDeployContractContainer({ account }: RpcStxDeployContractC
                 <StacksRpcTransactionRequestProvider
                   value={{
                     ...request,
-                    onUserActivatesSwitchAccount: toggleSwitchAccount,
                     isLoadingBalance: isLoadingAdditionalData,
                     address: account.address,
                     publicKey: account.stxPublicKey,

--- a/src/app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract.tsx
+++ b/src/app/pages/rpc-stx-deploy-contract/rpc-stx-deploy-contract.tsx
@@ -7,11 +7,14 @@ import {
 } from '@leather.io/stacks';
 import { createMoneyFromDecimal } from '@leather.io/utils';
 
+import { useConvertCryptoCurrencyToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
+import { AccountStacksAddress } from '@app/components/account/account-stacks-address';
 import { FeeEditor } from '@app/features/fee-editor/fee-editor';
 import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context';
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
 import { useNonceEditorContext } from '@app/features/nonce-editor/nonce-editor.context';
 import { RpcTransactionRequestLayout } from '@app/features/rpc-transaction-request/rpc-transaction-request.layout';
+import { SigningAccountCard } from '@app/features/rpc-transaction-request/signing-account-card/signing-account-card';
 import { ContractDeployDetailsLayout } from '@app/features/rpc-transaction-request/stacks/contract-deploy/contract-deploy-details.layout';
 import { PostConditionsDetailsLayout } from '@app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
@@ -22,9 +25,10 @@ import { getUnsignedStacksDeployContractOptions } from './rpc-stx-deploy-contrac
 
 export function RpcStxDeployContract() {
   const { address, isLoadingBalance, network, publicKey } = useStacksRpcTransactionRequestContext();
-  const { isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
+  const { availableBalance, isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
     useFeeEditorContext();
   const { nonce, onUserActivatesNonceEditor } = useNonceEditorContext();
+  const convertToFiatAmount = useConvertCryptoCurrencyToFiatAmount('STX');
   const signAndBroadcastTransaction = useSignAndBroadcastStacksTransaction(
     stxDeployContract.method
   );
@@ -63,6 +67,12 @@ export function RpcStxDeployContract() {
           ensurePostConditionWireFormat(pc)
         )}
         postConditionMode={txOptionsForBroadcast.postConditionMode}
+      />
+      <SigningAccountCard
+        address={<AccountStacksAddress />}
+        availableBalance={availableBalance}
+        fiatBalance={convertToFiatAmount(availableBalance)}
+        isLoadingBalance={isLoadingBalance}
       />
       <ContractDeployDetailsLayout
         address={address}

--- a/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction-container.tsx
+++ b/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction-container.tsx
@@ -5,7 +5,6 @@ import { isDefined } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { getTxSenderAddress } from '@app/common/transactions/stacks/transaction.utils';
 import { StacksNonceLoader } from '@app/components/loaders/stacks-nonce-loader';
 import { StxBalanceLoader } from '@app/components/loaders/stx-balance-loader';
@@ -27,7 +26,6 @@ export function RpcStxSignTransactionContainer({ account }: RpcStxSignTransactio
   const request = useRpcTransactionRequest();
   const network = useCurrentStacksNetworkState();
   const stxMarketData = useCryptoCurrencyMarketDataMeanAverage('STX');
-  const { toggleSwitchAccount } = useSwitchAccountSheet();
   const navigate = useNavigate();
 
   const unsignedTxForFeeEstimation = useMemo(

--- a/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction-container.tsx
+++ b/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction-container.tsx
@@ -55,7 +55,6 @@ export function RpcStxSignTransactionContainer({ account }: RpcStxSignTransactio
                 <StacksRpcTransactionRequestProvider
                   value={{
                     ...request,
-                    onUserActivatesSwitchAccount: toggleSwitchAccount,
                     isLoadingBalance: isLoadingAdditionalData,
                     address: account.address,
                     publicKey: account.stxPublicKey,

--- a/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.tsx
+++ b/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.tsx
@@ -32,7 +32,7 @@ import { ContractCallDetailsLayout } from '@app/features/rpc-transaction-request
 import { ContractDeployDetailsLayout } from '@app/features/rpc-transaction-request/stacks/contract-deploy/contract-deploy-details.layout';
 import { PostConditionsDetailsLayout } from '@app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
-import { SwitchAccountTrigger } from '@app/features/rpc-transaction-request/switch-account-trigger/switch-account-trigger';
+import { TransactionAccountSigner } from '@app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer';
 import { TransactionActionsWithSpend } from '@app/features/rpc-transaction-request/transaction-actions/transaction-actions-with-spend';
 import { useSignStacksTransaction } from '@app/store/transactions/transaction.hooks';
 
@@ -44,8 +44,7 @@ import {
 } from './rpc-stx-sign-transaction.utils';
 
 export function RpcStxSignTransaction() {
-  const { address, isLoadingBalance, onUserActivatesSwitchAccount, requestId, tabId } =
-    useStacksRpcTransactionRequestContext();
+  const { address, isLoadingBalance, requestId, tabId } = useStacksRpcTransactionRequestContext();
   const { availableBalance, isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
     useFeeEditorContext();
   const { nonce, onUserActivatesNonceEditor } = useNonceEditorContext();
@@ -115,12 +114,11 @@ export function RpcStxSignTransaction() {
     >
       {isTokenTransferPayload(unsignedTxForBroadcast.payload) ? (
         <>
-          <SwitchAccountTrigger
+          <TransactionAccountSigner
             address={<AccountStacksAddress />}
             availableBalance={availableBalance}
             fiatBalance={convertToFiatAmount(availableBalance)}
             isLoadingBalance={isLoadingBalance}
-            onSwitchAccount={onUserActivatesSwitchAccount}
           />
           <TransactionRecipientsLayout
             title="Stacks"

--- a/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.tsx
+++ b/src/app/pages/rpc-stx-sign-transaction/rpc-stx-sign-transaction.tsx
@@ -28,11 +28,11 @@ import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
 import { useNonceEditorContext } from '@app/features/nonce-editor/nonce-editor.context';
 import { RpcTransactionRequestLayout } from '@app/features/rpc-transaction-request/rpc-transaction-request.layout';
+import { SigningAccountCard } from '@app/features/rpc-transaction-request/signing-account-card/signing-account-card';
 import { ContractCallDetailsLayout } from '@app/features/rpc-transaction-request/stacks/contract-call/contract-call-details.layout';
 import { ContractDeployDetailsLayout } from '@app/features/rpc-transaction-request/stacks/contract-deploy/contract-deploy-details.layout';
 import { PostConditionsDetailsLayout } from '@app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
-import { TransactionAccountSigner } from '@app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer';
 import { TransactionActionsWithSpend } from '@app/features/rpc-transaction-request/transaction-actions/transaction-actions-with-spend';
 import { useSignStacksTransaction } from '@app/store/transactions/transaction.hooks';
 
@@ -98,6 +98,15 @@ export function RpcStxSignTransaction() {
     closeWindow();
   }
 
+  const signer = (
+    <SigningAccountCard
+      address={<AccountStacksAddress />}
+      availableBalance={availableBalance}
+      fiatBalance={convertToFiatAmount(availableBalance)}
+      isLoadingBalance={isLoadingBalance}
+    />
+  );
+
   return (
     <RpcTransactionRequestLayout
       title="Sign transaction"
@@ -114,12 +123,7 @@ export function RpcStxSignTransaction() {
     >
       {isTokenTransferPayload(unsignedTxForBroadcast.payload) ? (
         <>
-          <TransactionAccountSigner
-            address={<AccountStacksAddress />}
-            availableBalance={availableBalance}
-            fiatBalance={convertToFiatAmount(availableBalance)}
-            isLoadingBalance={isLoadingBalance}
-          />
+          {signer}
           <TransactionRecipientsLayout
             title="Stacks"
             caption="Stacks blockchain"
@@ -136,10 +140,13 @@ export function RpcStxSignTransaction() {
           />
         </>
       ) : (
-        <PostConditionsDetailsLayout
-          postConditions={unsignedTxForBroadcast.postConditions.values}
-          postConditionMode={unsignedTxForBroadcast.postConditionMode}
-        />
+        <>
+          <PostConditionsDetailsLayout
+            postConditions={unsignedTxForBroadcast.postConditions.values}
+            postConditionMode={unsignedTxForBroadcast.postConditionMode}
+          />
+          {signer}
+        </>
       )}
       {isContractCallPayload(unsignedTxForBroadcast.payload) && (
         <ContractCallDetailsLayout

--- a/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft-container.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft-container.tsx
@@ -6,7 +6,6 @@ import { isDefined } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { getTxSenderAddress } from '@app/common/transactions/stacks/transaction.utils';
 import { StacksNonceLoader } from '@app/components/loaders/stacks-nonce-loader';
 import { StxBalanceLoader } from '@app/components/loaders/stx-balance-loader';
@@ -32,7 +31,6 @@ export function RpcStxTransferSip10FtContainer({ account }: RpcStxTransferSip10F
   const request = useRpcTransactionRequest();
   const network = useCurrentStacksNetworkState();
   const stxMarketData = useCryptoCurrencyMarketDataMeanAverage('STX');
-  const { toggleSwitchAccount } = useSwitchAccountSheet();
   const navigate = useNavigate();
 
   const rpcRequest = useMemo(() => getDecodedRpcStxTransferSip10FtRequest(), []);

--- a/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft-container.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft-container.tsx
@@ -78,7 +78,6 @@ export function RpcStxTransferSip10FtContainer({ account }: RpcStxTransferSip10F
                 <StacksRpcTransactionRequestProvider
                   value={{
                     ...request,
-                    onUserActivatesSwitchAccount: toggleSwitchAccount,
                     isLoadingBalance: isLoadingAdditionalData,
                     address: account.address,
                     publicKey: account.stxPublicKey,

--- a/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip10-ft/rpc-stx-transfer-sip10-ft.tsx
@@ -7,11 +7,14 @@ import {
 } from '@leather.io/stacks';
 import { createMoneyFromDecimal } from '@leather.io/utils';
 
+import { useConvertCryptoCurrencyToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
+import { AccountStacksAddress } from '@app/components/account/account-stacks-address';
 import { FeeEditor } from '@app/features/fee-editor/fee-editor';
 import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context';
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
 import { useNonceEditorContext } from '@app/features/nonce-editor/nonce-editor.context';
 import { RpcTransactionRequestLayout } from '@app/features/rpc-transaction-request/rpc-transaction-request.layout';
+import { SigningAccountCard } from '@app/features/rpc-transaction-request/signing-account-card/signing-account-card';
 import { ContractCallDetailsLayout } from '@app/features/rpc-transaction-request/stacks/contract-call/contract-call-details.layout';
 import { PostConditionsDetailsLayout } from '@app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
@@ -25,9 +28,10 @@ import {
 
 export function RpcStxTransferSip10Ft() {
   const { address, isLoadingBalance, network, publicKey } = useStacksRpcTransactionRequestContext();
-  const { isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
+  const { availableBalance, isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
     useFeeEditorContext();
   const { nonce, onUserActivatesNonceEditor } = useNonceEditorContext();
+  const convertToFiatAmount = useConvertCryptoCurrencyToFiatAmount('STX');
   const signAndBroadcastTransaction = useSignAndBroadcastStacksTransaction(
     stxTransferSip10Ft.method
   );
@@ -68,6 +72,12 @@ export function RpcStxTransferSip10Ft() {
           ensurePostConditionWireFormat(pc)
         )}
         postConditionMode={txOptionsForBroadcast.postConditionMode}
+      />
+      <SigningAccountCard
+        address={<AccountStacksAddress />}
+        availableBalance={availableBalance}
+        fiatBalance={convertToFiatAmount(availableBalance)}
+        isLoadingBalance={isLoadingBalance}
       />
       <ContractCallDetailsLayout
         contractAddress={txOptionsForBroadcast.contractAddress}

--- a/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft-container.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft-container.tsx
@@ -78,7 +78,6 @@ export function RpcStxTransferSip9NftContainer({ account }: RpcStxTransferSip9Nf
                 <StacksRpcTransactionRequestProvider
                   value={{
                     ...request,
-                    onUserActivatesSwitchAccount: toggleSwitchAccount,
                     isLoadingBalance: isLoadingAdditionalData,
                     address: account.address,
                     publicKey: account.stxPublicKey,

--- a/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft-container.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft-container.tsx
@@ -6,7 +6,6 @@ import { isDefined } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { getTxSenderAddress } from '@app/common/transactions/stacks/transaction.utils';
 import { StacksNonceLoader } from '@app/components/loaders/stacks-nonce-loader';
 import { StxBalanceLoader } from '@app/components/loaders/stx-balance-loader';
@@ -32,7 +31,6 @@ export function RpcStxTransferSip9NftContainer({ account }: RpcStxTransferSip9Nf
   const request = useRpcTransactionRequest();
   const network = useCurrentStacksNetworkState();
   const stxMarketData = useCryptoCurrencyMarketDataMeanAverage('STX');
-  const { toggleSwitchAccount } = useSwitchAccountSheet();
   const navigate = useNavigate();
 
   const rpcRequest = useMemo(() => getDecodedRpcStxTransferSip9NftRequest(), []);

--- a/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.tsx
+++ b/src/app/pages/rpc-stx-transfer-sip9-nft/rpc-stx-transfer-sip9-nft.tsx
@@ -7,11 +7,14 @@ import {
 } from '@leather.io/stacks';
 import { createMoney } from '@leather.io/utils';
 
+import { useConvertCryptoCurrencyToFiatAmount } from '@app/common/hooks/use-convert-to-fiat-amount';
+import { AccountStacksAddress } from '@app/components/account/account-stacks-address';
 import { FeeEditor } from '@app/features/fee-editor/fee-editor';
 import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context';
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
 import { useNonceEditorContext } from '@app/features/nonce-editor/nonce-editor.context';
 import { RpcTransactionRequestLayout } from '@app/features/rpc-transaction-request/rpc-transaction-request.layout';
+import { SigningAccountCard } from '@app/features/rpc-transaction-request/signing-account-card/signing-account-card';
 import { ContractCallDetailsLayout } from '@app/features/rpc-transaction-request/stacks/contract-call/contract-call-details.layout';
 import { PostConditionsDetailsLayout } from '@app/features/rpc-transaction-request/stacks/post-conditions/post-conditions-details.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
@@ -22,9 +25,10 @@ import { getUnsignedStacksContractCallOptions } from './rpc-stx-transfer-sip9-nf
 
 export function RpcStxTransferSip9Nft() {
   const { address, isLoadingBalance, network, publicKey } = useStacksRpcTransactionRequestContext();
-  const { isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
+  const { availableBalance, isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
     useFeeEditorContext();
   const { nonce, onUserActivatesNonceEditor } = useNonceEditorContext();
+  const convertToFiatAmount = useConvertCryptoCurrencyToFiatAmount('STX');
   const signAndBroadcastTransaction = useSignAndBroadcastStacksTransaction(
     stxTransferSip9Nft.method
   );
@@ -59,6 +63,12 @@ export function RpcStxTransferSip9Nft() {
         />
       }
     >
+      <SigningAccountCard
+        address={<AccountStacksAddress />}
+        availableBalance={availableBalance}
+        fiatBalance={convertToFiatAmount(availableBalance)}
+        isLoadingBalance={isLoadingBalance}
+      />
       <PostConditionsDetailsLayout
         postConditions={(txOptionsForBroadcast.postConditions ?? []).map(pc =>
           ensurePostConditionWireFormat(pc)

--- a/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx-container.tsx
+++ b/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx-container.tsx
@@ -77,7 +77,6 @@ export function RpcStxTransferStxContainer({ account }: RpcStxTransferStxContain
                 <StacksRpcTransactionRequestProvider
                   value={{
                     ...request,
-                    onUserActivatesSwitchAccount: toggleSwitchAccount,
                     isLoadingBalance: isLoadingAdditionalData,
                     address: account.address,
                     publicKey: account.stxPublicKey,

--- a/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx-container.tsx
+++ b/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx-container.tsx
@@ -6,7 +6,6 @@ import { isDefined } from '@leather.io/utils';
 
 import { RouteUrls } from '@shared/route-urls';
 
-import { useSwitchAccountSheet } from '@app/common/switch-account/use-switch-account-sheet-context';
 import { getTxSenderAddress } from '@app/common/transactions/stacks/transaction.utils';
 import { StacksNonceLoader } from '@app/components/loaders/stacks-nonce-loader';
 import { StxBalanceLoader } from '@app/components/loaders/stx-balance-loader';
@@ -32,7 +31,7 @@ export function RpcStxTransferStxContainer({ account }: RpcStxTransferStxContain
   const request = useRpcTransactionRequest();
   const network = useCurrentStacksNetworkState();
   const stxMarketData = useCryptoCurrencyMarketDataMeanAverage('STX');
-  const { toggleSwitchAccount } = useSwitchAccountSheet();
+
   const navigate = useNavigate();
 
   const rpcRequest = useMemo(() => getDecodedRpcStxTransferStxRequest(), []);

--- a/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx.tsx
+++ b/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx.tsx
@@ -15,14 +15,13 @@ import { useNonceEditorContext } from '@app/features/nonce-editor/nonce-editor.c
 import { RpcTransactionRequestLayout } from '@app/features/rpc-transaction-request/rpc-transaction-request.layout';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
-import { SwitchAccountTrigger } from '@app/features/rpc-transaction-request/switch-account-trigger/switch-account-trigger';
+import { TransactionAccountSigner } from '@app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer';
 import { TransactionActionsWithSpend } from '@app/features/rpc-transaction-request/transaction-actions/transaction-actions-with-spend';
 
 import { getUnsignedStacksTokenTransferOptions } from './rpc-stx-transfer-stx.utils';
 
 export function RpcStxTransferStx() {
-  const { isLoadingBalance, network, publicKey, onUserActivatesSwitchAccount } =
-    useStacksRpcTransactionRequestContext();
+  const { isLoadingBalance, network, publicKey } = useStacksRpcTransactionRequestContext();
   const { availableBalance, isLoadingFees, marketData, onUserActivatesFeeEditor, selectedFee } =
     useFeeEditorContext();
   const { nonce, onUserActivatesNonceEditor } = useNonceEditorContext();
@@ -58,12 +57,11 @@ export function RpcStxTransferStx() {
         />
       }
     >
-      <SwitchAccountTrigger
+      <TransactionAccountSigner
         address={<AccountStacksAddress />}
         availableBalance={availableBalance}
         fiatBalance={convertToFiatAmount(availableBalance)}
         isLoadingBalance={isLoadingBalance}
-        onSwitchAccount={onUserActivatesSwitchAccount}
       />
       <TransactionRecipientsLayout
         title="Stacks"

--- a/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx.tsx
+++ b/src/app/pages/rpc-stx-transfer-stx/rpc-stx-transfer-stx.tsx
@@ -13,9 +13,9 @@ import { useFeeEditorContext } from '@app/features/fee-editor/fee-editor.context
 import { NonceEditor } from '@app/features/nonce-editor/nonce-editor';
 import { useNonceEditorContext } from '@app/features/nonce-editor/nonce-editor.context';
 import { RpcTransactionRequestLayout } from '@app/features/rpc-transaction-request/rpc-transaction-request.layout';
+import { SigningAccountCard } from '@app/features/rpc-transaction-request/signing-account-card/signing-account-card';
 import { useStacksRpcTransactionRequestContext } from '@app/features/rpc-transaction-request/stacks/stacks-rpc-transaction-request.context';
 import { useSignAndBroadcastStacksTransaction } from '@app/features/rpc-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction';
-import { TransactionAccountSigner } from '@app/features/rpc-transaction-request/transaction-account-signer/transaction-account-signer';
 import { TransactionActionsWithSpend } from '@app/features/rpc-transaction-request/transaction-actions/transaction-actions-with-spend';
 
 import { getUnsignedStacksTokenTransferOptions } from './rpc-stx-transfer-stx.utils';
@@ -57,7 +57,7 @@ export function RpcStxTransferStx() {
         />
       }
     >
-      <TransactionAccountSigner
+      <SigningAccountCard
         address={<AccountStacksAddress />}
         availableBalance={availableBalance}
         fiatBalance={convertToFiatAmount(availableBalance)}

--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -64,7 +64,7 @@ export function AccountCard({
         <Link
           _before={{ bg: 'transparent' }}
           _hover={{ color: 'ink.action-primary-hover' }}
-          data-testid={SettingsSelectors.TransactionAccountSigner}
+          data-testid={SettingsSelectors.SigningAccountCard}
           onClick={toggleSwitchAccount}
           variant="text"
           maxWidth="fit-content"

--- a/src/app/ui/components/account/account.card.tsx
+++ b/src/app/ui/components/account/account.card.tsx
@@ -64,7 +64,7 @@ export function AccountCard({
         <Link
           _before={{ bg: 'transparent' }}
           _hover={{ color: 'ink.action-primary-hover' }}
-          data-testid={SettingsSelectors.SwitchAccountTrigger}
+          data-testid={SettingsSelectors.TransactionAccountSigner}
           onClick={toggleSwitchAccount}
           variant="text"
           maxWidth="fit-content"

--- a/tests/page-object-models/home.page.ts
+++ b/tests/page-object-models/home.page.ts
@@ -146,7 +146,7 @@ export class HomePage {
   }
 
   async switchAccount(accountIndex: number) {
-    await this.page.getByTestId(SettingsSelectors.SwitchAccountTrigger).click();
+    await this.page.getByTestId(SettingsSelectors.TransactionAccountSigner).click();
     await this.page.getByTestId(`switch-account-item-${accountIndex}`).click();
   }
 }

--- a/tests/page-object-models/home.page.ts
+++ b/tests/page-object-models/home.page.ts
@@ -146,7 +146,7 @@ export class HomePage {
   }
 
   async switchAccount(accountIndex: number) {
-    await this.page.getByTestId(SettingsSelectors.TransactionAccountSigner).click();
+    await this.page.getByTestId(SettingsSelectors.SigningAccountCard).click();
     await this.page.getByTestId(`switch-account-item-${accountIndex}`).click();
   }
 }

--- a/tests/selectors/settings.selectors.ts
+++ b/tests/selectors/settings.selectors.ts
@@ -21,7 +21,7 @@ export enum SettingsSelectors {
   ShowSecretKeyBtn = 'show-secret-key-btn',
   GetSupportMenuItem = 'get-support-menu-item',
   SettingsMenuBtn = 'settings-menu-trigger',
-  SwitchAccountTrigger = 'switch-account-trigger',
+  TransactionAccountSigner = 'switch-account-trigger',
   SwitchAccountMenuItem = 'switch-account-menu-item',
   SwitchAccountItemIndex = 'switch-account-item-[index]',
   OpenWalletInNewTab = 'open-wallet-in-new-tab',

--- a/tests/selectors/settings.selectors.ts
+++ b/tests/selectors/settings.selectors.ts
@@ -21,7 +21,7 @@ export enum SettingsSelectors {
   ShowSecretKeyBtn = 'show-secret-key-btn',
   GetSupportMenuItem = 'get-support-menu-item',
   SettingsMenuBtn = 'settings-menu-trigger',
-  TransactionAccountSigner = 'switch-account-trigger',
+  SigningAccountCard = 'switch-account-trigger',
   SwitchAccountMenuItem = 'switch-account-menu-item',
   SwitchAccountItemIndex = 'switch-account-item-[index]',
   OpenWalletInNewTab = 'open-wallet-in-new-tab',


### PR DESCRIPTION
> Try out Leather build 346435d — [Extension build](https://github.com/leather-io/extension/actions/runs/15303574585), [Test report](https://leather-io.github.io/playwright-reports/refactor/rpc-requests-account-signer), [Storybook](https://refactor/rpc-requests-account-signer--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=refactor/rpc-requests-account-signer)<!-- Sticky Header Marker -->

This PR adds the account signer to all SIP-30 requests using Approver UX so that a user can see which account is signing the transaction.

<img width="406" alt="Screenshot 2025-05-27 at 8 42 28 PM" src="https://github.com/user-attachments/assets/e717a807-bb8b-4434-a4e0-5af1dee14e3b" />

I will tackle the design updates here:
https://linear.app/leather-io/issue/LEA-2678/update-all-requests-with-signing-account