### PR TITLE
chore: migrate integration tests to testnet4

### DIFF
--- a/src/app/store/networks/networks.utils.ts
+++ b/src/app/store/networks/networks.utils.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@stacks/network';
 
 import {
   BITCOIN_API_BASE_URL_MAINNET,
-  BITCOIN_API_BASE_URL_TESTNET3,
+  BITCOIN_API_BASE_URL_TESTNET4,
   type BitcoinNetwork,
   type NetworkConfiguration,
   bitcoinNetworkToNetworkMode,
@@ -47,7 +47,7 @@ function checkBitcoinNetworkProperties(
   network: PersistedNetworkConfiguration
 ): PersistedNetworkConfiguration {
   if (!network.bitcoinNetwork || !network.bitcoinUrl) {
-    const bitcoinNetwork = network.chainId === ChainId.Mainnet ? 'mainnet' : 'testnet3';
+    const bitcoinNetwork = network.chainId === ChainId.Mainnet ? 'mainnet' : 'testnet4';
     return {
       id: network.id,
       name: network.name,
@@ -59,7 +59,7 @@ function checkBitcoinNetworkProperties(
       bitcoinUrl:
         network.chainId === ChainId.Mainnet
           ? BITCOIN_API_BASE_URL_MAINNET
-          : BITCOIN_API_BASE_URL_TESTNET3,
+          : BITCOIN_API_BASE_URL_TESTNET4,
     };
   } else {
     return network;
@@ -98,7 +98,7 @@ export function transformNetworkStateToMultichainStucture(
                 mode: isValidBitcoinNetwork(bitcoinNetwork)
                   ? bitcoinNetworkToNetworkMode(bitcoinNetwork)
                   : 'testnet',
-                bitcoinUrl: bitcoinUrl ?? BITCOIN_API_BASE_URL_TESTNET3,
+                bitcoinUrl: bitcoinUrl ?? BITCOIN_API_BASE_URL_TESTNET4,
               },
             },
           },

--- a/tests/mocks/mock-bitcoin-tx.ts
+++ b/tests/mocks/mock-bitcoin-tx.ts
@@ -1,11 +1,11 @@
 import type { Page } from '@playwright/test';
 
-import { BITCOIN_API_BASE_URL_TESTNET3 } from '@leather.io/models';
+import { BITCOIN_API_BASE_URL_TESTNET4 } from '@leather.io/models';
 
 import { mockMainnetNsTransactionsTestAccount } from './mock-utxos';
 
 export async function mockTestAccountBtcBroadcastTransaction(page: Page) {
-  await page.route(`${BITCOIN_API_BASE_URL_TESTNET3}/tx`, route =>
+  await page.route(`${BITCOIN_API_BASE_URL_TESTNET4}/tx`, route =>
     route.fulfill({
       body: mockMainnetNsTransactionsTestAccount[0].txid,
     })

--- a/tests/mocks/mock-utxos.ts
+++ b/tests/mocks/mock-utxos.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-import { BITCOIN_API_BASE_URL_TESTNET3 } from '@leather.io/models';
+import { BITCOIN_API_BASE_URL_TESTNET4 } from '@leather.io/models';
 
 import { TEST_ACCOUNT_1_NATIVE_SEGWIT_ADDRESS } from './constants';
 
@@ -134,7 +134,7 @@ export async function mockMainnetTestAccountBitcoinRequests(page: Page) {
 }
 
 export async function mockTestnetTestAccountEmptyUtxosRequests(page: Page) {
-  await page.route(`${BITCOIN_API_BASE_URL_TESTNET3}/address/**/utxo`, route =>
+  await page.route(`${BITCOIN_API_BASE_URL_TESTNET4}/address/**/utxo`, route =>
     route.fulfill({
       json: [],
     })

--- a/tests/page-object-models/home.page.ts
+++ b/tests/page-object-models/home.page.ts
@@ -108,7 +108,7 @@ export class HomePage {
     await this.page.getByTestId(SettingsSelectors.SettingsMenuBtn).click();
     await this.page.getByTestId(SettingsSelectors.ChangeNetworkAction).click();
     await this.page.getByTestId(NetworkSelectors.NetworkListActiveNetwork).isVisible();
-    await this.page.getByTestId(WalletDefaultNetworkConfigurationIds.testnet).click();
+    await this.page.getByTestId(WalletDefaultNetworkConfigurationIds.testnet4).click();
   }
 
   async clickActivityTab() {

--- a/tests/selectors/network.selectors.ts
+++ b/tests/selectors/network.selectors.ts
@@ -16,7 +16,7 @@ export enum NetworkSelectors {
   // add network form
   AddNetworkBtn = 'add-network-btn',
   AddNetworkBitcoinAPISelector = 'add-network-bitcoin-api-selector',
-  BitcoinApiOptionTestnet = 'bitcoin-api-option-testnet3',
+  BitcoinApiOptionTestnet = 'bitcoin-api-option-testnet4',
 
   NetworkMenuBtn = 'network-menu-btn',
   EditNetworkMenuBtn = 'edit-network-menu-btn',

--- a/tests/specs/network/add-network.spec.ts
+++ b/tests/specs/network/add-network.spec.ts
@@ -1,7 +1,7 @@
 import { NetworkSelectors } from '@tests/selectors/network.selectors';
 import { SettingsSelectors } from '@tests/selectors/settings.selectors';
 
-import { BITCOIN_API_BASE_URL_TESTNET3 } from '@leather.io/models';
+import { BITCOIN_API_BASE_URL_TESTNET4 } from '@leather.io/models';
 
 import { test } from '../../fixtures/fixtures';
 
@@ -23,7 +23,7 @@ test.describe('Networks tests', () => {
 
     const bitcoinUrl = page.getByTestId(NetworkSelectors.NetworkBitcoinAddress);
 
-    test.expect(await bitcoinUrl.inputValue()).toEqual(BITCOIN_API_BASE_URL_TESTNET3);
+    test.expect(await bitcoinUrl.inputValue()).toEqual(BITCOIN_API_BASE_URL_TESTNET4);
   });
 
   test('validation error when stacks api url is empty', async ({ networkPage }) => {

--- a/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
+++ b/tests/specs/rpc-send-transfer/rpc-send-transfer.spec.ts
@@ -17,7 +17,7 @@ const baseParams = {
       amount: '900',
     },
   ],
-  network: 'testnet',
+  network: 'testnet4',
 };
 
 test.describe('RPC: sendTransfer', () => {


### PR DESCRIPTION
> Try out Leather build daa4f1c — [Extension build](https://github.com/leather-io/extension/actions/runs/17154523561), [Test report](https://leather-io.github.io/playwright-reports/chore/migrate-tests-to-testnet4), [Storybook](https://chore/migrate-tests-to-testnet4--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=chore/migrate-tests-to-testnet4)<!-- Sticky Header Marker -->

We favor Testnet4 over Testnet3 in most places. This PR updates our integration tests to also use Testnet4.