### PR TITLE
feat: install leather services package, closes LEA-3080

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@leather.io/provider": "1.5.1",
     "@leather.io/query": "2.41.0",
     "@leather.io/rpc": "2.20.0",
+    "@leather.io/services": "1.25.0",
     "@leather.io/stacks": "1.14.0",
     "@leather.io/tokens": "0.23.0",
     "@leather.io/ui": "1.77.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 0.7.0(encoding@0.1.13)
       '@coinbase/cbpay-js':
         specifier: 2.1.0
-        version: 2.1.0(regenerator-runtime@0.14.1)
+        version: 2.1.0(regenerator-runtime@0.13.11)
       '@fungible-systems/zone-file':
         specifier: 2.0.0
         version: 2.0.0
@@ -75,6 +75,9 @@ importers:
       '@leather.io/rpc':
         specifier: 2.20.0
         version: 2.20.0(encoding@0.1.13)
+      '@leather.io/services':
+        specifier: 1.25.0
+        version: 1.25.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(encoding@0.1.13)
       '@leather.io/stacks':
         specifier: 1.14.0
         version: 1.14.0(encoding@0.1.13)
@@ -83,7 +86,7 @@ importers:
         version: 0.23.0
       '@leather.io/ui':
         specifier: 1.77.0
-        version: 1.77.0(@babel/core@7.26.10)(@emotion/is-prop-valid@1.3.1)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(@vue/compiler-sfc@3.5.18)(graphql@16.11.0)
+        version: 1.77.0(@babel/core@7.26.10)(@emotion/is-prop-valid@1.3.1)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(@vue/compiler-sfc@3.5.16)(graphql@16.11.0)
       '@leather.io/utils':
         specifier: 0.40.0
         version: 0.40.0
@@ -417,13 +420,13 @@ importers:
         version: 3.2.2(react@19.0.0)(storybook@8.4.4(prettier@3.3.3))
       '@leather.io/eslint-config':
         specifier: 0.10.0
-        version: 0.10.0(eslint-config-prettier@10.1.8(eslint@8.56.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.56.0))(eslint-plugin-react@7.34.1(eslint@8.56.0))(eslint@8.56.0)(globals@16.3.0)(typescript-eslint@8.38.0(eslint@8.56.0)(typescript@5.4.5))
+        version: 0.10.0(eslint-config-prettier@10.1.5(eslint@8.56.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.56.0))(eslint-plugin-react@7.34.1(eslint@8.56.0))(eslint@8.56.0)(globals@13.24.0)(typescript-eslint@8.34.1(eslint@8.56.0)(typescript@5.4.5))
       '@leather.io/panda-preset':
         specifier: 0.12.9
         version: 0.12.9(jsdom@26.1.0)(typescript@5.4.5)
       '@leather.io/prettier-config':
         specifier: 0.6.1
-        version: 0.6.1(@vue/compiler-sfc@3.5.18)
+        version: 0.6.1(@vue/compiler-sfc@3.5.16)
       '@ls-lint/ls-lint':
         specifier: 2.2.3
         version: 2.2.3
@@ -567,7 +570,7 @@ importers:
         version: 7.5.0(eslint@8.56.0)(typescript@5.4.5)
       '@vitest/coverage-istanbul':
         specifier: 2.0.5
-        version: 2.0.5(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
+        version: 2.0.5(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0))
       audit-ci:
         specifier: 6.6.1
         version: 6.6.1
@@ -696,16 +699,16 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0)
       vm-browserify:
         specifier: 1.1.2
         version: 1.1.2
       web-ext:
         specifier: 7.8.0
-        version: 7.8.0(body-parser@2.2.0)
+        version: 7.8.0(body-parser@1.20.3)
       web-ext-submit:
         specifier: 7.8.0
-        version: 7.8.0(body-parser@2.2.0)
+        version: 7.8.0(body-parser@1.20.3)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(@swc/core@1.11.21)(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.94.0))
@@ -853,16 +856,12 @@ packages:
     resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.0':
-    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
+  '@babel/compat-data@7.27.5':
+    resolution: {integrity: sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.10':
     resolution: {integrity: sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.28.0':
-    resolution: {integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.17.7':
@@ -875,10 +874,6 @@ packages:
 
   '@babel/generator@7.27.5':
     resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.28.0':
-    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.25.9':
@@ -926,21 +921,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
-  '@babel/helper-define-polyfill-provider@0.6.5':
-    resolution: {integrity: sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
   '@babel/helper-environment-visitor@7.24.7':
     resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-function-name@7.24.7':
     resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-hoist-variables@7.24.7':
@@ -1067,10 +1053,6 @@ packages:
     resolution: {integrity: sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.2':
-    resolution: {integrity: sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/highlight@7.25.9':
     resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
     engines: {node: '>=6.9.0'}
@@ -1082,11 +1064,6 @@ packages:
 
   '@babel/parser@7.27.5':
     resolution: {integrity: sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.28.0':
-    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1120,14 +1097,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-proposal-decorators@7.28.0':
-    resolution: {integrity: sha512-zOiZqvANjWDUaUS9xMxbMcK/Zccztbe/6ikvUXaG9nsPH3w6qh5UaPGAnirI/WhIbZ8m3OHU0ReyPrknG+ZKeg==}
+  '@babel/plugin-proposal-decorators@7.25.9':
+    resolution: {integrity: sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-proposal-export-default-from@7.27.1':
-    resolution: {integrity: sha512-hjlsMBl1aJc5lp8MoCDEZCiYzlgdRAShOjAfRw6X+GlpLpUPU7c3XNLsKFZbQk/1cRzBlJ7CXg3xJAJMrFa1Uw==}
+  '@babel/plugin-proposal-export-default-from@7.25.9':
+    resolution: {integrity: sha512-ykqgwNfSnNOB+C8fV5X4mG3AVmvu+WVxcaU9xHHtBb7PCrPeweMmPjGsn8eMaeJg6SJuoUuZENeeSWaarWqonQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1159,8 +1136,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-decorators@7.27.1':
-    resolution: {integrity: sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==}
+  '@babel/plugin-syntax-decorators@7.25.9':
+    resolution: {integrity: sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1170,14 +1147,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-export-default-from@7.27.1':
-    resolution: {integrity: sha512-eBC/3KSekshx19+N40MzjWqJd7KTEdOoLesAfa4IDFI8eRz5a47i5Oszus6zG/cwIXN63YhgLOMSSNJx49sENg==}
+  '@babel/plugin-syntax-export-default-from@7.25.9':
+    resolution: {integrity: sha512-9MhJ/SMTsVqsd69GyQg89lYR4o9T+oDGv5F6IsigxxqFVOyR/IflDLYP8WDI1l8fkhNGGktqkvL5qwNCtGEpgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-flow@7.27.1':
-    resolution: {integrity: sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==}
+  '@babel/plugin-syntax-flow@7.26.0':
+    resolution: {integrity: sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1212,12 +1189,6 @@ packages:
 
   '@babel/plugin-syntax-jsx@7.25.9':
     resolution: {integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-jsx@7.27.1':
-    resolution: {integrity: sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1270,12 +1241,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-typescript@7.27.1':
-    resolution: {integrity: sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
@@ -1300,8 +1265,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0':
-    resolution: {integrity: sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==}
+  '@babel/plugin-transform-async-generator-functions@7.27.1':
+    resolution: {integrity: sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1330,8 +1295,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-block-scoping@7.28.0':
-    resolution: {integrity: sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==}
+  '@babel/plugin-transform-block-scoping@7.27.5':
+    resolution: {integrity: sha512-JF6uE2s67f0y2RZcm2kpAUEbD50vH62TyWVebxwHAlbSdM49VqPz8t4a1uIjp4NIOIZ4xzLfjY5emt/RCyC7TQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1360,8 +1325,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-classes@7.28.0':
-    resolution: {integrity: sha512-IjM1IoJNw72AZFlj33Cu8X0q2XK/6AaVC3jQu+cgQ5lThWD5ajnuUAml80dqRmOhmPkTH8uAwnpMu9Rvj0LTRA==}
+  '@babel/plugin-transform-classes@7.27.1':
+    resolution: {integrity: sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1384,8 +1349,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-destructuring@7.28.0':
-    resolution: {integrity: sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==}
+  '@babel/plugin-transform-destructuring@7.27.3':
+    resolution: {integrity: sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1432,8 +1397,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1':
-    resolution: {integrity: sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==}
+  '@babel/plugin-transform-flow-strip-types@7.26.5':
+    resolution: {integrity: sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1576,8 +1541,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-object-rest-spread@7.28.0':
-    resolution: {integrity: sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==}
+  '@babel/plugin-transform-object-rest-spread@7.27.3':
+    resolution: {integrity: sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1618,8 +1583,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-parameters@7.27.7':
-    resolution: {integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==}
+  '@babel/plugin-transform-parameters@7.27.1':
+    resolution: {integrity: sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1666,32 +1631,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-display-name@7.28.0':
-    resolution: {integrity: sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-jsx-development@7.25.9':
     resolution: {integrity: sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1':
-    resolution: {integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==}
+  '@babel/plugin-transform-react-jsx-self@7.25.9':
+    resolution: {integrity: sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+  '@babel/plugin-transform-react-jsx-source@7.25.9':
+    resolution: {integrity: sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1702,20 +1655,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx@7.27.1':
-    resolution: {integrity: sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-pure-annotations@7.25.9':
     resolution: {integrity: sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-pure-annotations@7.27.1':
-    resolution: {integrity: sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1726,8 +1667,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regenerator@7.28.1':
-    resolution: {integrity: sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==}
+  '@babel/plugin-transform-regenerator@7.27.5':
+    resolution: {integrity: sha512-uhB8yHerfe3MWnuLAhEbeQ4afVoqv8BQsPqrTv7e/jZ9y00kJL6l9a/f4OWaKxotmjzewfEyXE1vgDJenkQ2/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1744,8 +1685,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-runtime@7.28.0':
-    resolution: {integrity: sha512-dGopk9nZrtCs2+nfIem25UuHyt5moSJamArzIoh9/vezUQPmYDOzjaHDCkAzuGJibCIkPup8rMT2+wYB6S73cA==}
+  '@babel/plugin-transform-runtime@7.26.10':
+    resolution: {integrity: sha512-NWaL2qG6HRpONTnj4JvDU6th4jYeZOJgu3QhmFTCihib0ermtOJqktA5BduGm3suhhVe9EMP9c9+mfJ/I9slqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1810,12 +1751,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-typescript@7.28.0':
-    resolution: {integrity: sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-unicode-escapes@7.25.9':
     resolution: {integrity: sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==}
     engines: {node: '>=6.9.0'}
@@ -1863,20 +1798,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/preset-react@7.27.1':
-    resolution: {integrity: sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/preset-typescript@7.27.0':
     resolution: {integrity: sha512-vxaPFfJtHhgeOVXRKuHpHPAOgymmy8V8I65T1q53R7GCZlefKeCaTyDs3zOPHTTbmquvNlQYC5klEvWsBAtrBQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/preset-typescript@7.27.1':
-    resolution: {integrity: sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1887,10 +1810,6 @@ packages:
 
   '@babel/runtime@7.27.0':
     resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.28.2':
-    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.0':
@@ -1913,10 +1832,6 @@ packages:
     resolution: {integrity: sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.0':
-    resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.17.0':
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
     engines: {node: '>=6.9.0'}
@@ -1927,10 +1842,6 @@ packages:
 
   '@babel/types@7.27.6':
     resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.2':
-    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@bitcoinerlab/descriptors@1.1.1':
@@ -3108,46 +3019,43 @@ packages:
   '@expo/config-plugins@10.0.3':
     resolution: {integrity: sha512-fjCckkde67pSDf48x7wRuPsgQVIqlDwN7NlOk9/DFgQ1hCH0L5pGqoSmikA1vtAyiA83MOTpkGl3F3wyATyUog==}
 
-  '@expo/config-plugins@10.1.2':
-    resolution: {integrity: sha512-IMYCxBOcnuFStuK0Ay+FzEIBKrwW8OVUMc65+v0+i7YFIIe8aL342l7T4F8lR4oCfhXn7d6M5QPgXvjtc/gAcw==}
+  '@expo/config-types@53.0.4':
+    resolution: {integrity: sha512-0s+9vFx83WIToEr0Iwy4CcmiUXa5BgwBmEjylBB2eojX5XAMm9mJvw9KpjAb8m7zq2G0Q6bRbeufkzgbipuNQg==}
 
-  '@expo/config-types@53.0.5':
-    resolution: {integrity: sha512-kqZ0w44E+HEGBjy+Lpyn0BVL5UANg/tmNixxaRMLS6nf37YsDrLk2VMAmeKMMk5CKG0NmOdVv3ngeUjRQMsy9g==}
-
-  '@expo/config@11.0.13':
-    resolution: {integrity: sha512-TnGb4u/zUZetpav9sx/3fWK71oCPaOjZHoVED9NaEncktAd0Eonhq5NUghiJmkUGt3gGSjRAEBXiBbbY9/B1LA==}
+  '@expo/config@11.0.10':
+    resolution: {integrity: sha512-8S8Krr/c5lnl0eF03tA2UGY9rGBhZcbWKz2UWw5dpL/+zstwUmog8oyuuC8aRcn7GiTQLlbBkxcMeT8sOGlhbA==}
 
   '@expo/devcert@1.2.0':
     resolution: {integrity: sha512-Uilcv3xGELD5t/b0eM4cxBFEKQRIivB3v7i+VhWLV/gL98aw810unLKKJbGAxAIhY6Ipyz8ChWibFsKFXYwstA==}
 
-  '@expo/env@1.0.7':
-    resolution: {integrity: sha512-qSTEnwvuYJ3umapO9XJtrb1fAqiPlmUUg78N0IZXXGwQRt+bkp0OBls+Y5Mxw/Owj8waAM0Z3huKKskRADR5ow==}
+  '@expo/env@1.0.5':
+    resolution: {integrity: sha512-dtEZ4CAMaVrFu2+tezhU3FoGWtbzQl50xV+rNJE5lYVRjUflWiZkVHlHkWUlPAwDPifLy4TuissVfScGGPWR5g==}
 
   '@expo/fingerprint@0.12.4':
     resolution: {integrity: sha512-HOJVvjiQYVHIouCOfFf4JRrQvBDIV/12GVG2iwbw1iGwmpQVkPgEXa9lN0f2yuS4J3QXHs73wr9jvuCjMmJlfw==}
     hasBin: true
 
-  '@expo/image-utils@0.7.6':
-    resolution: {integrity: sha512-GKnMqC79+mo/1AFrmAcUcGfbsXXTRqOMNS1umebuevl3aaw+ztsYEFEiuNhHZW7PQ3Xs3URNT513ZxKhznDscw==}
+  '@expo/image-utils@0.7.4':
+    resolution: {integrity: sha512-LcZ82EJy/t/a1avwIboeZbO6hlw8CvsIRh2k6SWPcAOvW0RqynyKFzUJsvnjWlhUzfBEn4oI7y/Pu5Xkw3KkkA==}
 
-  '@expo/json-file@9.1.5':
-    resolution: {integrity: sha512-prWBhLUlmcQtvN6Y7BpW2k9zXGd3ySa3R6rAguMJkp1z22nunLN64KYTUWfijFlprFoxm9r2VNnGkcbndAlgKA==}
+  '@expo/json-file@9.1.4':
+    resolution: {integrity: sha512-7Bv86X27fPERGhw8aJEZvRcH9sk+9BenDnEmrI3ZpywKodYSBgc8lX9Y32faNVQ/p0YbDK9zdJ0BfAKNAOyi0A==}
 
   '@expo/metro-config@0.20.14':
     resolution: {integrity: sha512-tYDDubuZycK+NX00XN7BMu73kBur/evOPcKfxc+UBeFfgN2EifOITtdwSUDdRsbtJ2OnXwMY1HfRUG3Lq3l4cw==}
 
-  '@expo/osascript@2.2.5':
-    resolution: {integrity: sha512-Bpp/n5rZ0UmpBOnl7Li3LtM7la0AR3H9NNesqL+ytW5UiqV/TbonYW3rDZY38u4u/lG7TnYflVIVQPD+iqZJ5w==}
+  '@expo/osascript@2.2.4':
+    resolution: {integrity: sha512-Q+Oyj+1pdRiHHpev9YjqfMZzByFH8UhKvSszxa0acTveijjDhQgWrq4e9T/cchBHi0GWZpGczWyiyJkk1wM1dg==}
     engines: {node: '>=12'}
 
-  '@expo/package-manager@1.8.6':
-    resolution: {integrity: sha512-gcdICLuL+nHKZagPIDC5tX8UoDDB8vNA5/+SaQEqz8D+T2C4KrEJc2Vi1gPAlDnKif834QS6YluHWyxjk0yZlQ==}
+  '@expo/package-manager@1.8.4':
+    resolution: {integrity: sha512-8H8tLga/NS3iS7QaX/NneRPqbObnHvVCfMCo0ShudreOFmvmgqhYjRlkZTRstSyFqefai8ONaT4VmnLHneRYYg==}
 
-  '@expo/plist@0.3.5':
-    resolution: {integrity: sha512-9RYVU1iGyCJ7vWfg3e7c/NVyMFs8wbl+dMWZphtFtsqyN9zppGREU3ctlD3i8KUE0sCUTVnLjCWr+VeUIDep2g==}
+  '@expo/plist@0.3.4':
+    resolution: {integrity: sha512-MhBLaUJNe9FQDDU2xhSNS4SAolr6K2wuyi4+A79vYuXLkAoICsbTwcGEQJN5jPY6D9izO/jsXh5k0h+mIWQMdw==}
 
-  '@expo/prebuild-config@9.0.11':
-    resolution: {integrity: sha512-0DsxhhixRbCCvmYskBTq8czsU0YOBsntYURhWPNpkl0IPVpeP9haE5W4OwtHGzXEbmHdzaoDwNmVcWjS/mqbDw==}
+  '@expo/prebuild-config@9.0.7':
+    resolution: {integrity: sha512-1w5MBp6NdF51gPGp0HsCZt0QC82hZWo37wI9HfxhdQF/sN/92Mh4t30vaY7gjHe71T5QNyab00oxZH/wP0MDgQ==}
 
   '@expo/sdk-runtime-versions@1.0.0':
     resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
@@ -3271,6 +3179,25 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@inversifyjs/common@1.5.0':
+    resolution: {integrity: sha512-Qj5BELk11AfI2rgZEAaLPmOftmQRLLmoCXgAjmaF0IngQN5vHomVT5ML7DZ3+CA5fgGcEVMcGbUDAun+Rz+oNg==}
+
+  '@inversifyjs/container@1.5.4':
+    resolution: {integrity: sha512-mHAaWjAQb8m6TJksm5EJXW/kPcZFVEc1UKkWv5OnLbwbU0QvxM2UbEsuXzusGVHcrNY4TQp9Uh2wkRY6TN2WJg==}
+    peerDependencies:
+      reflect-metadata: ~0.2.2
+
+  '@inversifyjs/core@5.0.0':
+    resolution: {integrity: sha512-axOl+VZFGVA3nAMbs6RuHhQ8HvgO6/tKjlWJk4Nt0rUqed+1ksak4p5yZNtown1Kdm0GV2Oc57qLqqWd943hgA==}
+
+  '@inversifyjs/prototype-utils@0.1.0':
+    resolution: {integrity: sha512-lNz1yyajMRDXBHLvJsYYX81FcmeD15e5Qz1zAZ/3zeYTl+u7ZF/GxNRKJzNOloeMPMtuR8BnvzHA1SZxjR+J9w==}
+
+  '@inversifyjs/reflect-metadata-utils@1.1.0':
+    resolution: {integrity: sha512-jmuAuC3eL1GnFAYfJGJOMKRDL9q1mgzOyrban6zxfM8Yg1FUHsj25h27bW2G7p8X1Amvhg3MLkaOuogszkrofA==}
+    peerDependencies:
+      reflect-metadata: 0.2.2
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -3319,9 +3246,6 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jridgewell/gen-mapping@0.3.12':
-    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
-
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -3334,23 +3258,14 @@ packages:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/source-map@0.3.10':
-    resolution: {integrity: sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==}
-
   '@jridgewell/source-map@0.3.6':
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
-  '@jridgewell/sourcemap-codec@1.5.4':
-    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
-
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
-
-  '@jridgewell/trace-mapping@0.3.29':
-    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -3397,6 +3312,9 @@ packages:
 
   '@leather.io/rpc@2.20.0':
     resolution: {integrity: sha512-mlfmXLXeU/OjjrcCSykAOmocNyUGOQPwEuH8DDBTs8sCk9cZmYX9EFMo4LWMx/QB30qhYpyDJ6QrIlUfwVDyiw==}
+
+  '@leather.io/services@1.25.0':
+    resolution: {integrity: sha512-+z6ABn6yKPdiU2SWmOTL/BMJ+OQhkCzAR/aRCtBLJ+xB5QQGNesllnNhvvp3P/humjwLijtrIlLaHTPruW0YMA==}
 
   '@leather.io/stacks@1.14.0':
     resolution: {integrity: sha512-UVYkyN5dHZWqM9bZdwMfkrPb3q0mWmcTY5rH2avElSFsl97gXYkUZD7x+Uu2+w/P8W11hstIwwt6CC2+Q8EoNg==}
@@ -4734,41 +4652,41 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@react-native-community/cli-clean@19.1.1':
-    resolution: {integrity: sha512-pP7SmK+PNw5B1Aa2c6y06FBNc9iGah/leFFM2uewpyZRJQ4zycX6Zz1UANpq9YZfp65n7NZKV9Gct2uaVRuP/Q==}
+  '@react-native-community/cli-clean@13.6.6':
+    resolution: {integrity: sha512-cBwJTwl0NyeA4nyMxbhkWZhxtILYkbU3TW3k8AXLg+iGphe0zikYMGB3T+haTvTc6alTyEFwPbimk9bGIqkjAQ==}
 
-  '@react-native-community/cli-config-android@19.1.1':
-    resolution: {integrity: sha512-uAUXU/BPuasBy7For5lvVEpxiwA29X5BWKjM4fgxWmsQhaZHW//6PNRep94w3WVnAp+CUbW6+o3SzFqMX0PdIw==}
+  '@react-native-community/cli-config@13.6.6':
+    resolution: {integrity: sha512-mbG425zCKr8JZhv/j11382arezwS/70juWMsn8j2lmrGTrP1cUdW0MF15CCIFtJsqyK3Qs+FTmqttRpq81QfSg==}
 
-  '@react-native-community/cli-config-apple@19.1.1':
-    resolution: {integrity: sha512-dKS7pg5eAEgRB8sOWYpr6XCR/3xUcttHNsuYYbuMXfY9d0M3d0oGquuMOW/p3Ri9sJI16bRAs/YIXDF2m4gYIA==}
+  '@react-native-community/cli-debugger-ui@13.6.6':
+    resolution: {integrity: sha512-Vv9u6eS4vKSDAvdhA0OiQHoA7y39fiPIgJ6biT32tN4avHDtxlc6TWZGiqv7g98SBvDWvoVAmdPLcRf3kU+c8g==}
 
-  '@react-native-community/cli-config@19.1.1':
-    resolution: {integrity: sha512-qGLYCFf3whCa/we3iKd5BY4RlcAUhSykwGpnJpjseXLaI5iJzIn/IMd70EBG8QvhV/KQxM7VFMQj6KgGcoNKYg==}
+  '@react-native-community/cli-doctor@13.6.6':
+    resolution: {integrity: sha512-TWZb5g6EmQe2Ua2TEWNmyaEayvlWH4GmdD9ZC+p8EpKFpB1NpDGMK6sXbpb42TDvwZg5s4TDRplK0PBEA/SVDg==}
 
-  '@react-native-community/cli-doctor@19.1.1':
-    resolution: {integrity: sha512-P6JgTpa8fn6SfGiotyRhiCqBlRlKx8MUUdMESPGyPzvMb8omz+Jv0ibdNg9CVT11/0x5oRsoGv07os/o+Eg0zQ==}
+  '@react-native-community/cli-hermes@13.6.6':
+    resolution: {integrity: sha512-La5Ie+NGaRl3klei6WxKoOxmCUSGGxpOk6vU5pEGf0/O7ky+Ay0io+zXYUZqlNMi/cGpO7ZUijakBYOB/uyuFg==}
 
-  '@react-native-community/cli-platform-android@19.1.1':
-    resolution: {integrity: sha512-omEAcIYz22Lxi/WjYHkNaUMEKV+o60PL3DJE6Wz3c4bkuDfxICJ8JcPawT4fDMsBX7DYwnYf6/Lk/leqQmHzOw==}
+  '@react-native-community/cli-platform-android@13.6.6':
+    resolution: {integrity: sha512-/tMwkBeNxh84syiSwNlYtmUz/Ppc+HfKtdopL/5RB+fd3SV1/5/NPNjMlyLNgFKnpxvKCInQ7dnl6jGHJjeHjg==}
 
-  '@react-native-community/cli-platform-apple@19.1.1':
-    resolution: {integrity: sha512-nsJ/TlQ97Lcmz5dVZVSwYYQzJmK6q/9X31VTAFhUf94ShugF3zXjaNnOJieKYDJlXy4G0EnrEulX1gTt29ebyw==}
+  '@react-native-community/cli-platform-apple@13.6.6':
+    resolution: {integrity: sha512-bOmSSwoqNNT3AmCRZXEMYKz1Jf1l2F86Nhs7qBcXdY/sGiJ+Flng564LOqvdAlVLTbkgz47KjNKCS2pP4Jg0Mg==}
 
-  '@react-native-community/cli-platform-ios@19.1.1':
-    resolution: {integrity: sha512-QHw/eBszq+62xUBorVqjgDYsVrZ5JAYJZkc6UKO327LnVn10OUB/bPGA/FzDWZdGB77pt0IalNP8nxyGOytMfg==}
+  '@react-native-community/cli-platform-ios@13.6.6':
+    resolution: {integrity: sha512-vjDnRwhlSN5ryqKTas6/DPkxuouuyFBAqAROH4FR1cspTbn6v78JTZKDmtQy9JMMo7N5vZj1kASU5vbFep9IOQ==}
 
-  '@react-native-community/cli-server-api@19.1.1':
-    resolution: {integrity: sha512-p0FFm82uPrtLZBWTD3bZ43mMBIV5mXwvGFYMcsfGiuMoS9SNbw4ImEFTG2IutVpr7Qb6NMjx6SbgYYMnTdZXmw==}
+  '@react-native-community/cli-server-api@13.6.6':
+    resolution: {integrity: sha512-ZtCXxoFlM7oDv3iZ3wsrT3SamhtUJuIkX2WePLPlN5bcbq7zimbPm2lHyicNJtpcGQ5ymsgpUWPCNZsWQhXBqQ==}
 
-  '@react-native-community/cli-tools@19.1.1':
-    resolution: {integrity: sha512-0yWOdrfgO7jVtYzhNcm9hTA1hqrD6haqDaesFq4d3YCmh8lkkTb61Q/kNIKQCUfaCTR/Qcc4mdwy6ObdXRoTIQ==}
+  '@react-native-community/cli-tools@13.6.6':
+    resolution: {integrity: sha512-ptOnn4AJczY5njvbdK91k4hcYazDnGtEPrqIwEI+k/CTBHNdb27Rsm2OZ7ye6f7otLBqF8gj/hK6QzJs8CEMgw==}
 
-  '@react-native-community/cli-types@19.1.1':
-    resolution: {integrity: sha512-rOGiYjeDM9tkYBEuK6TJrnxpMhmaId1Un8pjQJswz7W9w2Vb6+nnLfWja7X7VmDIvqIK5GhVobRHsmKCKIdDEA==}
+  '@react-native-community/cli-types@13.6.6':
+    resolution: {integrity: sha512-733iaYzlmvNK7XYbnWlMjdE+2k0hlTBJW071af/xb6Bs+hbJqBP9c03FZuYH2hFFwDDntwj05bkri/P7VgSxug==}
 
-  '@react-native-community/cli@19.1.1':
-    resolution: {integrity: sha512-H17sV83KPg2H2GCNuUSMM1ZM2sy6msVSmxrhJSycH8ua3i9Iixja8DeYtGIcJUzjdU/4U2eSDs6PjOSZUVn8CQ==}
+  '@react-native-community/cli@13.6.6':
+    resolution: {integrity: sha512-IqclB7VQ84ye8Fcs89HOpOscY4284VZg2pojHNl8H0Lzd4DadXJWQoxC7zWm8v2f8eyeX2kdhxp2ETD5tceIgA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4824,8 +4742,8 @@ packages:
   '@react-native/normalize-colors@0.79.2':
     resolution: {integrity: sha512-+b+GNrupWrWw1okHnEENz63j7NSMqhKeFMOyzYLBwKcprG8fqJQhDIGXfizKdxeIa5NnGSAevKL1Ev1zJ56X8w==}
 
-  '@react-native/normalize-colors@0.79.5':
-    resolution: {integrity: sha512-nGXMNMclZgzLUxijQQ38Dm3IAEhgxuySAWQHnljFtfB0JdaMwpe0Ox9H7Tp2OgrEA+EMEv+Od9ElKlHwGKmmvQ==}
+  '@react-native/normalize-colors@0.79.4':
+    resolution: {integrity: sha512-247/8pHghbYY2wKjJpUsY6ZNbWcdUa5j5517LZMn6pXrbSSgWuj3JA4OYibNnocCHBaVrt+3R8XC3VEJqLlHFg==}
 
   '@react-native/virtualized-lists@0.79.2':
     resolution: {integrity: sha512-9G6ROJeP+rdw9Bvr5ruOlag11ET7j1z/En1riFFNo6W3xZvJY+alCuH1ttm12y9+zBm4n8jwCk4lGhjYaV4dKw==}
@@ -6116,11 +6034,6 @@ packages:
   '@types/hoist-non-react-statics@3.3.6':
     resolution: {integrity: sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==}
 
-  '@types/hoist-non-react-statics@3.3.7':
-    resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
-    peerDependencies:
-      '@types/react': '*'
-
   '@types/html-minifier-terser@6.1.0':
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
 
@@ -6394,11 +6307,11 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/eslint-plugin@8.38.0':
-    resolution: {integrity: sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==}
+  '@typescript-eslint/eslint-plugin@8.34.1':
+    resolution: {integrity: sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.38.0
+      '@typescript-eslint/parser': ^8.34.1
       eslint: 8.56.0
       typescript: '>=4.8.4 <5.9.0'
 
@@ -6412,15 +6325,15 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.38.0':
-    resolution: {integrity: sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==}
+  '@typescript-eslint/parser@8.34.1':
+    resolution: {integrity: sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: 8.56.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/project-service@8.38.0':
-    resolution: {integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==}
+  '@typescript-eslint/project-service@8.34.1':
+    resolution: {integrity: sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
@@ -6437,12 +6350,12 @@ packages:
     resolution: {integrity: sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.38.0':
-    resolution: {integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==}
+  '@typescript-eslint/scope-manager@8.34.1':
+    resolution: {integrity: sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.38.0':
-    resolution: {integrity: sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==}
+  '@typescript-eslint/tsconfig-utils@8.34.1':
+    resolution: {integrity: sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
@@ -6457,8 +6370,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/type-utils@8.38.0':
-    resolution: {integrity: sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==}
+  '@typescript-eslint/type-utils@8.34.1':
+    resolution: {integrity: sha512-Tv7tCCr6e5m8hP4+xFugcrwTOucB8lshffJ6zf1mF1TbU67R+ntCc6DzLNKM+s/uzDyv8gLq7tufaAhIBYeV8g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: 8.56.0
@@ -6476,8 +6389,8 @@ packages:
     resolution: {integrity: sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.38.0':
-    resolution: {integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==}
+  '@typescript-eslint/types@8.34.1':
+    resolution: {integrity: sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@6.21.0':
@@ -6504,8 +6417,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/typescript-estree@8.38.0':
-    resolution: {integrity: sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==}
+  '@typescript-eslint/typescript-estree@8.34.1':
+    resolution: {integrity: sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
@@ -6529,8 +6442,8 @@ packages:
       eslint: 8.56.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/utils@8.38.0':
-    resolution: {integrity: sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==}
+  '@typescript-eslint/utils@8.34.1':
+    resolution: {integrity: sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: 8.56.0
@@ -6548,18 +6461,18 @@ packages:
     resolution: {integrity: sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.38.0':
-    resolution: {integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==}
+  '@typescript-eslint/visitor-keys@8.34.1':
+    resolution: {integrity: sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@urql/core@5.2.0':
-    resolution: {integrity: sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==}
+  '@urql/core@5.1.1':
+    resolution: {integrity: sha512-aGh024z5v2oINGD/In6rAtVKTm4VmQ2TxKQBAtk2ZSME5dunZFcjltw4p5ENQg+5CBhZ3FHMzl0Oa+rwqiWqlg==}
 
-  '@urql/exchange-retry@1.3.2':
-    resolution: {integrity: sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg==}
+  '@urql/exchange-retry@1.3.1':
+    resolution: {integrity: sha512-EEmtFu8JTuwsInqMakhLq+U3qN8ZMd5V3pX44q0EqD2imqTDsa8ikZqJ1schVrN8HljOdN+C08cwZ1/r5uIgLw==}
     peerDependencies:
       '@urql/core': ^5.0.0
 
@@ -6615,38 +6528,35 @@ packages:
   '@vitest/utils@3.1.4':
     resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
 
-  '@vscode/sudo-prompt@9.3.1':
-    resolution: {integrity: sha512-9ORTwwS74VaTn38tNbQhsA5U44zkJfcb0BdTSyyG6frP4e8KMtHuTXYmwefe5dpL8XB1aGSIVTaLjD3BbWb5iA==}
-
   '@vue/compiler-core@3.4.19':
     resolution: {integrity: sha512-gj81785z0JNzRcU0Mq98E56e4ltO1yf8k5PQ+tV/7YHnbZkrM0fyFyuttnN8ngJZjbpofWE/m4qjKBiLl8Ju4w==}
 
-  '@vue/compiler-core@3.5.18':
-    resolution: {integrity: sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==}
+  '@vue/compiler-core@3.5.16':
+    resolution: {integrity: sha512-AOQS2eaQOaaZQoL1u+2rCJIKDruNXVBZSiUD3chnUrsoX5ZTQMaCvXlWNIfxBJuU15r1o7+mpo5223KVtIhAgQ==}
 
   '@vue/compiler-dom@3.4.19':
     resolution: {integrity: sha512-vm6+cogWrshjqEHTzIDCp72DKtea8Ry/QVpQRYoyTIg9k7QZDX6D8+HGURjtmatfgM8xgCFtJJaOlCaRYRK3QA==}
 
-  '@vue/compiler-dom@3.5.18':
-    resolution: {integrity: sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==}
+  '@vue/compiler-dom@3.5.16':
+    resolution: {integrity: sha512-SSJIhBr/teipXiXjmWOVWLnxjNGo65Oj/8wTEQz0nqwQeP75jWZ0n4sF24Zxoht1cuJoWopwj0J0exYwCJ0dCQ==}
 
   '@vue/compiler-sfc@3.4.19':
     resolution: {integrity: sha512-LQ3U4SN0DlvV0xhr1lUsgLCYlwQfUfetyPxkKYu7dkfvx7g3ojrGAkw0AERLOKYXuAGnqFsEuytkdcComei3Yg==}
 
-  '@vue/compiler-sfc@3.5.18':
-    resolution: {integrity: sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==}
+  '@vue/compiler-sfc@3.5.16':
+    resolution: {integrity: sha512-rQR6VSFNpiinDy/DVUE0vHoIDUF++6p910cgcZoaAUm3POxgNOOdS/xgoll3rNdKYTYPnnbARDCZOyZ+QSe6Pw==}
 
   '@vue/compiler-ssr@3.4.19':
     resolution: {integrity: sha512-P0PLKC4+u4OMJ8sinba/5Z/iDT84uMRRlrWzadgLA69opCpI1gG4N55qDSC+dedwq2fJtzmGald05LWR5TFfLw==}
 
-  '@vue/compiler-ssr@3.5.18':
-    resolution: {integrity: sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==}
+  '@vue/compiler-ssr@3.5.16':
+    resolution: {integrity: sha512-d2V7kfxbdsjrDSGlJE7my1ZzCXViEcqN6w14DOsDrUCHEA6vbnVCpRFfrc4ryCP/lCKzX2eS1YtnLE/BuC9f/A==}
 
   '@vue/shared@3.4.19':
     resolution: {integrity: sha512-/KliRRHMF6LoiThEy+4c1Z4KB/gbPrGjWwJR+crg2otgrf/egKzRaCPvJ51S5oetgsgXLfc4Rm5ZgrKHZrtMSw==}
 
-  '@vue/shared@3.5.18':
-    resolution: {integrity: sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==}
+  '@vue/shared@3.5.16':
+    resolution: {integrity: sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -7148,28 +7058,13 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
-  babel-plugin-polyfill-corejs2@0.4.14:
-    resolution: {integrity: sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
   babel-plugin-polyfill-corejs3@0.11.1:
     resolution: {integrity: sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
-  babel-plugin-polyfill-corejs3@0.13.0:
-    resolution: {integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
   babel-plugin-polyfill-regenerator@0.6.4:
     resolution: {integrity: sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
-  babel-plugin-polyfill-regenerator@0.6.5:
-    resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
@@ -7187,10 +7082,10 @@ packages:
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
 
-  babel-preset-current-node-syntax@1.1.1:
-    resolution: {integrity: sha512-23fWKohMTvS5s0wwJKycOe0dBdCwQ6+iiLaNR9zy8P13mtFRFM9qLLX6HJX5DL2pi/FNDf3fCQHM4FIMoHH/7w==}
+  babel-preset-current-node-syntax@1.1.0:
+    resolution: {integrity: sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==}
     peerDependencies:
-      '@babel/core': ^7.0.0 || ^8.0.0-0
+      '@babel/core': ^7.0.0
 
   babel-preset-expo@13.1.11:
     resolution: {integrity: sha512-jigWjvhRVdm9UTPJ1wjLYJ0OJvD5vLZ8YYkEknEl6+9S1JWORO/y3xtHr/hNj5n34nOilZqdXrmNFcqKc8YTsg==}
@@ -7330,10 +7225,6 @@ packages:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
-    engines: {node: '>=18'}
-
   bonjour-service@1.3.0:
     resolution: {integrity: sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==}
 
@@ -7412,11 +7303,6 @@ packages:
 
   browserslist@4.25.0:
     resolution: {integrity: sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.25.1:
-    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -7562,9 +7448,6 @@ packages:
 
   caniuse-lite@1.0.30001723:
     resolution: {integrity: sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==}
-
-  caniuse-lite@1.0.30001731:
-    resolution: {integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==}
 
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -7901,10 +7784,6 @@ packages:
     resolution: {integrity: sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==}
     engines: {node: '>= 0.8.0'}
 
-  compression@1.8.1:
-    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
-    engines: {node: '>= 0.8.0'}
-
   compute-gcd@1.2.1:
     resolution: {integrity: sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==}
 
@@ -7994,9 +7873,6 @@ packages:
 
   core-js-compat@3.42.0:
     resolution: {integrity: sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==}
-
-  core-js-compat@3.44.0:
-    resolution: {integrity: sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==}
 
   core-js-pure@3.42.0:
     resolution: {integrity: sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==}
@@ -8148,9 +8024,6 @@ packages:
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
 
-  css-select@5.2.2:
-    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
-
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
@@ -8168,10 +8041,6 @@ packages:
 
   css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
-    engines: {node: '>= 6'}
-
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
   css.escape@1.5.1:
@@ -8722,9 +8591,6 @@ packages:
   electron-to-chromium@1.5.169:
     resolution: {integrity: sha512-q7SQx6mkLy0GTJK9K9OiWeaBMV4XQtBSdf6MJUzDB/H/5tFXfIiX38Lci1Kl6SsgiEhz1SQI1ejEOU5asWEhwQ==}
 
-  electron-to-chromium@1.5.192:
-    resolution: {integrity: sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==}
-
   electron@31.7.7:
     resolution: {integrity: sha512-HZtZg8EHsDGnswFt0QeV8If8B+et63uD6RJ7I4/xhcXqmTIbI08GoubX/wm+HdY0DwcuPe1/xsgqpmYvjdjRoA==}
     engines: {node: '>= 12.20.55'}
@@ -8765,10 +8631,6 @@ packages:
 
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
-    engines: {node: '>=10.13.0'}
-
-  enhanced-resolve@5.18.2:
-    resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
     engines: {node: '>=10.13.0'}
 
   entities@2.2.0:
@@ -8933,8 +8795,8 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-config-prettier@10.1.8:
-    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+  eslint-config-prettier@10.1.5:
+    resolution: {integrity: sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==}
     hasBin: true
     peerDependencies:
       eslint: 8.56.0
@@ -9140,8 +9002,8 @@ packages:
       expo: '*'
       react-native: '*'
 
-  expo-file-system@18.1.11:
-    resolution: {integrity: sha512-HJw/m0nVOKeqeRjPjGdvm+zBi5/NxcdPf8M8P3G2JFvH5Z8vBWqVDic2O58jnT1OFEy0XXzoH9UqFu7cHg9DTQ==}
+  expo-file-system@18.1.10:
+    resolution: {integrity: sha512-SyaWg+HitScLuyEeSG9gMSDT0hIxbM9jiZjSBP9l9zMnwZjmQwsusE6+7qGiddxJzdOhTP4YGUfvEzeeS0YL3Q==}
     peerDependencies:
       expo: '*'
       react-native: '*'
@@ -9683,10 +9545,6 @@ packages:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
 
-  globals@16.3.0:
-    resolution: {integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==}
-    engines: {node: '>=18'}
-
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -9822,14 +9680,18 @@ packages:
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
-  hermes-estree@0.29.1:
-    resolution: {integrity: sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==}
+  hermes-estree@0.28.1:
+    resolution: {integrity: sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==}
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hermes-parser@0.29.1:
-    resolution: {integrity: sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==}
+  hermes-parser@0.28.1:
+    resolution: {integrity: sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==}
+
+  hermes-profile-transformer@0.0.6:
+    resolution: {integrity: sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==}
+    engines: {node: '>=8'}
 
   hex-rgba@1.0.2:
     resolution: {integrity: sha512-MKla68wFGv+i7zU3Q4giWN74f+zWdkuf2Tk21fISV7aw55r8dH/noBbH5JsVlM4Z2WRTYCEmSxsoZ1QR/o68jg==}
@@ -9987,10 +9849,6 @@ packages:
     resolution: {integrity: sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==}
     engines: {node: '>= 4'}
 
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
-
   image-size@1.0.2:
     resolution: {integrity: sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==}
     engines: {node: '>=14.0.0'}
@@ -10107,6 +9965,11 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  inversify@7.1.0:
+    resolution: {integrity: sha512-f8SlUTgecMZGr/rsFK36PD84/mH0+sp0/P/TuiGo3CcJywmF5kgoXeE2RW5IjaIt1SlqS5c5V9RuQc1+B8mw4Q==}
+    peerDependencies:
+      reflect-metadata: ~0.2.2
 
   invert-kv@3.0.1:
     resolution: {integrity: sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw==}
@@ -10552,8 +10415,8 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
-  jiti@2.5.1:
-    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
   jju@1.4.0:
@@ -10794,9 +10657,6 @@ packages:
 
   launch-editor@2.10.0:
     resolution: {integrity: sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==}
-
-  launch-editor@2.11.0:
-    resolution: {integrity: sha512-R/PIF14L6e2eHkhvQPu7jDRCr0msfCYCxbYiLgkkAGi0dVPWuM+RrsPu0a5dpuNe0KWGL3jpAkOlv53xGfPheQ==}
 
   lcid@3.1.1:
     resolution: {integrity: sha512-M6T051+5QCGLBQb8id3hdvIW8+zeFV2FyBGFS9IEK5H9Wt4MueD4bW1eWikpHgZp+5xR3l5c8pZUkQsIA0BFZg==}
@@ -11359,10 +11219,6 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
   mem@5.1.1:
     resolution: {integrity: sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==}
     engines: {node: '>=8'}
@@ -11406,61 +11262,61 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
-  metro-babel-transformer@0.82.5:
-    resolution: {integrity: sha512-W/scFDnwJXSccJYnOFdGiYr9srhbHPdxX9TvvACOFsIXdLilh3XuxQl/wXW6jEJfgIb0jTvoTlwwrqvuwymr6Q==}
+  metro-babel-transformer@0.82.4:
+    resolution: {integrity: sha512-4juJahGRb1gmNbQq48lNinB6WFNfb6m0BQqi/RQibEltNiqTCxew/dBspI2EWA4xVCd3mQWGfw0TML4KurQZnQ==}
     engines: {node: '>=18.18'}
 
-  metro-cache-key@0.82.5:
-    resolution: {integrity: sha512-qpVmPbDJuRLrT4kcGlUouyqLGssJnbTllVtvIgXfR7ZuzMKf0mGS+8WzcqzNK8+kCyakombQWR0uDd8qhWGJcA==}
+  metro-cache-key@0.82.4:
+    resolution: {integrity: sha512-2JCTqcpF+f2OghOpe/+x+JywfzDkrHdAqinPFWmK2ezNAU/qX0jBFaTETogPibFivxZJil37w9Yp6syX8rFUng==}
     engines: {node: '>=18.18'}
 
-  metro-cache@0.82.5:
-    resolution: {integrity: sha512-AwHV9607xZpedu1NQcjUkua8v7HfOTKfftl6Vc9OGr/jbpiJX6Gpy8E/V9jo/U9UuVYX2PqSUcVNZmu+LTm71Q==}
+  metro-cache@0.82.4:
+    resolution: {integrity: sha512-vX0ylSMGtORKiZ4G8uP6fgfPdDiCWvLZUGZ5zIblSGylOX6JYhvExl0Zg4UA9pix/SSQu5Pnp9vdODMFsNIxhw==}
     engines: {node: '>=18.18'}
 
-  metro-config@0.82.5:
-    resolution: {integrity: sha512-/r83VqE55l0WsBf8IhNmc/3z71y2zIPe5kRSuqA5tY/SL/ULzlHUJEMd1szztd0G45JozLwjvrhAzhDPJ/Qo/g==}
+  metro-config@0.82.4:
+    resolution: {integrity: sha512-Ki3Wumr3hKHGDS7RrHsygmmRNc/PCJrvkLn0+BWWxmbOmOcMMJDSmSI+WRlT8jd5VPZFxIi4wg+sAt5yBXAK0g==}
     engines: {node: '>=18.18'}
 
-  metro-core@0.82.5:
-    resolution: {integrity: sha512-OJL18VbSw2RgtBm1f2P3J5kb892LCVJqMvslXxuxjAPex8OH7Eb8RBfgEo7VZSjgb/LOf4jhC4UFk5l5tAOHHA==}
+  metro-core@0.82.4:
+    resolution: {integrity: sha512-Xo4ozbxPg2vfgJGCgXZ8sVhC2M0lhTqD+tsKO2q9aelq/dCjnnSb26xZKcQO80CQOQUL7e3QWB7pLFGPjZm31A==}
     engines: {node: '>=18.18'}
 
-  metro-file-map@0.82.5:
-    resolution: {integrity: sha512-vpMDxkGIB+MTN8Af5hvSAanc6zXQipsAUO+XUx3PCQieKUfLwdoa8qaZ1WAQYRpaU+CJ8vhBcxtzzo3d9IsCIQ==}
+  metro-file-map@0.82.4:
+    resolution: {integrity: sha512-eO7HD1O3aeNsbEe6NBZvx1lLJUrxgyATjnDmb7bm4eyF6yWOQot9XVtxTDLNifECuvsZ4jzRiTInrbmIHkTdGA==}
     engines: {node: '>=18.18'}
 
-  metro-minify-terser@0.82.5:
-    resolution: {integrity: sha512-v6Nx7A4We6PqPu/ta1oGTqJ4Usz0P7c+3XNeBxW9kp8zayS3lHUKR0sY0wsCHInxZlNAEICx791x+uXytFUuwg==}
+  metro-minify-terser@0.82.4:
+    resolution: {integrity: sha512-W79Mi6BUwWVaM8Mc5XepcqkG+TSsCyyo//dmTsgYfJcsmReQorRFodil3bbJInETvjzdnS1mCsUo9pllNjT1Hg==}
     engines: {node: '>=18.18'}
 
-  metro-resolver@0.82.5:
-    resolution: {integrity: sha512-kFowLnWACt3bEsuVsaRNgwplT8U7kETnaFHaZePlARz4Fg8tZtmRDUmjaD68CGAwc0rwdwNCkWizLYpnyVcs2g==}
+  metro-resolver@0.82.4:
+    resolution: {integrity: sha512-uWoHzOBGQTPT5PjippB8rRT3iI9CTgFA9tRiLMzrseA5o7YAlgvfTdY9vFk2qyk3lW3aQfFKWkmqENryPRpu+Q==}
     engines: {node: '>=18.18'}
 
-  metro-runtime@0.82.5:
-    resolution: {integrity: sha512-rQZDoCUf7k4Broyw3Ixxlq5ieIPiR1ULONdpcYpbJQ6yQ5GGEyYjtkztGD+OhHlw81LCR2SUAoPvtTus2WDK5g==}
+  metro-runtime@0.82.4:
+    resolution: {integrity: sha512-vVyFO7H+eLXRV2E7YAUYA7aMGBECGagqxmFvC2hmErS7oq90BbPVENfAHbUWq1vWH+MRiivoRxdxlN8gBoF/dw==}
     engines: {node: '>=18.18'}
 
-  metro-source-map@0.82.5:
-    resolution: {integrity: sha512-wH+awTOQJVkbhn2SKyaw+0cd+RVSCZ3sHVgyqJFQXIee/yLs3dZqKjjeKKhhVeudgjXo7aE/vSu/zVfcQEcUfw==}
+  metro-source-map@0.82.4:
+    resolution: {integrity: sha512-9jzDQJ0FPas1FuQFtwmBHsez2BfhFNufMowbOMeG3ZaFvzeziE8A0aJwILDS3U+V5039ssCQFiQeqDgENWvquA==}
     engines: {node: '>=18.18'}
 
-  metro-symbolicate@0.82.5:
-    resolution: {integrity: sha512-1u+07gzrvYDJ/oNXuOG1EXSvXZka/0JSW1q2EYBWerVKMOhvv9JzDGyzmuV7hHbF2Hg3T3S2uiM36sLz1qKsiw==}
+  metro-symbolicate@0.82.4:
+    resolution: {integrity: sha512-LwEwAtdsx7z8rYjxjpLWxuFa2U0J6TS6ljlQM4WAATKa4uzV8unmnRuN2iNBWTmRqgNR77mzmI2vhwD4QSCo+w==}
     engines: {node: '>=18.18'}
     hasBin: true
 
-  metro-transform-plugins@0.82.5:
-    resolution: {integrity: sha512-57Bqf3rgq9nPqLrT2d9kf/2WVieTFqsQ6qWHpEng5naIUtc/Iiw9+0bfLLWSAw0GH40iJ4yMjFcFJDtNSYynMA==}
+  metro-transform-plugins@0.82.4:
+    resolution: {integrity: sha512-NoWQRPHupVpnDgYguiEcm7YwDhnqW02iWWQjO2O8NsNP09rEMSq99nPjARWfukN7+KDh6YjLvTIN20mj3dk9kw==}
     engines: {node: '>=18.18'}
 
-  metro-transform-worker@0.82.5:
-    resolution: {integrity: sha512-mx0grhAX7xe+XUQH6qoHHlWedI8fhSpDGsfga7CpkO9Lk9W+aPitNtJWNGrW8PfjKEWbT9Uz9O50dkI8bJqigw==}
+  metro-transform-worker@0.82.4:
+    resolution: {integrity: sha512-kPI7Ad/tdAnI9PY4T+2H0cdgGeSWWdiPRKuytI806UcN4VhFL6OmYa19/4abYVYF+Cd2jo57CDuwbaxRfmXDhw==}
     engines: {node: '>=18.18'}
 
-  metro@0.82.5:
-    resolution: {integrity: sha512-8oAXxL7do8QckID/WZEKaIFuQJFUTLzfVcC48ghkHhNK2RGuQq8Xvf4AVd+TUA0SZtX0q8TGNXZ/eba1ckeGCg==}
+  metro@0.82.4:
+    resolution: {integrity: sha512-/gFmw3ux9CPG5WUmygY35hpyno28zi/7OUn6+OFfbweA8l0B+PPqXXLr0/T6cf5nclCcH0d22o+02fICaShVxw==}
     engines: {node: '>=18.18'}
     hasBin: true
 
@@ -11602,10 +11458,6 @@ packages:
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.1:
-    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -11954,8 +11806,8 @@ packages:
   oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
 
-  ob1@0.82.5:
-    resolution: {integrity: sha512-QyQQ6e66f+Ut/qUVjEce0E/wux5nAGLXYZDn1jr15JWstHsCH3l6VVrg8NKDptW9NEiBXKOJeGF/ydxeSDF3IQ==}
+  ob1@0.82.4:
+    resolution: {integrity: sha512-n9S8e4l5TvkrequEAMDidl4yXesruWTNTzVkeaHSGywoTOIwTzZzKw7Z670H3eaXDZui5MJXjWGNzYowVZIxCA==}
     engines: {node: '>=18.18'}
 
   obj-case@0.2.1:
@@ -12037,10 +11889,6 @@ packages:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
     engines: {node: '>= 0.8'}
 
-  on-headers@1.1.0:
-    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
-    engines: {node: '>= 0.8'}
-
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -12067,6 +11915,12 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  openapi-fetch@0.13.5:
+    resolution: {integrity: sha512-AQK8T9GSKFREFlN1DBXTYsLjs7YV2tZcJ7zUWxbjMoQmj8dDSFRrzhLCbHPZWA1TMV3vACqfCxLEZcwf2wxV6Q==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
 
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
@@ -12852,8 +12706,8 @@ packages:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
     engines: {node: '>=0.6'}
 
-  query-string@9.2.2:
-    resolution: {integrity: sha512-pDSIZJ9sFuOp6VnD+5IkakSVf+rICAuuU88Hcsr6AKL0QtxSIfVuKiVP2oahFI7tk3CRSexwV+Ya6MOoTxzg9g==}
+  query-string@9.2.1:
+    resolution: {integrity: sha512-3jTGGLRzlhu/1ws2zlr4Q+GVMLCQTLFOj8CMX5x44cdZG9FQE07x2mQhaNxaKVPNmIDu0mvJ/cEwtY7Pim7hqA==}
     engines: {node: '>=18'}
 
   queue-microtask@1.2.3:
@@ -12903,10 +12757,6 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
-  raw-body@3.0.0:
-    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
-    engines: {node: '>= 0.8'}
-
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -12943,8 +12793,8 @@ packages:
       typescript:
         optional: true
 
-  react-devtools-core@6.1.5:
-    resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
+  react-devtools-core@6.1.2:
+    resolution: {integrity: sha512-ldFwzufLletzCikNJVYaxlxMLu7swJ3T2VrGfzXlMsVhZhPDKXA38DEROidaYZVgMAmQnIjymrmqto5pyfrwPA==}
 
   react-docgen-typescript@2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
@@ -13271,6 +13121,9 @@ packages:
 
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -13613,17 +13466,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
-    engines: {node: '>= 0.8.0'}
-
-  send@0.19.1:
-    resolution: {integrity: sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==}
     engines: {node: '>= 0.8.0'}
 
   serialize-error@2.1.0:
@@ -13699,10 +13543,6 @@ packages:
 
   shell-quote@1.8.2:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
-    engines: {node: '>= 0.4'}
-
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
   shellwords@0.1.1:
@@ -14085,6 +13925,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  sudo-prompt@9.2.1:
+    resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -14146,10 +13990,6 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  tapable@2.2.2:
-    resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
-    engines: {node: '>=6'}
-
   tar-fs@2.1.3:
     resolution: {integrity: sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==}
 
@@ -14201,8 +14041,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  terser@5.43.1:
-    resolution: {integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==}
+  terser@5.43.0:
+    resolution: {integrity: sha512-CqNNxKSGKSZCunSvwKLTs8u8sGGlp27sxNZ4quGh0QeNuyHM0JSEM/clM9Mf4zUp6J+tO2gUXhgXT2YMMkwfKQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -14507,10 +14347,6 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
-
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -14539,8 +14375,8 @@ packages:
   typeforce@1.18.0:
     resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
 
-  typescript-eslint@8.38.0:
-    resolution: {integrity: sha512-FsZlrYK6bPDGoLeZRuvx2v6qrM03I0U0SnfCLPs/XCCPCFD80xU9Pg09H/K+XFa68uJuZo7l/Xhs+eDRg2l3hg==}
+  typescript-eslint@8.34.1:
+    resolution: {integrity: sha512-XjS+b6Vg9oT1BaIUfkW3M3LvqZE++rbzAMEHuccCfO/YkP43ha6w3jTEMilQxMF92nVOYCcdjv1ZUhAa1D/0ow==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: 8.56.0
@@ -15516,7 +15352,7 @@ snapshots:
 
   '@babel/compat-data@7.26.8': {}
 
-  '@babel/compat-data@7.28.0': {}
+  '@babel/compat-data@7.27.5': {}
 
   '@babel/core@7.26.10':
     dependencies:
@@ -15532,26 +15368,6 @@ snapshots:
       '@babel/types': 7.27.0
       convert-source-map: 2.0.0
       debug: 4.4.0(supports-color@5.5.0)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/core@7.28.0':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helpers': 7.28.2
-      '@babel/parser': 7.28.0
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.2
-      convert-source-map: 2.0.0
-      debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -15580,21 +15396,13 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
-  '@babel/generator@7.28.0':
-    dependencies:
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.2
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
-      jsesc: 3.1.0
-
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
       '@babel/types': 7.27.6
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.27.6
 
   '@babel/helper-compilation-targets@7.27.0':
     dependencies:
@@ -15606,9 +15414,9 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.27.5
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.1
+      browserslist: 4.25.0
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -15633,7 +15441,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.26.10)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -15663,17 +15471,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.1
-      lodash.debounce: 4.0.8
-      resolve: 1.22.10
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
       '@babel/types': 7.27.6
@@ -15682,8 +15479,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.27.6
-
-  '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
@@ -15698,8 +15493,8 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -15712,8 +15507,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -15731,16 +15526,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
-    dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15750,7 +15536,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.27.6
 
   '@babel/helper-plugin-utils@7.26.5': {}
 
@@ -15770,7 +15556,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.27.1
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15788,7 +15574,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15801,8 +15587,8 @@ snapshots:
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -15835,8 +15621,8 @@ snapshots:
   '@babel/helper-wrap-function@7.27.1':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -15844,11 +15630,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.0
       '@babel/types': 7.27.0
-
-  '@babel/helpers@7.28.2':
-    dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
 
   '@babel/highlight@7.25.9':
     dependencies:
@@ -15864,10 +15645,6 @@ snapshots:
   '@babel/parser@7.27.5':
     dependencies:
       '@babel/types': 7.27.6
-
-  '@babel/parser@7.28.0':
-    dependencies:
-      '@babel/types': 7.28.2
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -15904,16 +15681,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.26.10)':
+  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-export-default-from@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-proposal-export-default-from@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
@@ -15942,7 +15719,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
@@ -15952,12 +15729,12 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-export-default-from@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-syntax-export-default-from@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
@@ -15991,11 +15768,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.26.10)':
     dependencies:
@@ -16042,11 +15814,6 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -16072,12 +15839,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.26.10)':
+  '@babel/plugin-transform-async-generator-functions@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.26.10)
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16109,7 +15876,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.26.10)':
+  '@babel/plugin-transform-block-scoping@7.27.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
@@ -16150,15 +15917,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.0(@babel/core@7.26.10)':
+  '@babel/plugin-transform-classes@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.26.10)
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
+      globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16179,13 +15946,10 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.26.10)':
+  '@babel/plugin-transform-destructuring@7.27.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-dotall-regex@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -16224,11 +15988,11 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-flow-strip-types@7.26.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.26.10)
 
   '@babel/plugin-transform-for-of@7.26.9(@babel/core@7.26.10)':
     dependencies:
@@ -16260,7 +16024,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16380,16 +16144,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.26.10)
 
-  '@babel/plugin-transform-object-rest-spread@7.28.0(@babel/core@7.26.10)':
+  '@babel/plugin-transform-object-rest-spread@7.27.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.26.10)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.26.10)
-      '@babel/traverse': 7.28.0
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/plugin-transform-destructuring': 7.27.3(@babel/core@7.26.10)
+      '@babel/plugin-transform-parameters': 7.27.1(@babel/core@7.26.10)
 
   '@babel/plugin-transform-object-super@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -16430,7 +16191,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.26.10)':
+  '@babel/plugin-transform-parameters@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
@@ -16484,11 +16245,6 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-react-jsx-development@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -16496,19 +16252,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.26.10)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
@@ -16524,28 +16273,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.26.10)
-      '@babel/types': 7.28.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-react-pure-annotations@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-regenerator@7.27.0(@babel/core@7.26.10)':
     dependencies:
@@ -16553,7 +16285,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       regenerator-transform: 0.15.2
 
-  '@babel/plugin-transform-regenerator@7.28.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-regenerator@7.27.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
@@ -16569,14 +16301,14 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-runtime@7.28.0(@babel/core@7.26.10)':
+  '@babel/plugin-transform-runtime@7.26.10(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.26.10)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.26.10)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.26.10)
+      babel-plugin-polyfill-corejs2: 0.4.13(@babel/core@7.26.10)
+      babel-plugin-polyfill-corejs3: 0.11.1(@babel/core@7.26.10)
+      babel-plugin-polyfill-regenerator: 0.6.4(@babel/core@7.26.10)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -16640,17 +16372,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.10)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-typescript@7.28.0(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
 
@@ -16777,18 +16498,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-react@7.27.1(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.26.10)
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.26.10)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/preset-typescript@7.27.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -16800,17 +16509,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.27.1(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.26.10)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/runtime@7.21.0':
     dependencies:
       regenerator-runtime: 0.13.11
@@ -16818,8 +16516,6 @@ snapshots:
   '@babel/runtime@7.27.0':
     dependencies:
       regenerator-runtime: 0.14.1
-
-  '@babel/runtime@7.28.2': {}
 
   '@babel/template@7.27.0':
     dependencies:
@@ -16872,18 +16568,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.28.0':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.0
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/types@7.17.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -16895,11 +16579,6 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
 
   '@babel/types@7.27.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
-
-  '@babel/types@7.28.2':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -16996,9 +16675,9 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@coinbase/cbpay-js@2.1.0(regenerator-runtime@0.14.1)':
+  '@coinbase/cbpay-js@2.1.0(regenerator-runtime@0.13.11)':
     optionalDependencies:
-      regenerator-runtime: 0.14.1
+      regenerator-runtime: 0.13.11
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -17792,25 +17471,25 @@ snapshots:
   '@expo/cli@0.24.13(graphql@16.11.0)':
     dependencies:
       '@0no-co/graphql.web': 1.1.2(graphql@16.11.0)
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.27.0
       '@expo/code-signing-certificates': 0.0.5
-      '@expo/config': 11.0.13
+      '@expo/config': 11.0.10
       '@expo/config-plugins': 10.0.3
       '@expo/devcert': 1.2.0
-      '@expo/env': 1.0.7
-      '@expo/image-utils': 0.7.6
-      '@expo/json-file': 9.1.5
+      '@expo/env': 1.0.5
+      '@expo/image-utils': 0.7.4
+      '@expo/json-file': 9.1.4
       '@expo/metro-config': 0.20.14
-      '@expo/osascript': 2.2.5
-      '@expo/package-manager': 1.8.6
-      '@expo/plist': 0.3.5
-      '@expo/prebuild-config': 9.0.11
+      '@expo/osascript': 2.2.4
+      '@expo/package-manager': 1.8.4
+      '@expo/plist': 0.3.4
+      '@expo/prebuild-config': 9.0.7
       '@expo/spawn-async': 1.7.2
       '@expo/ws-tunnel': 1.0.6
       '@expo/xcpretty': 4.3.2
       '@react-native/dev-middleware': 0.79.2
-      '@urql/core': 5.2.0(graphql@16.11.0)
-      '@urql/exchange-retry': 1.3.2(@urql/core@5.2.0(graphql@16.11.0))
+      '@urql/core': 5.1.1(graphql@16.11.0)
+      '@urql/exchange-retry': 1.3.1(@urql/core@5.1.1(graphql@16.11.0))
       accepts: 1.3.8
       arg: 5.0.2
       better-opn: 3.0.2
@@ -17818,7 +17497,7 @@ snapshots:
       bplist-parser: 0.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
-      compression: 1.8.1
+      compression: 1.8.0
       connect: 3.7.0
       debug: 4.4.1
       env-editor: 0.4.2
@@ -17841,8 +17520,8 @@ snapshots:
       resolve: 1.22.10
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.2
-      send: 0.19.1
+      semver: 7.7.1
+      send: 0.19.0
       slugify: 1.6.6
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.11
@@ -17865,16 +17544,16 @@ snapshots:
 
   '@expo/config-plugins@10.0.3':
     dependencies:
-      '@expo/config-types': 53.0.5
-      '@expo/json-file': 9.1.5
-      '@expo/plist': 0.3.5
+      '@expo/config-types': 53.0.4
+      '@expo/json-file': 9.1.4
+      '@expo/plist': 0.3.4
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
       debug: 4.4.1
       getenv: 2.0.0
       glob: 10.4.5
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.1
       slash: 3.0.0
       slugify: 1.6.6
       xcode: 3.0.1
@@ -17882,40 +17561,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/config-plugins@10.1.2':
-    dependencies:
-      '@expo/config-types': 53.0.5
-      '@expo/json-file': 9.1.5
-      '@expo/plist': 0.3.5
-      '@expo/sdk-runtime-versions': 1.0.0
-      chalk: 4.1.2
-      debug: 4.4.1
-      getenv: 2.0.0
-      glob: 10.4.5
-      resolve-from: 5.0.0
-      semver: 7.7.2
-      slash: 3.0.0
-      slugify: 1.6.6
-      xcode: 3.0.1
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
+  '@expo/config-types@53.0.4': {}
 
-  '@expo/config-types@53.0.5': {}
-
-  '@expo/config@11.0.13':
+  '@expo/config@11.0.10':
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@expo/config-plugins': 10.1.2
-      '@expo/config-types': 53.0.5
-      '@expo/json-file': 9.1.5
+      '@expo/config-plugins': 10.0.3
+      '@expo/config-types': 53.0.4
+      '@expo/json-file': 9.1.4
       deepmerge: 4.3.1
-      getenv: 2.0.0
+      getenv: 1.0.0
       glob: 10.4.5
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.0
-      semver: 7.7.2
+      semver: 7.7.1
       slugify: 1.6.6
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -17929,13 +17589,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/env@1.0.7':
+  '@expo/env@1.0.5':
     dependencies:
       chalk: 4.1.2
       debug: 4.4.1
       dotenv: 16.4.5
       dotenv-expand: 11.0.7
-      getenv: 2.0.0
+      getenv: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17950,36 +17610,36 @@ snapshots:
       minimatch: 9.0.5
       p-limit: 3.1.0
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/image-utils@0.7.6':
+  '@expo/image-utils@0.7.4':
     dependencies:
       '@expo/spawn-async': 1.7.2
       chalk: 4.1.2
-      getenv: 2.0.0
+      getenv: 1.0.0
       jimp-compact: 0.16.1
       parse-png: 2.1.0
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.1
       temp-dir: 2.0.0
       unique-string: 2.0.0
 
-  '@expo/json-file@9.1.5':
+  '@expo/json-file@9.1.4':
     dependencies:
       '@babel/code-frame': 7.10.4
       json5: 2.2.3
 
   '@expo/metro-config@0.20.14':
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/generator': 7.28.0
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.2
-      '@expo/config': 11.0.13
-      '@expo/env': 1.0.7
-      '@expo/json-file': 9.1.5
+      '@babel/core': 7.26.10
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
+      '@expo/config': 11.0.10
+      '@expo/env': 1.0.5
+      '@expo/json-file': 9.1.4
       '@expo/spawn-async': 1.7.2
       chalk: 4.1.2
       debug: 4.4.1
@@ -17995,37 +17655,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/osascript@2.2.5':
+  '@expo/osascript@2.2.4':
     dependencies:
       '@expo/spawn-async': 1.7.2
       exec-async: 2.2.0
 
-  '@expo/package-manager@1.8.6':
+  '@expo/package-manager@1.8.4':
     dependencies:
-      '@expo/json-file': 9.1.5
+      '@expo/json-file': 9.1.4
       '@expo/spawn-async': 1.7.2
       chalk: 4.1.2
       npm-package-arg: 11.0.3
       ora: 3.4.0
       resolve-workspace-root: 2.0.0
 
-  '@expo/plist@0.3.5':
+  '@expo/plist@0.3.4':
     dependencies:
       '@xmldom/xmldom': 0.8.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  '@expo/prebuild-config@9.0.11':
+  '@expo/prebuild-config@9.0.7':
     dependencies:
-      '@expo/config': 11.0.13
-      '@expo/config-plugins': 10.1.2
-      '@expo/config-types': 53.0.5
-      '@expo/image-utils': 0.7.6
-      '@expo/json-file': 9.1.5
-      '@react-native/normalize-colors': 0.79.5
+      '@expo/config': 11.0.10
+      '@expo/config-plugins': 10.0.3
+      '@expo/config-types': 53.0.4
+      '@expo/image-utils': 0.7.4
+      '@expo/json-file': 9.1.4
+      '@react-native/normalize-colors': 0.79.4
       debug: 4.4.1
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.1
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -18038,11 +17698,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@expo/vector-icons@14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -18079,22 +17739,22 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@gorhom/bottom-sheet@5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@gorhom/bottom-sheet@5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@gorhom/portal': 1.0.14(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@gorhom/portal': 1.0.14(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       invariant: 2.2.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
-      react-native-gesture-handler: 2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-reanimated: 3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
+      react-native-gesture-handler: 2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-reanimated: 3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
     optionalDependencies:
       '@types/react': 19.0.12
 
-  '@gorhom/portal@1.0.14(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@gorhom/portal@1.0.14(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
       nanoid: 3.3.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
   '@graphql-tools/merge@8.4.2(graphql@16.11.0)':
     dependencies:
@@ -18150,6 +17810,31 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@inversifyjs/common@1.5.0': {}
+
+  '@inversifyjs/container@1.5.4(reflect-metadata@0.2.2)':
+    dependencies:
+      '@inversifyjs/common': 1.5.0
+      '@inversifyjs/core': 5.0.0(reflect-metadata@0.2.2)
+      '@inversifyjs/reflect-metadata-utils': 1.1.0(reflect-metadata@0.2.2)
+      reflect-metadata: 0.2.2
+
+  '@inversifyjs/core@5.0.0(reflect-metadata@0.2.2)':
+    dependencies:
+      '@inversifyjs/common': 1.5.0
+      '@inversifyjs/prototype-utils': 0.1.0
+      '@inversifyjs/reflect-metadata-utils': 1.1.0(reflect-metadata@0.2.2)
+    transitivePeerDependencies:
+      - reflect-metadata
+
+  '@inversifyjs/prototype-utils@0.1.0':
+    dependencies:
+      '@inversifyjs/common': 1.5.0
+
+  '@inversifyjs/reflect-metadata-utils@1.1.0(reflect-metadata@0.2.2)':
+    dependencies:
+      reflect-metadata: 0.2.2
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -18201,9 +17886,9 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.26.10
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -18237,11 +17922,6 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@jridgewell/gen-mapping@0.3.12':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
-      '@jridgewell/trace-mapping': 0.3.29
-
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -18252,11 +17932,6 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/source-map@0.3.10':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
-
   '@jridgewell/source-map@0.3.6':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
@@ -18264,17 +17939,10 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
-  '@jridgewell/sourcemap-codec@1.5.4': {}
-
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  '@jridgewell/trace-mapping@0.3.29':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -18316,14 +17984,14 @@ snapshots:
       '@scure/bip39': 1.5.4
       just-memoize: 2.2.0
 
-  '@leather.io/eslint-config@0.10.0(eslint-config-prettier@10.1.8(eslint@8.56.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.56.0))(eslint-plugin-react@7.34.1(eslint@8.56.0))(eslint@8.56.0)(globals@16.3.0)(typescript-eslint@8.38.0(eslint@8.56.0)(typescript@5.4.5))':
+  '@leather.io/eslint-config@0.10.0(eslint-config-prettier@10.1.5(eslint@8.56.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.56.0))(eslint-plugin-react@7.34.1(eslint@8.56.0))(eslint@8.56.0)(globals@13.24.0)(typescript-eslint@8.34.1(eslint@8.56.0)(typescript@5.4.5))':
     dependencies:
       eslint: 8.56.0
-      eslint-config-prettier: 10.1.8(eslint@8.56.0)
+      eslint-config-prettier: 10.1.5(eslint@8.56.0)
       eslint-plugin-react: 7.34.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
-      globals: 16.3.0
-      typescript-eslint: 8.38.0(eslint@8.56.0)(typescript@5.4.5)
+      globals: 13.24.0
+      typescript-eslint: 8.34.1(eslint@8.56.0)(typescript@5.4.5)
 
   '@leather.io/models@0.39.0':
     dependencies:
@@ -18338,17 +18006,17 @@ snapshots:
       - jsdom
       - typescript
 
-  '@leather.io/prettier-config@0.6.1(@vue/compiler-sfc@3.5.18)':
+  '@leather.io/prettier-config@0.6.1(@vue/compiler-sfc@3.5.16)':
     dependencies:
-      '@trivago/prettier-plugin-sort-imports': 4.3.0(@vue/compiler-sfc@3.5.18)(prettier@3.5.1)
+      '@trivago/prettier-plugin-sort-imports': 4.3.0(@vue/compiler-sfc@3.5.16)(prettier@3.5.1)
       prettier: 3.5.1
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - supports-color
 
-  '@leather.io/prettier-config@0.8.1(@vue/compiler-sfc@3.5.18)':
+  '@leather.io/prettier-config@0.8.1(@vue/compiler-sfc@3.5.16)':
     dependencies:
-      '@trivago/prettier-plugin-sort-imports': 4.3.0(@vue/compiler-sfc@3.5.18)(prettier@3.5.1)
+      '@trivago/prettier-plugin-sort-imports': 4.3.0(@vue/compiler-sfc@3.5.16)(prettier@3.5.1)
       prettier: 3.5.1
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
@@ -18412,6 +18080,30 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@leather.io/services@1.25.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(encoding@0.1.13)':
+    dependencies:
+      '@hirosystems/token-metadata-api-client': 1.2.0(encoding@0.1.13)
+      '@leather.io/bitcoin': 0.31.0
+      '@leather.io/constants': 0.25.0
+      '@leather.io/models': 0.39.0
+      '@leather.io/utils': 0.40.0
+      '@stacks/stacks-blockchain-api-types': 7.14.1
+      '@stacks/transactions': 7.0.5(encoding@0.1.13)
+      alex-sdk: 3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2(encoding@0.1.13))(@stacks/transactions@7.0.5(encoding@0.1.13))
+      axios: 1.8.2
+      bignumber.js: 9.1.2
+      inversify: 7.1.0(reflect-metadata@0.2.2)
+      openapi-fetch: 0.13.5
+      p-queue: 8.0.1
+      reflect-metadata: 0.2.2
+      uuid: 11.1.0
+      zod: 3.24.2
+    transitivePeerDependencies:
+      - '@stacks/common'
+      - '@stacks/network'
+      - debug
+      - encoding
+
   '@leather.io/stacks@1.14.0(encoding@0.1.13)':
     dependencies:
       '@leather.io/constants': 0.25.0
@@ -18432,39 +18124,39 @@ snapshots:
 
   '@leather.io/tokens@0.23.0': {}
 
-  '@leather.io/ui@1.77.0(@babel/core@7.26.10)(@emotion/is-prop-valid@1.3.1)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(@vue/compiler-sfc@3.5.18)(graphql@16.11.0)':
+  '@leather.io/ui@1.77.0(@babel/core@7.26.10)(@emotion/is-prop-valid@1.3.1)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(@vue/compiler-sfc@3.5.16)(graphql@16.11.0)':
     dependencies:
-      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      '@gorhom/bottom-sheet': 5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      '@leather.io/prettier-config': 0.8.1(@vue/compiler-sfc@3.5.18)
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@gorhom/bottom-sheet': 5.1.4(@types/react@19.0.12)(react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@leather.io/prettier-config': 0.8.1(@vue/compiler-sfc@3.5.16)
       '@leather.io/tokens': 0.23.0
       '@leather.io/utils': 0.40.0
       '@react-native/assets-registry': 0.73.1
       '@rnx-kit/metro-resolver-symlinks': 0.2.3
-      '@shopify/restyle': 2.4.2(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@shopify/restyle': 2.4.2(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       dompurify: 3.2.4
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-blur: 14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
-      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      expo-haptics: 14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
-      expo-image: 2.1.7(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-linear-gradient: 14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-splash-screen: 0.30.8(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
-      expo-squircle-view: 1.1.0(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-blur: 14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-haptics: 14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
+      expo-image: 2.1.7(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-linear-gradient: 14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-splash-screen: 0.30.8(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))
+      expo-squircle-view: 1.1.0(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       framer-motion: 12.11.0(@emotion/is-prop-valid@1.3.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       prism-react-renderer: 2.4.1(react@19.0.0)
       prismjs: 1.29.0
       radix-ui: 1.3.4(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
-      react-native-gesture-handler: 2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-reanimated: 3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.4.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-svg: 15.11.2(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native-webview: 13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
+      react-native-gesture-handler: 2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-reanimated: 3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-safe-area-context: 5.4.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.11.2(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-webview: 13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       use-events: 1.4.2(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -20174,144 +19866,162 @@ snapshots:
       '@types/react': 19.0.12
       '@types/react-dom': 19.0.4(@types/react@19.0.12)
 
-  '@react-native-community/cli-clean@19.1.1':
+  '@react-native-community/cli-clean@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 19.1.1
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
       fast-glob: 3.3.3
+    transitivePeerDependencies:
+      - encoding
     optional: true
 
-  '@react-native-community/cli-config-android@19.1.1':
+  '@react-native-community/cli-config@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 19.1.1
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
-      fast-glob: 3.3.3
-      fast-xml-parser: 4.4.1
-    optional: true
-
-  '@react-native-community/cli-config-apple@19.1.1':
-    dependencies:
-      '@react-native-community/cli-tools': 19.1.1
-      chalk: 4.1.2
-      execa: 5.1.1
-      fast-glob: 3.3.3
-    optional: true
-
-  '@react-native-community/cli-config@19.1.1(typescript@5.4.5)':
-    dependencies:
-      '@react-native-community/cli-tools': 19.1.1
-      chalk: 4.1.2
-      cosmiconfig: 9.0.0(typescript@5.4.5)
+      cosmiconfig: 5.2.1
       deepmerge: 4.3.1
       fast-glob: 3.3.3
       joi: 17.13.3
     transitivePeerDependencies:
-      - typescript
+      - encoding
     optional: true
 
-  '@react-native-community/cli-doctor@19.1.1(typescript@5.4.5)':
+  '@react-native-community/cli-debugger-ui@13.6.6':
     dependencies:
-      '@react-native-community/cli-config': 19.1.1(typescript@5.4.5)
-      '@react-native-community/cli-platform-android': 19.1.1
-      '@react-native-community/cli-platform-apple': 19.1.1
-      '@react-native-community/cli-platform-ios': 19.1.1
-      '@react-native-community/cli-tools': 19.1.1
+      serve-static: 1.16.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@react-native-community/cli-doctor@13.6.6(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-config': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-apple': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       command-exists: 1.2.9
       deepmerge: 4.3.1
       envinfo: 7.14.0
       execa: 5.1.1
+      hermes-profile-transformer: 0.0.6
       node-stream-zip: 1.15.0
       ora: 5.4.1
-      semver: 7.7.2
+      semver: 7.7.1
+      strip-ansi: 5.2.0
       wcwidth: 1.0.1
       yaml: 2.8.0
     transitivePeerDependencies:
-      - typescript
+      - encoding
     optional: true
 
-  '@react-native-community/cli-platform-android@19.1.1':
+  '@react-native-community/cli-hermes@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-config-android': 19.1.1
-      '@react-native-community/cli-tools': 19.1.1
+      '@react-native-community/cli-platform-android': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
-      execa: 5.1.1
-      logkitty: 0.7.1
+      hermes-profile-transformer: 0.0.6
+    transitivePeerDependencies:
+      - encoding
     optional: true
 
-  '@react-native-community/cli-platform-apple@19.1.1':
+  '@react-native-community/cli-platform-android@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-config-apple': 19.1.1
-      '@react-native-community/cli-tools': 19.1.1
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
+      fast-glob: 3.3.3
       fast-xml-parser: 4.4.1
+      logkitty: 0.7.1
+    transitivePeerDependencies:
+      - encoding
     optional: true
 
-  '@react-native-community/cli-platform-ios@19.1.1':
+  '@react-native-community/cli-platform-apple@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-platform-apple': 19.1.1
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
+      chalk: 4.1.2
+      execa: 5.1.1
+      fast-glob: 3.3.3
+      fast-xml-parser: 4.4.1
+      ora: 5.4.1
+    transitivePeerDependencies:
+      - encoding
     optional: true
 
-  '@react-native-community/cli-server-api@19.1.1':
+  '@react-native-community/cli-platform-ios@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 19.1.1
-      body-parser: 1.20.3
-      compression: 1.8.1
+      '@react-native-community/cli-platform-apple': 13.6.6(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+    optional: true
+
+  '@react-native-community/cli-server-api@13.6.6(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-debugger-ui': 13.6.6
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
+      compression: 1.8.0
       connect: 3.7.0
       errorhandler: 1.5.1
       nocache: 3.0.4
-      open: 6.4.0
       pretty-format: 26.6.2
       serve-static: 1.16.2
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
+      - encoding
       - supports-color
       - utf-8-validate
     optional: true
 
-  '@react-native-community/cli-tools@19.1.1':
+  '@react-native-community/cli-tools@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@vscode/sudo-prompt': 9.3.1
       appdirsjs: 1.2.7
       chalk: 4.1.2
       execa: 5.1.1
       find-up: 5.0.0
-      launch-editor: 2.11.0
       mime: 2.6.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+      open: 6.4.0
       ora: 5.4.1
-      prompts: 2.4.2
-      semver: 7.7.2
+      semver: 7.7.1
+      shell-quote: 1.8.2
+      sudo-prompt: 9.2.1
+    transitivePeerDependencies:
+      - encoding
     optional: true
 
-  '@react-native-community/cli-types@19.1.1':
+  '@react-native-community/cli-types@13.6.6':
     dependencies:
       joi: 17.13.3
     optional: true
 
-  '@react-native-community/cli@19.1.1(typescript@5.4.5)':
+  '@react-native-community/cli@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-clean': 19.1.1
-      '@react-native-community/cli-config': 19.1.1(typescript@5.4.5)
-      '@react-native-community/cli-doctor': 19.1.1(typescript@5.4.5)
-      '@react-native-community/cli-server-api': 19.1.1
-      '@react-native-community/cli-tools': 19.1.1
-      '@react-native-community/cli-types': 19.1.1
+      '@react-native-community/cli-clean': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-config': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-debugger-ui': 13.6.6
+      '@react-native-community/cli-doctor': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-hermes': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-server-api': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-types': 13.6.6
       chalk: 4.1.2
       commander: 9.5.0
       deepmerge: 4.3.1
       execa: 5.1.1
-      find-up: 5.0.0
+      find-up: 4.1.0
       fs-extra: 8.1.0
       graceful-fs: 4.2.11
       prompts: 2.4.2
-      semver: 7.7.2
+      semver: 7.7.1
     transitivePeerDependencies:
       - bufferutil
+      - encoding
       - supports-color
-      - typescript
       - utf-8-validate
     optional: true
 
@@ -20321,7 +20031,7 @@ snapshots:
 
   '@react-native/babel-plugin-codegen@0.79.2(@babel/core@7.26.10)':
     dependencies:
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
       '@react-native/codegen': 0.79.2(@babel/core@7.26.10)
     transitivePeerDependencies:
       - '@babel/core'
@@ -20330,20 +20040,20 @@ snapshots:
   '@react-native/babel-preset@0.79.2(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-proposal-export-default-from': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.10)
-      '@babel/plugin-syntax-export-default-from': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-syntax-export-default-from': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.10)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.10)
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-async-generator-functions': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-block-scoping': 7.28.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-block-scoping': 7.27.5(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-classes': 7.28.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-classes': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.26.10)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-destructuring': 7.27.3(@babel/core@7.26.10)
+      '@babel/plugin-transform-flow-strip-types': 7.26.5(@babel/core@7.26.10)
       '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.26.10)
@@ -20352,22 +20062,22 @@ snapshots:
       '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-object-rest-spread': 7.27.3(@babel/core@7.26.10)
       '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.26.10)
+      '@babel/plugin-transform-parameters': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.26.10)
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-regenerator': 7.28.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-runtime': 7.28.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-react-display-name': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-regenerator': 7.27.5(@babel/core@7.26.10)
+      '@babel/plugin-transform-runtime': 7.26.10(@babel/core@7.26.10)
       '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-typescript': 7.27.0(@babel/core@7.26.10)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.26.10)
       '@babel/template': 7.27.2
       '@react-native/babel-plugin-codegen': 0.79.2(@babel/core@7.26.10)
@@ -20386,18 +20096,18 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.79.2(@react-native-community/cli@19.1.1(typescript@5.4.5))':
+  '@react-native/community-cli-plugin@0.79.2(@react-native-community/cli@13.6.6(encoding@0.1.13))':
     dependencies:
       '@react-native/dev-middleware': 0.79.2
       chalk: 4.1.2
       debug: 2.6.9
       invariant: 2.2.4
-      metro: 0.82.5
-      metro-config: 0.82.5
-      metro-core: 0.82.5
-      semver: 7.7.2
+      metro: 0.82.4
+      metro-config: 0.82.4
+      metro-core: 0.82.4
+      semver: 7.7.1
     optionalDependencies:
-      '@react-native-community/cli': 19.1.1(typescript@5.4.5)
+      '@react-native-community/cli': 13.6.6(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -20429,14 +20139,14 @@ snapshots:
 
   '@react-native/normalize-colors@0.79.2': {}
 
-  '@react-native/normalize-colors@0.79.5': {}
+  '@react-native/normalize-colors@0.79.4': {}
 
-  '@react-native/virtualized-lists@0.79.2(@types/react@19.0.12)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@react-native/virtualized-lists@0.79.2(@types/react@19.0.12)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
     optionalDependencies:
       '@types/react': 19.0.12
 
@@ -20467,7 +20177,7 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.0.12)(react@19.0.0)(redux@5.0.1)
       redux: 5.0.1
       redux-persist: 6.0.0(react@19.0.0)(redux@5.0.1)
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20487,7 +20197,7 @@ snapshots:
       redux: 5.0.1
       redux-persist: 6.0.0(react@18.3.1)(redux@5.0.1)
       socketcluster-client: 19.2.3
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -20530,7 +20240,7 @@ snapshots:
       semver: 7.7.1
       socketcluster-server: 19.1.1
       sqlite3: 5.1.7
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
       uuid: 10.0.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -20573,7 +20283,7 @@ snapshots:
       react-icons: 5.5.0(react@18.3.1)
       redux: 5.0.1
       simple-diff: 1.7.2
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20667,7 +20377,7 @@ snapshots:
       react-base16-styling: 0.10.0
       react-json-tree: 0.20.0(@types/react@18.3.20)(react@18.3.1)
       redux: 5.0.1
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
       - supports-color
@@ -20688,7 +20398,7 @@ snapshots:
       react: 18.3.1
       react-base16-styling: 0.10.0
       redux: 5.0.1
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
       - supports-color
@@ -20711,7 +20421,7 @@ snapshots:
       react-icons: 5.5.0(react@18.3.1)
       react-select: 5.10.1(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       simple-element-resize-detector: 1.3.0
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
       - supports-color
@@ -20793,7 +20503,7 @@ snapshots:
       '@rnx-kit/console': 2.0.0
       '@rnx-kit/tools-node': 3.0.2
       '@rnx-kit/tools-react-native': 2.2.0
-      enhanced-resolve: 5.18.2
+      enhanced-resolve: 5.18.1
 
   '@rnx-kit/tools-node@3.0.2': {}
 
@@ -21058,10 +20768,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@shopify/restyle@2.4.2(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
+  '@shopify/restyle@2.4.2(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -21245,7 +20955,7 @@ snapshots:
   '@stacks/profile@6.15.0(encoding@0.1.13)':
     dependencies:
       '@stacks/common': 6.16.0
-      '@stacks/network': 6.13.0(encoding@0.1.13)
+      '@stacks/network': 6.17.0(encoding@0.1.13)
       '@stacks/transactions': 6.17.0(encoding@0.1.13)
       jsontokens: 4.0.1
       schema-inspector: 2.0.2
@@ -21963,7 +21673,7 @@ snapshots:
   '@tootallnate/once@1.1.2':
     optional: true
 
-  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.5.18)(prettier@3.5.1)':
+  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.5.16)(prettier@3.5.1)':
     dependencies:
       '@babel/generator': 7.17.7
       '@babel/parser': 7.27.5
@@ -21973,7 +21683,7 @@ snapshots:
       lodash: 4.17.21
       prettier: 3.5.1
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.16
     transitivePeerDependencies:
       - supports-color
 
@@ -22293,11 +22003,6 @@ snapshots:
       '@types/react': 19.0.12
       hoist-non-react-statics: 3.3.2
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@19.0.12)':
-    dependencies:
-      '@types/react': 19.0.12
-      hoist-non-react-statics: 3.3.2
-
   '@types/html-minifier-terser@6.1.0': {}
 
   '@types/html-minifier@4.0.5':
@@ -22502,7 +22207,7 @@ snapshots:
 
   '@types/styled-components@5.1.34':
     dependencies:
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.0.12)
+      '@types/hoist-non-react-statics': 3.3.6
       '@types/react': 19.0.12
       csstype: 3.1.3
 
@@ -22606,17 +22311,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.38.0(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/type-utils': 8.38.0(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.38.0(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.38.0
+      '@typescript-eslint/parser': 8.34.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 8.34.1
+      '@typescript-eslint/type-utils': 8.34.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.34.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 8.34.1
       eslint: 8.56.0
       graphemer: 1.4.0
-      ignore: 7.0.5
+      ignore: 7.0.4
       natural-compare: 1.4.0
       ts-api-utils: 2.1.0(typescript@5.4.5)
       typescript: 5.4.5
@@ -22636,22 +22341,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.38.0(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/parser@8.34.1(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.38.0
+      '@typescript-eslint/scope-manager': 8.34.1
+      '@typescript-eslint/types': 8.34.1
+      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
       eslint: 8.56.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.38.0(typescript@5.4.5)':
+  '@typescript-eslint/project-service@8.34.1(typescript@5.4.5)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.4.5)
-      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.4.5)
+      '@typescript-eslint/types': 8.34.1
       debug: 4.4.1
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -22672,12 +22377,12 @@ snapshots:
       '@typescript-eslint/types': 8.31.1
       '@typescript-eslint/visitor-keys': 8.31.1
 
-  '@typescript-eslint/scope-manager@8.38.0':
+  '@typescript-eslint/scope-manager@8.34.1':
     dependencies:
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/visitor-keys': 8.38.0
+      '@typescript-eslint/types': 8.34.1
+      '@typescript-eslint/visitor-keys': 8.34.1
 
-  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.4.5)':
+  '@typescript-eslint/tsconfig-utils@8.34.1(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
@@ -22693,11 +22398,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.38.0(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@8.34.1(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.38.0(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.34.1(eslint@8.56.0)(typescript@5.4.5)
       debug: 4.4.1
       eslint: 8.56.0
       ts-api-utils: 2.1.0(typescript@5.4.5)
@@ -22711,7 +22415,7 @@ snapshots:
 
   '@typescript-eslint/types@8.31.1': {}
 
-  '@typescript-eslint/types@8.38.0': {}
+  '@typescript-eslint/types@8.34.1': {}
 
   '@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.5)':
     dependencies:
@@ -22757,17 +22461,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.38.0(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@8.34.1(typescript@5.4.5)':
     dependencies:
-      '@typescript-eslint/project-service': 8.38.0(typescript@5.4.5)
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.4.5)
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/visitor-keys': 8.38.0
+      '@typescript-eslint/project-service': 8.34.1(typescript@5.4.5)
+      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.4.5)
+      '@typescript-eslint/types': 8.34.1
+      '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.7.1
       ts-api-utils: 2.1.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -22812,12 +22516,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.38.0(eslint@8.56.0)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.34.1(eslint@8.56.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.56.0)
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 8.34.1
+      '@typescript-eslint/types': 8.34.1
+      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.4.5)
       eslint: 8.56.0
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -22838,26 +22542,26 @@ snapshots:
       '@typescript-eslint/types': 8.31.1
       eslint-visitor-keys: 4.2.0
 
-  '@typescript-eslint/visitor-keys@8.38.0':
+  '@typescript-eslint/visitor-keys@8.34.1':
     dependencies:
-      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/types': 8.34.1
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@urql/core@5.2.0(graphql@16.11.0)':
+  '@urql/core@5.1.1(graphql@16.11.0)':
     dependencies:
       '@0no-co/graphql.web': 1.1.2(graphql@16.11.0)
       wonka: 6.3.5
     transitivePeerDependencies:
       - graphql
 
-  '@urql/exchange-retry@1.3.2(@urql/core@5.2.0(graphql@16.11.0))':
+  '@urql/exchange-retry@1.3.1(@urql/core@5.1.1(graphql@16.11.0))':
     dependencies:
-      '@urql/core': 5.2.0(graphql@16.11.0)
+      '@urql/core': 5.1.1(graphql@16.11.0)
       wonka: 6.3.5
 
-  '@vitest/coverage-istanbul@2.0.5(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))':
+  '@vitest/coverage-istanbul@2.0.5(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.0(supports-color@5.5.0)
@@ -22869,7 +22573,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22887,13 +22591,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@20.12.12)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))':
+  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@20.12.12)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@20.12.12)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.12.12)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -22945,9 +22649,6 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@vscode/sudo-prompt@9.3.1':
-    optional: true
-
   '@vue/compiler-core@3.4.19':
     dependencies:
       '@babel/parser': 7.27.5
@@ -22956,10 +22657,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.5.18':
+  '@vue/compiler-core@3.5.16':
     dependencies:
-      '@babel/parser': 7.28.0
-      '@vue/shared': 3.5.18
+      '@babel/parser': 7.27.5
+      '@vue/shared': 3.5.16
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -22970,10 +22671,10 @@ snapshots:
       '@vue/compiler-core': 3.4.19
       '@vue/shared': 3.4.19
 
-  '@vue/compiler-dom@3.5.18':
+  '@vue/compiler-dom@3.5.16':
     dependencies:
-      '@vue/compiler-core': 3.5.18
-      '@vue/shared': 3.5.18
+      '@vue/compiler-core': 3.5.16
+      '@vue/shared': 3.5.16
     optional: true
 
   '@vue/compiler-sfc@3.4.19':
@@ -22988,13 +22689,13 @@ snapshots:
       postcss: 8.4.47
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.5.18':
+  '@vue/compiler-sfc@3.5.16':
     dependencies:
-      '@babel/parser': 7.28.0
-      '@vue/compiler-core': 3.5.18
-      '@vue/compiler-dom': 3.5.18
-      '@vue/compiler-ssr': 3.5.18
-      '@vue/shared': 3.5.18
+      '@babel/parser': 7.27.5
+      '@vue/compiler-core': 3.5.16
+      '@vue/compiler-dom': 3.5.16
+      '@vue/compiler-ssr': 3.5.16
+      '@vue/shared': 3.5.16
       estree-walker: 2.0.2
       magic-string: 0.30.17
       postcss: 8.5.6
@@ -23006,15 +22707,15 @@ snapshots:
       '@vue/compiler-dom': 3.4.19
       '@vue/shared': 3.4.19
 
-  '@vue/compiler-ssr@3.5.18':
+  '@vue/compiler-ssr@3.5.16':
     dependencies:
-      '@vue/compiler-dom': 3.5.18
-      '@vue/shared': 3.5.18
+      '@vue/compiler-dom': 3.5.16
+      '@vue/shared': 3.5.16
     optional: true
 
   '@vue/shared@3.4.19': {}
 
-  '@vue/shared@3.5.18':
+  '@vue/shared@3.5.16':
     optional: true
 
   '@webassemblyjs/ast@1.14.1':
@@ -23170,12 +22871,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  addons-linter@6.13.0(body-parser@2.2.0)(node-fetch@3.3.1):
+  addons-linter@6.13.0(body-parser@1.20.3)(node-fetch@3.3.1):
     dependencies:
       '@fluent/syntax': 0.19.0
       '@mdn/browser-compat-data': 5.3.14
       addons-moz-compare: 1.3.0
-      addons-scanner-utils: 9.3.0(body-parser@2.2.0)(node-fetch@3.3.1)
+      addons-scanner-utils: 9.3.0(body-parser@1.20.3)(node-fetch@3.3.1)
       ajv: 8.12.0
       chalk: 4.1.2
       cheerio: 1.0.0-rc.12
@@ -23213,7 +22914,7 @@ snapshots:
 
   addons-moz-compare@1.3.0: {}
 
-  addons-scanner-utils@9.3.0(body-parser@2.2.0)(node-fetch@3.3.1):
+  addons-scanner-utils@9.3.0(body-parser@1.20.3)(node-fetch@3.3.1):
     dependencies:
       '@types/yauzl': 2.10.0
       common-tags: 1.8.2
@@ -23222,7 +22923,7 @@ snapshots:
       upath: 2.0.1
       yauzl: 2.10.0
     optionalDependencies:
-      body-parser: 2.2.0
+      body-parser: 1.20.3
       node-fetch: 3.3.1
 
   address@1.2.2: {}
@@ -23592,7 +23293,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
+      '@babel/types': 7.27.6
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
 
@@ -23611,28 +23312,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.26.10):
-    dependencies:
-      '@babel/compat-data': 7.28.0
-      '@babel/core': 7.26.10
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.26.10)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs3@0.11.1(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-define-polyfill-provider': 0.6.4(@babel/core@7.26.10)
       core-js-compat: 3.42.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.26.10):
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.26.10)
-      core-js-compat: 3.44.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23643,23 +23327,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.26.10):
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.26.10)
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-react-native-web@0.19.13: {}
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.26.10)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0))(supports-color@5.5.0):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.26.10)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.10)
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -23670,11 +23347,11 @@ snapshots:
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.26.10):
     dependencies:
-      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.26.10)
     transitivePeerDependencies:
       - '@babel/core'
 
-  babel-preset-current-node-syntax@1.1.1(@babel/core@7.26.10):
+  babel-preset-current-node-syntax@1.1.0(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.10)
@@ -23696,19 +23373,19 @@ snapshots:
   babel-preset-expo@13.1.11(@babel/core@7.26.10):
     dependencies:
       '@babel/helper-module-imports': 7.27.1
-      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.26.10)
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-syntax-export-default-from': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-proposal-export-default-from': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-syntax-export-default-from': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-flow-strip-types': 7.26.5(@babel/core@7.26.10)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.26.10)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.26.10)
+      '@babel/plugin-transform-object-rest-spread': 7.27.3(@babel/core@7.26.10)
+      '@babel/plugin-transform-parameters': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-runtime': 7.28.0(@babel/core@7.26.10)
-      '@babel/preset-react': 7.27.1(@babel/core@7.26.10)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-runtime': 7.26.10(@babel/core@7.26.10)
+      '@babel/preset-react': 7.26.3(@babel/core@7.26.10)
+      '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
       '@react-native/babel-preset': 0.79.2(@babel/core@7.26.10)
       babel-plugin-react-native-web: 0.19.13
       babel-plugin-syntax-hermes-parser: 0.25.1
@@ -23724,7 +23401,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.1(@babel/core@7.26.10)
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.10)
 
   babel-runtime@6.26.0:
     dependencies:
@@ -23783,7 +23460,7 @@ snapshots:
 
   bip21@3.0.0:
     dependencies:
-      query-string: 9.2.2
+      query-string: 9.2.1
 
   bip32-path@0.4.2: {}
 
@@ -23862,21 +23539,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-
-  body-parser@2.2.0:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.1
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
-      on-finished: 2.4.1
-      qs: 6.14.0
-      raw-body: 3.0.0
-      type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   bonjour-service@1.3.0:
     dependencies:
@@ -24002,13 +23664,6 @@ snapshots:
       electron-to-chromium: 1.5.169
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
-
-  browserslist@4.25.1:
-    dependencies:
-      caniuse-lite: 1.0.30001731
-      electron-to-chromium: 1.5.192
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
   bs58@4.0.1:
     dependencies:
@@ -24194,8 +23849,6 @@ snapshots:
   caniuse-lite@1.0.30001715: {}
 
   caniuse-lite@1.0.30001723: {}
-
-  caniuse-lite@1.0.30001731: {}
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
 
@@ -24522,18 +24175,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  compression@1.8.1:
-    dependencies:
-      bytes: 3.1.2
-      compressible: 2.0.18
-      debug: 2.6.9
-      negotiator: 0.6.4
-      on-headers: 1.1.0
-      safe-buffer: 5.2.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   compute-gcd@1.2.1:
     dependencies:
       validate.io-array: 1.0.6
@@ -24643,10 +24284,6 @@ snapshots:
   core-js-compat@3.42.0:
     dependencies:
       browserslist: 4.25.0
-
-  core-js-compat@3.44.0:
-    dependencies:
-      browserslist: 4.25.1
 
   core-js-pure@3.42.0: {}
 
@@ -24845,14 +24482,6 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
-  css-select@5.2.2:
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.2.2
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      nth-check: 2.1.1
-
   css-to-react-native@3.2.0:
     dependencies:
       camelize: 1.0.1
@@ -24875,8 +24504,6 @@ snapshots:
       source-map-js: 1.2.1
 
   css-what@6.1.0: {}
-
-  css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
 
@@ -25433,8 +25060,6 @@ snapshots:
 
   electron-to-chromium@1.5.169: {}
 
-  electron-to-chromium@1.5.192: {}
-
   electron@31.7.7:
     dependencies:
       '@electron/get': 2.0.3
@@ -25484,11 +25109,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
-
-  enhanced-resolve@5.18.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.2
 
   entities@2.2.0: {}
 
@@ -25816,7 +25436,7 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@8.56.0):
+  eslint-config-prettier@10.1.5(eslint@8.56.0):
     dependencies:
       eslint: 8.56.0
 
@@ -26094,62 +25714,62 @@ snapshots:
 
   expect-type@1.2.1: {}
 
-  expo-asset@11.1.5(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-asset@11.1.5(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@expo/image-utils': 0.7.6
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
+      '@expo/image-utils': 0.7.4
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-blur@14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-blur@14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  expo-constants@17.1.6(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)):
+  expo-constants@17.1.6(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)):
     dependencies:
-      '@expo/config': 11.0.13
-      '@expo/env': 1.0.7
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      '@expo/config': 11.0.10
+      '@expo/env': 1.0.5
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-file-system@18.1.11(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)):
+  expo-file-system@18.1.10(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)):
     dependencies:
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  expo-font@13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  expo-font@13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       fontfaceobserver: 2.3.0
       react: 19.0.0
 
-  expo-haptics@14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)):
+  expo-haptics@14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)):
     dependencies:
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
 
-  expo-image@2.1.7(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-image@2.1.7(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  expo-keep-awake@14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  expo-keep-awake@14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
-  expo-linear-gradient@14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-linear-gradient@14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
   expo-modules-autolinking@2.1.10:
     dependencies:
@@ -26165,42 +25785,42 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-splash-screen@0.30.8(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)):
+  expo-splash-screen@0.30.8(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)):
     dependencies:
-      '@expo/prebuild-config': 9.0.11
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@expo/prebuild-config': 9.0.7
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-squircle-view@1.1.0(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo-squircle-view@1.1.0(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.27.0
       '@expo/cli': 0.24.13(graphql@16.11.0)
-      '@expo/config': 11.0.13
+      '@expo/config': 11.0.10
       '@expo/config-plugins': 10.0.3
       '@expo/fingerprint': 0.12.4
       '@expo/metro-config': 0.20.14
-      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       babel-preset-expo: 13.1.11(@babel/core@7.26.10)
-      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
-      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
-      expo-file-system: 18.1.11(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))
-      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      expo-keep-awake: 14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))
+      expo-file-system: 18.1.10(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-keep-awake: 14.1.4(expo@53.0.9(@babel/core@7.26.10)(graphql@16.11.0)(react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0))(react@19.0.0)
       expo-modules-autolinking: 2.1.10
       expo-modules-core: 2.3.13
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
-      react-native-edge-to-edge: 1.6.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
-      react-native-webview: 13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native-webview: 13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-react-compiler
@@ -26766,8 +26386,6 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
-  globals@16.3.0: {}
-
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -26954,15 +26572,20 @@ snapshots:
 
   hermes-estree@0.25.1: {}
 
-  hermes-estree@0.29.1: {}
+  hermes-estree@0.28.1: {}
 
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
 
-  hermes-parser@0.29.1:
+  hermes-parser@0.28.1:
     dependencies:
-      hermes-estree: 0.29.1
+      hermes-estree: 0.28.1
+
+  hermes-profile-transformer@0.0.6:
+    dependencies:
+      source-map: 0.7.4
+    optional: true
 
   hex-rgba@1.0.2: {}
 
@@ -27157,8 +26780,6 @@ snapshots:
 
   ignore@7.0.4: {}
 
-  ignore@7.0.5: {}
-
   image-size@1.0.2:
     dependencies:
       queue: 6.0.2
@@ -27248,6 +26869,13 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  inversify@7.1.0(reflect-metadata@0.2.2):
+    dependencies:
+      '@inversifyjs/common': 1.5.0
+      '@inversifyjs/container': 1.5.4(reflect-metadata@0.2.2)
+      '@inversifyjs/core': 5.0.0(reflect-metadata@0.2.2)
+      reflect-metadata: 0.2.2
 
   invert-kv@3.0.1: {}
 
@@ -27548,8 +27176,8 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/core': 7.26.10
+      '@babel/parser': 7.27.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -27694,7 +27322,7 @@ snapshots:
 
   jiti@1.21.7: {}
 
-  jiti@2.5.1:
+  jiti@2.4.2:
     optional: true
 
   jju@1.4.0: {}
@@ -27939,12 +27567,6 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.2
-
-  launch-editor@2.11.0:
-    dependencies:
-      picocolors: 1.1.1
-      shell-quote: 1.8.3
-    optional: true
 
   lcid@3.1.1:
     dependencies:
@@ -28593,9 +28215,6 @@ snapshots:
 
   media-typer@0.3.0: {}
 
-  media-typer@1.1.0:
-    optional: true
-
   mem@5.1.1:
     dependencies:
       map-age-cleaner: 0.1.3
@@ -28645,50 +28264,50 @@ snapshots:
 
   methods@1.1.2: {}
 
-  metro-babel-transformer@0.82.5:
+  metro-babel-transformer@0.82.4:
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.26.10
       flow-enums-runtime: 0.0.6
-      hermes-parser: 0.29.1
+      hermes-parser: 0.28.1
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-cache-key@0.82.5:
+  metro-cache-key@0.82.4:
     dependencies:
       flow-enums-runtime: 0.0.6
 
-  metro-cache@0.82.5:
+  metro-cache@0.82.4:
     dependencies:
       exponential-backoff: 3.1.2
       flow-enums-runtime: 0.0.6
       https-proxy-agent: 7.0.6
-      metro-core: 0.82.5
+      metro-core: 0.82.4
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.82.5:
+  metro-config@0.82.4:
     dependencies:
       connect: 3.7.0
       cosmiconfig: 5.2.1
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.82.5
-      metro-cache: 0.82.5
-      metro-core: 0.82.5
-      metro-runtime: 0.82.5
+      metro: 0.82.4
+      metro-cache: 0.82.4
+      metro-core: 0.82.4
+      metro-runtime: 0.82.4
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  metro-core@0.82.5:
+  metro-core@0.82.4:
     dependencies:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
-      metro-resolver: 0.82.5
+      metro-resolver: 0.82.4
 
-  metro-file-map@0.82.5:
+  metro-file-map@0.82.4:
     dependencies:
       debug: 4.4.1
       fb-watchman: 2.0.2
@@ -28702,86 +28321,86 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-minify-terser@0.82.5:
+  metro-minify-terser@0.82.4:
     dependencies:
       flow-enums-runtime: 0.0.6
-      terser: 5.43.1
+      terser: 5.43.0
 
-  metro-resolver@0.82.5:
+  metro-resolver@0.82.4:
     dependencies:
       flow-enums-runtime: 0.0.6
 
-  metro-runtime@0.82.5:
+  metro-runtime@0.82.4:
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.27.0
       flow-enums-runtime: 0.0.6
 
-  metro-source-map@0.82.5:
+  metro-source-map@0.82.4:
     dependencies:
-      '@babel/traverse': 7.28.0
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.0'
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.27.4(supports-color@5.5.0)'
+      '@babel/types': 7.27.6
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-symbolicate: 0.82.5
+      metro-symbolicate: 0.82.4
       nullthrows: 1.1.1
-      ob1: 0.82.5
+      ob1: 0.82.4
       source-map: 0.5.7
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-symbolicate@0.82.5:
+  metro-symbolicate@0.82.4:
     dependencies:
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-source-map: 0.82.5
+      metro-source-map: 0.82.4
       nullthrows: 1.1.1
       source-map: 0.5.7
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-plugins@0.82.5:
+  metro-transform-plugins@0.82.4:
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/generator': 7.28.0
+      '@babel/core': 7.26.10
+      '@babel/generator': 7.27.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.82.5:
+  metro-transform-worker@0.82.4:
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/generator': 7.28.0
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.2
+      '@babel/core': 7.26.10
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
       flow-enums-runtime: 0.0.6
-      metro: 0.82.5
-      metro-babel-transformer: 0.82.5
-      metro-cache: 0.82.5
-      metro-cache-key: 0.82.5
-      metro-minify-terser: 0.82.5
-      metro-source-map: 0.82.5
-      metro-transform-plugins: 0.82.5
+      metro: 0.82.4
+      metro-babel-transformer: 0.82.4
+      metro-cache: 0.82.4
+      metro-cache-key: 0.82.4
+      metro-minify-terser: 0.82.4
+      metro-source-map: 0.82.4
+      metro-transform-plugins: 0.82.4
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  metro@0.82.5:
+  metro@0.82.4:
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.28.0
-      '@babel/generator': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/core': 7.26.10
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.27.4(supports-color@5.5.0)
+      '@babel/types': 7.27.6
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -28790,24 +28409,24 @@ snapshots:
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
-      hermes-parser: 0.29.1
+      hermes-parser: 0.28.1
       image-size: 1.2.1
       invariant: 2.2.4
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4
       lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.82.5
-      metro-cache: 0.82.5
-      metro-cache-key: 0.82.5
-      metro-config: 0.82.5
-      metro-core: 0.82.5
-      metro-file-map: 0.82.5
-      metro-resolver: 0.82.5
-      metro-runtime: 0.82.5
-      metro-source-map: 0.82.5
-      metro-symbolicate: 0.82.5
-      metro-transform-plugins: 0.82.5
-      metro-transform-worker: 0.82.5
+      metro-babel-transformer: 0.82.4
+      metro-cache: 0.82.4
+      metro-cache-key: 0.82.4
+      metro-config: 0.82.4
+      metro-core: 0.82.4
+      metro-file-map: 0.82.4
+      metro-resolver: 0.82.4
+      metro-runtime: 0.82.4
+      metro-source-map: 0.82.4
+      metro-symbolicate: 0.82.4
+      metro-transform-plugins: 0.82.4
+      metro-transform-worker: 0.82.4
       mime-types: 2.1.35
       nullthrows: 1.1.1
       serialize-error: 2.1.0
@@ -29122,11 +28741,6 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime-types@3.0.1:
-    dependencies:
-      mime-db: 1.54.0
-    optional: true
 
   mime@1.6.0: {}
 
@@ -29467,7 +29081,7 @@ snapshots:
 
   oauth-sign@0.9.0: {}
 
-  ob1@0.82.5:
+  ob1@0.82.4:
     dependencies:
       flow-enums-runtime: 0.0.6
 
@@ -29550,8 +29164,6 @@ snapshots:
 
   on-headers@1.0.2: {}
 
-  on-headers@1.1.0: {}
-
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -29586,6 +29198,12 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  openapi-fetch@0.13.5:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
 
   opener@1.5.2: {}
 
@@ -30479,7 +30097,7 @@ snapshots:
 
   qs@6.5.3: {}
 
-  query-string@9.2.2:
+  query-string@9.2.1:
     dependencies:
       decode-uri-component: 0.4.1
       filter-obj: 5.1.0
@@ -30579,14 +30197,6 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  raw-body@3.0.0:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
-      unpipe: 1.0.0
-    optional: true
-
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -30649,9 +30259,9 @@ snapshots:
       - supports-color
       - vue-template-compiler
 
-  react-devtools-core@6.1.5:
+  react-devtools-core@6.1.2:
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.8.2
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -30733,74 +30343,74 @@ snapshots:
       lottie-web: 5.12.2
       react: 19.0.0
 
-  react-native-edge-to-edge@1.6.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-edge-to-edge@1.6.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-gesture-handler@2.24.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native-is-edge-to-edge@1.1.7(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-is-edge-to-edge@1.1.7(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native-reanimated@3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-reanimated@3.17.5(@babel/core@7.26.10)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-classes': 7.28.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-classes': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.26.10)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.26.10)
+      '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
       convert-source-map: 2.0.0
       invariant: 2.2.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
-      react-native-is-edge-to-edge: 1.1.7(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
+      react-native-is-edge-to-edge: 1.1.7(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-safe-area-context@5.4.0(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native-svg@15.11.2(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-svg@15.11.2(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
-      css-select: 5.2.2
+      css-select: 5.1.0
       css-tree: 1.1.3
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
       warn-once: 0.1.1
 
-  react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
+  react-native-webview@13.14.1(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0)
 
-  react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0):
+  react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.79.2
       '@react-native/codegen': 0.79.2(@babel/core@7.26.10)
-      '@react-native/community-cli-plugin': 0.79.2(@react-native-community/cli@19.1.1(typescript@5.4.5))
+      '@react-native/community-cli-plugin': 0.79.2(@react-native-community/cli@13.6.6(encoding@0.1.13))
       '@react-native/gradle-plugin': 0.79.2
       '@react-native/js-polyfills': 0.79.2
       '@react-native/normalize-colors': 0.79.2
-      '@react-native/virtualized-lists': 0.79.2(@types/react@19.0.12)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@19.1.1(typescript@5.4.5))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
+      '@react-native/virtualized-lists': 0.79.2(@types/react@19.0.12)(react-native@0.79.2(@babel/core@7.26.10)(@react-native-community/cli@13.6.6(encoding@0.1.13))(@types/react@19.0.12)(react@19.0.0))(react@19.0.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -30815,17 +30425,17 @@ snapshots:
       invariant: 2.2.4
       jest-environment-node: 29.7.0
       memoize-one: 5.2.1
-      metro-runtime: 0.82.5
-      metro-source-map: 0.82.5
+      metro-runtime: 0.82.4
+      metro-source-map: 0.82.4
       nullthrows: 1.1.1
       pretty-format: 29.7.0
       promise: 8.3.0
       react: 19.0.0
-      react-devtools-core: 6.1.5
+      react-devtools-core: 6.1.2
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.25.0
-      semver: 7.7.2
+      semver: 7.7.1
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 8.17.1
@@ -31093,6 +30703,8 @@ snapshots:
       '@babel/runtime': 7.27.0
 
   redux@5.0.1: {}
+
+  reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -31516,32 +31128,12 @@ snapshots:
 
   semver@7.7.1: {}
 
-  semver@7.7.2: {}
-
   send@0.19.0:
     dependencies:
       debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  send@0.19.1:
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
       fresh: 0.5.2
@@ -31641,8 +31233,6 @@ snapshots:
   shell-quote@1.7.3: {}
 
   shell-quote@1.8.2: {}
-
-  shell-quote@1.8.3: {}
 
   shellwords@0.1.1: {}
 
@@ -32109,18 +31699,18 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1):
+  styled-components@5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0):
     dependencies:
       '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/traverse': 7.27.4(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.3.1
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.26.10)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0))(supports-color@5.5.0)
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.26.10)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
       css-to-react-native: 3.2.0
       hoist-non-react-statics: 3.3.2
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
       react-is: 18.3.1
       shallowequal: 1.1.0
       supports-color: 5.5.0
@@ -32131,13 +31721,16 @@ snapshots:
 
   sucrase@3.35.0:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/gen-mapping': 0.3.8
       commander: 4.1.1
       glob: 10.4.5
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
+
+  sudo-prompt@9.2.1:
+    optional: true
 
   sumchecker@3.0.1:
     dependencies:
@@ -32203,8 +31796,6 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  tapable@2.2.2: {}
-
   tar-fs@2.1.3:
     dependencies:
       chownr: 1.1.4
@@ -32268,9 +31859,9 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  terser@5.43.1:
+  terser@5.43.0:
     dependencies:
-      '@jridgewell/source-map': 0.3.10
+      '@jridgewell/source-map': 0.3.6
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
@@ -32530,13 +32121,6 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.1
-    optional: true
-
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -32580,12 +32164,11 @@ snapshots:
 
   typeforce@1.18.0: {}
 
-  typescript-eslint@8.38.0(eslint@8.56.0)(typescript@5.4.5):
+  typescript-eslint@8.34.1(eslint@8.56.0)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.38.0(@typescript-eslint/parser@8.38.0(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/parser': 8.38.0(eslint@8.56.0)(typescript@5.4.5)
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.38.0(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.34.1(eslint@8.56.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.34.1(eslint@8.56.0)(typescript@5.4.5)
       eslint: 8.56.0
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -32766,12 +32349,6 @@ snapshots:
   update-browserslist-db@1.1.3(browserslist@4.25.0):
     dependencies:
       browserslist: 4.25.0
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.1.3(browserslist@4.25.1):
-    dependencies:
-      browserslist: 4.25.1
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -32959,13 +32536,13 @@ snapshots:
       bl: 1.2.3
       through2: 2.0.5
 
-  vite-node@3.1.4(@types/node@20.12.12)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0):
+  vite-node@3.1.4(@types/node@20.12.12)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@20.12.12)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.12.12)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -32980,7 +32557,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@20.12.12)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0):
+  vite@6.3.5(@types/node@20.12.12)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.4(picomatch@4.0.2)
@@ -32991,15 +32568,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.12
       fsevents: 2.3.3
-      jiti: 2.5.1
+      jiti: 2.4.2
       lightningcss: 1.30.1
-      terser: 5.43.1
+      terser: 5.43.0
       yaml: 2.8.0
 
-  vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0):
+  vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.12.12)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@20.12.12)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@20.12.12)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -33016,8 +32593,8 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@20.12.12)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
-      vite-node: 3.1.4(@types/node@20.12.12)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@20.12.12)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0)
+      vite-node: 3.1.4(@types/node@20.12.12)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.0)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -33073,9 +32650,9 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  web-ext-submit@7.8.0(body-parser@2.2.0):
+  web-ext-submit@7.8.0(body-parser@1.20.3):
     dependencies:
-      web-ext: 7.8.0(body-parser@2.2.0)
+      web-ext: 7.8.0(body-parser@1.20.3)
     transitivePeerDependencies:
       - body-parser
       - bufferutil
@@ -33084,11 +32661,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  web-ext@7.8.0(body-parser@2.2.0):
+  web-ext@7.8.0(body-parser@1.20.3):
     dependencies:
       '@babel/runtime': 7.21.0
       '@devicefarmer/adbkit': 3.2.3
-      addons-linter: 6.13.0(body-parser@2.2.0)(node-fetch@3.3.1)
+      addons-linter: 6.13.0(body-parser@1.20.3)(node-fetch@3.3.1)
       bunyan: 1.8.15
       camelcase: 7.0.1
       chrome-launcher: 0.15.1

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -11,11 +11,13 @@ import { restoreWalletSession } from '@app/store/session-restore';
 
 import { App } from './app';
 import { setDebugOnGlobal } from './debug';
+import { initAppServices } from './services/init-app-services';
 
 // `bitcoinjs-lib` requires an elliptic curve library to be initialized, here we
 // do it globally for the entire app.
 bitcoin.initEccLib(ecc);
 
+initAppServices();
 initSentry();
 warnUsersAboutDevToolsDangers();
 setDebugOnGlobal();

--- a/src/app/services/extension-http-cache.service.ts
+++ b/src/app/services/extension-http-cache.service.ts
@@ -1,0 +1,21 @@
+import { HttpCacheOptions, HttpCacheService } from '@leather.io/services';
+
+import { logger } from '@shared/logger';
+
+import { queryClient } from '@app/common/persistence';
+
+export class ExtensionHttpCacheService extends HttpCacheService {
+  async fetchWithCacheInternal<T>(
+    key: unknown[],
+    fetchFn: () => Promise<T>,
+    options: HttpCacheOptions = {}
+  ): Promise<T> {
+    logger.info(key.join('|'), JSON.stringify(options));
+    return queryClient.fetchQuery({
+      queryKey: key,
+      queryFn: fetchFn,
+      staleTime: options.ttl ?? 0,
+      retry: false,
+    });
+  }
+}

--- a/src/app/services/extension-settings.service.ts
+++ b/src/app/services/extension-settings.service.ts
@@ -1,0 +1,13 @@
+import { SettingsService } from '@leather.io/services';
+
+import { store } from '@app/store';
+import { selectCurrentNetwork } from '@app/store/networks/networks.selectors';
+
+export class ExtensionSettingsService implements SettingsService {
+  getSettings() {
+    return {
+      quoteCurrency: 'USD',
+      network: selectCurrentNetwork(store.getState()),
+    };
+  }
+}

--- a/src/app/services/fetch-state.ts
+++ b/src/app/services/fetch-state.ts
@@ -1,0 +1,44 @@
+export type FetchState<T> =
+  | {
+      state: 'loading';
+    }
+  | {
+      state: 'success';
+      value: T;
+    }
+  | {
+      state: 'error';
+      errorMessage: string;
+    };
+
+export function toFetchState<T>({
+  data,
+  isLoading,
+  isError,
+  error,
+}: {
+  data?: T;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+}) {
+  if (isLoading) {
+    return { state: 'loading' } as const;
+  }
+  if (isError) {
+    return {
+      state: 'error',
+      errorMessage: error?.message ?? '',
+    } as const;
+  }
+  if (!data) {
+    return {
+      state: 'error',
+      errorMessage: '',
+    } as const;
+  }
+  return {
+    state: 'success',
+    value: data,
+  } as const;
+}

--- a/src/app/services/init-app-services.ts
+++ b/src/app/services/init-app-services.ts
@@ -1,0 +1,18 @@
+import { initServicesContainer } from '@leather.io/services';
+
+import { WALLET_ENVIRONMENT } from '@shared/environment';
+import { logger } from '@shared/logger';
+
+import { ExtensionHttpCacheService } from './extension-http-cache.service';
+import { ExtensionSettingsService } from './extension-settings.service';
+
+export function initAppServices() {
+  logger.debug('initAppServices');
+  initServicesContainer({
+    env: {
+      environment: WALLET_ENVIRONMENT,
+    },
+    cacheService: ExtensionHttpCacheService,
+    settingsService: ExtensionSettingsService,
+  });
+}

--- a/src/app/services/queries/balance/account-balances.query.ts
+++ b/src/app/services/queries/balance/account-balances.query.ts
@@ -1,0 +1,83 @@
+import type { Money } from '@leather.io/models';
+import type {
+  AccountQuotedBtcBalance,
+  AddressQuotedStxBalance,
+  RunesAccountBalance,
+  Sip10AddressBalance,
+} from '@leather.io/services';
+import { createMoney, isDefined, sumMoney } from '@leather.io/utils';
+
+import { type FetchState, toFetchState } from '@app/services/fetch-state';
+
+import { useCurrentAccountBtcBalance } from './btc-balance.query';
+import { useCurrentAccountRunesBalance } from './runes-balance.query';
+import { useCurrentAccountSip10Balance } from './sip10-balance.query';
+import { useCurrentAccountStxBalance } from './stx-balance.query';
+
+// ts-unused-exports:disable-next-line
+export interface AccountBalances {
+  btc: FetchState<AccountQuotedBtcBalance>;
+  stx: FetchState<AddressQuotedStxBalance>;
+  sip10: FetchState<Sip10AddressBalance>;
+  runes: FetchState<RunesAccountBalance>;
+  totalBalance: FetchState<Money>;
+  availableBalance: FetchState<Money>;
+}
+
+// ts-unused-exports:disable-next-line
+export function useCurrentAccountBalances(): AccountBalances {
+  const zeroMoneyUsd = createMoney(0, 'USD');
+
+  const btcAccountBalance = useCurrentAccountBtcBalance();
+  const stxAccountBalance = useCurrentAccountStxBalance();
+  const runesAccountBalance = useCurrentAccountRunesBalance();
+  const sip10AccountBalance = useCurrentAccountSip10Balance();
+
+  const isLoading =
+    btcAccountBalance.state === 'loading' &&
+    stxAccountBalance.state === 'loading' &&
+    sip10AccountBalance.state === 'loading' &&
+    runesAccountBalance.state === 'loading';
+  const isError =
+    btcAccountBalance.state === 'error' &&
+    stxAccountBalance.state === 'error' &&
+    sip10AccountBalance.state === 'error' &&
+    runesAccountBalance.state === 'error';
+  const accountAvailableBalance = sumMoney(
+    [
+      zeroMoneyUsd,
+      btcAccountBalance.value?.quote.availableBalance,
+      stxAccountBalance.value?.quote.availableBalance,
+      sip10AccountBalance.value?.quote.availableBalance,
+      runesAccountBalance.value?.quote.availableBalance,
+    ].filter(isDefined)
+  );
+  const accountTotalBalance = sumMoney(
+    [
+      zeroMoneyUsd,
+      btcAccountBalance.value?.quote.totalBalance,
+      stxAccountBalance.value?.quote.totalBalance,
+      sip10AccountBalance.value?.quote.totalBalance,
+      runesAccountBalance.value?.quote.totalBalance,
+    ].filter(isDefined)
+  );
+
+  return {
+    btc: btcAccountBalance,
+    stx: stxAccountBalance,
+    sip10: sip10AccountBalance,
+    runes: runesAccountBalance,
+    totalBalance: toFetchState({
+      isLoading,
+      data: accountTotalBalance,
+      isError,
+      error: new Error('Error loading account total balance data'),
+    }),
+    availableBalance: toFetchState({
+      isLoading,
+      data: accountAvailableBalance,
+      isError,
+      error: new Error('Error loading account available balance data'),
+    }),
+  };
+}

--- a/src/app/services/queries/balance/balance-query-options.ts
+++ b/src/app/services/queries/balance/balance-query-options.ts
@@ -1,0 +1,12 @@
+import { UseQueryOptions } from '@tanstack/react-query';
+
+import { oneWeekInMs } from '@leather.io/utils';
+
+export const balanceQueryOptions = {
+  refetchOnMount: true,
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+  staleTime: 2000,
+  gcTime: oneWeekInMs,
+  retry: 0,
+} satisfies Partial<UseQueryOptions>;

--- a/src/app/services/queries/balance/btc-balance.query.ts
+++ b/src/app/services/queries/balance/btc-balance.query.ts
@@ -1,0 +1,53 @@
+import { type QueryFunctionContext, useQuery } from '@tanstack/react-query';
+
+import { BtcAccountRequest, getBtcBalancesService } from '@leather.io/services';
+
+import { toFetchState } from '@app/services/fetch-state';
+import { useAccountAddresses } from '@app/services/use-account-addresses';
+import { useDiscardedInscriptions } from '@app/store/settings/settings.selectors';
+
+import { balanceQueryOptions } from './balance-query-options';
+
+// ts-unused-exports:disable-next-line
+export function useCurrentAccountNativeSegwitBtcBalance() {
+  const account = useAccountAddresses();
+  const { discardedInscriptions } = useDiscardedInscriptions();
+  return toFetchState(
+    useGetBtcAccountBalanceQuery({
+      account,
+      unprotectedUtxos: discardedInscriptions.map(satPoint => ({
+        txid: satPoint.split(':')[0],
+        vout: Number(satPoint.split(':')[1]),
+      })),
+      exclude: { taprootAddresses: true },
+    })
+  );
+}
+
+export function useCurrentAccountBtcBalance() {
+  const account = useAccountAddresses();
+  const { discardedInscriptions } = useDiscardedInscriptions();
+  return toFetchState(
+    useGetBtcAccountBalanceQuery({
+      account,
+      unprotectedUtxos: discardedInscriptions.map(satPoint => ({
+        txid: satPoint.split(':')[0],
+        vout: Number(satPoint.split(':')[1]),
+      })),
+    })
+  );
+}
+
+function useGetBtcAccountBalanceQuery(request: BtcAccountRequest) {
+  return useQuery({
+    queryKey: [
+      'btc-balance-service-get-btc-account-balance',
+      request.account.id.fingerprint,
+      request.account.id.accountIndex,
+      JSON.stringify(request.unprotectedUtxos),
+    ],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getBtcBalancesService().getBtcAccountBalance(request, signal),
+    ...balanceQueryOptions,
+  });
+}

--- a/src/app/services/queries/balance/runes-balance.query.ts
+++ b/src/app/services/queries/balance/runes-balance.query.ts
@@ -1,0 +1,27 @@
+import { type QueryFunctionContext, useQuery } from '@tanstack/react-query';
+
+import type { AccountAddresses } from '@leather.io/models';
+import { getRunesBalancesService } from '@leather.io/services';
+
+import { toFetchState } from '@app/services/fetch-state';
+import { useAccountAddresses } from '@app/services/use-account-addresses';
+
+import { balanceQueryOptions } from './balance-query-options';
+
+export function useCurrentAccountRunesBalance() {
+  const account = useAccountAddresses();
+  return toFetchState(useGetRunesAccountBalanceQuery(account));
+}
+
+function useGetRunesAccountBalanceQuery(account: AccountAddresses) {
+  return useQuery({
+    queryKey: [
+      'runes-balances-service-get-runes-account-balance',
+      account.id.fingerprint,
+      account.id.accountIndex,
+    ],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getRunesBalancesService().getRunesAccountBalance(account, signal),
+    ...balanceQueryOptions,
+  });
+}

--- a/src/app/services/queries/balance/sip10-balance.query.ts
+++ b/src/app/services/queries/balance/sip10-balance.query.ts
@@ -1,0 +1,22 @@
+import { type QueryFunctionContext, useQuery } from '@tanstack/react-query';
+
+import { getSip10BalancesService } from '@leather.io/services';
+
+import { toFetchState } from '@app/services/fetch-state';
+import { useCurrentStacksAccountAddress } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+
+import { balanceQueryOptions } from './balance-query-options';
+
+export function useCurrentAccountSip10Balance() {
+  const stxAddress = useCurrentStacksAccountAddress();
+  return toFetchState(useGetSip10AddressBalanceQuery(stxAddress));
+}
+
+function useGetSip10AddressBalanceQuery(address: string) {
+  return useQuery({
+    queryKey: ['sip10-balances-service-get-sip10-address-balance', address],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getSip10BalancesService().getSip10AddressBalance(address, signal),
+    ...balanceQueryOptions,
+  });
+}

--- a/src/app/services/queries/balance/stx-balance.query.ts
+++ b/src/app/services/queries/balance/stx-balance.query.ts
@@ -1,0 +1,22 @@
+import { type QueryFunctionContext, useQuery } from '@tanstack/react-query';
+
+import { getStxBalancesService } from '@leather.io/services';
+
+import { toFetchState } from '@app/services/fetch-state';
+import { useCurrentStacksAccountAddress } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+
+import { balanceQueryOptions } from './balance-query-options';
+
+export function useCurrentAccountStxBalance() {
+  const stxAddress = useCurrentStacksAccountAddress();
+  return toFetchState(useGetStxAddressBalanceQuery(stxAddress));
+}
+
+function useGetStxAddressBalanceQuery(address: string) {
+  return useQuery({
+    queryKey: ['stx-balances-service-get-stx-address-balance', address],
+    queryFn: ({ signal }: QueryFunctionContext) =>
+      getStxBalancesService().getStxAddressBalance(address, signal),
+    ...balanceQueryOptions,
+  });
+}

--- a/src/app/services/use-account-addresses.ts
+++ b/src/app/services/use-account-addresses.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+
+import { createAccountAddresses } from '@leather.io/utils';
+
+import { useCurrentAccountIndex } from '@app/store/accounts/account';
+import { useCurrentBitcoinAccountXpubs } from '@app/store/accounts/blockchain/bitcoin/bitcoin.hooks';
+import { useCurrentStacksAccountAddress } from '@app/store/accounts/blockchain/stacks/stacks-account.hooks';
+
+export function useAccountAddresses() {
+  const accountXpubs = useCurrentBitcoinAccountXpubs();
+  const stxAddress = useCurrentStacksAccountAddress();
+  const accountIndex = useCurrentAccountIndex();
+
+  return useMemo(() => {
+    return createAccountAddresses(
+      { fingerprint: 'master', accountIndex },
+      accountXpubs,
+      stxAddress
+    );
+  }, [accountXpubs, stxAddress, accountIndex]);
+}


### PR DESCRIPTION
> Try out Leather build 91c1a89 — [Extension build](https://github.com/leather-io/extension/actions/runs/16626542703), [Test report](https://leather-io.github.io/playwright-reports/feat/add-services-package), [Storybook](https://feat/add-services-package--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=feat/add-services-package)<!-- Sticky Header Marker -->

Installs and initializes the `@leather.io/services` package. 

There are a few helpers and balance-related hooks that were used to validate the implementation. These will be used in follow-on PRs to rework balance data fetching using services.