### PR TITLE
fix: use correct balance in the "insufficient balance" message for sip-10 send, closes LEA-3147

### DIFF
--- a/src/app/common/error-formatters.ts
+++ b/src/app/common/error-formatters.ts
@@ -1,5 +1,5 @@
 import type { Money } from '@leather.io/models';
-import { isFunction } from '@leather.io/utils';
+import { createMoney, isFunction } from '@leather.io/utils';
 
 import { FormErrorMessages } from '@shared/error-messages';
 
@@ -14,11 +14,11 @@ export function formatInsufficientBalanceError(
   formatterFn?: (amount: Money) => string
 ) {
   if (!sum) return FormErrorMessages.CannotDetermineBalance;
-  const isAmountLessThanZero = sum.amount.lt(0);
 
-  const formattedAmount = isFunction(formatterFn) ? formatterFn(sum) : sum.amount.toString(10);
+  const normalizedSum = sum.amount.isLessThan(0) ? createMoney(0, sum.symbol, sum.decimals) : sum;
+  const formattedAmount = isFunction(formatterFn)
+    ? formatterFn(normalizedSum)
+    : normalizedSum.amount.toString(10);
 
-  return `${FormErrorMessages.InsufficientBalance} ${
-    isAmountLessThanZero ? '0' : formattedAmount
-  } ${sum.symbol}`;
+  return `${FormErrorMessages.InsufficientBalance} ${formattedAmount}`;
 }

--- a/src/app/common/validation/forms/amount-validators.ts
+++ b/src/app/common/validation/forms/amount-validators.ts
@@ -8,14 +8,15 @@ import {
   convertAmountToBaseUnit,
   countDecimals,
   isNumber,
-  microStxToStx,
   satToBtc,
   stxToMicroStx,
 } from '@leather.io/utils';
 
+import { FormErrorMessages } from '@shared/error-messages';
 import { analytics } from '@shared/utils/analytics';
 
-import { FormErrorMessages } from '../../../../shared/error-messages';
+import { formatCurrency } from '@app/common/currency-formatter';
+
 import { formatInsufficientBalanceError, formatPrecisionError } from '../../error-formatters';
 import { currencyAmountValidator, stxAmountPrecisionValidator } from './currency-validators';
 
@@ -88,9 +89,7 @@ export function stxAvailableBalanceValidator(availableBalance: Money) {
     .number()
     .typeError(FormErrorMessages.MustBeNumber)
     .test({
-      message: formatInsufficientBalanceError(availableBalance, sum =>
-        microStxToStx(sum.amount).toString()
-      ),
+      message: formatInsufficientBalanceError(availableBalance, formatCurrency),
       test(value: unknown) {
         const fee = new BigNumber(stxToMicroStx(this.parent.fee));
         if (!fee.isFinite()) {
@@ -124,7 +123,7 @@ export function stacksFungibleTokenAmountValidator(balance: Money) {
       return true;
     })
     .test({
-      message: formatInsufficientBalanceError(balance, sum => microStxToStx(sum.amount).toString()),
+      message: formatInsufficientBalanceError(balance, formatCurrency),
       test(value) {
         if (!isNumber(value) || !amount) return false;
         return new BigNumber(value).isLessThanOrEqualTo(convertAmountToBaseUnit(amount, decimals));

--- a/src/app/common/validation/forms/fee-validators.ts
+++ b/src/app/common/validation/forms/fee-validators.ts
@@ -2,8 +2,9 @@ import BigNumber from 'bignumber.js';
 import { AnyObject, NumberSchema } from 'yup';
 
 import type { Money } from '@leather.io/models';
-import { btcToSat, isNumber, moneyToBaseUnit, stxToMicroStx } from '@leather.io/utils';
+import { btcToSat, isNumber, stxToMicroStx } from '@leather.io/utils';
 
+import { formatCurrency } from '@app/common/currency-formatter';
 import { formatInsufficientBalanceError, formatPrecisionError } from '@app/common/error-formatters';
 import {
   btcAmountPrecisionValidator,
@@ -21,9 +22,7 @@ function feeValidatorFactory({
   validator,
 }: FeeValidatorFactoryArgs) {
   return validator(formatPrecisionError(availableBalance)).test({
-    message: formatInsufficientBalanceError(availableBalance, sum =>
-      moneyToBaseUnit(sum).toString()
-    ),
+    message: formatInsufficientBalanceError(availableBalance, formatCurrency),
     test(fee: unknown) {
       if (!availableBalance || !isNumber(fee)) return false;
       return availableBalance.amount.isGreaterThanOrEqualTo(unitConverter(fee));


### PR DESCRIPTION
> Try out Leather build ccc21c0 — [Extension build](https://github.com/leather-io/extension/actions/runs/17203538845), [Test report](https://leather-io.github.io/playwright-reports/fix/insufficient-balance-amount), [Storybook](https://fix/insufficient-balance-amount--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/insufficient-balance-amount)<!-- Sticky Header Marker -->

Replaces manual formatting in form amount validators with the new formatter, fixing an issue with incorrect available balance for SIP-10 tokens in the "Insufficient balance" message.

https://github.com/user-attachments/assets/02b4c6e1-f82f-462b-9184-8e75032031ee

