### PR TITLE
fix: wrong prop passed to migration fn

### DIFF
--- a/src/shared/crypto/mnemonic-encryption.ts
+++ b/src/shared/crypto/mnemonic-encryption.ts
@@ -56,7 +56,7 @@ export async function decryptMnemonic({
       secretKey,
       encryptedSecretKey: newEncryptedKey.encryptedSecretKey,
       salt: newEncryptedKey.salt,
-      encryptionKey: newEncryptedKey.encryptedSecretKey,
+      encryptionKey: newEncryptedKey.encryptionKey,
     };
   }
 }


### PR DESCRIPTION
> Try out Leather build 1547e61 — [Extension build](https://github.com/leather-io/extension/actions/runs/15732347494), [Test report](https://leather-io.github.io/playwright-reports/fix/bug-with-legacy-key-migration), [Storybook](https://fix/bug-with-legacy-key-migration--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/bug-with-legacy-key-migration)<!-- Sticky Header Marker -->

Fixes wrong prop being passed to migration fn