### PR TITLE
fix: ledger contract deploy details, closes LEA-3045

### DIFF
--- a/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
+++ b/src/app/features/ledger/flows/bitcoin-tx-signing/ledger-bitcoin-sign-tx-container.tsx
@@ -74,24 +74,24 @@ function LedgerSignBitcoinTxContainer() {
       connectApp: connectLedgerBitcoinApp(network.chain.bitcoin.mode),
       async signTransactionWithDevice(bitcoinApp) {
         if (!inputsToSign) {
-          ledgerNavigate.cancelLedgerAction();
+          void ledgerNavigate.cancelLedgerAction();
           toast.error('No input signing config defined');
           return;
         }
 
-        ledgerNavigate.toDeviceBusyStep('Verifying public key on Ledger…');
+        void ledgerNavigate.toDeviceBusyStep('Verifying public key on Ledger…');
 
-        ledgerNavigate.toConnectionSuccessStep('bitcoin');
+        void ledgerNavigate.toConnectionSuccessStep('bitcoin');
         await delay(1200);
         if (!unsignedTransaction) throw new Error('No unsigned tx');
 
-        ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: false });
+        void ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: false });
 
         try {
           const btcTx = await signLedger(bitcoinApp, unsignedTransaction.toPSBT(), inputsToSign);
 
           if (!btcTx || !unsignedTransactionRaw) throw new Error('No tx returned');
-          ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: true });
+          void ledgerNavigate.toAwaitingDeviceOperation({ hasApprovedOperation: true });
           await delay(1200);
           appEvents.publish('ledgerBitcoinTxSigned', {
             signedPsbt: btcTx,
@@ -100,7 +100,7 @@ function LedgerSignBitcoinTxContainer() {
         } catch (e) {
           logger.error('Unable to sign tx with ledger', e);
           ledgerAnalytics.transactionSignedOnLedgerRejected();
-          ledgerNavigate.toOperationRejectedStep();
+          void ledgerNavigate.toOperationRejectedStep();
         } finally {
           void bitcoinApp.transport.close();
         }
@@ -111,7 +111,7 @@ function LedgerSignBitcoinTxContainer() {
     appEvents.publish('ledgerBitcoinTxSigningCancelled', {
       unsignedPsbt: unsignedTransaction ? bytesToHex(unsignedTransaction.toPSBT()) : '',
     });
-    ledgerNavigate.cancelLedgerAction();
+    void ledgerNavigate.cancelLedgerAction();
   }
 
   const ledgerContextValue: LedgerTxSigningContext = {

--- a/src/app/features/ledger/flows/stacks-tx-signing/steps/approve-sign-stacks-ledger-tx.tsx
+++ b/src/app/features/ledger/flows/stacks-tx-signing/steps/approve-sign-stacks-ledger-tx.tsx
@@ -62,6 +62,23 @@ export function ApproveSignLedgerStacksTx() {
         .map(cv => cvToString(cv))
         .map((value, index) => [`Argument ${index + 0}`, value]);
 
+    if (
+      transaction.payload.payloadType === PayloadType.SmartContract ||
+      transaction.payload.payloadType === PayloadType.VersionedSmartContract
+    ) {
+      return [
+        ['Contract address', currentAccount?.address ?? ''],
+        ['Contract name', transaction.payload.contractName.content],
+        ['Contract code', transaction.payload.codeBody.content],
+        ['Nonce', String(transaction.auth.spendingCondition.nonce)],
+        [
+          'Fee (µSTX)',
+          String(transaction.auth.spendingCondition.fee),
+          formatTooltipLabel(transaction.auth.spendingCondition.fee),
+        ],
+      ];
+    }
+
     return [];
   }, [chain, currentAccount?.address, transaction]);
 

--- a/src/app/features/ledger/generic-flows/tx-signing/use-ledger-sign-tx.ts
+++ b/src/app/features/ledger/generic-flows/tx-signing/use-ledger-sign-tx.ts
@@ -61,7 +61,7 @@ export function useLedgerSignTx<App extends StacksApp | BitcoinApp>({
       app = await connectApp();
       await checkCorrectAppIsOpenWithFailState(app);
       setAwaitingDeviceConnection(false);
-      ledgerNavigate.toConnectionSuccessStep(chain);
+      void ledgerNavigate.toConnectionSuccessStep(chain);
       await delay(1250);
       await signTransactionWithDevice(app);
       onSuccess?.();
@@ -72,7 +72,7 @@ export function useLedgerSignTx<App extends StacksApp | BitcoinApp>({
         return;
       }
 
-      ledgerNavigate.toErrorStep(chain);
+      return ledgerNavigate.toErrorStep(chain);
     } finally {
       await app?.transport.close();
     }

--- a/src/app/features/ledger/hooks/use-verify-matching-stacks-public-key.ts
+++ b/src/app/features/ledger/hooks/use-verify-matching-stacks-public-key.ts
@@ -16,7 +16,7 @@ export function useVerifyMatchingLedgerStacksPublicKey() {
       if (!account) return;
       const { publicKey } = await requestPublicKeyForStxAccount(stacksApp)(account.index);
       if (publicKey.toString('hex') !== account.stxPublicKey) {
-        ledgerNavigate.toPublicKeyMismatchStep();
+        void ledgerNavigate.toPublicKeyMismatchStep();
         throw new Error('Mismatching public keys');
       }
     },

--- a/src/app/features/rpc-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction.ts
+++ b/src/app/features/rpc-transaction-request/stacks/use-sign-and-broadcast-stacks-transaction.ts
@@ -86,7 +86,7 @@ export function useSignAndBroadcastStacksTransaction(method: RpcMethodNames) {
           })
         );
 
-        navigate(RouteUrls.BroadcastError, { state: { message } });
+        return navigate(RouteUrls.BroadcastError, { state: { message } });
       }
 
       async function onSuccess(txid: string, transaction: StacksTransactionWire) {

--- a/src/app/features/stacks-transaction-request/hooks/use-legacy-stacks-broadcast-transaction.tsx
+++ b/src/app/features/stacks-transaction-request/hooks/use-legacy-stacks-broadcast-transaction.tsx
@@ -71,7 +71,7 @@ export function useStacksBroadcastTransaction({
         });
       }
       if (txId) {
-        navigate(
+        void navigate(
           RouteUrls.SentStxTxSummary.replace(':symbol', token.toLowerCase()).replace(
             ':txId',
             `${txId}`
@@ -97,11 +97,11 @@ export function useStacksBroadcastTransaction({
           return await broadcastTransactionFn({
             onError(e: Error | string) {
               const message = isString(e) ? e : e.message;
-              navigate(RouteUrls.TransactionBroadcastError, { state: { message } });
+              return navigate(RouteUrls.TransactionBroadcastError, { state: { message } });
             },
             onSuccess(txId) {
               if (showSummaryPage) return handlePreviewSuccess(signedTx, txId);
-              navigate(RouteUrls.Activity);
+              void navigate(RouteUrls.Activity);
               if (isCancelTransaction) return toast.success('Transaction cancelled successfully');
               if (isIncreaseFeeTransaction) return toast.success('Fee increased successfully');
               return;
@@ -110,7 +110,7 @@ export function useStacksBroadcastTransaction({
           })(signedTx);
         }
       } catch (e) {
-        navigate(RouteUrls.TransactionBroadcastError, {
+        return navigate(RouteUrls.TransactionBroadcastError, {
           state: { message: isError(e) ? e.message : 'Unknown error' },
         });
       } finally {

--- a/src/app/pages/transaction-request/transaction-request.tsx
+++ b/src/app/pages/transaction-request/transaction-request.tsx
@@ -99,8 +99,9 @@ function TransactionRequestBase() {
           signedSponsoredTx
         );
         if (!result.txid) {
-          navigate(RouteUrls.TransactionBroadcastError, { state: { message: result.error } });
-          return;
+          return navigate(RouteUrls.TransactionBroadcastError, {
+            state: { message: result.error },
+          });
         }
         if (requestToken && tabId) {
           finalizeTxSignature({
@@ -114,7 +115,7 @@ function TransactionRequestBase() {
         }
       } catch (e: any) {
         const message = isString(e) ? e : e.message;
-        navigate(RouteUrls.TransactionBroadcastError, { state: { message } });
+        return navigate(RouteUrls.TransactionBroadcastError, { state: { message } });
       }
     } else {
       const unsignedTx = await generateUnsignedTx(values);

--- a/src/app/store/transactions/transaction.hooks.ts
+++ b/src/app/store/transactions/transaction.hooks.ts
@@ -131,7 +131,7 @@ export function useSignStacksTransaction() {
     whenWallet({
       async ledger(tx: StacksTransactionWire) {
         const serializedTx = tx.serialize();
-        ledgerNavigate.toConnectAndSignStacksTransactionStep(serializedTx);
+        void ledgerNavigate.toConnectAndSignStacksTransactionStep(serializedTx);
         return listenForStacksTxLedgerSigning(serializedTx);
       },
       async software(tx: StacksTransactionWire) {


### PR DESCRIPTION
> Try out Leather build 3980137 — [Extension build](https://github.com/leather-io/extension/actions/runs/16778664652), [Test report](https://leather-io.github.io/playwright-reports/fix/ledger-contract-deploy), [Storybook](https://fix/ledger-contract-deploy--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/ledger-contract-deploy)<!-- Sticky Header Marker -->

This PR fixes missing information when signing a contract deploy on Ledger...

<img width="403" height="772" alt="Screenshot 2025-07-24 at 2 51 33 PM" src="https://github.com/user-attachments/assets/44d96fc2-945a-45de-8a27-8a7b84380655" />

*Note: I still hit this error in the explorer bc we default to Clarity version 3 if not passed, which appears unsupported by Ledger?...

<img width="413" height="779" alt="Screenshot 2025-07-24 at 12 56 58 PM" src="https://github.com/user-attachments/assets/1765de0e-3aa2-4338-b05a-9382e4f94a76" />
