### PR TITLE
fix: remove outdated color definitions from sign out flow buttons

### DIFF
--- a/src/app/features/settings/sign-out/sign-out.tsx
+++ b/src/app/features/settings/sign-out/sign-out.tsx
@@ -41,7 +41,6 @@ export function SignOutSheet({ isShowing, onUserDeleteWallet, onClose }: SignOut
       footer={
         <ButtonRow flexDirection="row">
           <Button
-            color="gray"
             data-testid={SettingsSelectors.BtnSignOutReturnToHomeScreen}
             flexGrow={1}
             variant="outline"
@@ -50,7 +49,6 @@ export function SignOutSheet({ isShowing, onUserDeleteWallet, onClose }: SignOut
             Cancel
           </Button>
           <Button
-            color="lightModeInk.1"
             opacity={!canSignOut ? 0.8 : undefined}
             data-testid={SettingsSelectors.BtnSignOutActuallyDeleteWallet}
             flexGrow={1}


### PR DESCRIPTION
> Try out Leather build e9bd464 — [Extension build](https://github.com/leather-io/extension/actions/runs/17199518780), [Test report](https://leather-io.github.io/playwright-reports/fix/sign-out-buttons), [Storybook](https://fix/sign-out-buttons--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/sign-out-buttons)<!-- Sticky Header Marker -->

Fixes a regression with button text colors on the Sign out screen. These has some outdated color definitions that were previously ignored in the old button implementation, but showed up in the new one.

<img width="2904" height="1528" alt="image" src="https://github.com/user-attachments/assets/15e74595-b4a3-4bc6-9888-117fdb714eb8" />