### PR TITLE
feat: only display valid pairs in swaps UI

### DIFF
--- a/src/app/pages/swap/components/swap-asset-sheet/components/swap-asset-list.tsx
+++ b/src/app/pages/swap/components/swap-asset-sheet/components/swap-asset-list.tsx
@@ -2,6 +2,7 @@ import { SwapSelectors } from '@tests/selectors/swap.selectors';
 import { Stack } from 'leather-styles/jsx';
 
 import type { SwapAsset } from '@app/query/common/alex-sdk/alex-sdk.hooks';
+import { LoadingSpinner } from '@app/components/loading-spinner';
 
 import { SwapAssetItem } from './swap-asset-item';
 import { useSwapAssetList } from './use-swap-asset-list';
@@ -11,10 +12,24 @@ export interface SwapAssetListProps {
   type: string;
 }
 export function SwapAssetList({ assets, type }: SwapAssetListProps) {
-  const { selectableAssets, onSelectAsset } = useSwapAssetList({ assets, type });
+  const { selectableAssets, onSelectAsset, isValidPairsLoading, isValidPairsError } = useSwapAssetList({ assets, type });
+
+  if (isValidPairsLoading) {
+    return (
+      <Stack mb="space.05" p="space.05" width="100%" alignItems="center" justifyContent="center" minHeight="100px">
+        <LoadingSpinner />
+      </Stack>
+    );
+  }
 
   return (
     <Stack mb="space.05" p="space.05" width="100%" data-testid={SwapSelectors.SwapAssetList}>
+      {/* Show error message if valid pairs query failed, but still show assets (graceful degradation) */}
+      {isValidPairsError && (
+        <Stack fontSize="sm" color="yellow.600" p="space.02" mb="space.02">
+          Valid pairs filtering unavailable - showing all assets
+        </Stack>
+      )}
       {selectableAssets.map((asset, idx) => (
         <SwapAssetItem
           asset={asset}

--- a/src/app/pages/swap/hooks/use-bitflow-valid-pairs.tsx
+++ b/src/app/pages/swap/hooks/use-bitflow-valid-pairs.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { logger } from '@shared/logger';
+import { bitflow } from '@shared/utils/bitflow-sdk';
+
+import type { SwapAsset } from '@app/query/common/alex-sdk/alex-sdk.hooks';
+
+interface ValidPairsCache {
+  [tokenId: string]: string[];
+}
+
+const validPairsQueryKey = ['bitflow', 'valid-pairs'] as const;
+
+async function fetchValidPairs(tokens: SwapAsset[]): Promise<ValidPairsCache> {
+  const validPairsCache: ValidPairsCache = {};
+
+  await Promise.allSettled(
+    tokens.map(async token => {
+      try {
+        if (!token.tokenId) return;
+
+        const possibleTokens = await bitflow.getAllPossibleTokenY(token.tokenId);
+        if (Array.isArray(possibleTokens)) {
+          validPairsCache[token.tokenId] = possibleTokens;
+        }
+      } catch (error) {
+        logger.error(`Failed to fetch valid pairs for token ${token.tokenId}:`, error);
+        validPairsCache[token.tokenId] = [];
+      }
+    })
+  );
+
+  return validPairsCache;
+}
+
+interface UseBitflowValidPairsOptions {
+  enabled?: boolean;
+}
+
+export function useBitflowValidPairs(
+  availableTokens: SwapAsset[] = [],
+  options: UseBitflowValidPairsOptions = {}
+) {
+  const { enabled = true } = options;
+
+  const query = useQuery({
+    queryKey: [...validPairsQueryKey, availableTokens.length],
+    queryFn: () => fetchValidPairs(availableTokens),
+    enabled: enabled && availableTokens.length > 0,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+    retry: (failureCount, error) => {
+      logger.warn(`Bitflow valid pairs query failed (attempt ${failureCount}):`, error);
+      return failureCount < 2;
+    },
+  });
+
+  const validPairsLookup = useMemo(() => {
+    return query.data || {};
+  }, [query.data]);
+
+  const getValidQuoteTokensForBase = useMemo(() => {
+    return (baseTokenId: string): string[] => {
+      return validPairsLookup[baseTokenId] || [];
+    };
+  }, [validPairsLookup]);
+
+  const getValidBaseTokensForQuote = useMemo(() => {
+    return (quoteTokenId: string): string[] => {
+      return Object.keys(validPairsLookup).filter(baseTokenId =>
+        validPairsLookup[baseTokenId]?.includes(quoteTokenId)
+      );
+    };
+  }, [validPairsLookup]);
+
+  const isValidPair = useMemo(() => {
+    return (baseTokenId?: string, quoteTokenId?: string): boolean => {
+      if (!baseTokenId || !quoteTokenId) return false;
+
+      const validQuoteTokens = validPairsLookup[baseTokenId];
+      return Array.isArray(validQuoteTokens) && validQuoteTokens.includes(quoteTokenId);
+    };
+  }, [validPairsLookup]);
+
+  const filterValidAssets = useMemo(() => {
+    return (
+      assets: SwapAsset[],
+      selectedTokenId?: string,
+      filterType: 'base' | 'quote' = 'quote'
+    ): SwapAsset[] => {
+      if (!selectedTokenId || query.isError || query.isLoading || !query.data) {
+        logger.debug('Bitflow valid pairs: falling back to all assets', {
+          selectedTokenId,
+          isError: query.isError,
+          isLoading: query.isLoading,
+          hasData: !!query.data,
+        });
+        return assets;
+      }
+
+      let validTokenIds: string[];
+
+      if (filterType === 'quote') {
+        validTokenIds = getValidQuoteTokensForBase(selectedTokenId);
+      } else {
+        validTokenIds = getValidBaseTokensForQuote(selectedTokenId);
+      }
+
+      if (validTokenIds.length === 0) {
+        logger.debug('Bitflow valid pairs: no valid pairs found, showing all assets', {
+          selectedTokenId,
+          filterType,
+        });
+        return assets;
+      }
+
+      const filteredAssets = assets.filter(
+        asset => asset.tokenId && validTokenIds.includes(asset.tokenId)
+      );
+
+      logger.debug('Bitflow valid pairs: filtered assets', {
+        selectedTokenId,
+        filterType,
+        originalCount: assets.length,
+        filteredCount: filteredAssets.length,
+        validTokenIds,
+      });
+
+      return filteredAssets;
+    };
+  }, [
+    query.isError,
+    query.isLoading,
+    query.data,
+    getValidQuoteTokensForBase,
+    getValidBaseTokensForQuote,
+  ]);
+
+  return {
+    validPairsCache: validPairsLookup,
+    getValidQuoteTokensForBase,
+    getValidBaseTokensForQuote,
+    isValidPair,
+    filterValidAssets,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+  };
+}


### PR DESCRIPTION
> Try out Leather build 1aa39fd — [Extension build](https://github.com/leather-io/extension/actions/runs/16603843166), [Test report](https://leather-io.github.io/playwright-reports/feat/bitflow-valid-pairs-filter), [Storybook](https://feat/bitflow-valid-pairs-filter--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/bitflow-valid-pairs-filter)<!-- Sticky Header Marker -->

@fbwoolf / @kyranjamie need some good eyes on this - it's working but I have done way more testing and work in the mobile arena. 

The intention here is to omit any irrelevant tokens when a user has a base token selected - still a draft and will try to finish it tomorrow. 