### PR TITLE
ci: ignore dependabot in all-checks

### DIFF
--- a/.github/workflows/all-checks-pass.yml
+++ b/.github/workflows/all-checks-pass.yml
@@ -18,3 +18,5 @@ jobs:
 
     steps:
       - uses: wechuli/allcheckspassed@v1
+        with:
+          checks_exclude: 'Dependabot'


### PR DESCRIPTION
> Try out Leather build e5175b3 — [Extension build](https://github.com/leather-io/extension/actions/runs/16292943744), [Test report](https://leather-io.github.io/playwright-reports/ci/all-checks-ignore-dbot), [Storybook](https://ci/all-checks-ignore-dbot--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=ci/all-checks-ignore-dbot)<!-- Sticky Header Marker -->

For some reason the all checks job is failing because of dependabot, even though there's no visible action fail