### PR TITLE
fix: missing swap event tracking, closes LEA-3088

### DIFF
--- a/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
+++ b/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
@@ -21,6 +21,7 @@ import { btcToSat, createMoney } from '@leather.io/utils';
 
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
+import { analytics } from '@shared/utils/analytics';
 
 import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
 import {
@@ -151,13 +152,16 @@ export function useSbtcDepositTransaction(signer: BitcoinSigner<P2Ret>, utxos: U
         const txid = await client.broadcastTx(deposit.transaction);
         logger.info('Broadcasted tx', txid);
 
+        void analytics.untypedTrack('bitcoin_swap_succeeded', { txid });
+
         await client.notifySbtc(deposit);
         toast.success('Transaction submitted!');
         setIsIdle();
-        navigate(RouteUrls.Activity);
+        return navigate(RouteUrls.Activity);
       } catch (error) {
         setIsIdle();
         logger.error(`Deposit error: ${error}`);
+        void analytics.untypedTrack('bitcoin_swap_failed', { error });
       } finally {
         setIsIdle();
       }

--- a/src/app/pages/swap/hooks/use-stacks-broadcast-swap.tsx
+++ b/src/app/pages/swap/hooks/use-stacks-broadcast-swap.tsx
@@ -7,6 +7,7 @@ import { isError, isString } from '@leather.io/utils';
 
 import { logger } from '@shared/logger';
 import { RouteUrls } from '@shared/route-urls';
+import { analytics } from '@shared/utils/analytics';
 
 import { LoadingKeys, useLoading } from '@app/common/hooks/use-loading';
 import { useSubmitTransactionCallback } from '@app/common/hooks/use-submit-stx-transaction';
@@ -33,18 +34,20 @@ export function useStacksBroadcastSwap() {
           onError(e: Error | string) {
             setIsIdle();
             const message = isString(e) ? e : e.message;
-            navigate(RouteUrls.TransactionBroadcastError, { state: { message } });
+            return navigate(RouteUrls.TransactionBroadcastError, { state: { message } });
           },
-          onSuccess() {
+          onSuccess(txId) {
             toast.success('Transaction submitted!');
             setIsIdle();
-            navigate(RouteUrls.Activity);
+            void analytics.untypedTrack('stacks_swap_succeeded', { txid: txId });
+            return navigate(RouteUrls.Activity);
           },
           replaceByFee: false,
         })(signedTx);
       } catch (e) {
         setIsIdle();
-        navigate(RouteUrls.TransactionBroadcastError, {
+        void analytics.untypedTrack('stacks_swap_failed', { error: e });
+        return navigate(RouteUrls.TransactionBroadcastError, {
           state: { message: isError(e) ? e.message : 'Unknown error' },
         });
       } finally {

--- a/src/app/pages/swap/providers/use-stacks-swap.tsx
+++ b/src/app/pages/swap/providers/use-stacks-swap.tsx
@@ -167,7 +167,7 @@ export function useStacksSwap(nonce: number | string) {
 
         return await broadcastStacksSwap(signedTx);
       } catch (e) {
-        navigate(RouteUrls.SwapError, {
+        return navigate(RouteUrls.SwapError, {
           state: {
             message: isError(e) ? e.message : '',
             title: 'Swap Error',


### PR DESCRIPTION
> Try out Leather build 303e57b — [Extension build](https://github.com/leather-io/extension/actions/runs/16779877035), [Test report](https://leather-io.github.io/playwright-reports/fix/swap-event-tracking), [Storybook](https://fix/swap-event-tracking--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/swap-event-tracking)<!-- Sticky Header Marker -->

This PR adds event tracking analytics to swaps. Open to feedback here, bitcoin is just sBTC deposits rn so we could also name the event accordingly?