### PR TITLE
fix(analytics): cap session duration tracking

### DIFF
--- a/src/shared/analytics/session-duration-tracking.ts
+++ b/src/shared/analytics/session-duration-tracking.ts
@@ -52,10 +52,17 @@ export function listenForSessionDurationPort({ onSessionEnd }: ListenForSessionD
 
       if (!isDefined(startTime) || !frameType) return;
 
+      function capDurationAt10Minutes(duration: number) {
+        return Math.min(duration, 600);
+      }
+
       tabIdSessionStartMap.delete(id);
       onSessionEnd({
         sessionFrame: frameType,
-        durationSeconds: (new Date().valueOf() - startTime) / 1000,
+        // Frames could last days at a time, and users are of unlikely to be
+        // actively using leather for such long durations. This cap is a measure
+        // to prevent unrealistically high session durations
+        durationSeconds: capDurationAt10Minutes((new Date().valueOf() - startTime) / 1000),
       });
     });
   });


### PR DESCRIPTION
> Try out Leather build adede02 — [Extension build](https://github.com/leather-io/extension/actions/runs/17821190631), [Test report](https://leather-io.github.io/playwright-reports/fix/cap-session-duration-tracking), [Storybook](https://fix/cap-session-duration-tracking--65982789c7e2278518f189e7.chromatic.com), [Chromatic](https://www.chromatic.com/library?appId=65982789c7e2278518f189e7&branch=fix/cap-session-duration-tracking)<!-- Sticky Header Marker -->

@fabric-8 @mica000 we're seeing loads of usage of fullscreen vs the other views. 

<img width="1374" height="359" alt="image" src="https://github.com/user-attachments/assets/748351f8-6286-4ab6-8f84-91e52346ec24" />

This is partially skewed given users can unintentionally leave `fullscreen` and `window-popups` open indefinitely. I think it's fairer to set a max value of what we record. Now a user leaving a page open overnight will track as 10 minutes, not many hours. 