### PR TITLE
refactor: use UI library input in the password field

### DIFF
--- a/src/app/components/request-password.tsx
+++ b/src/app/components/request-password.tsx
@@ -1,10 +1,10 @@
-import { FormEvent, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 import { Box, Stack, styled } from 'leather-styles/jsx';
 
-import { Button, Link, Logo } from '@leather.io/ui';
+import { Button, Input, Link, Logo } from '@leather.io/ui';
 
 import { RouteUrls } from '@shared/route-urls';
 import { analytics } from '@shared/utils/analytics';
@@ -85,28 +85,22 @@ export function RequestPassword({ onSuccess, showForgotPassword = false }: Reque
         <Stack gap="space.05" px="space.05" minHeight="330px">
           <styled.h3 textStyle="heading.03">Enter your password</styled.h3>
           <styled.p textStyle="label.02">{(isRunning && waitingMessage) || caption}</styled.p>
-          <styled.input
-            _focus={{ border: 'focus' }}
-            autoCapitalize="off"
-            autoComplete="off"
-            autoFocus
-            border="active"
-            borderRadius="sm"
-            data-testid={SettingsSelectors.EnterPasswordInput}
-            height="inputHeight"
-            onChange={(e: FormEvent<HTMLInputElement>) => {
-              setError('');
-              setPassword(e.currentTarget.value);
-            }}
-            onKeyUp={buildEnterKeyEvent(submit)}
-            p="space.04"
-            placeholder="Enter your password"
-            ring="none"
-            type="password"
-            textStyle="body.02"
-            value={password}
-            width="100%"
-          />
+          <Input.Root>
+            <Input.Label>Enter your password</Input.Label>
+            <Input.Field
+              autoFocus
+              autoCapitalize="off"
+              autoComplete="off"
+              type="password"
+              data-testid={SettingsSelectors.EnterPasswordInput}
+              value={password}
+              onChange={event => {
+                setError('');
+                setPassword(event.currentTarget.value);
+              }}
+              onKeyUp={buildEnterKeyEvent(submit)}
+            />
+          </Input.Root>
           {showForgotPassword && (
             <Link width="fit-content" onClick={() => navigate(RouteUrls.ForgotPassword)}>
               Forgot password?


### PR DESCRIPTION
> Try out Leather build 50916ca — [Extension build](https://github.com/leather-io/extension/actions/runs/16412358131), [Test report](https://leather-io.github.io/playwright-reports/fix/password-input-border), [Storybook](https://fix/password-input-border--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/password-input-border)<!-- Sticky Header Marker -->

Noticed the password input was missing the border. Apparently this was a pre UI library implementation, and the border was lost somewhere along the way (perhaps breaking changes in Panda). 
This replaces the field with the one from our library.

### Before
<img width="1788" height="1252" alt="image" src="https://github.com/user-attachments/assets/42cdfaa0-624c-4dbc-9792-8932306c7793" />

### After
<img width="874" height="612" alt="image" src="https://github.com/user-attachments/assets/22d4d522-1a48-4b27-8179-e11c9af7eca8" />
<img width="890" height="638" alt="image" src="https://github.com/user-attachments/assets/b594b84c-e8fe-4746-a63a-7ada573865e6" />
