### PR TITLE
fix: share manage token state across accounts, closes LEA-3107

### DIFF
--- a/src/app/common/hooks/use-manage-tokens.ts
+++ b/src/app/common/hooks/use-manage-tokens.ts
@@ -2,7 +2,6 @@ import {
   useConfigSbtc,
   useConfigTokensEnabledByDefault,
 } from '@app/query/common/remote-config/remote-config.query';
-import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { useUserAllTokens } from '@app/store/manage-tokens/manage-tokens.slice';
 
 interface IsTokenEnabledArgs {
@@ -21,11 +20,10 @@ export function useManageTokens() {
   const configEnabledTokens = useConfigTokensEnabledByDefault();
   const { contractId: sbtcContractId, isSbtcEnabled } = useConfigSbtc();
 
-  const accountIndex = useCurrentAccountIndex();
   const userTokensList = useUserAllTokens();
 
   function isTokenEnabled({ tokenId, preEnabledTokensIds }: IsTokenEnabledArgs) {
-    const token = userTokensList.find(t => t.accountIndex === accountIndex && t.id === tokenId);
+    const token = userTokensList.find(t => t.id === tokenId);
     const isEnabledByDefault =
       configEnabledTokens.includes(tokenId) || preEnabledTokensIds?.includes(tokenId);
 

--- a/src/app/components/crypto-asset-item/crypto-asset-item-toggle.tsx
+++ b/src/app/components/crypto-asset-item/crypto-asset-item-toggle.tsx
@@ -7,7 +7,6 @@ import { Box, VStack } from 'leather-styles/jsx';
 import { ItemLayout, Pressable, Switch } from '@leather.io/ui';
 
 import { useSpamFilterWithWhitelist } from '@app/common/spam-filter/use-spam-filter';
-import { useCurrentAccountIndex } from '@app/store/accounts/account';
 import { manageTokensSlice } from '@app/store/manage-tokens/manage-tokens.slice';
 
 export interface CryptoAssetItemToggleProps {
@@ -25,7 +24,6 @@ export function CryptoAssetItemToggle({
   assetId,
   isCheckedByDefault = false,
 }: CryptoAssetItemToggleProps) {
-  const accountIndex = useCurrentAccountIndex();
   const dispatch = useDispatch();
 
   const switchRef = useRef<HTMLButtonElement>(null);
@@ -39,7 +37,6 @@ export function CryptoAssetItemToggle({
         manageTokensSlice.actions.userTogglesTokenVisibility({
           id: assetId,
           enabled,
-          accountIndex,
         })
       );
     });

--- a/src/app/store/manage-tokens/manage-tokens.slice.ts
+++ b/src/app/store/manage-tokens/manage-tokens.slice.ts
@@ -7,7 +7,6 @@ import type { RootState } from '..';
 interface TokenUserSetting {
   id: string;
   enabled: boolean;
-  accountIndex: number;
 }
 
 const manageTokensAdapter = createEntityAdapter<TokenUserSetting>();
@@ -16,14 +15,10 @@ export const manageTokensSlice = createSlice({
   name: 'manageTokens',
   initialState: manageTokensAdapter.getInitialState(),
   reducers: {
-    userTogglesTokenVisibility(
-      state,
-      action: PayloadAction<{ id: string; enabled: boolean; accountIndex: number }>
-    ) {
+    userTogglesTokenVisibility(state, action: PayloadAction<{ id: string; enabled: boolean }>) {
       manageTokensAdapter.setOne(state, {
         id: action.payload.id,
         enabled: action.payload.enabled,
-        accountIndex: action.payload.accountIndex,
       });
     },
     removeAllTokens(state) {


### PR DESCRIPTION
> Try out Leather build c0e847e — [Extension build](https://github.com/leather-io/extension/actions/runs/16773233449), [Test report](https://leather-io.github.io/playwright-reports/fix/manage-token-global-state), [Storybook](https://fix/manage-token-global-state--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/manage-token-global-state)<!-- Sticky Header Marker -->

Removes `accountIndex` from manage token state and filtering. Token management status (enabled / disabled) is always shared by all accounts.