### PR TITLE
fix(sbtc): passing non-finalized tx

### DIFF
--- a/src/app/features/ledger/generic-flows/tx-signing/use-ledger-sign-tx.ts
+++ b/src/app/features/ledger/generic-flows/tx-signing/use-ledger-sign-tx.ts
@@ -6,6 +6,8 @@ import BitcoinApp from 'ledger-bitcoin';
 import type { SupportedBlockchains } from '@leather.io/models';
 import { delay, isError } from '@leather.io/utils';
 
+import { logger } from '@shared/logger';
+
 import { useLedgerNavigate } from '../../hooks/use-ledger-navigate';
 import { BitcoinAppVersion } from '../../utils/bitcoin-ledger-utils';
 import {
@@ -74,7 +76,11 @@ export function useLedgerSignTx<App extends StacksApp | BitcoinApp>({
 
       return ledgerNavigate.toErrorStep(chain);
     } finally {
-      await app?.transport.close();
+      try {
+        await app?.transport.close();
+      } catch {
+        logger.warn('Failed to close transport connection to Ledger device');
+      }
     }
   }
 


### PR DESCRIPTION
> Try out Leather build a910799 — [Extension build](https://github.com/leather-io/extension/actions/runs/17799015264), [Test report](https://leather-io.github.io/playwright-reports/fix/sbtc-ledger-fix), [Storybook](https://fix/sbtc-ledger-fix--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/sbtc-ledger-fix)<!-- Sticky Header Marker -->

sBTC implementation relies on mutative software behaviours. Ledger return a new tx object. Figured this is worth a comment as it's not very clear.