### PR TITLE
fix: remove old sbtc withdrawal warning

### DIFF
--- a/src/app/pages/swap/components/swap-review/bitcoin-swap-review.tsx
+++ b/src/app/pages/swap/components/swap-review/bitcoin-swap-review.tsx
@@ -1,5 +1,3 @@
-import { Callout } from '@leather.io/ui';
-
 import { SwapAssetsPair } from '../swap-assets-pair/swap-assets-pair';
 import { BitcoinSwapDetails } from '../swap-details/bitcoin-swap-details';
 import { SwapReviewLayout } from './swap-review.layout';
@@ -7,9 +5,6 @@ import { SwapReviewLayout } from './swap-review.layout';
 export function BitcoinSwapReview() {
   return (
     <SwapReviewLayout>
-      <Callout borderRadius="4px" variant="warning" width="100%">
-        Note that bridging from sBTC back to BTC is currently unavailable.
-      </Callout>
       <SwapAssetsPair />
       <BitcoinSwapDetails />
     </SwapReviewLayout>


### PR DESCRIPTION
> Try out Leather build 21d109c — [Extension build](https://github.com/leather-io/extension/actions/runs/17738161714), [Test report](https://leather-io.github.io/playwright-reports/fix/remove-sbtc-withdrawal-warning), [Storybook](https://fix/remove-sbtc-withdrawal-warning--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/remove-sbtc-withdrawal-warning)<!-- Sticky Header Marker -->

