### PR TITLE
fix: swaps with undefined route

### DIFF
--- a/src/app/pages/swap/components/swap-asset-select/components/swap-amount-field.tsx
+++ b/src/app/pages/swap/components/swap-asset-select/components/swap-amount-field.tsx
@@ -54,8 +54,12 @@ export function SwapAmountField<T extends BaseSwapContext<T>>({
     onSetIsFetchingExchangeRate(true);
     const toAmount = await fetchQuoteAmount(swapAssetBase, swapAssetQuote, value);
     onSetIsFetchingExchangeRate(false);
+    if (isUndefined(toAmount)) {
+      await setFieldValue('swapAmountQuote', undefined);
+      return;
+    }
     const valueLengthAsDecimals = value.length - 1;
-    if (isUndefined(toAmount) || valueLengthAsDecimals > swapAssetBase.balance.decimals) {
+    if (valueLengthAsDecimals > swapAssetBase.balance.decimals) {
       await setFieldValue('swapAmountQuote', '');
       return;
     }

--- a/src/app/pages/swap/components/swap-asset-select/components/swap-toggle-button.tsx
+++ b/src/app/pages/swap/components/swap-asset-select/components/swap-toggle-button.tsx
@@ -37,7 +37,7 @@ export function SwapToggleButton<T extends BaseSwapContext<T>>() {
       const quoteAmount = await fetchQuoteAmount(prevAssetQuote, prevAssetBase, prevAmountQuote);
       onSetIsFetchingExchangeRate(false);
       if (isUndefined(quoteAmount)) {
-        void setFieldValue('swapAmountQuote', '');
+        void setFieldValue('swapAmountQuote', undefined);
         return;
       }
       void setFieldValue('swapAmountQuote', Number(quoteAmount));
@@ -59,7 +59,11 @@ export function SwapToggleButton<T extends BaseSwapContext<T>>() {
   return (
     <styled.button
       alignSelf="flex-start"
-      disabled={isUndefined(values.swapAssetQuote) || isFetchingExchangeRate}
+      disabled={
+        isUndefined(values.swapAssetQuote) ||
+        isUndefined(values.swapAmountQuote) ||
+        isFetchingExchangeRate
+      }
       onClick={onToggleSwapAssets}
       type="button"
     >

--- a/src/app/pages/swap/components/swap-asset-select/swap-asset-select-base.tsx
+++ b/src/app/pages/swap/components/swap-asset-select/swap-asset-select-base.tsx
@@ -56,7 +56,7 @@ export function SwapAssetSelectBase<T extends BaseSwapContext<T>>() {
     if (isUndefined(swapAssetQuote)) return;
     const toAmount = await fetchQuoteAmount(swapAssetBase, swapAssetQuote, formattedBalance);
     if (isUndefined(toAmount)) {
-      await setFieldValue('swapAmountQuote', '');
+      await setFieldValue('swapAmountQuote', undefined);
       return;
     }
     const toAmountAsMoney = createMoney(

--- a/src/app/pages/swap/components/swap-asset-select/swap-asset-select-quote.tsx
+++ b/src/app/pages/swap/components/swap-asset-select/swap-asset-select-quote.tsx
@@ -19,7 +19,7 @@ import { SwapAssetSelectLayout } from './components/swap-asset-select.layout';
 
 export function SwapAssetSelectQuote<T extends BaseSwapContext<T>>() {
   const { isCrossChainSwap, isFetchingExchangeRate } = useSwapContext<T>();
-  const [amountField] = useField('swapAmountQuote');
+  const [amountField, amountFieldMeta] = useField('swapAmountQuote');
   const [assetField] = useField('swapAssetQuote');
   const swapNavigate = useSwapNavigate();
 
@@ -34,9 +34,11 @@ export function SwapAssetSelectQuote<T extends BaseSwapContext<T>>() {
   return (
     <SwapAssetSelectLayout
       caption="You have"
+      error={amountFieldMeta.error}
       icon={assetField.value?.icon}
       name="swapAmountQuote"
       onSelectAsset={() => swapNavigate(RouteUrls.SwapAssetSelectQuote)}
+      showError={!!amountFieldMeta.error}
       showToggle={!isCrossChainSwap}
       swapAmountInput={
         isFetchingExchangeRate ? (

--- a/src/app/pages/swap/form/use-swap-form.tsx
+++ b/src/app/pages/swap/form/use-swap-form.tsx
@@ -9,6 +9,7 @@ import {
   convertAmountToBaseUnit,
   convertAmountToFractionalUnit,
   createMoney,
+  isDefined,
   isUndefined,
 } from '@leather.io/utils';
 
@@ -161,7 +162,14 @@ export function useSwapForm<T extends BaseSwapContext<T>>() {
       .positive(FormErrorMessages.MustBePositive),
     swapAmountQuote: yup
       .number()
-      .required(FormErrorMessages.AmountRequired)
+      .test({
+        message: 'No route found',
+        test(value) {
+          const { swapAmountBase } = this.parent;
+          if (isDefined(swapAmountBase) && isUndefined(value)) return false;
+          return true;
+        },
+      })
       .typeError(FormErrorMessages.MustBeNumber)
       .positive(FormErrorMessages.MustBePositive),
   });

--- a/tests/mocks/mock-stacks-bns.ts
+++ b/tests/mocks/mock-stacks-bns.ts
@@ -60,3 +60,29 @@ export function mockBnsV2ZoneFileLookup(page: Page) {
       route.fulfill({ json: createSuccessfulBnsV2ZoneFileLookupMockResponse(owner, btcAddress) })
     );
 }
+
+export function mockBnsV2NameLookup(page: Page) {
+  return function ({ name, fullName, owner }: { name: string; fullName: string; owner: string }) {
+    return page.route(`**/api.bnsv2.com/names/${fullName}`, route =>
+      route.fulfill({
+        json: {
+          current_burn_block: 900937,
+          status: 'active',
+          data: {
+            name_string: name,
+            namespace_string: 'btc',
+            full_name: fullName,
+            owner,
+            registered_at: '17467',
+            renewal_height: '1125982',
+            stx_burn: '0',
+            revoked: false,
+            imported_at: 'none',
+            preordered_by: 'none',
+            is_valid: true,
+          },
+        },
+      })
+    );
+  };
+}

--- a/tests/page-object-models/swap.page.ts
+++ b/tests/page-object-models/swap.page.ts
@@ -33,7 +33,7 @@ export class SwapPage {
     const swapAssetSelectors = await this.page.locator(this.selectAssetBtn).all();
     await swapAssetSelectors[1].click();
     await this.page.locator(this.chooseAssetList).waitFor();
-    await this.page.locator('text="ALEX"').click();
+    await this.page.locator('text="USDA"').click();
   }
 
   async inputSwapAmountBase() {

--- a/tests/specs/send/send-stx.spec.ts
+++ b/tests/specs/send/send-stx.spec.ts
@@ -4,7 +4,7 @@ import {
   TEST_BNS_RESOLVED_ADDRESS,
   TEST_TESTNET_ACCOUNT_2_STX_ADDRESS,
 } from '@tests/mocks/constants';
-import { mockBnsV2ZoneFileLookup } from '@tests/mocks/mock-stacks-bns';
+import { mockBnsV2NameLookup, mockBnsV2ZoneFileLookup } from '@tests/mocks/mock-stacks-bns';
 import { SendCryptoAssetSelectors } from '@tests/selectors/send.selectors';
 import { SharedComponentsSelectors } from '@tests/selectors/shared-component.selectors';
 import { getDisplayerAddress } from '@tests/utils';
@@ -212,6 +212,11 @@ test.describe('send stx: tests on mainnet', () => {
         name: TEST_BNS_NAME,
         owner: TEST_BNS_RESOLVED_ADDRESS,
         btcAddress: 'unused-btc-address',
+      });
+      await mockBnsV2NameLookup(sendPage.page)({
+        name: TEST_BNS_NAME.replace('.btc', ''),
+        fullName: TEST_BNS_NAME,
+        owner: TEST_BNS_RESOLVED_ADDRESS,
       });
       await sendPage.amountInput.fill('.0001');
       await sendPage.amountInput.blur();

--- a/tests/specs/swap/swap.spec.ts
+++ b/tests/specs/swap/swap.spec.ts
@@ -29,8 +29,9 @@ test.describe('Swaps', () => {
     const swapAssets = await swapPage.swapDetailsSymbol.all();
     const swapAssetBase = await swapAssets[0].innerText();
     const swapAssetQuote = await swapAssets[1].innerText();
+
     test.expect(swapAssetBase).toEqual('STX');
-    test.expect(swapAssetQuote).toEqual('ALEX');
+    test.expect(swapAssetQuote).toEqual('USDA');
 
     const swapAmounts = await swapPage.swapDetailsAmount.all();
     const swapAmountBase = await swapAmounts[0].innerText();


### PR DESCRIPTION
> Try out Leather build 2539d54 — [Extension build](https://github.com/leather-io/extension/actions/runs/15711446257), [Test report](https://leather-io.github.io/playwright-reports/fix/alex-swaps), [Storybook](https://fix/alex-swaps--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/alex-swaps)<!-- Sticky Header Marker -->

This should fix failing swap tests which used the ALEX token, and I've added feedback in the UI for when the `bestRoute` is `undefined` from bitflow...

![Screenshot 2025-06-17 at 10 36 52 AM](https://github.com/user-attachments/assets/8311db66-8024-4cca-92ef-6822e01a2263)
