### PR TITLE
fix: webpack dev server

### DIFF
--- a/webpack/dev-server.js
+++ b/webpack/dev-server.js
@@ -33,7 +33,9 @@ const compiler = webpack(config);
 
 const server = new WebpackDevServer(
   {
-    https: false,
+    server: {
+      type: 'http',
+    },
     webSocketServer: 'ws',
     // Disabled as web configure manually above
     hot: false,


### PR DESCRIPTION
> Try out Leather build 7b7c572 — [Extension build](https://github.com/leather-io/extension/actions/runs/16294912907), [Test report](https://leather-io.github.io/playwright-reports/fix/webpack-dev-server), [Storybook](https://fix/webpack-dev-server--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/webpack-dev-server)<!-- Sticky Header Marker -->

@pete-watters I think this is needed from some changes you made while I was out? I made them locally on the working branch, but prob should get them committed for others. Local dev won't build w/out this fix, but just wanting to confirm w/ you this seems correct? I saw you changed to this in the test-app.