### PR TITLE
fix: open swap request double popup

### DIFF
--- a/src/background/messaging/rpc-methods/open-swap.ts
+++ b/src/background/messaging/rpc-methods/open-swap.ts
@@ -24,15 +24,15 @@ export const openSwapHandler = defineRpcRequestHandler(openSwap.method, async (r
       }).replace('{chain}', 'bitcoin'),
       urlParams
     );
+  } else {
+    await triggerSwapWindowOpen(
+      replaceRouteParams(RouteUrls.Swap, {
+        base: base,
+        quote: quote ?? '',
+      }).replace('{chain}', 'stacks'),
+      urlParams
+    );
   }
-
-  await triggerSwapWindowOpen(
-    replaceRouteParams(RouteUrls.Swap, {
-      base: base,
-      quote: quote ?? '',
-    }).replace('{chain}', 'stacks'),
-    urlParams
-  );
 
   void trackRpcRequestSuccess({ endpoint: request.method });
 


### PR DESCRIPTION
> Try out Leather build c4b9125 — [Extension build](https://github.com/leather-io/extension/actions/runs/16175642387), [Test report](https://leather-io.github.io/playwright-reports/fix/open-swap-request), [Storybook](https://fix/open-swap-request--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/open-swap-request)<!-- Sticky Header Marker -->

In testing work on: https://github.com/leather-io/mono/pull/1251 I noticed a double popup for base as 'BTC' with `openSwap`.