### PR TITLE
ci: dont comment for new stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
           days-before-issue-stale: 60
           days-before-issue-close: 14
           stale-issue-label: 'stale'
-          stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity.'
+          stale-issue-message: ''
           close-issue-message: 'This issue was closed because it has been inactive for 14 days since being marked as stale.'
           days-before-pr-stale: -1
           days-before-pr-close: -1


### PR DESCRIPTION
> Try out Leather build 17b4122 — [Extension build](https://github.com/leather-io/extension/actions/runs/15817177148), [Test report](https://leather-io.github.io/playwright-reports/ci/stop-stale-comments), [Storybook](https://ci/stop-stale-comments--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci/stop-stale-comments)<!-- Sticky Header Marker -->

This should prevent stalebot comments on newly-found stale issues.

Honestly, I find this tool counterproductive. It's purpose is to trim irrelevant issues to focus on what's important, but instead it surfaces them to me with regular github notifications about old issues, cobra effect.