### PR TITLE
fix(sbtc): navigate to error page

### DIFF
--- a/src/app/components/transaction/transaction-title.tsx
+++ b/src/app/components/transaction/transaction-title.tsx
@@ -23,7 +23,7 @@ export function TransactionTitle(props: TransactionTitleProps) {
   useOnResizeListener(onResize);
 
   return (
-    <BasicTooltip disabled={!isEllipsisActive} label={title} side="top">
+    <BasicTooltip asChild disabled={!isEllipsisActive} label={title} side="top">
       <Title
         overflow="hidden"
         ref={ref}

--- a/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
+++ b/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
@@ -180,16 +180,15 @@ export function useSbtcDepositTransaction(signer: BitcoinSigner<P2Ret>, utxos: U
         const signedDepositTx = await sign(deposit.transaction.toPSBT());
         signedDepositTx.finalize();
 
-        logger.info('Deposit', { deposit });
+        logger.info('Deposit', deposit);
 
         const txid = await client.broadcastTx(signedDepositTx);
         logger.info('Broadcasted tx', txid);
 
         const amount = deposit.transaction.getOutput(0).amount;
 
-        if (amount) {
+        if (amount)
           void analytics.untypedTrack('bitcoin_swap_succeeded', { amount: Number(amount) });
-        }
 
         await client.notifySbtc(deposit);
         toast.success('Transaction submitted!');
@@ -200,7 +199,7 @@ export function useSbtcDepositTransaction(signer: BitcoinSigner<P2Ret>, utxos: U
         logger.error(`Deposit error: ${error}`);
         void analytics.untypedTrack('bitcoin_swap_failed', { error });
         return navigate(RouteUrls.SwapError, {
-          state: { title: 'sBTC Bridge error', message: serializeError(error).message },
+          state: { title: 'sBTC swap error', message: serializeError(error).message },
         });
       } finally {
         setIsIdle();

--- a/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
+++ b/src/app/pages/swap/hooks/use-sbtc-deposit-transaction.tsx
@@ -31,6 +31,7 @@ import {
   determineUtxosForSpend,
   determineUtxosForSpendAll,
 } from '@app/common/transactions/bitcoin/coinselect/local-coin-selection';
+import { serializeError } from '@app/common/utils';
 import { useToast } from '@app/features/toasts/use-toast';
 import { useAverageBitcoinFeeRates } from '@app/query/bitcoin/fees/fee-estimates.hooks';
 import { useBreakOnNonCompliantEntity } from '@app/query/common/compliance-checker/compliance-checker.query';
@@ -198,6 +199,9 @@ export function useSbtcDepositTransaction(signer: BitcoinSigner<P2Ret>, utxos: U
         setIsIdle();
         logger.error(`Deposit error: ${error}`);
         void analytics.untypedTrack('bitcoin_swap_failed', { error });
+        return navigate(RouteUrls.SwapError, {
+          state: { title: 'sBTC Bridge error', message: serializeError(error).message },
+        });
       } finally {
         setIsIdle();
       }


### PR DESCRIPTION
> Try out Leather build c0cd404 — [Extension build](https://github.com/leather-io/extension/actions/runs/17797974567), [Test report](https://leather-io.github.io/playwright-reports/fix/navigate-to-error-page-in-bad-swap), [Storybook](https://fix/navigate-to-error-page-in-bad-swap--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/navigate-to-error-page-in-bad-swap)<!-- Sticky Header Marker -->

Adds an error page when the tx fails.